### PR TITLE
feat(UI): Item accordion now have dynamic cursor

### DIFF
--- a/skore-ui/src/components/TreeAccordionItem.vue
+++ b/skore-ui/src/components/TreeAccordionItem.vue
@@ -49,7 +49,7 @@ function onAction(action: string) {
 <template>
   <div
     class="tree-accordion-item"
-    :class="{ first: isRoot }"
+    :class="{ first: isRoot, enabled: props.enabled }"
     :style="{ '--children-count': totalChildrenCount }"
     :data-name="props.name"
   >
@@ -109,7 +109,6 @@ function onAction(action: string) {
   position: relative;
   overflow: hidden;
   margin-left: 19px;
-  cursor: pointer;
 
   &.first {
     margin-left: 0;
@@ -127,17 +126,11 @@ function onAction(action: string) {
     .label {
       display: flex;
       height: var(--label-height);
+      flex: 1;
       flex-direction: row;
       align-items: center;
+      cursor: help;
       transition: background-color var(--animation-duration) var(--animation-easing);
-
-      &:not(.has-children):hover {
-        background-color: var(--color-background-secondary);
-      }
-
-      &[draggable="true"] {
-        cursor: grabbing;
-      }
 
       & .children-indicator {
         color: var(--color-text-secondary);
@@ -200,6 +193,18 @@ function onAction(action: string) {
       .actions {
         opacity: 1;
       }
+    }
+  }
+
+  &.enabled > .label-container > .label {
+    cursor: pointer;
+
+    &:not(.has-children):hover {
+      background-color: var(--color-background-secondary);
+    }
+
+    &[draggable="true"] {
+      cursor: grabbing;
     }
   }
 


### PR DESCRIPTION
## Changes

- pointer cursor is used when item is enabled
- grab cursor when label is clicked
- label now grows to use all available space (fixes #682)
- help cursor is used when item is disabled to indicate the scroll to item feature

## UI preview

https://github.com/user-attachments/assets/0aaea1b2-ba8c-400a-af95-7c2e2698af5f

Fixes #685 


