### PR TITLE
fix(ci): Fix ruff being skipped in CI by prefixing destinations with `skore/` after #440

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,10 @@ repos:
     rev: v0.6.9
     hooks:
       - id: ruff
-        files: ^(src|tests)/
+        files: ^skore/(src|tests)/
         args: [--fix]
       - id: ruff-format
-        files: ^(src|tests)/
+        files: ^skore/(src|tests)/
 
   - repo: local
     hooks:

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -123,13 +123,11 @@ select = [
 convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
+"src/*" = ["UP007"]
 "tests/*" = ["D"]
 "examples/*" = [
   "D",
-  # It's fine not to put the import at the top of the file in the examples
-  # folder.
   "E402",
-  # Useless expressions are useful!
   "B018",
 ]
 

--- a/skore/src/skore/cli/launch_dashboard.py
+++ b/skore/src/skore/cli/launch_dashboard.py
@@ -3,6 +3,7 @@
 import webbrowser
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Union
 
 import uvicorn
 from fastapi import FastAPI
@@ -10,7 +11,6 @@ from fastapi import FastAPI
 from skore.cli import logger
 from skore.project import load
 from skore.ui.app import create_app
-from typing import Union
 
 
 class ProjectNotFound(Exception):

--- a/skore/src/skore/persistence/abstract_storage.py
+++ b/skore/src/skore/persistence/abstract_storage.py
@@ -1,7 +1,8 @@
 """Abstract storage interface."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 
 class AbstractStorage(ABC):

--- a/skore/src/skore/persistence/disk_cache_storage.py
+++ b/skore/src/skore/persistence/disk_cache_storage.py
@@ -1,7 +1,8 @@
 """In-memory storage."""
 
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 from diskcache import Cache
 

--- a/skore/src/skore/persistence/in_memory_storage.py
+++ b/skore/src/skore/persistence/in_memory_storage.py
@@ -1,6 +1,7 @@
 """In-memory storage."""
 
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 from .abstract_storage import AbstractStorage
 

--- a/skore/src/skore/ui/app.py
+++ b/skore/src/skore/ui/app.py
@@ -1,5 +1,7 @@
 """FastAPI factory used to create the API to interact with stores."""
 
+from typing import Optional
+
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -8,7 +10,6 @@ from starlette.types import Lifespan
 from skore.project import Project, load
 from skore.ui.dependencies import get_static_path
 from skore.ui.project_routes import router as project_router
-from typing import Optional
 
 
 def create_app(


### PR DESCRIPTION
We can see in #541 that pre-commit doesn't execute ruff:

![image](https://github.com/user-attachments/assets/3822a0e6-ca08-43a8-934b-0c417d6d7b6e)

Now:

![image](https://github.com/user-attachments/assets/c89394dd-5c8c-49d5-ba67-e05724505608)

