### PR TITLE
feat(api): Change views API in the backend

### DIFF
--- a/src/skore/ui/report.py
+++ b/src/skore/ui/report.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.params import Depends
 from fastapi.templating import Jinja2Templates
 
@@ -141,5 +141,20 @@ async def put_view(request: Request, key: str, layout: Layout):
 
     view = View(layout=layout)
     project.put_view(key, view)
+
+    return __serialize_project(project)
+
+
+@router.delete("/report/view/{key:path}", status_code=status.HTTP_200_OK)
+async def delete_view(request: Request, key: str):
+    """Delete the view corresponding to `key`."""
+    project: Project = request.app.state.project
+
+    try:
+        project.delete_view(key)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="View not found"
+        ) from None
 
     return __serialize_project(project)

--- a/src/skore/ui/report.py
+++ b/src/skore/ui/report.py
@@ -34,14 +34,25 @@ class SerializedItem:
 
 
 @dataclass
+class SerializedView:
+    """Serialized view."""
+
+    layout: Layout
+
+
+@dataclass
 class SerializedProject:
     """Serialized project, to be sent to the frontend."""
 
-    layout: Layout
     items: dict[str, SerializedItem]
+    views: dict[str, SerializedView]
 
 
 def __serialize_project(project: Project) -> SerializedProject:
+    views = {}
+    for key in project.list_view_keys():
+        views[key] = project.get_view(key)
+
     items = {}
     for key in project.list_item_keys():
         item = project.get_item(key)
@@ -75,14 +86,9 @@ def __serialize_project(project: Project) -> SerializedProject:
             created_at=item.created_at,
         )
 
-    try:
-        layout = project.get_view("layout").layout
-    except KeyError:
-        layout = []
-
     return SerializedProject(
-        layout=layout,
         items=items,
+        views=views,
     )
 
 

--- a/src/skore/ui/report.py
+++ b/src/skore/ui/report.py
@@ -131,12 +131,15 @@ async def share_store(
     )
 
 
-@router.put("/report/layout", status_code=201)
-async def set_view_layout(request: Request, layout: Layout):
-    """Set the view layout."""
+@router.put("/report/view/{key:path}", status_code=201)
+async def put_view(request: Request, key: str, layout: Layout):
+    """Set the layout of the view corresponding to `key`.
+
+    If the view corresponding to `key` does not exist, it will be created.
+    """
     project: Project = request.app.state.project
 
     view = View(layout=layout)
-    project.put_view("layout", view)
+    project.put_view(key, view)
 
     return __serialize_project(project)

--- a/src/skore/ui/report.py
+++ b/src/skore/ui/report.py
@@ -127,7 +127,7 @@ async def share_store(
     # Fill the Jinja context
     context = {
         "project": asdict(__serialize_project(project)),
-        "layout": [{"key": item.key, "size": item.size} for item in view.layout],
+        "layout": view.layout,
         "script": script_content,
         "styles": styles_content,
     }

--- a/src/skore/view/view.py
+++ b/src/skore/view/view.py
@@ -1,26 +1,9 @@
 """Project View models."""
 
 from dataclasses import dataclass
-from enum import StrEnum
 
-
-class LayoutItemSize(StrEnum):
-    """The size of a layout item."""
-
-    SMALL = "small"
-    MEDIUM = "medium"
-    LARGE = "large"
-
-
-@dataclass
-class LayoutItem:
-    """A layout item."""
-
-    key: str
-    size: LayoutItemSize
-
-
-Layout = list[LayoutItem]
+# An ordered list of keys to display
+Layout = list[str]
 
 
 @dataclass
@@ -29,10 +12,7 @@ class View:
 
     Examples
     --------
-    >>> View(layout=[
-    ...     {"key": "a", "size": "medium"},
-    ...     {"key": "b", "size": "small"},
-    ... ])
+    >>> View(layout=["a", "b"])
     View(...)
     """
 

--- a/tests/integration/ui/test_ui.py
+++ b/tests/integration/ui/test_ui.py
@@ -4,6 +4,7 @@ from skore.item.item_repository import ItemRepository
 from skore.persistence.in_memory_storage import InMemoryStorage
 from skore.project import Project
 from skore.ui.app import create_app
+from skore.view.view import View
 from skore.view.view_repository import ViewRepository
 
 
@@ -71,3 +72,14 @@ def test_put_view_layout(client):
         json=[{"key": "test", "size": "large"}],
     )
     assert response.status_code == 201
+
+
+def test_delete_view(client, project):
+    project.put_view("hello", View(layout=[]))
+    response = client.delete("/api/report/view/hello")
+    assert response.status_code == 200
+
+
+def test_delete_view_missing(client):
+    response = client.delete("/api/report/view/hello")
+    assert response.status_code == 404

--- a/tests/integration/ui/test_ui.py
+++ b/tests/integration/ui/test_ui.py
@@ -59,11 +59,16 @@ def test_get_items(client, project):
 
 
 def test_share_view(client, project):
-    project.put("test", "test")
+    project.put_view("hello", View(layout=[]))
 
-    response = client.post("/api/report/share", json=[{"key": "test", "size": "large"}])
+    response = client.post("/api/report/share/hello")
     assert response.status_code == 200
     assert b"<!DOCTYPE html>" in response.content
+
+
+def test_share_view_not_found(client, project):
+    response = client.post("/api/report/share/hello")
+    assert response.status_code == 404
 
 
 def test_put_view_layout(client):

--- a/tests/integration/ui/test_ui.py
+++ b/tests/integration/ui/test_ui.py
@@ -37,7 +37,7 @@ def test_get_items(client, project):
     response = client.get("/api/items")
 
     assert response.status_code == 200
-    assert response.json() == {"layout": [], "items": {}}
+    assert response.json() == {"views": {}, "items": {}}
 
     project.put("test", "test")
     item = project.get_item("test")
@@ -45,7 +45,7 @@ def test_get_items(client, project):
     response = client.get("/api/items")
     assert response.status_code == 200
     assert response.json() == {
-        "layout": [],
+        "views": {},
         "items": {
             "test": {
                 "media_type": "text/markdown",

--- a/tests/integration/ui/test_ui.py
+++ b/tests/integration/ui/test_ui.py
@@ -67,15 +67,7 @@ def test_share_view(client, project):
 
 def test_put_view_layout(client):
     response = client.put(
-        "/api/report/layout",
-        json=[{"key": "test", "size": "large"}],
-    )
-    assert response.status_code == 201
-
-
-def test_put_view_layout_with_slash_in_name(client):
-    response = client.put(
-        "/api/report/layout",
+        "/api/report/view/hello",
         json=[{"key": "test", "size": "large"}],
     )
     assert response.status_code == 201

--- a/tests/integration/ui/test_ui.py
+++ b/tests/integration/ui/test_ui.py
@@ -72,10 +72,7 @@ def test_share_view_not_found(client, project):
 
 
 def test_put_view_layout(client):
-    response = client.put(
-        "/api/report/view/hello",
-        json=[{"key": "test", "size": "large"}],
-    )
+    response = client.put("/api/report/view/hello", json=["test"])
     assert response.status_code == 201
 
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -13,7 +13,7 @@ from sklearn.ensemble import RandomForestClassifier
 from skore.item import ItemRepository
 from skore.persistence.in_memory_storage import InMemoryStorage
 from skore.project import Project, ProjectLoadError, ProjectPutError, load
-from skore.view.view import LayoutItem, LayoutItemSize, View
+from skore.view.view import View
 from skore.view.view_repository import ViewRepository
 
 
@@ -175,10 +175,7 @@ def test_keys(project):
 
 
 def test_view(project):
-    layout = [
-        LayoutItem(key="key1", size=LayoutItemSize.LARGE),
-        LayoutItem(key="key2", size=LayoutItemSize.SMALL),
-    ]
+    layout = ["key1", "key2"]
 
     view = View(layout=layout)
 

--- a/tests/unit/view/test_view_repository.py
+++ b/tests/unit/view/test_view_repository.py
@@ -1,6 +1,6 @@
 import pytest
 from skore.persistence.in_memory_storage import InMemoryStorage
-from skore.view.view import LayoutItem, LayoutItemSize, View
+from skore.view.view import View
 from skore.view.view_repository import ViewRepository
 
 
@@ -10,12 +10,7 @@ def view_repository():
 
 
 def test_get(view_repository):
-    view = View(
-        layout=[
-            LayoutItem(key="key1", size=LayoutItemSize.LARGE),
-            LayoutItem(key="key2", size=LayoutItemSize.SMALL),
-        ]
-    )
+    view = View(layout=["key1", "key2"])
 
     view_repository.put_view("view", view)
 


### PR DESCRIPTION
- Serialize views in API layer
- Change "set report layout"  (now "put view") endpoint to take a `key` argument
- Add "delete view" endpoint
- Change "share report" endpoint to take a view key
- Remove `LayoutItemSize`

Addresses #336
