### PR TITLE
Use `::` instead of `=` for drag-and-drop handle

### DIFF
--- a/frontend/src/components/DataStoreKey.vue
+++ b/frontend/src/components/DataStoreKey.vue
@@ -28,7 +28,7 @@ function onDragStart(event: DragEvent) {
   >
     <div class="actions">
       <div class="add" @click="addKey">+</div>
-      <div class="drag" @mousedown="isDraggable = true">=</div>
+      <div class="drag" @mousedown="isDraggable = true">::</div>
     </div>
     <div class="label">
       {{ props.itemKey }}
@@ -58,6 +58,7 @@ function onDragStart(event: DragEvent) {
     right: 5px;
     display: flex;
     color: var(--text-color-normal);
+    font-weight: bolder;
     gap: var(--spacing-padding-small);
 
     & .drag {


### PR DESCRIPTION
Action buttons are now bolder:

<img width="205" alt="Screenshot 2024-08-13 at 15 48 43" src="https://github.com/user-attachments/assets/6f79bb30-e2c6-46d9-bc6d-235ee7c07db6">
