### PR TITLE
feat(cli): Remove default project argument in `launch` command

### DIFF
--- a/skore/src/skore/cli/cli.py
+++ b/skore/src/skore/cli/cli.py
@@ -22,9 +22,7 @@ def cli(args: list[str]):
     parser_launch = subparsers.add_parser("launch", help="Launch the web UI")
     parser_launch.add_argument(
         "project_name",
-        nargs="?",
-        help="the name or path of the project to open (default: %(default)s)",
-        default="project.skore",
+        help="the name or path of the project to open",
     )
     parser_launch.add_argument(
         "--port",

--- a/skore/tests/unit/cli/test_cli.py
+++ b/skore/tests/unit/cli/test_cli.py
@@ -1,5 +1,6 @@
 """Test CLI properly calls the app."""
 
+import pytest
 from skore.cli.cli import cli
 
 
@@ -24,3 +25,8 @@ def test_cli_launch(monkeypatch):
     assert launch_project_name == "project.skore"
     assert launch_port == 0
     assert not launch_open_browser
+
+
+def test_cli_launch_no_project_name(monkeypatch):
+    with pytest.raises(SystemExit):
+        cli(["launch", "--port", 0, "--no-open-browser"])


### PR DESCRIPTION
Previous behaviour was to try to launch project "project.skore" if no project name was given.

Closes #507
