### PR TITLE
refactor(cli-errors): Merge project validation exceptions into `InvalidProjectNameError`

### DIFF
--- a/skore/src/skore/cli/create_project.py
+++ b/skore/src/skore/cli/create_project.py
@@ -7,22 +7,14 @@ from typing import Optional, Union
 from skore.cli import logger
 
 
-class ProjectNameTooLong(Exception):
-    """The project name must be at most 255 characters long (including ".skore")."""
+class InvalidProjectNameError(Exception):
+    """The project name does not fit with one or more of the project name rules.
 
-
-class ReservedProjectName(Exception):
-    """The project name must not be a reserved OS file name.
-
-    For example, CON, AUX, NUL... on Windows.
-    """
-
-
-class ImproperProjectName(Exception):
-    """The project name must contain only the allowed characters.
-
-    The project name must start with an alphanumeric character, and must not contain
+    - The project name must start with an alphanumeric character, and must not contain
     special characters other than '_' (underscore) and '-' (hyphen).
+    - The project name must be at most 255 characters long (including ".skore").
+    - The project name must not be a reserved OS file name.
+    For example, CON, AUX, NUL... on Windows.
     """
 
 
@@ -36,7 +28,7 @@ def validate_project_name(project_name: str) -> tuple[bool, Optional[Exception]]
     # characters long.
     # FIXME: On Linux the OS already checks filename lengths
     if len(project_name) + len(".skore") > 255:
-        return False, ProjectNameTooLong(
+        return False, InvalidProjectNameError(
             "Project name length cannot exceed 255 characters."
         )
 
@@ -46,7 +38,7 @@ def validate_project_name(project_name: str) -> tuple[bool, Optional[Exception]]
     # LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9
     reserved_patterns = "|".join(["CON", "PRN", "AUX", "NUL", r"COM\d+", r"LPT\d+"])
     if re.fullmatch(f"^({reserved_patterns})$", project_name):
-        return False, ReservedProjectName(
+        return False, InvalidProjectNameError(
             "Project name must not be a reserved OS filename."
         )
 
@@ -56,7 +48,7 @@ def validate_project_name(project_name: str) -> tuple[bool, Optional[Exception]]
     # Hyphen (-)
     # Starting Character: The project name must start with an alphanumeric character.
     if not re.fullmatch(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$", project_name):
-        return False, ImproperProjectName(
+        return False, InvalidProjectNameError(
             "Project name must contain only alphanumeric characters, '_' and '-'."
         )
 
@@ -71,7 +63,7 @@ class ProjectCreationError(Exception):
     """Project creation failed."""
 
 
-class ProjectAlreadyExists(Exception):
+class ProjectAlreadyExistsError(Exception):
     """A project with this name already exists."""
 
 
@@ -123,7 +115,7 @@ def __create(
     try:
         project_directory.mkdir()
     except FileExistsError as e:
-        raise ProjectAlreadyExists(
+        raise ProjectAlreadyExistsError(
             f"Unable to create project file '{project_directory}' because a file "
             "with that name already exists. Please choose a different name or delete "
             "the existing file."

--- a/skore/src/skore/cli/quickstart_command.py
+++ b/skore/src/skore/cli/quickstart_command.py
@@ -1,7 +1,7 @@
 """Implement the "quickstart" command."""
 
 from skore.cli import logger
-from skore.cli.create_project import ProjectAlreadyExists, __create
+from skore.cli.create_project import ProjectAlreadyExistsError, __create
 from skore.cli.launch_dashboard import __launch
 
 
@@ -19,7 +19,7 @@ def __quickstart():
 
     try:
         __create(project_name=project_name)
-    except ProjectAlreadyExists:
+    except ProjectAlreadyExistsError:
         logger.info(
             f"Project file '{project_name}' already exists. Skipping creation step."
         )

--- a/skore/tests/integration/cli/test_create.py
+++ b/skore/tests/integration/cli/test_create.py
@@ -2,10 +2,9 @@ import subprocess
 
 import pytest
 from skore.cli.create_project import (
-    ImproperProjectName,
-    ProjectAlreadyExists,
+    InvalidProjectNameError,
+    ProjectAlreadyExistsError,
     ProjectCreationError,
-    ProjectNameTooLong,
     __create,
     validate_project_name,
 )
@@ -13,15 +12,15 @@ from skore.cli.create_project import (
 test_cases = [
     (
         "a" * 250,
-        (False, ProjectNameTooLong()),
+        (False, InvalidProjectNameError()),
     ),
     (
         "%",
-        (False, ImproperProjectName()),
+        (False, InvalidProjectNameError()),
     ),
     (
         "hello world",
-        (False, ImproperProjectName()),
+        (False, InvalidProjectNameError()),
     ),
 ]
 
@@ -50,7 +49,7 @@ def test_create_project_absolute_path(tmp_path):
 def test_create_project_fails_if_file_exists(tmp_path):
     __create(tmp_path / "hello")
     assert (tmp_path / "hello.skore").exists()
-    with pytest.raises(ProjectAlreadyExists):
+    with pytest.raises(ProjectAlreadyExistsError):
         __create(tmp_path / "hello")
 
 
@@ -89,4 +88,4 @@ def test_create_project_cli_invalid_name(tmp_path):
     )
     with pytest.raises(subprocess.CalledProcessError):
         completed_process.check_returncode()
-    assert b"ImproperProjectName" in completed_process.stderr
+    assert b"InvalidProjectNameError" in completed_process.stderr


### PR DESCRIPTION
Also, rename `ProjectAlreadyExists` to `ProjectAlreadyExistsError`.

Closes #484