### PR TITLE
accept all types of altair charts

### DIFF
--- a/src/mandr/api/schema/vega.py
+++ b/src/mandr/api/schema/vega.py
@@ -2,7 +2,7 @@
 
 import typing
 
-import altair
+import altair.vegalite.v5.schema.core
 import pydantic
 
 
@@ -21,7 +21,7 @@ class Vega(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(strict=True, arbitrary_types_allowed=True)
 
     type: typing.Literal["vega"] = "vega"
-    data: typing.Union[altair.vegalite.v5.api.Chart, altair.vegalite.v5.api.LayerChart]
+    data: altair.vegalite.v5.schema.core.TopLevelSpec
     metadata: typing.Optional[typing.Any] = None
 
     @pydantic.field_serializer("data")

--- a/src/mandr/item/display_type.py
+++ b/src/mandr/item/display_type.py
@@ -11,7 +11,7 @@ import pathlib
 from enum import StrEnum, auto
 from typing import Any
 
-import altair
+import altair.vegalite.v5.schema.core
 import matplotlib.figure
 import numpy
 import pandas
@@ -75,9 +75,10 @@ class DisplayType(StrEnum):
             matplotlib.figure.Figure: DisplayType.MATPLOTLIB_FIGURE,
             float: DisplayType.NUMBER,
             numpy.ndarray: DisplayType.NUMPY_ARRAY,
-            altair.vegalite.v5.api.Chart: DisplayType.VEGA,
-            altair.vegalite.v5.api.LayerChart: DisplayType.VEGA,
         }
+
+        if isinstance(x, altair.vegalite.v5.schema.core.TopLevelSpec):
+            return DisplayType.VEGA
 
         # `Paths` are `PosixPath` or `WindowsPath` when instantiated
         if isinstance(x, pathlib.Path):

--- a/tests/unit/api/schema/test_store.py
+++ b/tests/unit/api/schema/test_store.py
@@ -125,6 +125,62 @@ class TestStore:
                 },
             ),
             (
+                {
+                    "type": "vega",
+                    "data": (
+                        altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                        | altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                    ),
+                },
+                {
+                    "type": "vega",
+                    "data": (
+                        altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                        | altair.Chart(
+                            pandas.DataFrame({"a": ["A"], "b": [28]})
+                        ).mark_bar()
+                    ).to_dict(),
+                },
+            ),
+            (
+                {
+                    "type": "vega",
+                    "data": (
+                        altair.Chart(pandas.DataFrame({"a": ["A"], "b": [28]}))
+                        .mark_point()
+                        .encode(
+                            altair.X(altair.repeat("column")),
+                            altair.Y(altair.repeat("row")),
+                        )
+                        .repeat(
+                            row=["a", "b"],
+                            column=["b", "a"],
+                        )
+                    ),
+                },
+                {
+                    "type": "vega",
+                    "data": (
+                        altair.Chart(pandas.DataFrame({"a": ["A"], "b": [28]}))
+                        .mark_point()
+                        .encode(
+                            altair.X(altair.repeat("column")),
+                            altair.Y(altair.repeat("row")),
+                        )
+                        .repeat(
+                            row=["a", "b"],
+                            column=["b", "a"],
+                        )
+                    ).to_dict(),
+                },
+            ),
+            (
                 {"type": "numpy_array", "data": np.array([1, 2, 3, 4, 5])},
                 {"type": "numpy_array", "data": np.array([1, 2, 3, 4, 5]).tolist()},
             ),
@@ -230,7 +286,7 @@ class TestStore:
             (
                 {"type": "vega", "data": None},
                 ValidationError,
-                "Input should be an instance of Chart",
+                "Input should be an instance of TopLevelSpec",
             ),
             (
                 {"type": "numpy_array", "data": None},


### PR DESCRIPTION
Specifically, all instances of `altair.vegalite.v5.schema.core.TopLevelSpec`.

Closes #199
