### PR TITLE
ci: Modularize CI pipeline and test Python >= 3.11

### DIFF
--- a/.github/workflows/add-pr-assignee.yml
+++ b/.github/workflows/add-pr-assignee.yml
@@ -1,9 +1,11 @@
+name: Add PR assignee
+
 on:
   pull_request:
     types: [opened]
 
 jobs:
-  add-assignee:
+  add-pr-assignee:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,7 +6,6 @@ on:
       - 'src/**'
       - 'tests/**'
       - 'pyproject.toml'
-      - 'Makefile'
       - 'requirements*.txt'
       - '.github/workflows/backend.yml'
 
@@ -14,41 +13,74 @@ permissions:
   contents: read
 
 jobs:
-  lint-backend:
+  build-frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-node@v4
         with:
-          python-version: '3.12'
-          cache: 'pip'
-      - name: Lint backend
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - shell: bash
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade pre-commit
+          cd frontend
 
-          pre-commit run --all-files ruff
+          npm install
+          npm run build
+          npm run build:lib -- --emptyOutDir false
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-package-distributions
+          path: frontend/dist
 
   test-backend:
     runs-on: ubuntu-latest
+    needs: build-frontend
+    continue-on-error: ${{ matrix.python-version != '3.12' }}
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - name: Build frontend and share library
-        shell: bash
-        run: make build-frontend
-      - name: Build package distributions
+
+      - name: Lint
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+          pre-commit run --all-files ruff
+
+      - name: Download package distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-package-distributions
+          path: src/skore/ui/static
+
+      - name: Build
+        run: |
           python -m pip install --upgrade build
           python -m build
+
       - name: Install
         run: |
           python -m pip install dist/*.whl --no-dependencies
           python -m pip install -r requirements.txt -r requirements-test.txt
-      - name: Pytest
+
+      - name: Test
         timeout-minutes: 5
         run: python -m pytest
+
+  cleanup:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: test-backend
+    steps:
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: frontend-package-distributions

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,16 +1,6 @@
-name: Backend
+name: Reusable backend workflow
 
-on:
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'requirements*.txt'
-      - '.github/workflows/backend.yml'
-
-permissions:
-  contents: read
+on: [workflow_call]
 
 jobs:
   build-frontend:
@@ -19,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '20'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - shell: bash

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -27,11 +27,10 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     needs: build-frontend
-    continue-on-error: ${{ matrix.python-version != '3.12' }}
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'requirements*.txt'
+              - '.github/workflows/backend.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/frontend.yml'
+
+  lint-all-files:
+    uses: ./.github/workflows/lint.yml
+    permissions:
+      contents: read
+
+  lint-and-test-backend:
+    needs: [lint-all-files, changes]
+    if: ${{ needs.changes.outputs.backend == 'true' }}
+    uses: ./.github/workflows/backend.yml
+    permissions:
+      contents: read
+
+  lint-and-test-frontend:
+    needs: [lint-all-files, changes]
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
+    uses: ./.github/workflows/frontend.yml
+    permissions:
+      contents: read
+      pull-requests: write
+
+  ci-all-green:
+    needs:
+      - lint-all-files
+      - lint-and-test-backend
+      - lint-and-test-frontend
+    if: ${{ always() }}
+    runs-on: Ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          [[  ${{ contains(needs.*.result, 'failure') }} = false ]]

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,14 +1,6 @@
-name: Frontend
+name: Reusable frontend workflow
 
-on:
-  pull_request:
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend.yml'
-
-permissions:
-  contents: read
-  pull-requests: write
+on: [workflow_call]
 
 jobs:
   lint-frontend:
@@ -32,6 +24,7 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
+    needs: lint-frontend
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     paths:
       - 'frontend/**'
-      - Makefile
-      - .github/workflows/frontend.yml
+      - '.github/workflows/frontend.yml'
 
 permissions:
   contents: read
@@ -43,6 +42,7 @@ jobs:
       - name: Test frontend
         run: |
           cd frontend
+
           npm install
           npm run test:unit:coverage
       - name: Report coverage
@@ -64,4 +64,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Build frontend
         shell: bash
-        run: make build-frontend
+        run: |
+          cd frontend
+
+          npm install
+          npm run build
+          npm run build:lib -- --emptyOutDir false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
-name: Lint
+name: Reusable lint workflow
 
-on: [pull_request]
-
-permissions:
-  contents: read
+on: [workflow_call]
 
 jobs:
   lint-all-files:


### PR DESCRIPTION
- Remove reference of `Makefile` in workflow's instructions to build front-end
- Use matrix to test back-end on all versions of python `>=3.9` (only success on `3.12` is mandatory)
- Trigger CI tasks at job level instead of workflow level
- Use one and only entry-point to define if pipeline succeed `ci-all-green`

---

Example: https://github.com/probabl-ai/skore/actions/runs/11146672648

![image](https://github.com/user-attachments/assets/294b9b89-0e86-43ae-a432-320d1ece016f)
