### PR TITLE
docs(fix): Force plotly figure resizing after HTML/CSS layout loading

### DIFF
--- a/examples/plot_01_getting_started.py
+++ b/examples/plot_01_getting_started.py
@@ -142,25 +142,7 @@ from skore import cross_validate
 cv_results = cross_validate(Ridge(), X, y, cv=5, project=my_project)
 
 fig_plotly = my_project.get_item("cross_validation").plot
-
-# %%
-# .. note::
-#   Because Plotly graphs currently do not properly render in our Sphinx
-#   auto-examples docs engine due to
-#   `a bug in Plotly <https://github.com/plotly/plotly.py/issues/4828>`_,
-#   we display its static image below.
-
-# %%
-import matplotlib.pyplot as plt
-import matplotlib.image as mpimg
-
-fig_plotly.write_image("plot_01_cross_validation.png", scale=4)
-
-img = mpimg.imread("plot_01_cross_validation.png")
-fig, ax = plt.subplots(layout="constrained", dpi=200)
-ax.axis("off")
-ax.imshow(img)
-plt.show()
+fig_plotly
 
 # %%
 # Manipulating the skore UI

--- a/examples/plot_03_cross_validate.py
+++ b/examples/plot_03_cross_validate.py
@@ -130,27 +130,6 @@ fig_plotly_clf = my_project_gs.get_item("cross_validation").plot
 fig_plotly_clf
 
 # %%
-# .. note::
-#   Because Plotly graphs currently do not properly render in our Sphinx
-#   auto-examples docs engine due to
-#   `a bug in Plotly <https://github.com/plotly/plotly.py/issues/4828>`_,
-#   we also display its static image below.
-#   Alternatively, we recommend zooming in / out in your browser window for the
-#   Plotly graphs to display properly.
-
-# %%
-import matplotlib.image as mpimg
-import matplotlib.pyplot as plt
-
-fig_plotly_clf.write_image("plot_03_cross_validate_clf.png", scale=4)
-
-img = mpimg.imread("plot_03_cross_validate_clf.png")
-fig, ax = plt.subplots(layout="constrained", dpi=200)
-ax.axis("off")
-ax.imshow(img)
-plt.show()
-
-# %%
 # |
 # Skore's :func:`~skore.cross_validate` advantages are the following:
 #

--- a/sphinx/_static/js/sg_plotly_resize.js
+++ b/sphinx/_static/js/sg_plotly_resize.js
@@ -1,0 +1,15 @@
+function resizePlotlyGraphs() {
+    // Find all plotly graph divs
+    const plotlyDivs = document.getElementsByClassName("plotly-graph-div");
+
+    // Iterate through each div and resize
+    for (const div of plotlyDivs) {
+        Plotly.Plots.resize(div);
+    }
+}
+
+// Call resize when window is resized
+window.addEventListener("resize", resizePlotlyGraphs);
+
+// Initial resize call after plots are created
+document.addEventListener("DOMContentLoaded", resizePlotlyGraphs);

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -39,7 +39,9 @@ html_static_path = ["_static"]
 html_css_files = [
     "css/custom.css",
 ]
-html_js_files = []
+html_js_files = [
+    "js/sg_plotly_resize.js",
+]
 
 # sphinx_gallery options
 sphinx_gallery_conf = {


### PR DESCRIPTION
This should fix the issue observed on the documentation page.
It forces to resize the plotly figures once everything is loaded (and mainly the right sidebar).

Right now the bug is that the image is loaded and adapted before that the right sidebar is toggled (I think).

It feels like a hack but the rendering is better and our users should not see so much the difference since the figure are not shown as the first element of the page.

@rouk1 you might have a better understanding than me regarding all those JS stuff. So if this hack makes you think of the "right" way of fixing it, this could be cool.