### PR TITLE
fix(Item): Use specific exception in `item.factory` to not swallow unexpected exceptions in `object_to_item`

### DIFF
--- a/skore/src/skore/item/__init__.py
+++ b/skore/src/skore/item/__init__.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from typing import Any
 
 from skore.item.cross_validation_item import CrossValidationItem
-from skore.item.item import Item
+from skore.item.item import Item, ItemTypeError
 from skore.item.item_repository import ItemRepository
 from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
@@ -24,23 +24,23 @@ def object_to_item(object: Any) -> Item:
         PandasSeriesItem,
         NumpyArrayItem,
         SklearnBaseEstimatorItem,
-        CrossValidationItem,
         MediaItem,
     ):
-        with suppress(ImportError, TypeError):
+        with suppress(ImportError, ItemTypeError):
             # ImportError:
             #     The factories are responsible to import third-party libraries in a
             #     lazy way. If library is missing, an ImportError exception will
             #     automatically be thrown.
-            # TypeError:
+            # ItemTypeError:
             #     The factories are responsible for checking that parameters are of the
-            #     correct type. If not, they throw a TypeError exception.
+            #     correct type. If not, they throw a ItemTypeError exception.
             return cls.factory(object)
 
     raise NotImplementedError(f"Type '{object.__class__}' is not supported.")
 
 
 __all__ = [
+    "CrossValidationItem",
     "Item",
     "ItemRepository",
     "MediaItem",

--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -14,7 +14,7 @@ import numpy
 import plotly.graph_objects
 import plotly.io
 
-from skore.item.item import Item
+from skore.item.item import Item, ItemTypeError
 
 if TYPE_CHECKING:
     import sklearn.base
@@ -238,7 +238,7 @@ class CrossValidationItem(Item):
             A new CrossValidationItem instance.
         """
         if not isinstance(cv_results, dict):
-            raise TypeError(f"Type '{cv_results.__class__}' is not supported.")
+            raise ItemTypeError(f"Type '{cv_results.__class__}' is not supported.")
 
         cv_results_serialized = {}
         for k, v in cv_results.items():

--- a/skore/src/skore/item/item.py
+++ b/skore/src/skore/item/item.py
@@ -9,6 +9,10 @@ from functools import cached_property
 from typing import Any, Optional
 
 
+class ItemTypeError(Exception):
+    """Item type exception."""
+
+
 class Item(ABC):
     """
     Abstract base class for all items in the project.

--- a/skore/src/skore/item/item.py
+++ b/skore/src/skore/item/item.py
@@ -10,7 +10,11 @@ from typing import Any, Optional
 
 
 class ItemTypeError(Exception):
-    """Item type exception."""
+    """Item type exception.
+
+    Exception raised when an attempt is made to convert an object to an Item, but the
+    object's type is not supported.
+    """
 
 
 class Item(ABC):

--- a/skore/src/skore/item/media_item.py
+++ b/skore/src/skore/item/media_item.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
+from skore.item.item import Item, ItemTypeError
+
 if TYPE_CHECKING:
     from altair.vegalite.v5.schema.core import TopLevelSpec as Altair
     from matplotlib.figure import Figure as Matplotlib
     from PIL.Image import Image as Pillow
     from plotly.basedatatypes import BaseFigure as Plotly
-
-from skore.item.item import Item
 
 
 def lazy_is_instance(object: Any, cls_fullname: str) -> bool:
@@ -97,7 +97,7 @@ class MediaItem(Item):
         if lazy_is_instance(media, "plotly.basedatatypes.BaseFigure"):
             return cls.factory_plotly(media, *args, **kwargs)
 
-        raise TypeError(f"Type '{media.__class__}' is not supported.")
+        raise ItemTypeError(f"Type '{media.__class__}' is not supported.")
 
     @classmethod
     def factory_bytes(

--- a/skore/src/skore/item/numpy_array_item.py
+++ b/skore/src/skore/item/numpy_array_item.py
@@ -9,10 +9,10 @@ from functools import cached_property
 from json import dumps, loads
 from typing import TYPE_CHECKING
 
+from skore.item.item import Item, ItemTypeError
+
 if TYPE_CHECKING:
     import numpy
-
-from skore.item.item import Item
 
 
 class NumpyArrayItem(Item):
@@ -75,6 +75,6 @@ class NumpyArrayItem(Item):
         import numpy
 
         if not isinstance(array, numpy.ndarray):
-            raise TypeError(f"Type '{array.__class__}' is not supported.")
+            raise ItemTypeError(f"Type '{array.__class__}' is not supported.")
 
         return cls(array_json=dumps(array.tolist()))

--- a/skore/src/skore/item/pandas_dataframe_item.py
+++ b/skore/src/skore/item/pandas_dataframe_item.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from skore.item.item import Item, ItemTypeError
+
 if TYPE_CHECKING:
     import pandas
-
-from skore.item.item import Item
 
 
 class PandasDataFrameItem(Item):
@@ -97,7 +97,7 @@ class PandasDataFrameItem(Item):
         import pandas
 
         if not isinstance(dataframe, pandas.DataFrame):
-            raise TypeError(f"Type '{dataframe.__class__}' is not supported.")
+            raise ItemTypeError(f"Type '{dataframe.__class__}' is not supported.")
 
         # Two native methods are available to serialize dataframe with multi-index,
         # while keeping the index names:

--- a/skore/src/skore/item/pandas_series_item.py
+++ b/skore/src/skore/item/pandas_series_item.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from skore.item.item import Item, ItemTypeError
+
 if TYPE_CHECKING:
     import pandas
-
-from skore.item.item import Item
 
 
 class PandasSeriesItem(Item):
@@ -70,7 +70,7 @@ class PandasSeriesItem(Item):
         import pandas
 
         if not isinstance(series, pandas.Series):
-            raise TypeError(f"Type '{series.__class__}' is not supported.")
+            raise ItemTypeError(f"Type '{series.__class__}' is not supported.")
 
         instance = cls(series_list=series.to_list())
 

--- a/skore/src/skore/item/primitive_item.py
+++ b/skore/src/skore/item/primitive_item.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skore.item.item import Item
+from skore.item.item import Item, ItemTypeError
 
 if TYPE_CHECKING:
     from typing import Union
@@ -83,6 +83,6 @@ class PrimitiveItem(Item):
             A new PrimitiveItem instance.
         """
         if not is_primitive(primitive):
-            raise TypeError(f"Type '{primitive.__class__}' is not supported.")
+            raise ItemTypeError(f"Type '{primitive.__class__}' is not supported.")
 
         return cls(primitive=primitive)

--- a/skore/src/skore/item/sklearn_base_estimator_item.py
+++ b/skore/src/skore/item/sklearn_base_estimator_item.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from skore.item.item import Item, ItemTypeError
+
 if TYPE_CHECKING:
     import sklearn.base
-
-from skore.item.item import Item
 
 
 class SklearnBaseEstimatorItem(Item):
@@ -89,7 +89,7 @@ class SklearnBaseEstimatorItem(Item):
         import skops.io
 
         if not isinstance(estimator, sklearn.base.BaseEstimator):
-            raise TypeError(f"Type '{estimator.__class__}' is not supported.")
+            raise ItemTypeError(f"Type '{estimator.__class__}' is not supported.")
 
         estimator_html_repr = sklearn.utils.estimator_html_repr(estimator)
         estimator_skops = skops.io.dumps(estimator)

--- a/skore/tests/unit/item/test_cross_validation_item.py
+++ b/skore/tests/unit/item/test_cross_validation_item.py
@@ -1,6 +1,6 @@
 import numpy
 import pytest
-from skore.item import CrossValidationItem
+from skore.item import CrossValidationItem, ItemTypeError
 
 
 class TestCrossValidationItem:
@@ -9,8 +9,13 @@ class TestCrossValidationItem:
         monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
 
     def test_factory_exception(self):
-        with pytest.raises(TypeError):
-            CrossValidationItem.factory(None)
+        with pytest.raises(ItemTypeError):
+            CrossValidationItem.factory(
+                cv_results=None,
+                estimator=None,
+                X=None,
+                y=None,
+            )
 
     def test_factory(self, monkeypatch, mock_nowstr):
         monkeypatch.setattr(

--- a/skore/tests/unit/item/test_media_item.py
+++ b/skore/tests/unit/item/test_media_item.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot
 import PIL as pillow
 import plotly.graph_objects as go
 import pytest
-from skore.item import MediaItem
+from skore.item import ItemTypeError, MediaItem
 
 
 class TestMediaItem:
@@ -14,7 +14,7 @@ class TestMediaItem:
         monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
 
     def test_factory_exception(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(ItemTypeError):
             MediaItem.factory(None)
 
     def test_factory_bytes(self, mock_nowstr):

--- a/skore/tests/unit/item/test_numpy_array_item.py
+++ b/skore/tests/unit/item/test_numpy_array_item.py
@@ -2,13 +2,17 @@ import json
 
 import numpy
 import pytest
-from skore.item import NumpyArrayItem
+from skore.item import ItemTypeError, NumpyArrayItem
 
 
 class TestNumpyArrayItem:
     @pytest.fixture(autouse=True)
     def monkeypatch_datetime(self, monkeypatch, MockDatetime):
         monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
+
+    def test_factory_exception(self):
+        with pytest.raises(ItemTypeError):
+            NumpyArrayItem.factory(None)
 
     @pytest.mark.order(0)
     def test_factory(self, mock_nowstr):

--- a/skore/tests/unit/item/test_pandas_dataframe_item.py
+++ b/skore/tests/unit/item/test_pandas_dataframe_item.py
@@ -2,13 +2,17 @@ import numpy as np
 import pytest
 from pandas import DataFrame, Index, MultiIndex
 from pandas.testing import assert_frame_equal
-from skore.item import PandasDataFrameItem
+from skore.item import ItemTypeError, PandasDataFrameItem
 
 
 class TestPandasDataFrameItem:
     @pytest.fixture(autouse=True)
     def monkeypatch_datetime(self, monkeypatch, MockDatetime):
         monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
+
+    def test_factory_exception(self):
+        with pytest.raises(ItemTypeError):
+            PandasDataFrameItem.factory(None)
 
     @pytest.mark.order(0)
     def test_factory(self, mock_nowstr):

--- a/skore/tests/unit/item/test_pandas_series_item.py
+++ b/skore/tests/unit/item/test_pandas_series_item.py
@@ -1,13 +1,17 @@
 import pytest
 from pandas import Series
 from pandas.testing import assert_series_equal
-from skore.item import PandasSeriesItem
+from skore.item import ItemTypeError, PandasSeriesItem
 
 
 class TestPandasSeriesItem:
     @pytest.fixture(autouse=True)
     def monkeypatch_datetime(self, monkeypatch, MockDatetime):
         monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
+
+    def test_factory_exception(self):
+        with pytest.raises(ItemTypeError):
+            PandasSeriesItem.factory(None)
 
     @pytest.mark.order(0)
     def test_factory(self, mock_nowstr):

--- a/skore/tests/unit/item/test_primitive_item.py
+++ b/skore/tests/unit/item/test_primitive_item.py
@@ -1,5 +1,5 @@
 import pytest
-from skore.item import PrimitiveItem
+from skore.item import ItemTypeError, PrimitiveItem
 
 
 class TestPrimitiveItem:
@@ -23,3 +23,7 @@ class TestPrimitiveItem:
         assert item.primitive == primitive
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
+
+    def test_factory_exception(self):
+        with pytest.raises(ItemTypeError):
+            PrimitiveItem.factory(None)

--- a/skore/tests/unit/item/test_sklearn_base_estimator_item.py
+++ b/skore/tests/unit/item/test_sklearn_base_estimator_item.py
@@ -1,7 +1,7 @@
 import pytest
 import sklearn.svm
 import skops.io
-from skore.item import SklearnBaseEstimatorItem
+from skore.item import ItemTypeError, SklearnBaseEstimatorItem
 
 
 class Estimator(sklearn.svm.SVC):
@@ -12,6 +12,10 @@ class TestSklearnBaseEstimatorItem:
     @pytest.fixture(autouse=True)
     def monkeypatch_datetime(self, monkeypatch, MockDatetime):
         monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
+
+    def test_factory_exception(self):
+        with pytest.raises(ItemTypeError):
+            SklearnBaseEstimatorItem.factory(None)
 
     @pytest.mark.order(0)
     def test_factory(self, monkeypatch, mock_nowstr):


### PR DESCRIPTION
Some `TypeError` exceptions are swallowed during item construction, but it should not:

![image](https://github.com/user-attachments/assets/c2eecf87-054f-43d1-b9d1-c874aa65ad72)

Furthermore, during serialization, JSON can raise `TypeError`, that must not be catched.