### PR TITLE
feat(cli): add `dashboard` CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ for key, value in store.items():
     print(f"Key {key} corresponds to value {value}")
 ```
 
-Then, to use the frontend, execute this Python code:
-```python
-from mandr.dashboard import Dashboard
-Dashboard().open()
+Then, in your project root (i.e. where `.datamander` is), run the following command to start the frontend locally:
+```sh
+python -m mandr dashboard
 ```
+This should automatically open a browser tab pointing at the app URL.
 
 ## ML-specific example
 

--- a/src/mandr/__main__.py
+++ b/src/mandr/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point to Mandr CLI."""
+
+import sys
+
+from mandr.cli import cli
+
+if __name__ == "__main__":
+    cli(sys.argv[1:])

--- a/src/mandr/cli.py
+++ b/src/mandr/cli.py
@@ -1,0 +1,42 @@
+"""CLI for Mandr."""
+
+import argparse
+
+from mandr.dashboard.dashboard import Dashboard
+
+
+def cli(args: list[str]):
+    """CLI for Mandr."""
+    parser = argparse.ArgumentParser(
+        prog="mandr",
+    )
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    parser_dashboard = subparsers.add_parser("dashboard", help="Start the dashboard")
+    parser_dashboard.add_argument(
+        "--port",
+        type=int,
+        help="the port at which to bind the UI server (default: %(default)s)",
+        default=22140,
+    )
+    parser_dashboard.add_argument(
+        "--open-browser",
+        action=argparse.BooleanOptionalAction,
+        help=(
+            "whether to automatically open a browser tab showing the dashboard "
+            "(default: %(default)s)"
+        ),
+        default=True,
+    )
+
+    parsed_args: argparse.Namespace = parser.parse_args(args)
+
+    match parsed_args.subcommand:
+        case None:
+            parser.print_help()
+        case "dashboard":
+            Dashboard(port=parsed_args.port).open(open_browser=parsed_args.open_browser)
+        case _:
+            # `parser.parse_args` raises an error if an unknown subcommand is passed,
+            # so this case is impossible
+            return

--- a/tests/integration/cli/test_dashboard.py
+++ b/tests/integration/cli/test_dashboard.py
@@ -1,0 +1,69 @@
+"""Test CLI properly starts serving the app."""
+
+import subprocess
+from contextlib import contextmanager
+from time import monotonic
+
+import httpx
+import pytest
+
+
+@contextmanager
+def terminate(process):
+    """Terminate `process` upon exit.
+
+    Adapted from [contextlib.closing](https://docs.python.org/3/library/contextlib.html#contextlib.closing).
+    """
+    try:
+        yield process
+    finally:
+        process.terminate()
+
+
+def test_no_subcommand():
+    """If the CLI is given no subcommand, it should output the help menu."""
+    completed_process = subprocess.run("python -m mandr".split())
+
+    completed_process.check_returncode()
+
+
+def test_invalid_subcommand():
+    """If the CLI is given an invalid subcommand,
+    it should exit and warn that the subcommand is invalid."""
+    completed_process = subprocess.run(
+        "python -m mandr probabl-wrong-command".split(), capture_output=True
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        completed_process.check_returncode()
+
+    assert b"invalid" in completed_process.stderr
+    assert b"probabl-wrong-command" in completed_process.stderr
+
+
+def test_dashboard():
+    """If the `dashboard` subcommand is called, the app is properly served at the
+    specified port."""
+
+    PORT = 22140
+    # Limit time of test to make sure it doesn't run forever
+    MAX_TIME = 10  # seconds
+
+    with terminate(
+        subprocess.Popen(
+            f"python -m mandr dashboard --no-open-browser --port {PORT}".split()
+        )
+    ):
+        start = monotonic()
+        while monotonic() - start < MAX_TIME:
+            try:
+                response = httpx.get(f"http://localhost:{PORT}")
+            except httpx.ConnectError:
+                continue
+
+            assert response.is_success
+            assert b"<!DOCTYPE html>" in response.content
+            assert b"<title>:mandr.</title>" in response.content
+            return
+
+        raise AssertionError("Dashboard took too long to start")


### PR DESCRIPTION
It is now possible to launch the dashboard from the CLI, with the following command:

```sh
python -m mandr dashboard --port PORT --[no-]open-browser
```

Full help message:
```
usage: mandr dashboard [-h] [--port PORT]
                       [--open-browser | --no-open-browser]

options:
  -h, --help            show this help message and exit
  --port PORT           the port at which to bind the UI server
                        (default: 22140)
  --open-browser, --no-open-browser
                        whether to automatically open a browser tab
                        showing the dashboard (default: True)
```

---

This PR also initializes the general CLI (which only has the `dashboard` subcommand for now). Running just `python -m mandr` shows the general help menu:
```
usage: mandr [-h] {dashboard} ...

positional arguments:
  {dashboard}
    dashboard  Start the dashboard

options:
  -h, --help   show this help message and exit
```
