### PR TITLE
Fix frontend artifacts directory in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ pattern = "(?P<version>[^']+)"
 
 [tool.hatch.build.targets.sdist]
 only-include = ["src/"]
-artifacts = ["src/skore/dashboard/static/"]
+artifacts = ["src/skore/ui/static/"]
 
 [tool.hatch.build.targets.wheel]
 package = ["src/skore/"]
-artifacts = ["src/skore/dashboard/static/"]
+artifacts = ["src/skore/ui/static/"]
 
 [project]
 name = "skore"


### PR DESCRIPTION
Fixes an issue where the static directory where the frontend build is placed was not the one declared explicitly in the `pyproject.toml`. The frontend build directory was moved from `skore/src/dashboard/static/` to `skore/src/ui/static` during #325 and the change was not made in `pyproject.toml`.