### PR TITLE
feat: Add `/docs` used to deploy documentation to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,5 +178,7 @@ tramp
 .\#*
 
 # Sphinx documentation
-doc/_build/
-doc/auto_examples/
+sphinx/build/
+sphinx/auto_examples/
+sphinx/generated/
+sphinx/sg_execution_times.rst

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,9 @@
+exclude: |
+     (?x)
+     (fixtures/)|
+     (^sphinx/)|
+     (^docs/)
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -52,5 +58,3 @@ repos:
         name: Use stylelint to lint CSS.
         entry: bash -c "cd skore-ui && npm run style-lint"
         files: ^skore-ui/
-
-exclude: fixtures/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,3 @@
+<head>
+  <meta http-equiv="refresh" content="0;latest/index.html">
+</head>

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -77,6 +77,16 @@ test = [
   "scikit-learn",
 ]
 
+sphinx = [
+  "sphinx",
+  "pydata-sphinx-theme",
+  "sphinx-gallery",
+  "sphinx-design",
+  "matplotlib",
+  "scikit-learn",
+  "numpydoc",
+]
+
 [tool.pytest.ini_options]
 addopts = [
   "--doctest-modules",

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -1,0 +1,62 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "skore"
+copyright = "2024, Probabl team"
+author = "Probabl team"
+version = "0"
+release = "0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "numpydoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+    "sphinx_design",
+    "sphinx_gallery.gen_gallery",
+]
+templates_path = ["_templates"]
+exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "pydata_sphinx_theme"
+html_static_path = ["_static"]
+
+html_css_files = [
+    "css/custom.css",
+]
+html_js_files = []
+
+# sphinx_gallery options
+sphinx_gallery_conf = {
+    "examples_dirs": "../examples",  # path to example scripts
+    "gallery_dirs": "auto_examples",  # path to gallery generated output
+}
+
+# intersphinx configuration
+intersphinx_mapping = {
+    "sklearn": ("https://scikit-learn.org/stable/", None),
+}
+
+numpydoc_show_class_members = False
+
+html_title = "skore"
+
+html_theme_options = {
+    "announcement": (
+        "https://raw.githubusercontent.com/soda-inria/hazardous/main/doc/announcement.html"
+    ),
+}


### PR DESCRIPTION
Following the [official documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch), i propose the current workflow to build the sphinx documentation:

1. (in the current iteration)
    Use a dedicated `docs/` directory to store documentation artifacts that will be automatically rendered by GitHub on GitHub Pages.
    Every time something changes in this directory on the `main` branch, the GitHub Pages will be refreshed.
    So you can manually edit the site content on a PR, and push that PR on `main` to be applied.
    Documentation can be managed independently of release.

2. (in the next iteration) 
    Populate `docs/` by triggering `sphinx` in a GitHub action when something changes in the `skore/` directory.    
    
----

![image](https://github.com/user-attachments/assets/b9e21e21-8e0f-465d-8347-4a6bc81280f7)

       
