### PR TITLE
244 hard reload of the web app does not load the current mander

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -51,18 +51,26 @@ function onDragLeave(event: DragEvent) {
   }
 }
 
+function setSelectedReportUri(uriSegments: string | Array<string>) {
+  const uri = Array.isArray(uriSegments) ? uriSegments.join("/") : uriSegments;
+  reportsStore.selectedReportUri = uri;
+}
+
 watch(
   () => route.params.segments,
   (newSegments) => {
-    const uri = Array.isArray(newSegments) ? newSegments.join("/") : newSegments;
-    reportsStore.selectedReportUri = uri;
+    setSelectedReportUri(newSegments);
     // relaunch the background polling to get report right now
     reportsStore.stopBackendPolling();
     reportsStore.startBackendPolling();
   }
 );
 
-onMounted(() => reportsStore.startBackendPolling());
+onMounted(() => {
+  setSelectedReportUri(route.params.segments);
+  reportsStore.startBackendPolling();
+});
+
 onBeforeUnmount(() => reportsStore.stopBackendPolling());
 </script>
 


### PR DESCRIPTION
- **add light mode (#245)**
- **only activate DataTables pagination if table has more than 10 rows (#243)**
- **sklearn models (`BaseEstimator`) now serialize as their HTML representation (#239)**
- **mark currently selected store (#240)**
- **add `Store.set_layout` and `Store.get_layout` (#242)**
- **add placeholders for empty file manager and report (#236)**
- **set selected report URI on mount of `DashboardView`**
