### PR TITLE
chore(pre-commit): Stop `nbstripout` from re-assigning cell IDs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     rev: 0.7.1
     hooks:
       - id: nbstripout
+        args: [--keep-id]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9


### PR DESCRIPTION
Closes #482
