### PR TITLE
hide end of the DataStoreKey label when it overflows

### DIFF
--- a/frontend/src/components/DataStoreKey.vue
+++ b/frontend/src/components/DataStoreKey.vue
@@ -83,9 +83,12 @@ const lastUpdate = computed(() => {
   }
 
   & .label {
+    padding-right: 30px;
     color: var(--text-color-highlight);
     font-size: var(--text-size-highlight);
     font-weight: var(--text-weight-highlight);
+    overflow-x: hidden;
+    text-overflow: ellipsis;
   }
 
   & .metadata {


### PR DESCRIPTION
Screenshot:
![2024-08-29T14_59_56_screenshot](https://github.com/user-attachments/assets/812e0de6-6b7d-431d-a1e8-9e251326e0be)

Closes #101 

Thanks @rouk1 :)

Co-authored-by: Matthieu Jouis <matthieu@probabl.ai>
