### PR TITLE
rename "board" into "report"

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -95,7 +95,7 @@ await fetchDataStoreDetail(route.params.segments);
         @dragleave="onDragLeave"
       >
         <div class="editor-header" ref="editorHeader">
-          <h1>Board</h1>
+          <h1>Report</h1>
           <SimpleButton label="Save report settings" @click="onSaveBoard" />
         </div>
         <div class="drop-indicator" :class="{ visible: isDropIndicatorVisible }"></div>


### PR DESCRIPTION
Right part of the screen is now named "report" in the header.
<img width="1781" alt="Screenshot 2024-08-13 at 14 18 41" src="https://github.com/user-attachments/assets/ef8d2195-6fb8-48ca-9cf6-1b4d7268c4d4">
