### PR TITLE
docs: Fix some issues

### DIFF
--- a/examples/plot_02_basic_usage.py
+++ b/examples/plot_02_basic_usage.py
@@ -203,7 +203,6 @@ ax.set_xlabel("x label")
 ax.set_ylabel("y label")
 ax.set_title("Simple Plot")
 ax.legend()
-plt.show()
 
 my_project_gs.put("my_figure", fig)
 
@@ -223,7 +222,6 @@ my_altair_chart = (
     .interactive()
     .properties(title="My title")
 )
-my_altair_chart.show()
 
 my_project_gs.put("my_altair_chart", my_altair_chart)
 
@@ -245,7 +243,7 @@ df = px.data.iris()
 fig = px.scatter(
     df, x=df.sepal_length, y=df.sepal_width, color=df.species, size=df.petal_length
 )
-fig.show()
+
 my_project_gs.put("my_plotly_fig", fig)
 
 # %%
@@ -267,7 +265,7 @@ my_anim_plotly_fig = px.scatter(
     range_x=[100, 100000],
     range_y=[25, 90],
 )
-my_anim_plotly_fig.show()
+
 my_project_gs.put("my_anim_plotly_fig", my_anim_plotly_fig)
 
 # %%

--- a/skore/src/skore/cross_validate.py
+++ b/skore/src/skore/cross_validate.py
@@ -1,6 +1,6 @@
 """cross_validate function.
 
-This function implements a wrapper over scikit-learn's [cross_validate](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html#sklearn.model_selection.cross_validate)
+This function implements a wrapper over scikit-learn's `cross_validate <https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html#sklearn.model_selection.cross_validate>`_
 function in order to enrich it with more information and enable more analysis.
 """
 
@@ -190,7 +190,7 @@ def cross_validate(
 ) -> CrossValidationItem:
     """Evaluate estimator by cross-validation and output UI-friendly object.
 
-    This function wraps scikit-learn's [cross_validate](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html#sklearn.model_selection.cross_validate)
+    This function wraps scikit-learn's `cross_validate <https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html#sklearn.model_selection.cross_validate>`_
     function, to provide more context and facilitate the analysis.
     As such, the arguments are the same as scikit-learn's cross_validate function.
 

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -44,6 +44,8 @@ html_js_files = []
 sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to example scripts
     "gallery_dirs": "auto_examples",  # path to gallery generated output
+    "show_memory": False,
+    "write_computation_times": False,
 }
 
 # intersphinx configuration


### PR DESCRIPTION
Fix some issues in documentation:

- Change hyperlinks from `md` to `rst` to be compliant with numpydoc conventions,
- Disable sphinx metadata in the html output,
- Don't show anymore the figures in example,
- Rebuild documentation.