### PR TITLE
ci: Skip checks after commits of `github-actions[bot]`

### DIFF
--- a/.github/actions/sphinx/deploy/action.yml
+++ b/.github/actions/sphinx/deploy/action.yml
@@ -12,7 +12,8 @@ runs:
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git config commit.cleanup 'verbatim'
 
         git add docs/latest
-        git commit -m 'docs: Build documentation triggered by ${{ github.sha }}'
+        git commit -m $'docs: Build documentation triggered by ${{ github.sha }}\n\n\nskip-checks:true'
         git push


### PR DESCRIPTION
Currently, the documentation bot push a new commit after building the documentation using a special token to sign commits.
It implies to re-run the CI for nothing with the latest changes https://github.com/probabl-ai/skore/pull/703.

---

The solution is to skip checks after commits of `github-actions[bot]`.