### PR TITLE
Add a minimal example using skrub and Mandr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ pip-compile:
 	pip-compile --extra=doc --output-file=requirements-doc.txt pyproject.toml
 
 install:
-	python -m pip install -e . -r requirements.txt -r requirements-test.txt -r requirements-tools.txt
+	python -m pip install -e . -r requirements.txt -r requirements-test.txt -r \
+	requirements-tools.txt -r requirements-doc.txt
 	pre-commit install
 
 check-wip:

--- a/notebooks/skrub_demo.py
+++ b/notebooks/skrub_demo.py
@@ -7,8 +7,6 @@ import altair as alt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from mandr import Store
-from mandr.storage import FileSystem
 from matplotlib import pyplot as plt
 from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor
 from sklearn.inspection import permutation_importance
@@ -20,7 +18,10 @@ from skrub import TableReport, tabular_learner
 from skrub.datasets import fetch_employee_salaries
 from tqdm import tqdm
 
-DIR_MANDER = ".datamander"
+from mandr import Mandr
+from mandr.storage import FileSystem
+
+DIR_MANDER = "datamander"
 PATH_PROJECT = Path("skrub_demo")
 N_SEEDS = 5
 
@@ -53,7 +54,7 @@ def evaluate_models(model_names):
     mander = get_mander(str(PATH_PROJECT))
     mander.insert("skrub_report", plot_skrub_report(), display_type="html")
     mander.insert("target_distribution", plot_y_distribution())
-    mander.insert("Metrics", plot_table_metrics(results), display_type="html")
+    mander.insert("Metrics", plot_table_metrics(results))
     mander.insert("R2 vs fit time", plot_r2_vs_fit_time(results), display_type="html")
 
 
@@ -159,11 +160,7 @@ def plot_table_metrics(results):
         )
         df = df.drop([mean_key, std_key], axis=1)
 
-    return (
-        df.style.map(lambda x: "color:white").set_table_styles(
-            [{"selector": "th", "props": "color: white;"}]
-        )
-    ).to_html()
+    return df
 
 
 def plot_r2_vs_fit_time(results):
@@ -268,7 +265,7 @@ def plot_model_repr(model):
 
 
 def get_mander(path):
-    return Store(
+    return Mandr(
         path,
         storage=FileSystem(directory=DIR_MANDER),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ doc = [
   "skrub",
   "sphinx",
   "sphinx-gallery",
-  "matplotlib"
+  "matplotlib",
+  "seaborn",
+  "tqdm"
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -4,34 +4,26 @@
 #
 #    pip-compile --extra=doc --output-file=requirements-doc.txt pyproject.toml
 #
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
-altair==5.3.0
+altair==5.4.0
     # via mandr (pyproject.toml)
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
-attrs==23.2.0
+    # via starlette
+attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 certifi==2024.7.4
-    # via
-    #   httpcore
-    #   httpx
-    #   requests
+    # via requests
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via
-    #   typer
-    #   uvicorn
+    # via uvicorn
 compress-pickle[lz4]==2.1.0
     # via pydantic-numpy
 contourpy==1.2.1
@@ -40,42 +32,23 @@ cycler==0.12.1
     # via matplotlib
 diskcache==5.6.3
     # via mandr (pyproject.toml)
-dnspython==2.6.1
-    # via email-validator
 docutils==0.21.2
     # via sphinx
-email-validator==2.2.0
-    # via fastapi
-fastapi==0.111.1
+fastapi==0.112.1
     # via mandr (pyproject.toml)
-fastapi-cli==0.0.4
-    # via fastapi
 fonttools==4.53.1
     # via matplotlib
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
 jinja2==3.1.4
     # via
     #   altair
-    #   fastapi
-    #   flask
-    #   mandr (pyproject.toml)
     #   skrub
     #   sphinx
 joblib==1.4.2
@@ -92,21 +65,24 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-matplotlib==3.9.1
+matplotlib==3.9.2
     # via
     #   mandr (pyproject.toml)
+    #   seaborn
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-numpy==2.0.1
+narwhals==1.4.2
+    # via altair
+numpy==2.1.0
     # via
-    #   altair
     #   contourpy
     #   matplotlib
     #   pandas
     #   pydantic-numpy
     #   scikit-learn
     #   scipy
+    #   seaborn
     #   skrub
 packaging==24.1
     # via
@@ -116,14 +92,14 @@ packaging==24.1
     #   sphinx
 pandas==2.2.2
     # via
-    #   altair
     #   mandr (pyproject.toml)
+    #   seaborn
     #   skrub
 pillow==10.4.0
     # via
     #   matplotlib
     #   sphinx-gallery
-polars==1.3.0
+polars==1.5.0
     # via mandr (pyproject.toml)
 pydantic==2.8.2
     # via
@@ -144,14 +120,8 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
 pytz==2024.1
     # via pandas
-pyyaml==6.0.1
-    # via uvicorn
 referencing==0.35.1
     # via
     #   jsonschema
@@ -159,10 +129,8 @@ referencing==0.35.1
 requests==2.32.3
     # via sphinx
 rich==13.7.1
-    # via
-    #   mandr (pyproject.toml)
-    #   typer
-rpds-py==0.19.0
+    # via mandr (pyproject.toml)
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
@@ -175,64 +143,54 @@ scikit-learn==1.5.1
     #   mandr (pyproject.toml)
     #   skrub
 scipy==1.14.0
-    # via scikit-learn
+    # via
+    #   scikit-learn
+    #   skrub
+seaborn==0.13.2
+    # via mandr (pyproject.toml)
 semver==3.0.2
     # via pydantic-numpy
-shellingham==1.5.4
-    # via typer
 six==1.16.0
     # via python-dateutil
 skrub==0.3.0
     # via mandr (pyproject.toml)
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.4.7
+sphinx==8.0.2
     # via
     #   mandr (pyproject.toml)
     #   sphinx-gallery
-sphinx-gallery==0.17.0
+sphinx-gallery==0.17.1
     # via mandr (pyproject.toml)
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.6
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.8
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-starlette==0.37.2
+starlette==0.38.2
     # via fastapi
 threadpoolctl==3.5.0
     # via scikit-learn
-toolz==0.12.1
-    # via altair
-typer==0.12.3
-    # via fastapi-cli
+tqdm==4.66.5
+    # via mandr (pyproject.toml)
 typing-extensions==4.12.2
     # via
+    #   altair
     #   fastapi
     #   pydantic
     #   pydantic-core
-    #   typer
 tzdata==2024.1
     # via pandas
 urllib3==2.2.2
     # via requests
-uvicorn[standard]==0.30.3
-    # via
-    #   fastapi
-    #   mandr (pyproject.toml)
-uvloop==0.19.0
-    # via uvicorn
-watchfiles==0.22.0
-    # via uvicorn
-websockets==12.0
-    # via uvicorn
+uvicorn==0.30.6
+    # via mandr (pyproject.toml)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=test --output-file=requirements-test.txt pyproject.toml
 #
-altair==5.3.0
+altair==5.4.0
     # via mandr (pyproject.toml)
 annotated-types==0.7.0
     # via pydantic
@@ -12,10 +12,9 @@ anyio==4.4.0
     # via
     #   httpx
     #   starlette
-    #   watchfiles
 arrow==1.3.0
     # via isoduration
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
@@ -26,14 +25,12 @@ certifi==2024.7.4
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
-    # via
-    #   typer
-    #   uvicorn
+    # via uvicorn
 compress-pickle[lz4]==2.1.0
     # via pydantic-numpy
 contourpy==1.2.1
     # via matplotlib
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -41,14 +38,8 @@ diskcache==5.6.3
     # via mandr (pyproject.toml)
 distlib==0.3.8
     # via virtualenv
-dnspython==2.6.1
-    # via email-validator
-email-validator==2.2.0
-    # via fastapi
-fastapi==0.111.1
+fastapi==0.112.1
     # via mandr (pyproject.toml)
-fastapi-cli==0.0.4
-    # via fastapi
 filelock==3.15.4
     # via virtualenv
 fonttools==4.53.1
@@ -61,18 +52,13 @@ h11==0.14.0
     #   uvicorn
 httpcore==1.0.5
     # via httpx
-httptools==0.6.1
-    # via uvicorn
 httpx==0.27.0
-    # via
-    #   fastapi
-    #   mandr (pyproject.toml)
+    # via mandr (pyproject.toml)
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via
     #   anyio
-    #   email-validator
     #   httpx
     #   jsonschema
 iniconfig==2.0.0
@@ -80,9 +66,7 @@ iniconfig==2.0.0
 isoduration==20.11.0
     # via jsonschema
 jinja2==3.1.4
-    # via
-    #   altair
-    #   fastapi
+    # via altair
 joblib==1.4.2
     # via scikit-learn
 jsonpointer==3.0.0
@@ -101,15 +85,16 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-matplotlib==3.9.1
+matplotlib==3.9.2
     # via mandr (pyproject.toml)
 mdurl==0.1.2
     # via markdown-it-py
+narwhals==1.4.2
+    # via altair
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.0.0
+numpy==2.1.0
     # via
-    #   altair
     #   contourpy
     #   matplotlib
     #   pandas
@@ -122,18 +107,16 @@ packaging==24.1
     #   matplotlib
     #   pytest
 pandas==2.2.2
-    # via
-    #   altair
-    #   mandr (pyproject.toml)
+    # via mandr (pyproject.toml)
 pillow==10.4.0
     # via matplotlib
 platformdirs==4.2.2
     # via virtualenv
 pluggy==1.5.0
     # via pytest
-polars==1.2.1
+polars==1.5.0
     # via mandr (pyproject.toml)
-pre-commit==3.7.1
+pre-commit==3.8.0
     # via mandr (pyproject.toml)
 pydantic==2.8.2
     # via
@@ -148,7 +131,7 @@ pygments==2.18.0
     # via rich
 pyparsing==3.1.2
     # via matplotlib
-pytest==8.2.2
+pytest==8.3.2
     # via
     #   mandr (pyproject.toml)
     #   pytest-cov
@@ -162,16 +145,10 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   matplotlib
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
 pytz==2024.1
     # via pandas
-pyyaml==6.0.1
-    # via
-    #   pre-commit
-    #   uvicorn
+pyyaml==6.0.2
+    # via pre-commit
 referencing==0.35.1
     # via
     #   jsonschema
@@ -181,10 +158,8 @@ rfc3339-validator==0.1.4
 rfc3987==1.3.8
     # via jsonschema
 rich==13.7.1
-    # via
-    #   mandr (pyproject.toml)
-    #   typer
-rpds-py==0.19.0
+    # via mandr (pyproject.toml)
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
@@ -192,7 +167,7 @@ ruamel-yaml==0.18.6
     # via pydantic-numpy
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.5.3
+ruff==0.6.1
     # via mandr (pyproject.toml)
 scikit-learn==1.5.1
     # via mandr (pyproject.toml)
@@ -200,8 +175,6 @@ scipy==1.14.0
     # via scikit-learn
 semver==3.0.2
     # via pydantic-numpy
-shellingham==1.5.4
-    # via typer
 six==1.16.0
     # via
     #   python-dateutil
@@ -210,37 +183,25 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-starlette==0.37.2
+starlette==0.38.2
     # via fastapi
 threadpoolctl==3.5.0
     # via scikit-learn
-toolz==0.12.1
-    # via altair
-typer==0.12.3
-    # via fastapi-cli
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.12.2
     # via
+    #   altair
     #   fastapi
     #   pydantic
     #   pydantic-core
-    #   typer
 tzdata==2024.1
     # via pandas
 uri-template==1.3.0
     # via jsonschema
-uvicorn[standard]==0.30.1
-    # via
-    #   fastapi
-    #   mandr (pyproject.toml)
-uvloop==0.19.0
-    # via uvicorn
+uvicorn==0.30.6
+    # via mandr (pyproject.toml)
 virtualenv==20.26.3
     # via pre-commit
-watchfiles==0.22.0
-    # via uvicorn
-webcolors==24.6.0
+webcolors==24.8.0
     # via jsonschema
-websockets==12.0
-    # via uvicorn

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -4,29 +4,21 @@
 #
 #    pip-compile --extra=tools --output-file=requirements-tools.txt pyproject.toml
 #
-altair==5.3.0
+altair==5.4.0
     # via mandr (pyproject.toml)
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
-attrs==23.2.0
+    # via starlette
+attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
 build==1.2.1
     # via pip-tools
-certifi==2024.7.4
-    # via
-    #   httpcore
-    #   httpx
 click==8.1.7
     # via
     #   pip-tools
-    #   typer
     #   uvicorn
 compress-pickle[lz4]==2.1.0
     # via pydantic-numpy
@@ -36,35 +28,16 @@ cycler==0.12.1
     # via matplotlib
 diskcache==5.6.3
     # via mandr (pyproject.toml)
-dnspython==2.6.1
-    # via email-validator
-email-validator==2.2.0
-    # via fastapi
-fastapi==0.111.1
+fastapi==0.112.1
     # via mandr (pyproject.toml)
-fastapi-cli==0.0.4
-    # via fastapi
 fonttools==4.53.1
     # via matplotlib
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
 idna==3.7
-    # via
-    #   anyio
-    #   email-validator
-    #   httpx
+    # via anyio
 jinja2==3.1.4
-    # via
-    #   altair
-    #   fastapi
+    # via altair
 joblib==1.4.2
     # via scikit-learn
 jsonschema==4.23.0
@@ -79,13 +52,14 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-matplotlib==3.9.1
+matplotlib==3.9.2
     # via mandr (pyproject.toml)
 mdurl==0.1.2
     # via markdown-it-py
-numpy==2.0.0
+narwhals==1.4.2
+    # via altair
+numpy==2.1.0
     # via
-    #   altair
     #   contourpy
     #   matplotlib
     #   pandas
@@ -98,14 +72,12 @@ packaging==24.1
     #   build
     #   matplotlib
 pandas==2.2.2
-    # via
-    #   altair
-    #   mandr (pyproject.toml)
+    # via mandr (pyproject.toml)
 pillow==10.4.0
     # via matplotlib
 pip-tools==7.4.1
     # via mandr (pyproject.toml)
-polars==1.2.1
+polars==1.5.0
     # via mandr (pyproject.toml)
 pydantic==2.8.2
     # via
@@ -128,23 +100,15 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
 pytz==2024.1
     # via pandas
-pyyaml==6.0.1
-    # via uvicorn
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via
-    #   mandr (pyproject.toml)
-    #   typer
-rpds-py==0.19.0
+    # via mandr (pyproject.toml)
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
@@ -158,41 +122,25 @@ scipy==1.14.0
     # via scikit-learn
 semver==3.0.2
     # via pydantic-numpy
-shellingham==1.5.4
-    # via typer
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
-starlette==0.37.2
+    # via anyio
+starlette==0.38.2
     # via fastapi
 threadpoolctl==3.5.0
     # via scikit-learn
-toolz==0.12.1
-    # via altair
-typer==0.12.3
-    # via fastapi-cli
 typing-extensions==4.12.2
     # via
+    #   altair
     #   fastapi
     #   pydantic
     #   pydantic-core
-    #   typer
 tzdata==2024.1
     # via pandas
-uvicorn[standard]==0.30.1
-    # via
-    #   fastapi
-    #   mandr (pyproject.toml)
-uvloop==0.19.0
-    # via uvicorn
-watchfiles==0.22.0
-    # via uvicorn
-websockets==12.0
-    # via uvicorn
-wheel==0.43.0
+uvicorn==0.30.6
+    # via mandr (pyproject.toml)
+wheel==0.44.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,27 +4,18 @@
 #
 #    pip-compile --output-file=requirements.txt pyproject.toml
 #
-altair==5.3.0
+altair==5.4.0
     # via mandr (pyproject.toml)
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
-attrs==23.2.0
+    # via starlette
+attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-certifi==2024.7.4
-    # via
-    #   httpcore
-    #   httpx
 click==8.1.7
-    # via
-    #   typer
-    #   uvicorn
+    # via uvicorn
 compress-pickle[lz4]==2.1.0
     # via pydantic-numpy
 contourpy==1.2.1
@@ -33,35 +24,16 @@ cycler==0.12.1
     # via matplotlib
 diskcache==5.6.3
     # via mandr (pyproject.toml)
-dnspython==2.6.1
-    # via email-validator
-email-validator==2.2.0
-    # via fastapi
-fastapi==0.111.1
+fastapi==0.112.1
     # via mandr (pyproject.toml)
-fastapi-cli==0.0.4
-    # via fastapi
 fonttools==4.53.1
     # via matplotlib
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
 idna==3.7
-    # via
-    #   anyio
-    #   email-validator
-    #   httpx
+    # via anyio
 jinja2==3.1.4
-    # via
-    #   altair
-    #   fastapi
+    # via altair
 joblib==1.4.2
     # via scikit-learn
 jsonschema==4.23.0
@@ -76,13 +48,14 @@ markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-matplotlib==3.9.1
+matplotlib==3.9.2
     # via mandr (pyproject.toml)
 mdurl==0.1.2
     # via markdown-it-py
-numpy==2.0.0
+narwhals==1.4.2
+    # via altair
+numpy==2.1.0
     # via
-    #   altair
     #   contourpy
     #   matplotlib
     #   pandas
@@ -94,12 +67,10 @@ packaging==24.1
     #   altair
     #   matplotlib
 pandas==2.2.2
-    # via
-    #   altair
-    #   mandr (pyproject.toml)
+    # via mandr (pyproject.toml)
 pillow==10.4.0
     # via matplotlib
-polars==1.2.1
+polars==1.5.0
     # via mandr (pyproject.toml)
 pydantic==2.8.2
     # via
@@ -118,23 +89,15 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-dotenv==1.0.1
-    # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
 pytz==2024.1
     # via pandas
-pyyaml==6.0.1
-    # via uvicorn
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via
-    #   mandr (pyproject.toml)
-    #   typer
-rpds-py==0.19.0
+    # via mandr (pyproject.toml)
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
@@ -148,37 +111,21 @@ scipy==1.14.0
     # via scikit-learn
 semver==3.0.2
     # via pydantic-numpy
-shellingham==1.5.4
-    # via typer
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
-starlette==0.37.2
+    # via anyio
+starlette==0.38.2
     # via fastapi
 threadpoolctl==3.5.0
     # via scikit-learn
-toolz==0.12.1
-    # via altair
-typer==0.12.3
-    # via fastapi-cli
 typing-extensions==4.12.2
     # via
+    #   altair
     #   fastapi
     #   pydantic
     #   pydantic-core
-    #   typer
 tzdata==2024.1
     # via pandas
-uvicorn[standard]==0.30.1
-    # via
-    #   fastapi
-    #   mandr (pyproject.toml)
-uvloop==0.19.0
-    # via uvicorn
-watchfiles==0.22.0
-    # via uvicorn
-websockets==12.0
-    # via uvicorn
+uvicorn==0.30.6
+    # via mandr (pyproject.toml)


### PR DESCRIPTION
This PR adds an example using Mander which compares 3 models on a skrub dataset, featuring HTML items like model representation, skrub Table Reporter, and base64 encoded images.

The idea is to showcase a hierarchy of Manders in the following order:

- `project_name`
    - `model_name`
        - `random_state` (aka seed)

and perform some aggregation of metrics/plots at each level.

Below are some screenshots of the top-level (project_name) artifacts produced.

I put this example in the `notebook` folder because we don't have a dedicated place yet (the `example` folder should be reserved for sphinx CI if we want to have it, IMO)

Usage:
```shell
pip install -r requirements-doc.txt
python notebooks/skrub_demo.py
make serve-dashboard
````

![Screenshot 2024-08-14 at 18 16 13](https://github.com/user-attachments/assets/d8bb797a-74ab-4545-b105-ce7bfd4ad060)

![Screenshot 2024-08-14 at 18 15 57](https://github.com/user-attachments/assets/56ad3a2b-0510-4cee-a4fa-8136305c5596)

cc @koaning @tuscland 