### PR TITLE
Add altair LayerChart to schema

### DIFF
--- a/src/mandr/api/schema/vega.py
+++ b/src/mandr/api/schema/vega.py
@@ -21,7 +21,7 @@ class Vega(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(strict=True, arbitrary_types_allowed=True)
 
     type: typing.Literal["vega"] = "vega"
-    data: altair.vegalite.v5.api.Chart
+    data: typing.Union[altair.vegalite.v5.api.Chart, altair.vegalite.v5.api.LayerChart]
 
     @pydantic.field_serializer("data")
     def serialize_data(self, data: altair.vegalite.v5.api.Chart) -> dict:

--- a/src/mandr/item/display_type.py
+++ b/src/mandr/item/display_type.py
@@ -76,6 +76,7 @@ class DisplayType(StrEnum):
             float: DisplayType.NUMBER,
             numpy.ndarray: DisplayType.NUMPY_ARRAY,
             altair.vegalite.v5.api.Chart: DisplayType.VEGA,
+            altair.vegalite.v5.api.LayerChart: DisplayType.VEGA,
         }
 
         # `Paths` are `PosixPath` or `WindowsPath` when instantiated

--- a/tests/unit/api/schema/test_store.py
+++ b/tests/unit/api/schema/test_store.py
@@ -96,6 +96,30 @@ class TestStore:
                 },
             ),
             (
+                {
+                    "type": "vega",
+                    "data": (
+                        altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                        + altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                    ),
+                },
+                {
+                    "type": "vega",
+                    "data": (
+                        altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                        + altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                    ).to_dict(),
+                },
+            ),
+            (
                 {"type": "numpy_array", "data": np.array([1, 2, 3, 4, 5])},
                 {"type": "numpy_array", "data": np.array([1, 2, 3, 4, 5]).tolist()},
             ),


### PR DESCRIPTION
**What does this PR suggest?**
Adding two different altair Charts creates a LayerChart, which stacks figures. Since this is a basic altair feature and
we currently only support Chart, LayerChart would be a useful addition for https://github.com/probabl-ai/mandr/pull/186. I didn't add an issue for this PR as this is a quick fix.

WDYT?