### PR TITLE
fix(docs): Fix cross-validation example aggregation issues

### DIFF
--- a/examples/plot_03_cross_validate.py
+++ b/examples/plot_03_cross_validate.py
@@ -158,6 +158,13 @@ plt.show()
 # ^^^^^^^^^^^^^^^
 
 # %%
+# For now all cross-validation information is stored in the same place, which might lead to comparing two models that don't do the same thing. To remedy this, we clear the information stored in skore; in the future this will be managed automatically.
+
+# %%
+my_project_gs.delete_item("cross_validation")
+my_project_gs.delete_item("cross_validation_aggregated")
+
+# %%
 diabetes = datasets.load_diabetes()
 X = diabetes.data[:150]
 y = diabetes.target[:150]


### PR DESCRIPTION
Currently cross-validation aggregation works by manipulating the contents of the keys "cross_validation" and "cross_validation_aggregated", and we assume that the user is only working on one model so that it makes sense to compare different runs in a plot.

In example 3 of the docs we first perform cross-validation on a classification model, and then later on a regression model. Because of this, the aggregation process fails and the docs cannot be built.

This is a dirty, quick fix where we delete the contents of the keys "cross_validation" and "cross_validation_aggregated" before the regression example, to start fresh.

We are already planning more robust, automatic solutions to relax the "one-model" assumption: see
- https://github.com/probabl-ai/skore/issues/557
- https://github.com/probabl-ai/skore/issues/558
