### PR TITLE
fix(NumpyArrayItem): Use JSON to serialize array instead of pickle

### DIFF
--- a/skore/src/skore/item/numpy_array_item.py
+++ b/skore/src/skore/item/numpy_array_item.py
@@ -6,6 +6,7 @@ This module defines the NumpyArrayItem class, which represents a NumPy array ite
 from __future__ import annotations
 
 from functools import cached_property
+from json import dumps, loads
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -19,27 +20,11 @@ class NumpyArrayItem(Item):
     A class to represent a NumPy array item.
 
     This class encapsulates a NumPy array along with its creation and update timestamps.
-
-    Attributes
-    ----------
-    array_list : list
-        The list representation of the NumPy array.
-    created_at : str
-        The timestamp when the item was created, in ISO format.
-    updated_at : str
-        The timestamp when the item was last updated, in ISO format.
-
-    Methods
-    -------
-    array() : numpy.ndarray
-        Returns the NumPy array representation of the stored list.
-    factory(array: numpy.ndarray) : NumpyArrayItem
-        Creates a new NumpyArrayItem instance from a NumPy array.
     """
 
     def __init__(
         self,
-        array_list: list,
+        array_json: str,
         created_at: str | None = None,
         updated_at: str | None = None,
     ):
@@ -48,8 +33,8 @@ class NumpyArrayItem(Item):
 
         Parameters
         ----------
-        array_list : list
-            The list representation of the NumPy array.
+        array_json : str
+            The JSON representation of the array.
         created_at : str
             The creation timestamp in ISO format.
         updated_at : str
@@ -57,21 +42,20 @@ class NumpyArrayItem(Item):
         """
         super().__init__(created_at, updated_at)
 
-        self.array_list = array_list
+        self.array_json = array_json
 
     @cached_property
     def array(self) -> numpy.ndarray:
         """
-        Convert the stored list to a NumPy array.
+        The numpy array from the persistence.
 
-        Returns
-        -------
-        numpy.ndarray
-            The NumPy array representation of the stored list.
+        Its content can differ from the original array because it has been serialized
+        using `json.dumps` function and not pickled, in order to be
+        environment-independent.
         """
         import numpy
 
-        return numpy.asarray(self.array_list)
+        return numpy.asarray(loads(self.array_json))
 
     @classmethod
     def factory(cls, array: numpy.ndarray) -> NumpyArrayItem:
@@ -93,9 +77,4 @@ class NumpyArrayItem(Item):
         if not isinstance(array, numpy.ndarray):
             raise TypeError(f"Type '{array.__class__}' is not supported.")
 
-        instance = cls(array_list=array.tolist())
-
-        # add array as cached property
-        instance.array = array
-
-        return instance
+        return cls(array_json=dumps(array.tolist()))

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -47,7 +47,7 @@ def __serialize_project(project: Project) -> SerializedProject:
                 value = item.primitive
                 media_type = "text/markdown"
             elif isinstance(item, NumpyArrayItem):
-                value = item.array_list
+                value = item.array.tolist()
                 media_type = "text/markdown"
             elif isinstance(item, PandasDataFrameItem):
                 value = item.dataframe.to_dict(orient="tight")

--- a/skore/tests/unit/item/test_numpy_array_item.py
+++ b/skore/tests/unit/item/test_numpy_array_item.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy
 import pytest
 from skore.item import NumpyArrayItem
@@ -11,25 +13,32 @@ class TestNumpyArrayItem:
     @pytest.mark.order(0)
     def test_factory(self, mock_nowstr):
         array = numpy.array([1, 2, 3])
-        array_list = array.tolist()
+        array_json = json.dumps(array.tolist())
 
         item = NumpyArrayItem.factory(array)
 
-        assert item.array_list == array_list
+        assert item.array_json == array_json
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
 
     @pytest.mark.order(1)
     def test_array(self, mock_nowstr):
         array = numpy.array([1, 2, 3])
-        array_list = array.tolist()
+        array_json = json.dumps(array.tolist())
 
         item1 = NumpyArrayItem.factory(array)
         item2 = NumpyArrayItem(
-            array_list=array_list,
+            array_json=array_json,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,
         )
 
         numpy.testing.assert_array_equal(item1.array, array)
         numpy.testing.assert_array_equal(item2.array, array)
+
+    @pytest.mark.order(1)
+    def test_array_with_complex_object(self, mock_nowstr):
+        array = numpy.array([object])
+
+        with pytest.raises(TypeError, match="type is not JSON serializable"):
+            NumpyArrayItem.factory(array)


### PR DESCRIPTION
Same problem as https://github.com/probabl-ai/skore/pull/621, but on `numpy.array`.