### PR TITLE
set selected report URI on mount of `DashboardView`

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -51,18 +51,26 @@ function onDragLeave(event: DragEvent) {
   }
 }
 
+function setSelectedReportUri(uriSegments: string | Array<string>) {
+  const uri = Array.isArray(uriSegments) ? uriSegments.join("/") : uriSegments;
+  reportsStore.selectedReportUri = uri;
+}
+
 watch(
   () => route.params.segments,
   (newSegments) => {
-    const uri = Array.isArray(newSegments) ? newSegments.join("/") : newSegments;
-    reportsStore.selectedReportUri = uri;
+    setSelectedReportUri(newSegments);
     // relaunch the background polling to get report right now
     reportsStore.stopBackendPolling();
     reportsStore.startBackendPolling();
   }
 );
 
-onMounted(() => reportsStore.startBackendPolling());
+onMounted(() => {
+  setSelectedReportUri(route.params.segments);
+  reportsStore.startBackendPolling();
+});
+
 onBeforeUnmount(() => reportsStore.stopBackendPolling());
 </script>
 


### PR DESCRIPTION
This makes it so we properly show a Mandr's content when navigating to its URL (rather than using the file manager on the left pane), whereas previously this might have resulted in a "Mandr not found" screen.

Closes #244
