### PR TITLE
fix behavior when MANDR_ROOT is set to a relative path

### DIFF
--- a/src/mandr/store/store.py
+++ b/src/mandr/store/store.py
@@ -18,20 +18,13 @@ if TYPE_CHECKING:
     from mandr.storage import Storage
 
 
-class MandrRootException(Exception):
-    """Raise when the MANDR_ROOT variable is set to a relative path."""
-
-
 def _get_storage_path(MANDR_ROOT: str | None) -> Path:
     """Decide on the `Storage`'s location based on MANDR_ROOT."""
     if MANDR_ROOT is None:
         return Path.cwd() / ".datamander"
 
     if not Path(MANDR_ROOT).is_absolute():
-        raise MandrRootException(
-            "MANDR_ROOT must be set to an absolute path or unset, not set "
-            f"to a relative path; got '{MANDR_ROOT}'."
-        )
+        return Path.cwd() / MANDR_ROOT
 
     return Path(MANDR_ROOT)
 

--- a/tests/integration/test_dashboard_open.py
+++ b/tests/integration/test_dashboard_open.py
@@ -17,7 +17,8 @@ def test_dashboard_open_with_no_mandr_root(monkeypatch, tmp_path):
         assert response.is_success
 
 
-def test_dashboard_open_with_relative_mandr_root(monkeypatch):
+def test_dashboard_open_with_relative_mandr_root(monkeypatch, tmp_path):
+    monkeypatch.setattr("pathlib.Path.cwd", lambda: tmp_path)
     monkeypatch.setenv("MANDR_ROOT", ".datamander")
 
     dashboard = Dashboard()
@@ -27,11 +28,13 @@ def test_dashboard_open_with_relative_mandr_root(monkeypatch):
         host = dashboard.server.config.host
         port = dashboard.server.config.port
         response = httpx.get(f"http://{host}:{port}/api/mandrs")
-        assert response.is_server_error
+        assert response.is_success
+
+    assert (tmp_path / ".datamander").exists()
 
 
 def test_dashboard_open_with_absolute_mandr_root(monkeypatch, tmp_path):
-    monkeypatch.setenv("MANDR_ROOT", str(tmp_path))
+    monkeypatch.setenv("MANDR_ROOT", str(tmp_path / ".datamander"))
 
     dashboard = Dashboard()
     with contextlib.closing(dashboard.open(open_browser=False)):
@@ -41,3 +44,5 @@ def test_dashboard_open_with_absolute_mandr_root(monkeypatch, tmp_path):
         port = dashboard.server.config.port
         response = httpx.get(f"http://{host}:{port}/api/mandrs")
         assert response.is_success
+
+    assert (tmp_path / ".datamander").exists()

--- a/tests/integration/test_default_store.py
+++ b/tests/integration/test_default_store.py
@@ -1,9 +1,7 @@
 from pathlib import Path
 
-import pytest
 from mandr.storage import FileSystem
 from mandr.store import Store
-from mandr.store.store import MandrRootException
 
 
 class TestDefaultStorage:
@@ -21,10 +19,12 @@ class TestDefaultStorage:
     def test_relative_path(self, monkeypatch, tmp_path):
         """If MANDR_ROOT is a relative path, we raise an error."""
         monkeypatch.setattr("pathlib.Path.cwd", lambda: tmp_path)
-        monkeypatch.setenv("MANDR_ROOT", ".not_datamander")
+        monkeypatch.setenv("MANDR_ROOT", ".datamander")
 
-        with pytest.raises(MandrRootException, match="got '.not_datamander'"):
-            Store("root/probabl")
+        store = Store("root/probabl")
+
+        assert isinstance(store.storage, FileSystem)
+        assert Path(store.storage.cache.directory) == tmp_path / ".datamander"
 
     def test_relative_path_no_mandr_root(self, monkeypatch, tmp_path):
         """If MANDR_ROOT is unset, the storage is in ".datamander",


### PR DESCRIPTION
This behavior was previous unsupported; now, we interpret relative paths
as relative to the current working directory.

Closes #185
