### PR TITLE
use performance.now instead of date to avoid 1ms error in tests

### DIFF
--- a/frontend/tests/services/utils.spec.ts
+++ b/frontend/tests/services/utils.spec.ts
@@ -15,9 +15,9 @@ import { describe, expect, it, vi } from "vitest";
 describe("utils", () => {
   it("Can sleep for a given time.", async () => {
     const delay = 10;
-    const tic = Date.now();
+    const tic = performance.now();
     await sleep(delay);
-    const toc = Date.now();
+    const toc = performance.now();
     expect(toc).toBeGreaterThanOrEqual(tic + delay);
   });
 


### PR DESCRIPTION
Change testing function to avoid error in builds like [here](https://github.com/probabl-ai/mandr/actions/runs/10721447656/job/29729983320#step:9:39).