### PR TITLE
fix(ci): Make `lint-pr-title` run on PR `synchronize`

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -2,7 +2,7 @@ name: Lint PR title
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
This fixes a bug where the workflow was skipped when a new commit was pushed to a PR with an offending title.
