### PR TITLE
ci: Enforce conventional commit format in PR title

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,7 +1,0 @@
-# Rules for commitlint
-# Reference of all rules: https://commitlint.js.org/reference/rules.html
-# This file adds customizations rules to the default ones defined in https://www.npmjs.com/package/@commitlint/config-conventional
-
-extends: ["@commitlint/config-conventional"]
-rules:
-  "subject-case": [2, "always", ["sentence-case"]]

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,7 @@
+# Rules for commitlint
+# Reference of all rules: https://commitlint.js.org/reference/rules.html
+# This file adds customizations rules to the default ones defined in https://www.npmjs.com/package/@commitlint/config-conventional
+
+extends: ["@commitlint/config-conventional"]
+rules:
+  "subject-case": [2, "always", ["sentence-case"]]

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -11,11 +11,6 @@ jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     steps:
-      # Only download commitlint config, not the whole repo
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: "*commitlint*"
-          sparse-checkout-cone-mode: false
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -23,6 +18,15 @@ jobs:
         run: |
           npm install @commitlint/config-conventional@19.5.0
           npm install commitlint@19.2.0
+      - name: Generate config file
+        # Here we define our custom rules for commitlint
+        # Reference of all rules: https://commitlint.js.org/reference/rules.html
+        run: |
+          tee -a .commitlintrc.yml << END
+          extends: ["@commitlint/config-conventional"]
+          rules:
+            "subject-case": [2, "always", ["sentence-case"]]
+          END
       - name: Lint PR title
         # Use an environment variable to avoid a security vulnerability
         # https://stackoverflow.com/a/76679447

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,31 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      # Only download commitlint config, not the whole repo
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: "*commitlint*"
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install commitlint
+        run: |
+          npm install @commitlint/config-conventional@19.5.0
+          npm install commitlint@19.2.0
+      - name: Lint PR title
+        # Use an environment variable to avoid a security vulnerability
+        # https://stackoverflow.com/a/76679447
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo $PR_TITLE | npx commitlint --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ Then, you can access the local build via:
 open doc/_build/html/index.html
 ```
 
+### PR format
+
+We use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format, and we automatically check that the PR title fits this format.
+In particular, commits are "sentence case", meaning "fix: Fix issue" passes, while "fix: fix issue" doesn't.
+Our custom set of rules is in [commitlint.config.js](./commitlint.config.js).
+
+Generally the description of a commit should start with a verb in the imperative voice, so that it would properly complete the sentence: "When applied, this commit will [...]".
+
 ## Help for common issues
 
 ### `make build-frontend` doesn't work!


### PR DESCRIPTION
- Add commitlint workflow to lint the PR title (not the individual PR commits)
- Make sentence-case the only allowed PR title format (first letter must be capitalized, like "Merge commit ..." or "Revert commit ...")

Closes #66