### PR TITLE
feat(cli): implement "create project" command

### DIFF
--- a/src/mandr/cli.py
+++ b/src/mandr/cli.py
@@ -1,15 +1,15 @@
 """CLI for Mandr."""
 
 import argparse
+import pathlib
 
+from mandr.create_project import create_project
 from mandr.dashboard.dashboard import Dashboard
 
 
 def cli(args: list[str]):
     """CLI for Mandr."""
-    parser = argparse.ArgumentParser(
-        prog="mandr",
-    )
+    parser = argparse.ArgumentParser(prog="mandr")
     subparsers = parser.add_subparsers(dest="subcommand")
 
     parser_dashboard = subparsers.add_parser("dashboard", help="Start the dashboard")
@@ -29,6 +29,23 @@ def cli(args: list[str]):
         default=True,
     )
 
+    parser_create = subparsers.add_parser("create", help="Create a project")
+    parser_create.add_argument(
+        "project_name",
+        nargs="?",
+        help="the name of the project (default: %(default)s)",
+        default="project",
+    )
+    parser_create.add_argument(
+        "--working-dir",
+        type=pathlib.Path,
+        help=(
+            "the directory relative to which the project name will be interpreted; "
+            "default is the current working directory (mostly used for testing)"
+        ),
+        default=None,
+    )
+
     parsed_args: argparse.Namespace = parser.parse_args(args)
 
     match parsed_args.subcommand:
@@ -36,6 +53,12 @@ def cli(args: list[str]):
             parser.print_help()
         case "dashboard":
             Dashboard(port=parsed_args.port).open(open_browser=parsed_args.open_browser)
+        case "create":
+            project_directory = create_project(
+                project_name=parsed_args.project_name,
+                working_dir=parsed_args.working_dir,
+            )
+            print(f"Project file '{project_directory}' was successfully created.")  # noqa: T201
         case _:
             # `parser.parse_args` raises an error if an unknown subcommand is passed,
             # so this case is impossible

--- a/src/mandr/create_project.py
+++ b/src/mandr/create_project.py
@@ -1,0 +1,129 @@
+"""Implement the "create project" feature."""
+
+import os
+import re
+from pathlib import Path
+
+
+class ProjectNameTooLong(Exception):
+    """The project name must be at most 255 characters long (including ".mandr")."""
+
+
+class ReservedProjectName(Exception):
+    """The project name must not be a reserved OS file name.
+
+    For example, CON, AUX, NUL... on Windows.
+    """
+
+
+class ImproperProjectName(Exception):
+    """The project name must contain only the allowed characters.
+
+    The project name must start with an alphanumeric character, and must not contain
+    special characters other than '_' (underscore) and '-' (hyphen).
+    """
+
+
+def validate_project_name(project_name: str) -> (bool, Exception | None):
+    """Validate the project name (the part before ".mandr").
+
+    Returns `(True, None)` if validation succeeded and `(False, Exception(...))`
+    otherwise.
+    """
+    # The project name (including the .mandr extension) must be between 5 and 255
+    # characters long.
+    # FIXME: On Linux the OS already checks filename lengths
+    if len(project_name) + len(".mandr") > 255:
+        return False, ProjectNameTooLong(
+            "Project name length cannot exceed 255 characters."
+        )
+
+    # Reserved Names: The following names are reserved and cannot be used:
+    # CON, PRN, AUX, NUL
+    # COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9
+    # LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9
+    reserved_patterns = "|".join(["CON", "PRN", "AUX", "NUL", r"COM\d+", r"LPT\d+"])
+    if re.fullmatch(f"^({reserved_patterns})$", project_name):
+        return False, ReservedProjectName(
+            "Project name must not be a reserved OS filename."
+        )
+
+    # Allowed Characters:
+    # Alphanumeric characters (a-z, A-Z, 0-9)
+    # Underscore (_)
+    # Hyphen (-)
+    # Starting Character: The project name must start with an alphanumeric character.
+    if not re.fullmatch(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$", project_name):
+        return False, ImproperProjectName(
+            "Project name must contain only alphanumeric characters, '_' and '-'."
+        )
+
+    # Case Sensitivity: File names are case-insensitive on Windows and case-sensitive
+    # on Unix-based systems. The CLI should warn users about potential case conflicts
+    # on Unix systems.
+
+    return True, None
+
+
+class ProjectCreationError(Exception):
+    """Creating the project failed."""
+
+
+def create_project(project_name: str | Path, working_dir: Path | None = None) -> Path:
+    """Create a project file named according to `project_name`.
+
+    Parameters
+    ----------
+    project_name : Path-like
+        Name of the project to be created, or a relative or absolute path.
+    working_dir : Path or None
+        If `project_name` is not an absolute path, it will be considered relative to
+        `working_dir`. If `project_name` is an absolute path, `working_dir` will have
+        no effect. If set to None (the default), `working_dir` will be re-set to the
+        current working directory.
+
+    Returns
+    -------
+    The project directory path
+    """
+    project_path = Path(project_name)
+
+    # Remove trailing ".mandr" if it exists to check the name is valid
+    checked_project_name: str = project_path.name.split(".mandr")[0]
+
+    validation_passed, validation_error = validate_project_name(checked_project_name)
+    if not validation_passed:
+        raise ProjectCreationError(
+            f"Unable to create project file '{project_path}'."
+        ) from validation_error
+
+    # The file must end with the ".mandr" extension.
+    # If not provided, it will be automatically appended.
+    # If project name is an absolute path, we keep that path
+
+    # NOTE: `working_dir` has no effect if `checked_project_name` is absolute
+    if working_dir is None:
+        working_dir = Path.cwd()
+    project_directory = working_dir / (
+        project_path.with_name(checked_project_name + ".mandr")
+    )
+
+    try:
+        os.mkdir(project_directory)
+    except FileExistsError as e:
+        raise ProjectCreationError(
+            f"Unable to create project file '{project_directory}' because a file "
+            "with that name already exists. Please choose a different name or delete "
+            "the existing file."
+        ) from e
+    except PermissionError as e:
+        raise ProjectCreationError(
+            f"Unable to create project file '{project_directory}'. "
+            "Please check your permissions for the current directory."
+        ) from e
+    except Exception as e:
+        raise ProjectCreationError(
+            f"Unable to create project file '{project_directory}'."
+        ) from e
+
+    return project_directory

--- a/tests/integration/cli/test_create.py
+++ b/tests/integration/cli/test_create.py
@@ -1,0 +1,97 @@
+import subprocess
+
+import pytest
+from mandr.create_project import (
+    ImproperProjectName,
+    ProjectCreationError,
+    ProjectNameTooLong,
+    create_project,
+    validate_project_name,
+)
+
+test_cases = [
+    (
+        "a" * 250,
+        (False, ProjectNameTooLong()),
+    ),
+    (
+        "%",
+        (False, ImproperProjectName()),
+    ),
+    (
+        "hello world",
+        (False, ImproperProjectName()),
+    ),
+]
+
+
+@pytest.mark.parametrize("project_name,expected", test_cases)
+def test_validate_project_name(project_name, expected):
+    result, exception = validate_project_name(project_name)
+    expected_result, expected_exception = expected
+    assert result == expected_result
+    assert type(exception) is type(expected_exception)
+
+
+@pytest.mark.parametrize("project_name", ["hello", "hello.mandr"])
+def test_create_project(project_name, tmp_path):
+    create_project(project_name, working_dir=tmp_path)
+    assert (tmp_path / "hello.mandr").exists()
+
+
+# TODO: If using fixtures in test cases is possible, join this with
+# `test_create_project`
+def test_create_project_absolute_path(tmp_path):
+    create_project(tmp_path / "hello")
+    assert (tmp_path / "hello.mandr").exists()
+
+
+def test_create_project_fails_if_file_exists(tmp_path):
+    create_project(tmp_path / "hello")
+    assert (tmp_path / "hello.mandr").exists()
+    with pytest.raises(ProjectCreationError):
+        create_project(tmp_path / "hello")
+
+
+def test_create_project_fails_if_permission_denied(tmp_path):
+    with pytest.raises(ProjectCreationError):
+        create_project("/")
+
+
+@pytest.mark.parametrize("project_name", ["hello.txt", "%%%", "COM1"])
+def test_create_project_fails_if_invalid_name(project_name, tmp_path):
+    with pytest.raises(ProjectCreationError):
+        create_project(project_name, working_dir=tmp_path)
+
+
+def test_create_project_cli_default_argument(tmp_path):
+    completed_process = subprocess.run(
+        f"python -m mandr create --working-dir {tmp_path}".split(), capture_output=True
+    )
+    assert (
+        f"Project file '{tmp_path}/project.mandr' was successfully created.".encode()
+        in completed_process.stdout
+    )
+    assert (tmp_path / "project.mandr").exists()
+
+
+def test_create_project_cli_ends_in_mandr(tmp_path):
+    completed_process = subprocess.run(
+        f"python -m mandr create hello.mandr --working-dir {tmp_path}".split(),
+        capture_output=True,
+    )
+    assert (
+        f"Project file '{tmp_path}/hello.mandr' was successfully created.".encode()
+        in completed_process.stdout
+    )
+    assert (tmp_path / "hello.mandr").exists()
+
+
+def test_create_project_cli_invalid_name(tmp_path):
+    completed_process = subprocess.run(
+        f"python -m mandr create hello.txt --working-dir {tmp_path}".split(),
+        capture_output=True,
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        completed_process.check_returncode()
+    assert b"ImproperProjectName" in completed_process.stderr


### PR DESCRIPTION
It is now possible to create a project from the CLI, with the following command:
```sh
python -m mandr create [project_name]
```
