### PR TITLE
docs: Improve example using the temporary folder and cleaning

### DIFF
--- a/examples/plot_01_getting_started.py
+++ b/examples/plot_01_getting_started.py
@@ -18,19 +18,23 @@ Creating a skore project, loading it, and launching the UI
 """
 
 # %%
-# From your shell, initialize a skore project, here named ``my_project``:
-
-# %%
-import subprocess
+# We start by creating a temporary directory to store our project such that we can
+# easily clean it after executing this example. If you want to keep the project,
+# you have to skip this section.
 import tempfile
 from pathlib import Path
 
-# create a temporary directory that will be cleaned up automatically
-temp_dir = Path(tempfile.mkdtemp(prefix="skore_example_"))
+temp_dir = tempfile.TemporaryDirectory(prefix="skore_example_")
+temp_dir_path = Path(temp_dir.name)
 
+# %%
+# From your shell, initialize a skore project, here named ``my_project``:
+import subprocess
 
 # create the skore project
-subprocess.run(f"python3 -m skore create my_project --working-dir {temp_dir}".split())
+subprocess.run(
+    f"python3 -m skore create my_project --working-dir {temp_dir.name}".split()
+)
 
 # %%
 # This will create a skore project directory named ``my_project.skore`` in your
@@ -51,7 +55,7 @@ subprocess.run(f"python3 -m skore create my_project --working-dir {temp_dir}".sp
 # %%
 from skore import load
 
-my_project = load(temp_dir / "my_project.skore")
+my_project = load(temp_dir_path / "my_project.skore")
 my_project.put("my_int", 3)
 
 # %%
@@ -182,7 +186,4 @@ plt.show()
 # -------------------
 #
 # Remove the temporary directory:
-
-import shutil
-
-shutil.rmtree(temp_dir)
+temp_dir.cleanup()

--- a/examples/plot_02_overview_skore_ui.py
+++ b/examples/plot_02_overview_skore_ui.py
@@ -10,47 +10,38 @@ of items that you can store in a skore :class:`~skore.Project`.
 """
 
 # %%
-import altair as alt
-import io
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
-import plotly.express as px
-import PIL
-
-from sklearn.datasets import load_diabetes
-from sklearn.linear_model import Lasso
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import StandardScaler
-
-from skore import load
-from skore.item import MediaItem
-
-# %%
 # Creating and loading a skore project
 # ====================================
+#
+# We start by creating a temporary directory to store our project such that we can
+# easily clean it after executing this example. If you want to keep the project,
+# you have to skip this section.
+import tempfile
+from pathlib import Path
+
+temp_dir = tempfile.TemporaryDirectory(prefix="skore_example_")
+temp_dir_path = Path(temp_dir.name)
 
 # %%
 import subprocess
 
-# remove the skore project if it already exists
-subprocess.run("rm -rf my_project_ui.skore".split())
-
 # create the skore project
-subprocess.run("python3 -m skore create my_project_ui".split())
-
+subprocess.run(
+    f"python3 -m skore create my_project_ui --working-dir {temp_dir.name}".split()
+)
 
 # %%
 from skore import load
 
-my_project_ui = load("my_project_ui.skore")
+my_project_ui = load(temp_dir_path / "my_project_ui.skore")
 
 
 # %%
 # Storing integers
 # ================
 #
-# Now, let us store our first object using :func:`~skore.Project.put`, for example an integer:
+# Now, let us store our first object using :func:`~skore.Project.put`, for example an
+# integer:
 
 # %%
 my_project_ui.put("my_int", 3)
@@ -64,7 +55,8 @@ my_project_ui.put("my_int", 3)
 my_project_ui.get("my_int")
 
 # %%
-# Careful; like in a traditional Python dictionary, the ``put`` method will *overwrite* past data if you use a key which already exists!
+# Careful; like in a traditional Python dictionary, the ``put`` method will *overwrite*
+# past data if you use a key which already exists!
 
 # %%
 my_project_ui.put("my_int", 30_000)
@@ -76,7 +68,8 @@ my_project_ui.put("my_int", 30_000)
 my_project_ui.get("my_int")
 
 # %%
-# By using the :func:`~skore.Project.delete_item` method, you can also delete an object so that your skore UI does not become cluttered:
+# By using the :func:`~skore.Project.delete_item` method, you can also delete an object
+# so that your skore UI does not become cluttered:
 
 # %%
 my_project_ui.put("my_int_2", 10)
@@ -104,7 +97,9 @@ my_project_ui.put("my_string", "Hello world!")
 my_project_ui.get("my_string")
 
 # %%
-# :func:`~skore.Project.get` infers the type of the inserted object by default. For example, strings are assumed to be in Markdown format. Hence, you can customize the display of your text:
+# :func:`~skore.Project.get` infers the type of the inserted object by default. For
+# example, strings are assumed to be in Markdown format. Hence, you can customize the
+# display of your text:
 
 # %%
 my_project_ui.put(
@@ -121,18 +116,20 @@ def my_func(x):
 )
 
 # %%
-# Moreover, you can also explicitly tell skore the media type of an object, for example in HTML:
+# Moreover, you can also explicitly tell skore the media type of an object, for example
+# in HTML:
 
 # %%
+from skore.item import MediaItem
+
 my_project_ui.put_item(
     "my_string_3",
     MediaItem.factory(
-        "<p><h1>Title</h1> <b>bold</b>, <i>italic</i>, etc.</p>",
-        media_type="text/html"
+        "<p><h1>Title</h1> <b>bold</b>, <i>italic</i>, etc.</p>", media_type="text/html"
     ),
 )
 
-#%%
+# %%
 # .. note::
 #   We used :func:`~skore.Project.put_item` instead of :func:`~skore.Project.put`.
 
@@ -179,6 +176,8 @@ my_dict
 # Numpy array:
 
 # %%
+import numpy as np
+
 my_arr = np.random.randn(3, 3)
 my_project_ui.put("my_arr", my_arr)
 my_arr
@@ -187,6 +186,8 @@ my_arr
 # Pandas data frame:
 
 # %%
+import pandas as pd
+
 my_df = pd.DataFrame(np.random.randn(10, 5))
 my_project_ui.put("my_df", my_df)
 my_df.head()
@@ -195,12 +196,15 @@ my_df.head()
 # Storing data visualizations
 # ===========================
 #
-# Note that, in the dashboard, the interactivity of plots is supported, for example for Altair and Plotly.
+# Note that, in the dashboard, the interactivity of plots is supported, for example for
+# Altair and Plotly.
 
 # %%
 # Matplotlib figure:
 
 # %%
+import matplotlib.pyplot as plt
+
 x = np.linspace(0, 2, 100)
 
 fig, ax = plt.subplots(layout="constrained", dpi=200)
@@ -220,6 +224,8 @@ my_project_ui.put("my_figure", fig)
 # Altair chart:
 
 # %%
+import altair as alt
+
 num_points = 100
 df_plot = pd.DataFrame(
     {"x": np.random.randn(num_points), "y": np.random.randn(num_points)}
@@ -237,10 +243,11 @@ my_project_ui.put("my_altair_chart", my_altair_chart)
 
 # %%
 # .. note::
-#     For Plotly figures, some users reported the following error when running Plotly cells:
-#     ``ValueError: Mime type rendering requires nbformat>=4.2.0 but it is not installed``.
-#     This is a Plotly issue which is documented `here <https://github.com/plotly/plotly.py/issues/3285>`_;
-#     to solve it, we recommend installing nbformat in your environment, e.g. with:
+#     For Plotly figures, some users reported the following error when running Plotly
+#     cells: ``ValueError: Mime type rendering requires nbformat>=4.2.0 but it is not
+#     installed``. This is a Plotly issue which is documented `here
+#     <https://github.com/plotly/plotly.py/issues/3285>`_; to solve it, we recommend
+#     installing nbformat in your environment, e.g. with:
 #
 #     .. code-block:: console
 #
@@ -250,13 +257,11 @@ my_project_ui.put("my_altair_chart", my_altair_chart)
 # Plotly figure:
 
 # %%
+import plotly.express as px
+
 df = px.data.iris()
 fig = px.scatter(
-    df,
-    x=df.sepal_length,
-    y=df.sepal_width,
-    color=df.species,
-    size=df.petal_length
+    df, x=df.sepal_length, y=df.sepal_width, color=df.species, size=df.petal_length
 )
 
 my_project_ui.put("my_plotly_fig", fig)
@@ -287,6 +292,9 @@ my_project_ui.put("my_anim_plotly_fig", my_anim_plotly_fig)
 # PIL image:
 
 # %%
+import io
+import PIL
+
 my_pil_image = PIL.Image.new("RGB", (100, 100), color="red")
 with io.BytesIO() as output:
     my_pil_image.save(output, format="png")
@@ -297,11 +305,14 @@ my_project_ui.put("my_pil_image", my_pil_image)
 # Storing scikit-learn models and pipelines
 # =========================================
 #
-# As skore is developed by `Probabl <https://probabl.ai>`_, the spin-off of scikit-learn, skore treats scikit-learn models and pipelines as first-class citizens.
+# As skore is developed by `Probabl <https://probabl.ai>`_, the spin-off of
+# scikit-learn, skore treats scikit-learn models and pipelines as first-class citizens.
 #
 # First of all, you can store a scikit-learn model:
 
 # %%
+from sklearn.linear_model import Lasso
+
 my_model = Lasso(alpha=2)
 my_project_ui.put("my_model", my_model)
 my_model
@@ -310,6 +321,9 @@ my_model
 # You can also store scikit-learn pipelines:
 
 # %%
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
 my_pipeline = Pipeline(
     [("standard_scaler", StandardScaler()), ("lasso", Lasso(alpha=2))]
 )
@@ -320,6 +334,8 @@ my_pipeline
 # Moreover, you can store fitted scikit-learn pipelines:
 
 # %%
+from sklearn.datasets import load_diabetes
+
 diabetes = load_diabetes()
 X = diabetes.data[:150]
 y = diabetes.target[:150]
@@ -327,3 +343,10 @@ my_pipeline.fit(X, y)
 
 my_project_ui.put("my_fitted_pipeline", my_pipeline)
 my_pipeline
+
+# %%
+# Cleanup the project
+# -------------------
+#
+# Remove the temporary directory:
+temp_dir.cleanup()

--- a/examples/plot_03_cross_validate.py
+++ b/examples/plot_03_cross_validate.py
@@ -11,33 +11,31 @@ ML/DS projects.
 """
 
 # %%
-import subprocess
-
-import matplotlib.pyplot as plt
-import matplotlib.image as mpimg
-
-from sklearn import datasets, linear_model
-from sklearn import svm
-from sklearn.model_selection import cross_validate as sklearn_cross_validate
-
-import skore
-
-
-# %%
 # Creating and loading the skore project
 # ======================================
+#
+# We start by creating a temporary directory to store our project such that we can
+# easily clean it after executing this example. If you want to keep the project,
+# you have to skip this section.
+import tempfile
+from pathlib import Path
+
+temp_dir = tempfile.TemporaryDirectory(prefix="skore_example_")
+temp_dir_path = Path(temp_dir.name)
 
 # %%
-
-# remove the skore project if it already exists
-subprocess.run("rm -rf my_project_cv.skore".split())
+import subprocess
 
 # create the skore project
-subprocess.run("python3 -m skore create my_project_cv".split())
+subprocess.run(
+    f"python3 -m skore create my_project_cv --working-dir {temp_dir.name}".split()
+)
 
 
 # %%
-my_project_gs = skore.load("my_project_cv.skore")
+import skore
+
+my_project_gs = skore.load(temp_dir_path / "my_project_cv.skore")
 
 # %%
 # Cross-validation in scikit-learn
@@ -48,57 +46,66 @@ my_project_gs = skore.load("my_project_cv.skore")
 # * :func:`sklearn.model_selection.cross_val_score`
 # * :func:`sklearn.model_selection.cross_validate`
 #
-# Essentially, ``cross_val_score`` runs cross-validation for single metric
-# evaluation, while ``cross_validate`` runs cross-validation with multiple
-# metrics and can also return extra information such as train scores, fit times, and score times.
+# Essentially, :func:`sklearn.model_selection.cross_val_score` runs cross-validation for
+# single metric evaluation, while :func:`sklearn.model_selection.cross_validate` runs
+# cross-validation with multiple metrics and can also return extra information such as
+# train scores, fit times, and score times.
 #
-# Hence, in skore, we are more interested in the ``cross_validate`` function as
-# it allows to do more than the historical ``cross_val_score``.
+# Hence, in skore, we are more interested in the
+# :func:`sklearn.model_selection.cross_validate` function as it allows to do
+# more than the historical :func:`sklearn.model_selection.cross_val_score`.
 #
 # Let us illustrate cross-validation on a multi-class classification task.
 
 # %%
-X, y = datasets.load_iris(return_X_y=True)
-clf = svm.SVC(kernel="linear", C=1, random_state=0)
+from sklearn.datasets import load_iris
+from sklearn.svm import SVC
+
+X, y = load_iris(return_X_y=True)
+clf = SVC(kernel="linear", C=1, random_state=0)
 
 # %%
-# Single metric evaluation using ``cross_validate``:
+# Single metric evaluation using :func:`sklearn.model_selection.cross_validate`:
 
 # %%
+from sklearn.model_selection import cross_validate as sklearn_cross_validate
+
 cv_results = sklearn_cross_validate(clf, X, y, cv=5)
-cv_results["test_score"]
+print(f"test_score: {cv_results['test_score']}")
 
 # %%
-# Multiple metric evaluation using ``cross_validate``:
+# Multiple metric evaluation using :func:`sklearn.model_selection.cross_validate`:
 
 # %%
-scores = sklearn_cross_validate(
+import pandas as pd
+
+cv_results = sklearn_cross_validate(
     clf,
     X,
     y,
     cv=5,
     scoring=["accuracy", "precision_macro"],
 )
-print(scores["test_accuracy"])
-print(scores["test_precision_macro"])
+test_scores = pd.DataFrame(cv_results)[["test_accuracy", "test_precision_macro"]]
+test_scores
 
 # %%
 # In scikit-learn, why do we recommend using ``cross_validate`` over ``cross_val_score``?
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Here, for the :class:`~sklearn.svm.SVC`,
-# the default score is the accuracy.
+# Here, for the :class:`~sklearn.svm.SVC`, the default score is the accuracy.
 # If the users want other scores to better understand their model such as the
 # precision and the recall, they can specify it which is very convenient.
-# Otherwise, they would have to run several ``cross_val_score`` with different
-# ``scoring`` parameters each time, which leads to more unnecessary compute.
+# Otherwise, they would have to run several
+# :func:`sklearn.model_selection.cross_val_score` with different ``scoring``
+# parameters each time, which leads to more unnecessary compute.
 #
 # Why do we recommend using skore's ``cross_validate`` over scikit-learn's?
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # In the example above, what if the users ran scikit-learn's
-# ``cross_validate`` but forgot to manually add a crucial score for their use
-# case such as the recall?
+# :func:`sklearn.model_selection.cross_validate` but forgot to manually add a
+# crucial score for their use case such as the recall?
 # They would have to re-run the whole cross-validation experiment by adding this
 # crucial score, which leads to more compute.
 
@@ -132,6 +139,9 @@ fig_plotly_clf
 #   Plotly graphs to display properly.
 
 # %%
+import matplotlib.image as mpimg
+import matplotlib.pyplot as plt
+
 fig_plotly_clf.write_image("plot_03_cross_validate_clf.png", scale=4)
 
 img = mpimg.imread("plot_03_cross_validate_clf.png")
@@ -142,17 +152,22 @@ plt.show()
 
 # %%
 # |
-# Skore's ``cross_validate`` advantages are the following:
+# Skore's :func:`~skore.cross_validate` advantages are the following:
 #
-# * By default, it computes several useful scores without the need for the user to manually specify them. For classification, you can observe that it computed the accuracy, the precision, and the recall.
+# * By default, it computes several useful scores without the need for the user to
+#   manually specify them. For classification, you can observe that it computed the
+#   accuracy, the precision, and the recall.
 #
-# * You automatically get some interactive Plotly graphs to better understand how your model behaves depending on the split. For example:
+# * You automatically get some interactive Plotly graphs to better understand how your
+#   model behaves depending on the split. For example:
 #
 #   * You can compare the fitting and scoring times together for each split.
 #
-#   * You can compare the accuracy, precision, and recall scores together for each split.
+#   * You can compare the accuracy, precision, and recall scores together for each
+#     split.
 #
-# * The results and plots are automatically saved in your skore project, so that you can visualize them later in the UI for example.
+# * The results and plots are automatically saved in your skore project, so that you can
+#   visualize them later in the UI for example.
 
 # %%
 # Regression task
@@ -175,12 +190,22 @@ my_project_gs.delete_item("cross_validation_aggregated")
 #   automatically.
 
 # %%
-diabetes = datasets.load_diabetes()
+from sklearn.datasets import load_diabetes
+from sklearn.linear_model import Lasso
+
+diabetes = load_diabetes()
 X = diabetes.data[:150]
 y = diabetes.target[:150]
-lasso = linear_model.Lasso()
+lasso = Lasso()
 
 cv_results = skore.cross_validate(lasso, X, y, cv=5, project=my_project_gs)
 
 fig_plotly_reg = my_project_gs.get_item("cross_validation").plot
 fig_plotly_reg
+
+# %%
+# Cleanup the project
+# -------------------
+#
+# Remove the temporary directory:
+temp_dir.cleanup()


### PR DESCRIPTION
Proposes a couple of enhancement in the documentation.

- I reuse the pattern proposed by @adrinjalali. We discussed this morning IRL, and using the high-level API of the class seems better that the low-level functions.
- I move the import close to their first use because it is more intuitive when reading a notebook.
- Wrapping the line to have 88 characters in the description (so does it mean that linters are not run on those files?)
- I added links to the documentation instead of plain double back ticks when it makes sense.