### PR TITLE
Replace third-part libraries imports by lazy imports

### DIFF
--- a/src/skore/__init__.py
+++ b/src/skore/__init__.py
@@ -34,5 +34,3 @@ handler.setFormatter(formatter)
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-
-

--- a/src/skore/item/media_item.py
+++ b/src/skore/item/media_item.py
@@ -17,6 +17,7 @@ from skore.item.item import Item
 
 
 def lazy_is_instance(object: Any, cls_fullname: str) -> bool:
+    """Return True if object is an instance of a class named `cls_fullname`."""
     return cls_fullname in {
         f"{cls.__module__}.{cls.__name__}" for cls in object.__class__.__mro__
     }


### PR DESCRIPTION
Fix missing imports in project.py by implementing a lazy isinstance function.