### PR TITLE
hide vega actions button and avoid memory leak when unloading vega charts

### DIFF
--- a/frontend/src/components/VegaWidget.vue
+++ b/frontend/src/components/VegaWidget.vue
@@ -32,6 +32,7 @@ onMounted(async () => {
       {
         theme: "dark",
         config: vegaConfig,
+        actions: false,
       }
     );
     vegaView = r.view;
@@ -42,6 +43,9 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   if (container.value) {
     resizeObserver.unobserve(container.value);
+  }
+  if (vegaView) {
+    vegaView.finalize();
   }
 });
 </script>


### PR DESCRIPTION
Actions buttons are not displayed anymore; see screenshot below:

![Screenshot 2024-08-23 at 11 23 46](https://github.com/user-attachments/assets/1db7d590-e981-4fa2-9ebc-3fbedb6caafb)

Also, charts are now properly unloaded when unmounted from the DOM.