### PR TITLE
katex support in markdown widget

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mandr-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@vscode/markdown-it-katex": "^1.1.0",
         "datatables.net-buttons-dt": "^3.1.2",
         "datatables.net-vue3": "^3.0.2",
         "date-fns": "^3.6.0",
@@ -2258,6 +2259,15 @@
         "@volar/language-core": "2.4.1",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/markdown-it-katex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/markdown-it-katex/-/markdown-it-katex-1.1.0.tgz",
+      "integrity": "sha512-9cF2eJpsJOEs2V1cCAoJW/boKz9GQQLvZhNvI030K90z6ZE9lRGc9hDVvKut8zdFO2ObjwylPXXXVYvTdP2O2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "katex": "^0.16.4"
       }
     },
     "node_modules/@vue/babel-helper-vue-transform-on": {
@@ -5094,6 +5104,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
+      "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@vscode/markdown-it-katex": "^1.1.0",
     "datatables.net-buttons-dt": "^3.1.2",
     "datatables.net-vue3": "^3.0.2",
     "date-fns": "^3.6.0",

--- a/frontend/src/assets/fixtures/markdown.md
+++ b/frontend/src/assets/fixtures/markdown.md
@@ -1,4 +1,4 @@
-# h1 Heading 8-)
+# h1 Heading
 
 ## h2 Heading
 
@@ -33,10 +33,6 @@ test.. test... test..... test?..... test!....
 ## Emphasis
 
 **This is bold text**
-
-**This is bold text**
-
-_This is italic text_
 
 _This is italic text_
 
@@ -95,12 +91,11 @@ Sample text here...
 
 Syntax highlighting
 
-```js
-var foo = function (bar) {
-  return bar++;
-};
+```python
+def foo(bar):
+  return bar + 1
 
-console.log(foo(5));
+print(foo(5));
 ```
 
 ## Tables
@@ -125,20 +120,9 @@ Right aligned columns
 
 [link with title](http://nodeca.github.io/pica/demo/ "title text!")
 
-Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
-
 ## Images
 
-![Minion](https://octodex.github.com/images/minion.png)
-![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
-
-Like links, Images also have a footnote style syntax
-
-![Alt text][id]
-
-With a reference later in the document defining the URL location:
-
-[id]: https://octodex.github.com/images/dojocat.jpg "The Dojocat"
+![placeholder](https://placehold.co/600x300 "placeholder")
 
 ## Plugins
 
@@ -157,3 +141,11 @@ see [how to change output](https://github.com/markdown-it/markdown-it-emoji#chan
 
 - 19^th^
 - H~2~O
+
+### [Katex](https://github.com/waylonflinn/markdown-it-katex)
+
+$$
+\sum_{x=1}^{3} x_i
+$$
+
+$\sum_{x=1}^{3} x_i$

--- a/frontend/src/components/MarkdownWidget.vue
+++ b/frontend/src/components/MarkdownWidget.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
-import { isString } from "@/services/utils";
+import katex from "@vscode/markdown-it-katex";
 import hljs from "highlight.js/lib/core";
 import json from "highlight.js/lib/languages/json";
 import python from "highlight.js/lib/languages/python";
 import sql from "highlight.js/lib/languages/sql";
 import xml from "highlight.js/lib/languages/xml";
+import "katex/dist/katex.min.css";
 import MarkdownIt from "markdown-it";
 import { full as emoji } from "markdown-it-emoji";
 import highlightjs from "markdown-it-highlightjs/core";
 import sub from "markdown-it-sub";
 import sup from "markdown-it-sup";
 import { computed } from "vue";
+
+import { isString } from "@/services/utils";
 
 hljs.registerLanguage("python", python);
 hljs.registerLanguage("sql", sql);
@@ -26,6 +29,7 @@ const renderer = MarkdownIt({
   .use(emoji)
   .use(sub)
   .use(sup)
+  .use(katex)
   .use(highlightjs, { inline: true, hljs });
 
 const html = computed(() => {


### PR DESCRIPTION
You can now use latex in markdown and it will be rendered.

In markdown:

```md
$$
\sum_{x=1}^{3} x_i
$$

$\sum_{x=1}^{3} x_i$
```

In python:

```python
s = Store(name)
s.insert("Math", "$\\sum_{x=1}^{3} x_i$")
```
<img width="371" alt="Screenshot 2024-09-06 at 09 58 05" src="https://github.com/user-attachments/assets/552168b1-f1ee-4af1-9349-568e3d589b13">
