### PR TITLE
fix(PandasDataFrameItem): Use JSON to serialize dataframe instead of pickle

### DIFF
--- a/skore/src/skore/item/pandas_dataframe_item.py
+++ b/skore/src/skore/item/pandas_dataframe_item.py
@@ -56,8 +56,9 @@ class PandasDataFrameItem(Item):
         """
         The pandas DataFrame from the persistence.
 
-        Its content can differ from the original dataframe because it has been serialize
-        using pandas `to_json` function and not pickled, to be environment independent.
+        Its content can differ from the original dataframe because it has been
+        serialized using pandas' `to_json` function and not pickled, in order to be
+        environment-independent.
         """
         import io
 
@@ -99,7 +100,7 @@ class PandasDataFrameItem(Item):
             raise TypeError(f"Type '{dataframe.__class__}' is not supported.")
 
         # Two native methods are available to serialize dataframe with multi-index,
-        # while keepping the index names:
+        # while keeping the index names:
         #
         # 1. Using table orientation with JSON serializer:
         #    ```python
@@ -107,7 +108,7 @@ class PandasDataFrameItem(Item):
         #    dataframe = pandas.read_json(json, orient="table", dtype=False)
         #    ```
         #
-        #    This method fails when columns name is an integer.
+        #    This method fails when a column name is an integer.
         #
         # 2. Using record orientation with indexes as columns:
         #    ```python

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -54,7 +54,7 @@ def __serialize_project(project: Project) -> SerializedProject:
             value = item.array_list
             media_type = "text/markdown"
         elif isinstance(item, PandasDataFrameItem):
-            value = item.dataframe_dict
+            value = item.dataframe.to_dict(orient="tight")
             media_type = "application/vnd.dataframe+json"
         elif isinstance(item, PandasSeriesItem):
             value = item.series_list

--- a/skore/tests/unit/item/test_pandas_dataframe_item.py
+++ b/skore/tests/unit/item/test_pandas_dataframe_item.py
@@ -1,5 +1,5 @@
 import pytest
-from pandas import DataFrame
+from pandas import DataFrame, Index, MultiIndex
 from pandas.testing import assert_frame_equal
 from skore.item import PandasDataFrameItem
 
@@ -11,23 +11,56 @@ class TestPandasDataFrameItem:
 
     @pytest.mark.order(0)
     def test_factory(self, mock_nowstr):
-        dataframe = DataFrame([{"key": "value"}])
-        dataframe_dict = dataframe.to_dict(orient="tight")
+        dataframe = DataFrame([{"key": "value"}], Index([0], name="myIndex"))
+
+        orient = PandasDataFrameItem.ORIENT
+        index_json = dataframe.index.to_frame(index=False).to_json(orient=orient)
+        dataframe_json = dataframe.reset_index(drop=True).to_json(orient=orient)
 
         item = PandasDataFrameItem.factory(dataframe)
 
-        assert item.dataframe_dict == dataframe_dict
+        assert item.index_json == index_json
+        assert item.dataframe_json == dataframe_json
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
 
     @pytest.mark.order(1)
     def test_dataframe(self, mock_nowstr):
-        dataframe = DataFrame([{"key": "value"}])
-        dataframe_dict = dataframe.to_dict(orient="tight")
+        dataframe = DataFrame([{"key": "value"}], Index([0], name="myIndex"))
+
+        orient = PandasDataFrameItem.ORIENT
+        index_json = dataframe.index.to_frame(index=False).to_json(orient=orient)
+        dataframe_json = dataframe.reset_index(drop=True).to_json(orient=orient)
 
         item1 = PandasDataFrameItem.factory(dataframe)
         item2 = PandasDataFrameItem(
-            dataframe_dict=dataframe_dict,
+            index_json=index_json,
+            dataframe_json=dataframe_json,
+            created_at=mock_nowstr,
+            updated_at=mock_nowstr,
+        )
+
+        assert_frame_equal(item1.dataframe, dataframe)
+        assert_frame_equal(item2.dataframe, dataframe)
+
+    @pytest.mark.order(1)
+    def test_dataframe_with_integer_columns_name_and_multiindex(self, mock_nowstr):
+        dataframe = DataFrame(
+            [[">70", "1M", "M", 1], [">70", "2F", "F", 2]],
+            MultiIndex.from_arrays(
+                [["france", "usa"], ["paris", "nyc"], ["1", "1"]],
+                names=("country", "city", "district"),
+            ),
+        )
+
+        orient = PandasDataFrameItem.ORIENT
+        index_json = dataframe.index.to_frame(index=False).to_json(orient=orient)
+        dataframe_json = dataframe.reset_index(drop=True).to_json(orient=orient)
+
+        item1 = PandasDataFrameItem.factory(dataframe)
+        item2 = PandasDataFrameItem(
+            index_json=index_json,
+            dataframe_json=dataframe_json,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,
         )

--- a/skore/tests/unit/item/test_pandas_dataframe_item.py
+++ b/skore/tests/unit/item/test_pandas_dataframe_item.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pandas import DataFrame, Index, MultiIndex
 from pandas.testing import assert_frame_equal
@@ -42,6 +43,13 @@ class TestPandasDataFrameItem:
 
         assert_frame_equal(item1.dataframe, dataframe)
         assert_frame_equal(item2.dataframe, dataframe)
+
+    @pytest.mark.order(1)
+    def test_dataframe_with_complex_object(self, mock_nowstr):
+        dataframe = DataFrame([{"key": np.array([1])}], Index([0], name="myIndex"))
+        item = PandasDataFrameItem.factory(dataframe)
+
+        assert type(item.dataframe["key"].iloc[0]) is list
 
     @pytest.mark.order(1)
     def test_dataframe_with_integer_columns_name_and_multiindex(self, mock_nowstr):

--- a/skore/tests/unit/test_project.py
+++ b/skore/tests/unit/test_project.py
@@ -45,7 +45,15 @@ def test_put_dict_item(in_memory_project):
 
 
 def test_put_pandas_dataframe(in_memory_project):
-    dataframe = pandas.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    dataframe = pandas.DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": [4, 5, 6],
+            "C": [7, 8, 9],
+        },
+        index=pandas.Index([0, 1, 2], name="myIndex"),
+    )
+
     in_memory_project.put("pandas_dataframe", dataframe)
     pandas.testing.assert_frame_equal(
         in_memory_project.get("pandas_dataframe"), dataframe


### PR DESCRIPTION
Pandas Dataframes including complex objects (e.g. numpy arrays) were stored as-is.
They are now serialized using JSON to make them environment-independent.

---

Two native methods are available to serialize dataframe with multi-index, while
keepping the index names:                                                      
                                                                               
1. Using table orientation with JSON serializer:                               
   ```python                                                                   
   json = dataframe.to_json(orient="table")                                    
   dataframe = pandas.read_json(json, orient="table", dtype=False)             
   ```                                                                         
                                                                               
   This method fails when columns name is an integer.                          
                                                                               
2. Using record orientation with indexes as columns:                           
   ```python                                                                   
   dataframe = dataframe.reset_index()                                         
   json = dataframe.to_json(orient="records")                                  
   dataframe = pandas.read_json(json, orient="records", dtype=False)           
   ```                                                                         
                                                                               
   This method fails when the index has the same name as one of the columns.   
                                                                               
None of those methods being compatible, we decide to store indexes separately. 