### PR TITLE
Remove leading slash in sent URI when clicking a `FileTreeItem`

### DIFF
--- a/frontend/src/components/FileTreeItem.vue
+++ b/frontend/src/components/FileTreeItem.vue
@@ -16,10 +16,18 @@ const label = computed(() => {
 });
 
 function onClick() {
+  var segments = props.uri.split("/");
+
+  // Take out leading slash to get a valid URL
+  const [head, ...tail] = segments;
+  if (head === "") {
+    segments = tail;
+  }
+
   router.push({
     name: "dashboard",
     params: {
-      segments: props.uri.split("/"),
+      segments: segments,
     },
   });
 }


### PR DESCRIPTION
This fixes an issue where the updated URL was `http://localhost/#//my/mandr` (note the two slashes).