### PR TITLE
feat: Aggregate latest cross-validation and its history

### DIFF
--- a/skore-ui/src/components/PlotlyWidget.vue
+++ b/skore-ui/src/components/PlotlyWidget.vue
@@ -20,6 +20,13 @@ function makeLayout(): Partial<Layout> {
   };
 }
 
+async function buildPlot(containerValue: HTMLDivElement, plotData: any) {
+  const plot = await react(containerValue, plotData, makeLayout());
+  if (props.spec.frames) {
+    addFrames(plot, props.spec.frames);
+  }
+}
+
 const resizeObserver = new ResizeObserver(() => {
   if (container.value) {
     relayout(container.value, makeLayout());
@@ -29,10 +36,7 @@ const resizeObserver = new ResizeObserver(() => {
 onMounted(async () => {
   if (container.value) {
     resizeObserver.observe(container.value);
-    const plot = await react(container.value, props.spec.data, makeLayout());
-    if (props.spec.frames) {
-      addFrames(plot, props.spec.frames);
-    }
+    buildPlot(container.value, props.spec.data);
   }
 });
 
@@ -46,12 +50,9 @@ onBeforeUnmount(() => {
 watch(
   () => props.spec.data,
   async (newData, oldData) => {
-    if (container.value) {
-      if (!isDeepEqual(newData, oldData)) {
-        const plot = await react(container.value, newData, makeLayout());
-        if (props.spec.frames) {
-          addFrames(plot, props.spec.frames);
-        }
+    if (!isDeepEqual(newData, oldData)) {
+      if (container.value) {
+        buildPlot(container.value, newData);
       }
     }
   }

--- a/skore-ui/src/components/PlotlyWidget.vue
+++ b/skore-ui/src/components/PlotlyWidget.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from "vue";
 import { addFrames, react, purge, relayout, type Layout } from "plotly.js-dist-min";
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { isDeepEqual } from "@/services/utils";
 
 const props = defineProps<{
   spec: { data: any; layout: any; frames: any };
@@ -41,6 +42,20 @@ onBeforeUnmount(() => {
     purge(container.value);
   }
 });
+
+watch(
+  () => props.spec.data,
+  async (newData, oldData) => {
+    if (container.value) {
+      if (!isDeepEqual(newData, oldData)) {
+        const plot = await react(container.value, newData, makeLayout());
+        if (props.spec.frames) {
+          addFrames(plot, props.spec.frames);
+        }
+      }
+    }
+  }
+);
 </script>
 
 <template>

--- a/skore-ui/src/components/PlotlyWidget.vue
+++ b/skore-ui/src/components/PlotlyWidget.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { addFrames, newPlot, purge, relayout, type Layout } from "plotly.js-dist-min";
 import { onBeforeUnmount, onMounted, ref } from "vue";
+import { addFrames, react, purge, relayout, type Layout } from "plotly.js-dist-min";
 
 const props = defineProps<{
   spec: { data: any; layout: any; frames: any };
@@ -28,7 +28,7 @@ const resizeObserver = new ResizeObserver(() => {
 onMounted(async () => {
   if (container.value) {
     resizeObserver.observe(container.value);
-    const plot = await newPlot(container.value, props.spec.data, makeLayout());
+    const plot = await react(container.value, props.spec.data, makeLayout());
     if (props.spec.frames) {
       addFrames(plot, props.spec.frames);
     }

--- a/skore/src/skore/cross_validate.py
+++ b/skore/src/skore/cross_validate.py
@@ -250,7 +250,18 @@ def cross_validate(*args, project: Optional[Project] = None, **kwargs) -> dict:
     cv_results = sklearn.model_selection.cross_validate(
         *args, **kwargs, scoring=new_scorers
     )
-    cross_validation_item = CrossValidationItem.factory(cv_results, estimator, X, y)
+
+    if project is not None:
+        try:
+            cv_results_history = project.get_item_versions("cross_validation")
+        except KeyError:
+            cv_results_history = []
+    else:
+        cv_results_history = []
+
+    cross_validation_item = CrossValidationItem.factory(
+        cv_results, cv_results_history, estimator, X, y
+    )
 
     if project is not None:
         project.put_item("cross_validation", cross_validation_item)

--- a/skore/src/skore/cross_validate.py
+++ b/skore/src/skore/cross_validate.py
@@ -8,7 +8,10 @@ function in order to enrich it with more information and enable more analysis.
 import contextlib
 from typing import Literal, Optional
 
-from skore.item.cross_validation_item import AggCrossValidationItem, CrossValidationItem
+from skore.item.cross_validation_item import (
+    CrossValidationAggregationItem,
+    CrossValidationItem,
+)
 from skore.project import Project
 
 
@@ -259,7 +262,7 @@ def cross_validate(*args, project: Optional[Project] = None, **kwargs) -> dict:
         except KeyError:
             cv_results_history = []
 
-        agg_cross_validation_item = AggCrossValidationItem.factory(
+        agg_cross_validation_item = CrossValidationAggregationItem.factory(
             cv_results_history + [cross_validation_item]
         )
 

--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -142,14 +142,13 @@ def plot_cross_validation(cv_results: dict) -> plotly.graph_objects.Figure:
 
 
 def plot_cross_validation_aggregation(
-    cv_results_items_history: list[Item],
-    cv_results: dict,
+    cv_results_items_versions: list[CrossValidationItem],
 ) -> plotly.graph_objects.Figure:
     """Plot the result of the aggregation of several cross-validation runs.
 
     Parameters
     ----------
-    cv_results_list : list[dict]
+    cv_results_items_versions : list[dict]
         A list of outputs of scikit-learn's cross_validate function.
 
     Returns
@@ -163,10 +162,8 @@ def plot_cross_validation_aggregation(
 
     scores = []
 
-    for item in cv_results_items_history:
+    for item in cv_results_items_versions:
         scores.append(mean(item.cv_results_serialized["fit_time"]))
-
-    scores.append(mean(cv_results["fit_time"]))
 
     fig = go.Figure()
     fig.add_trace(
@@ -216,7 +213,6 @@ class CrossValidationItem(Item):
         X_info: dict,
         y_info: dict,
         plot_bytes: bytes,
-        aggregation_plot_bytes: bytes,
         created_at: str | None = None,
         updated_at: str | None = None,
     ):
@@ -236,9 +232,6 @@ class CrossValidationItem(Item):
             A summary of the target, input of scikit-learn's cross_validation function.
         plot_bytes : bytes
             A plot of the current cross-validation results, in the form of bytes.
-        aggregation_plot_bytes : bytes
-            A plot aggregating the data from all versions of the
-            cross-validation results, in the form of bytes.
         created_at : str
             The creation timestamp in ISO format.
         updated_at : str
@@ -251,13 +244,11 @@ class CrossValidationItem(Item):
         self.X_info = X_info
         self.y_info = y_info
         self.plot_bytes = plot_bytes
-        self.aggregation_plot_bytes = aggregation_plot_bytes
 
     @classmethod
     def factory(
         cls,
         cv_results: dict,
-        cv_results_items_history: list[CrossValidationItem],
         estimator: sklearn.base.BaseEstimator,
         X: Data,
         y: Target | None,
@@ -269,8 +260,6 @@ class CrossValidationItem(Item):
         ----------
         cv_results : dict
             The dict output of scikit-learn's cross_validate function.
-        cv_results_items_history: list[CrossValidationItem]
-            A list of previous cross_validate items.
         estimator : sklearn.base.BaseEstimator,
             The estimator that was cross-validated.
         X
@@ -317,27 +306,16 @@ class CrossValidationItem(Item):
         plot = plot_cross_validation(cv_results_serialized)
         plot_bytes = plotly.io.to_json(plot, engine="json").encode("utf-8")
 
-        aggregation_plot = plot_cross_validation_aggregation(
-            cv_results_items_history,
-            cv_results,
-        )
-
-        aggregation_plot_bytes = plotly.io.to_json(
-            aggregation_plot, engine="json"
-        ).encode("utf-8")
-
         instance = cls(
             cv_results_serialized=cv_results_serialized,
             estimator_info=estimator_info,
             X_info=X_info,
             y_info=y_info,
             plot_bytes=plot_bytes,
-            aggregation_plot_bytes=aggregation_plot_bytes,
         )
 
         # Cache plots
         instance.plot = plot
-        instance.aggregation_plot = aggregation_plot
 
         return instance
 
@@ -346,10 +324,67 @@ class CrossValidationItem(Item):
         """A plot of the cross-validation results."""
         return plotly.io.from_json(self.plot_bytes.decode("utf-8"))
 
+
+class AggCrossValidationItem(Item):
+    """Aggregated outputs of several cross-validation workflow runs."""
+
+    def __init__(
+        self,
+        plot_bytes: bytes,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+    ):
+        """
+        Initialize an AggCrossValidationItem.
+
+        Parameters
+        ----------
+        plot_bytes : bytes
+            A plot of the aggregated cross-validation results, in the form of bytes.
+        created_at : str
+            The creation timestamp in ISO format.
+        updated_at : str
+            The last update timestamp in ISO format.
+        """
+        super().__init__(created_at, updated_at)
+
+        self.plot_bytes = plot_bytes
+
+    @classmethod
+    def factory(
+        cls,
+        cv_results_items_versions: list[CrossValidationItem],
+    ) -> AggCrossValidationItem:
+        """
+        Create a new AggCrossValidationItem instance.
+
+        Parameters
+        ----------
+        cv_results_items_versions: list[CrossValidationItem]
+            A list of cross_validate items to be aggregated.
+
+        Returns
+        -------
+        AggCrossValidationItem
+            A new AggCrossValidationItem instance.
+        """
+        plot = plot_cross_validation_aggregation(cv_results_items_versions)
+
+        plot_bytes = plotly.io.to_json(plot, engine="json").encode("utf-8")
+
+        instance = cls(
+            plot_bytes=plot_bytes,
+        )
+
+        # Cache plots
+        instance.plot = plot
+
+        return instance
+
     @cached_property
-    def aggregation_plot(self):
+    def plot(self):
         """An aggregation plot of all the cross-validation results.
 
-        Results are aggregation from the oldest to the current.
+        Results are shown from the oldest to the current.
         """
-        return plotly.io.from_json(self.aggregation_plot_bytes.decode("utf-8"))
+        return plotly.io.from_json(self.plot_bytes.decode("utf-8"))

--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -375,7 +375,7 @@ class CrossValidationItem(Item):
         return plotly.io.from_json(self.plot_bytes.decode("utf-8"))
 
 
-class AggCrossValidationItem(Item):
+class CrossValidationAggregationItem(Item):
     """Aggregated outputs of several cross-validation workflow runs."""
 
     def __init__(
@@ -385,7 +385,7 @@ class AggCrossValidationItem(Item):
         updated_at: str | None = None,
     ):
         """
-        Initialize an AggCrossValidationItem.
+        Initialize an CrossValidationAggregationItem.
 
         Parameters
         ----------
@@ -404,9 +404,9 @@ class AggCrossValidationItem(Item):
     def factory(
         cls,
         cv_results_items_versions: list[CrossValidationItem],
-    ) -> AggCrossValidationItem:
+    ) -> CrossValidationAggregationItem:
         """
-        Create a new AggCrossValidationItem instance.
+        Create a new CrossValidationAggregationItem instance.
 
         Parameters
         ----------
@@ -415,8 +415,8 @@ class AggCrossValidationItem(Item):
 
         Returns
         -------
-        AggCrossValidationItem
-            A new AggCrossValidationItem instance.
+        CrossValidationAggregationItem
+            A new CrossValidationAggregationItem instance.
         """
         plot = plot_cross_validation_aggregation(cv_results_items_versions)
 

--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -281,7 +281,7 @@ class CrossValidationItem(Item):
         y_info : dict
             A summary of the target, input of scikit-learn's cross_validation function.
         plot_bytes : bytes
-            A plot of the current cross-validation results, in the form of bytes.
+            A plot of the cross-validation results, in the form of bytes.
         created_at : str
             The creation timestamp in ISO format.
         updated_at : str
@@ -364,7 +364,7 @@ class CrossValidationItem(Item):
             plot_bytes=plot_bytes,
         )
 
-        # Cache plots
+        # Cache plot
         instance.plot = plot
 
         return instance
@@ -426,7 +426,7 @@ class CrossValidationAggregationItem(Item):
             plot_bytes=plot_bytes,
         )
 
-        # Cache plots
+        # Cache plot
         instance.plot = plot
 
         return instance

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -13,7 +13,10 @@ if TYPE_CHECKING:
     from skore.persistence.abstract_storage import AbstractStorage
 
 
-from skore.item.cross_validation_item import AggCrossValidationItem, CrossValidationItem
+from skore.item.cross_validation_item import (
+    CrossValidationAggregationItem,
+    CrossValidationItem,
+)
 from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
 from skore.item.pandas_dataframe_item import PandasDataFrameItem
@@ -39,8 +42,8 @@ class ItemRepository:
         "PandasSeriesItem": PandasSeriesItem,
         "PrimitiveItem": PrimitiveItem,
         "CrossValidationItem": CrossValidationItem,
+        "CrossValidationAggregationItem": CrossValidationAggregationItem,
         "SklearnBaseEstimatorItem": SklearnBaseEstimatorItem,
-        "AggCrossValidationItem": AggCrossValidationItem,
     }
 
     def __init__(self, storage: AbstractStorage):

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from skore.persistence.abstract_storage import AbstractStorage
 
 
-from skore.item.cross_validation_item import CrossValidationItem
+from skore.item.cross_validation_item import AggCrossValidationItem, CrossValidationItem
 from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
 from skore.item.pandas_dataframe_item import PandasDataFrameItem
@@ -40,6 +40,7 @@ class ItemRepository:
         "PrimitiveItem": PrimitiveItem,
         "CrossValidationItem": CrossValidationItem,
         "SklearnBaseEstimatorItem": SklearnBaseEstimatorItem,
+        "AggCrossValidationItem": AggCrossValidationItem,
     }
 
     def __init__(self, storage: AbstractStorage):

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -7,7 +7,10 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, status
 
-from skore.item.cross_validation_item import AggCrossValidationItem, CrossValidationItem
+from skore.item.cross_validation_item import (
+    CrossValidationAggregationItem,
+    CrossValidationItem,
+)
 from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
 from skore.item.pandas_dataframe_item import PandasDataFrameItem
@@ -61,7 +64,9 @@ def __serialize_project(project: Project) -> SerializedProject:
             elif isinstance(item, MediaItem):
                 value = base64.b64encode(item.media_bytes).decode()
                 media_type = item.media_type
-            elif isinstance(item, (CrossValidationItem, AggCrossValidationItem)):
+            elif isinstance(
+                item, (CrossValidationItem, CrossValidationAggregationItem)
+            ):
                 value = base64.b64encode(item.plot_bytes).decode()
                 media_type = "application/vnd.plotly.v1+json"
             else:

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, status
 
-from skore.item.cross_validation_item import CrossValidationItem
+from skore.item.cross_validation_item import AggCrossValidationItem, CrossValidationItem
 from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
 from skore.item.pandas_dataframe_item import PandasDataFrameItem
@@ -61,7 +61,7 @@ def __serialize_project(project: Project) -> SerializedProject:
             elif isinstance(item, MediaItem):
                 value = base64.b64encode(item.media_bytes).decode()
                 media_type = item.media_type
-            elif isinstance(item, CrossValidationItem):
+            elif isinstance(item, (CrossValidationItem, AggCrossValidationItem)):
                 value = base64.b64encode(item.plot_bytes).decode()
                 media_type = "application/vnd.plotly.v1+json"
             else:

--- a/skore/tests/integration/test_cross_validate.py
+++ b/skore/tests/integration/test_cross_validate.py
@@ -170,10 +170,3 @@ def test_aggregated_cross_validation(rf, in_memory_project):
         in_memory_project.item_repository.get_item("cross_validation_aggregated"),
         CrossValidationAggregationItem,
     )
-
-    cross_validate(*args, project=in_memory_project)
-    cross_validate(*args, project=in_memory_project)
-    cross_validate(*args, project=in_memory_project)
-    in_memory_project.item_repository.get_item(
-        "cross_validation_aggregated"
-    ).plot.show()

--- a/skore/tests/integration/test_cross_validate.py
+++ b/skore/tests/integration/test_cross_validate.py
@@ -9,7 +9,11 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.multiclass import OneVsOneClassifier
 from sklearn.svm import SVC
 from skore.cross_validate import cross_validate
-from skore.item.cross_validation_item import CrossValidationItem, plot_cross_validation
+from skore.item.cross_validation_item import (
+    AggCrossValidationItem,
+    CrossValidationItem,
+    plot_cross_validation,
+)
 
 
 @pytest.fixture
@@ -157,3 +161,19 @@ def test_plot_cross_validation():
         ),
     }
     plot_cross_validation(cv_results)
+
+
+def test_aggregated_cross_validation(rf, in_memory_project):
+    args = rf
+    cross_validate(*args, project=in_memory_project)
+    assert isinstance(
+        in_memory_project.item_repository.get_item("cross_validation_aggregated"),
+        AggCrossValidationItem,
+    )
+
+    cross_validate(*args, project=in_memory_project)
+    cross_validate(*args, project=in_memory_project)
+    cross_validate(*args, project=in_memory_project)
+    in_memory_project.item_repository.get_item(
+        "cross_validation_aggregated"
+    ).plot.show()

--- a/skore/tests/integration/test_cross_validate.py
+++ b/skore/tests/integration/test_cross_validate.py
@@ -10,7 +10,7 @@ from sklearn.multiclass import OneVsOneClassifier
 from sklearn.svm import SVC
 from skore.cross_validate import cross_validate
 from skore.item.cross_validation_item import (
-    AggCrossValidationItem,
+    CrossValidationAggregationItem,
     CrossValidationItem,
     plot_cross_validation,
 )
@@ -168,7 +168,7 @@ def test_aggregated_cross_validation(rf, in_memory_project):
     cross_validate(*args, project=in_memory_project)
     assert isinstance(
         in_memory_project.item_repository.get_item("cross_validation_aggregated"),
-        AggCrossValidationItem,
+        CrossValidationAggregationItem,
     )
 
     cross_validate(*args, project=in_memory_project)

--- a/skore/tests/unit/item/test_cross_validation_item.py
+++ b/skore/tests/unit/item/test_cross_validation_item.py
@@ -30,7 +30,9 @@ class TestCrossValidationItem:
             cv_results={
                 "test_score": numpy.array([1, 2, 3]),
                 "estimator": [MyEstimator(), MyEstimator(), MyEstimator()],
+                "fit_time": [1, 2, 3],
             },
+            cv_results_items_history=[],
             estimator=MyEstimator(),
             X=[[1.0]],
             y=[1],
@@ -41,5 +43,6 @@ class TestCrossValidationItem:
         assert item.X_info == {"nb_cols": 1, "nb_rows": 1, "hash": ""}
         assert item.y_info == {"hash": ""}
         assert isinstance(item.plot_bytes, bytes)
+        assert isinstance(item.aggregation_plot_bytes, bytes)
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr

--- a/skore/tests/unit/item/test_cross_validation_item.py
+++ b/skore/tests/unit/item/test_cross_validation_item.py
@@ -32,7 +32,6 @@ class TestCrossValidationItem:
                 "estimator": [MyEstimator(), MyEstimator(), MyEstimator()],
                 "fit_time": [1, 2, 3],
             },
-            cv_results_items_history=[],
             estimator=MyEstimator(),
             X=[[1.0]],
             y=[1],
@@ -43,6 +42,5 @@ class TestCrossValidationItem:
         assert item.X_info == {"nb_cols": 1, "nb_rows": 1, "hash": ""}
         assert item.y_info == {"hash": ""}
         assert isinstance(item.plot_bytes, bytes)
-        assert isinstance(item.aggregation_plot_bytes, bytes)
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr


### PR DESCRIPTION
This adds a new item type, `CrossValidationAggregationItem`, which allows to both record new cross-validation data (at key `cross_validation`), and update an aggregation plot (at key `cross_validation_aggregated`) when `skore.cross_validate` is called.

Co-authored-by: Auguste Baum <auguste@probabl.ai>

Closes #681 