### PR TITLE
remove duplicated card resize button

### DIFF
--- a/frontend/src/components/DataStoreCard.vue
+++ b/frontend/src/components/DataStoreCard.vue
@@ -35,9 +35,6 @@ const emit = defineEmits<{
         <button @click="emit('layoutChanged', 'large')">
           <span class="icon-grid-layout-large"></span>
         </button>
-        <button @click="emit('layoutChanged', 'large')">
-          <span class="icon-grid-layout-large"></span>
-        </button>
         <button v-if="props.canMoveUp" @click="emit('positionChanged', 'up')">
           <span class="icon-up"></span>
         </button>


### PR DESCRIPTION
Double button is now removed.

Closes #316. 
<img width="212" alt="Screenshot 2024-09-06 at 14 27 41" src="https://github.com/user-attachments/assets/f591d2b5-d43d-4300-9888-2ba451fc975e">
