### PR TITLE
fix(UI): Datatable index name now points to the correct data attribute

### DIFF
--- a/skore-ui/src/ShareApp.vue
+++ b/skore-ui/src/ShareApp.vue
@@ -38,7 +38,7 @@ function getItemSubtitle(created_at: Date, updated_at: Date) {
             :columns="data.columns"
             :data="data.data"
             :index="data.index"
-            :indexNames="data.indexNames"
+            :index-names="data.index_names"
           />
           <ImageWidget
             v-if="['image/svg+xml', 'image/png', 'image/jpeg', 'image/webp'].includes(mediaType)"

--- a/skore-ui/src/views/project/ProjectView.vue
+++ b/skore-ui/src/views/project/ProjectView.vue
@@ -126,7 +126,7 @@ onBeforeUnmount(() => {
                   :columns="data.columns"
                   :data="data.data"
                   :index="data.index"
-                  :indexNames="data.indexNames"
+                  :index-names="data.index_names"
                 />
                 <ImageWidget
                   v-if="


### PR DESCRIPTION
Made a mistake during previous merge. This PR fixes dataframe hydration.