### PR TITLE
populate report layout in shared report

### DIFF
--- a/frontend/src/share.ts
+++ b/frontend/src/share.ts
@@ -17,4 +17,5 @@ export default function share() {
   const ds = new DataStore(m.uri, m.payload, m.layout);
   const reportsStore = useReportsStore();
   reportsStore.selectedReport = ds;
+  reportsStore.layout = ds.layout;
 }


### PR DESCRIPTION
Fix empty shared report by populating the layout.

The layout is kept separate from the `selectedReport` because layout should be reactive (in order for it to refresh properly when a Mandr is updated) whereas `selectedReport` is too large to be reactive.

Fixes #257 