### PR TITLE
ci: Ensure documentation can be built

### DIFF
--- a/.github/actions/sphinx/build/action.yml
+++ b/.github/actions/sphinx/build/action.yml
@@ -1,0 +1,12 @@
+name: Build sphinx documentation
+runs:
+  using: composite
+  steps:
+    - working-directory: skore
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install '.[sphinx]'
+    - working-directory: sphinx
+      shell: bash
+      run: make html

--- a/.github/actions/sphinx/deploy/action.yml
+++ b/.github/actions/sphinx/deploy/action.yml
@@ -1,0 +1,18 @@
+name: Deploy sphinx documentation
+permissions:
+  contents: write
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        rm -rf docs/latest
+        mv sphinx/build/html docs/latest
+    - shell: bash
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+        git add docs/latest
+        git commit -m 'docs: Build documentation triggered by ${{ github.sha }}'
+        git push

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,25 +1,26 @@
 name: Sphinx
 
 on:
+  pull_request:
+    paths:
+      - '.github/actions/sphinx/**'
+      - '.github/workflows/sphinx.yml'
+      - 'examples/**'
+      - 'sphinx/**'
+      - 'skore/**'
   push:
     branches:
       - main
     paths:
+      - '.github/actions/sphinx/**'
       - '.github/workflows/sphinx.yml'
       - 'examples/**'
-      - 'skore/**'
       - 'sphinx/**'
-
-permissions:
-  contents: write
+      - 'skore/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-defaults:
-  run:
-    shell: bash
 
 jobs:
   sphinx:
@@ -32,23 +33,6 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - name: Build
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install './skore[sphinx]'
-
-          ( \
-              cd sphinx; \
-              make html; \
-          )
-
-          rm -rf docs/latest
-          mv sphinx/build/html docs/latest
-      - name: Commit
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-
-          git add docs/latest
-          git commit -m 'docs: Build documentation triggered by ${{ github.sha }}'
-          git push
+      - uses: ./.github/actions/sphinx/build
+      - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: ./.github/actions/sphinx/deploy

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ sphinx/auto_examples/
 sphinx/generated/
 sphinx/sg_execution_times.rst
 examples/plot_*.png
+
+# Include excluded directories from github-actions
+!/.github/**/build/


### PR DESCRIPTION
Currently, a pull-request on `sphinx/` or `skore/` can break documentation building and be merged without notice.

---

![image](https://github.com/user-attachments/assets/66273013-e0a3-4309-a535-7b6998650658)
