### PR TITLE
fix(readme): Use raw.githubusercontent.com to render GIF in PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These are only the first features of `skore`'s roadmap.
 Stay tuned!
 
 <p align="center">
-    <img width="100%" src="https://github.com/sylvaincom/sylvaincom.github.io/blob/master/files/probabl/skore/2024_10_08_skore_demo.gif"/>
+    <img width="100%" src="https://raw.githubusercontent.com/sylvaincom/sylvaincom.github.io/master/files/probabl/skore/2024_10_08_skore_demo.gif"/>
 </p>
 
 ## ⚙️ Installation


### PR DESCRIPTION
Actually, on PyPI:

![image](https://github.com/user-attachments/assets/36f42041-1439-4825-82ef-ec9b8cb50cc9)
![image](https://github.com/user-attachments/assets/cef99349-734b-4ce5-8fb7-d01446195724)

---

Fixed via this PR but the image is too large:

![image](https://github.com/user-attachments/assets/c81055e6-8fe8-4688-9271-df7267bd68df)
