### PR TITLE
fix repr of URI

### DIFF
--- a/src/mandr/storage/uri.py
+++ b/src/mandr/storage/uri.py
@@ -28,19 +28,19 @@ class URI:
         Examples
         --------
         >>> URI("/", "r", "/", "o", "/", "o", "/", "t")
-        URI(r,o,o,t)
+        URI("/r/o/o/t")
 
         >>> URI("/r/o", "/o/t")
-        URI(r,o,o,t)
+        URI("/r/o/o/t")
 
         >>> URI("/r/o/o/t")
-        URI(r,o,o,t)
+        URI("/r/o/o/t")
 
         >>> URI("r/o/o/t")
-        URI(r,o,o,t)
+        URI("/r/o/o/t")
 
         >>> URI("r", "o", "o", "t")
-        URI(r,o,o,t)
+        URI("/r/o/o/t")
 
         >>> URI("/")
         Traceback (most recent call last):
@@ -110,7 +110,7 @@ class URI:
 
     def __repr__(self) -> str:
         """Return repr(self)."""
-        return f"URI({','.join(self.__segments)})"
+        return f'URI("{self}")'
 
     def __hash__(self) -> int:
         """Return hash(self)."""

--- a/tests/unit/storage/test_uri.py
+++ b/tests/unit/storage/test_uri.py
@@ -59,12 +59,14 @@ class TestURI:
         assert str(URI("r/o/o/t")) == root
 
     def test_repr(self):
-        root = "URI(r,o,o,t)"
+        root = 'URI("/r/o/o/t")'
 
         assert repr(URI("/", "r", "/", "o", "/", "o", "/", "t")) == root
         assert repr(URI("/r/o", "/o/t")) == root
         assert repr(URI("/r/o/o/t")) == root
         assert repr(URI("r/o/o/t")) == root
+
+        assert eval(repr(root)) == root
 
     def test_hash(self):
         root = hash(("r", "o", "o", "t"))


### PR DESCRIPTION
Namely, make it respect `eval(repr(uri)) == uri`.

Closes #155
