### PR TITLE
add a check-wip target to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ install:
 
 check-wip:
 	pre-commit run --all-files
-	pytest
+    python -m pytest tests


### PR DESCRIPTION
I run all the time:

```bash
pre-commit run --all-files
pytest
```

So, can we add them to the makefile helpers ?