### PR TITLE
feat: Cross-validation reporter with accessors

### DIFF
--- a/examples/plot_04_alternative_cross_validate.py
+++ b/examples/plot_04_alternative_cross_validate.py
@@ -1,3 +1,11 @@
+"""
+==========================================================================
+Using a reporting class with accessors to display cross-validation results
+==========================================================================
+
+Just an example.
+"""
+
 # %%
 import tempfile
 from pathlib import Path
@@ -28,6 +36,8 @@ cv_results = cross_validate(
     classifier, X, y, return_estimator=True, return_indices=True
 )
 reporter = CrossValidationReporter(cv_results, X, y)
+
+# %%
 reporter.plot.roc(backend="plotly")
 
 # %%
@@ -51,6 +61,12 @@ reporter._cache  # stuff are still cached
 
 # %%
 reporter._hash
+
+# %%
+reporter.metrics.accuracy()
+
+# %%
+reporter.metrics.precision(positive_class=1)
 
 # %%
 # Cleanup the project

--- a/examples/plot_04_alternative_cross_validate.py
+++ b/examples/plot_04_alternative_cross_validate.py
@@ -31,6 +31,9 @@ reporter = CrossValidationReporter(cv_results, X, y)
 reporter.plot.roc(backend="plotly")
 
 # %%
+reporter.plot.roc(backend="matplotlib")
+
+# %%
 # I probably would like to do the following:
 # project.put("reporter", reporter)
 
@@ -44,6 +47,16 @@ reporter = joblib.load(temp_dir_path / "reporter.joblib")
 reporter.plot.roc(backend="plotly")
 
 # %%
-reporter._cache
+reporter._cache  # stuff are still cached
+
+# %%
+reporter._hash
+
+# %%
+# Cleanup the project
+# -------------------
+#
+# Remove the temporary directory:
+temp_dir.cleanup()
 
 # %%

--- a/examples/plot_04_alternative_cross_validate.py
+++ b/examples/plot_04_alternative_cross_validate.py
@@ -1,0 +1,49 @@
+# %%
+import tempfile
+from pathlib import Path
+
+temp_dir = tempfile.TemporaryDirectory(prefix="skore_example_")
+temp_dir_path = Path(temp_dir.name)
+
+# %%
+import subprocess
+
+subprocess.run(f"python3 -m skore create project --working-dir {temp_dir.name}".split())
+
+# %%
+import skore
+
+project = skore.load(temp_dir_path / "project.skore")
+
+# %%
+from sklearn import datasets, linear_model
+from sklearn.model_selection import cross_validate
+from skore.sklearn import CrossValidationReporter
+
+X, y = datasets.make_classification(
+    n_samples=1_000, n_features=20, class_sep=0.5, random_state=42
+)
+classifier = linear_model.LogisticRegression(max_iter=1_000)
+cv_results = cross_validate(
+    classifier, X, y, return_estimator=True, return_indices=True
+)
+reporter = CrossValidationReporter(cv_results, X, y)
+reporter.plot.roc(backend="plotly")
+
+# %%
+# I probably would like to do the following:
+# project.put("reporter", reporter)
+
+# %%
+import joblib
+
+joblib.dump(reporter, temp_dir_path / "reporter.joblib")
+
+# %%
+reporter = joblib.load(temp_dir_path / "reporter.joblib")
+reporter.plot.roc(backend="plotly")
+
+# %%
+reporter._cache
+
+# %%

--- a/examples/plot_04_alternative_cross_validate.py
+++ b/examples/plot_04_alternative_cross_validate.py
@@ -29,7 +29,12 @@ from sklearn.model_selection import cross_validate
 from skore.sklearn import CrossValidationReporter
 
 X, y = datasets.make_classification(
-    n_samples=1_000, n_features=20, class_sep=0.5, random_state=42
+    n_samples=1_000,
+    n_features=20,
+    class_sep=0.5,
+    n_classes=2,
+    n_clusters_per_class=1,
+    random_state=42,
 )
 classifier = linear_model.LogisticRegression(max_iter=1_000)
 cv_results = cross_validate(
@@ -38,10 +43,11 @@ cv_results = cross_validate(
 reporter = CrossValidationReporter(cv_results, X, y)
 
 # %%
-reporter.plot.roc(backend="plotly")
+fig = reporter.plot.roc(backend="plotly")
+fig
 
 # %%
-reporter.plot.roc(backend="matplotlib")
+fig = reporter.plot.roc(backend="matplotlib")
 
 # %%
 # I probably would like to do the following:
@@ -54,7 +60,8 @@ joblib.dump(reporter, temp_dir_path / "reporter.joblib")
 
 # %%
 reporter = joblib.load(temp_dir_path / "reporter.joblib")
-reporter.plot.roc(backend="plotly")
+fig = reporter.plot.roc(backend="plotly")
+fig
 
 # %%
 reporter._cache  # stuff are still cached
@@ -66,7 +73,14 @@ reporter._hash
 reporter.metrics.accuracy()
 
 # %%
-reporter.metrics.precision(positive_class=1)
+reporter.metrics.precision(average="binary")
+
+# %%
+reporter.metrics.recall(average=None)
+
+# %%
+reporter.metrics.report_stats()
+
 
 # %%
 # Cleanup the project

--- a/skore/src/skore/sklearn/__init__.py
+++ b/skore/src/skore/sklearn/__init__.py
@@ -1,7 +1,8 @@
 """Enhance `sklearn` functions."""
 
-from skore.sklearn.cross_validate import cross_validate
+from skore.sklearn.cross_validate import CrossValidationReporter, cross_validate
 
 __all__ = [
     "cross_validate",
+    "CrossValidationReporter",
 ]

--- a/skore/src/skore/sklearn/_plot.py
+++ b/skore/src/skore/sklearn/_plot.py
@@ -1,0 +1,135 @@
+import inspect
+
+from sklearn.metrics import RocCurveDisplay
+
+
+def _despine_matplotlib_axis(ax):
+    for s in ["top", "right"]:
+        ax.spines[s].set_visible(False)
+    for s in ["bottom", "left"]:
+        ax.spines[s].set_bounds(0, 1)
+
+
+class RocCurveDisplay(RocCurveDisplay):
+    def _plot_matplotlib(
+        self,
+        ax=None,
+        *,
+        name=None,
+        plot_chance_level=False,
+        chance_level_kw=None,
+        despine=False,
+        **kwargs,
+    ):
+        # only in scikit-learn >= 1.6+
+        parent_plot = super().plot
+        plot_params = inspect.signature(parent_plot).parameters
+        plot_kwargs = {
+            "ax": ax,
+            "name": name,
+            "plot_chance_level": plot_chance_level,
+            "chance_level_kw": chance_level_kw,
+            **kwargs,
+        }
+
+        if "despine" in plot_params:
+            plot_kwargs["despine"] = despine
+            super().plot(**plot_kwargs)
+        else:
+            super().plot(**plot_kwargs)
+            if despine:
+                _despine_matplotlib_axis(self.ax_)
+
+        return self
+
+    def _plot_plotly(
+        self,
+        ax=None,
+        *,
+        name=None,
+        plot_chance_level=False,
+        chance_level_kw=None,
+        despine=False,
+        **kwargs,
+    ):
+        import plotly.graph_objects as go
+
+        fig = go.Figure() if ax is None else ax
+
+        # Add ROC curve trace
+        name_str = ""
+        if self.roc_auc is not None and name is not None:
+            name_str = f"{name} (AUC = {self.roc_auc:0.2f})"
+        elif self.roc_auc is not None:
+            name_str = f"AUC = {self.roc_auc:0.2f}"
+        elif name is not None:
+            name_str = name
+
+        fig.add_trace(
+            go.Scatter(x=self.fpr, y=self.tpr, name=name_str, mode="lines", **kwargs)
+        )
+
+        if plot_chance_level:
+            chance_level_kwargs = {
+                "name": "Chance level (AUC = 0.5)",
+                "line": {"color": "black", "dash": "dash"},
+            }
+            if chance_level_kw is not None:
+                chance_level_kwargs.update(chance_level_kw)
+
+            fig.add_trace(
+                go.Scatter(x=[0, 1], y=[0, 1], mode="lines", **chance_level_kwargs)
+            )
+
+        info_pos_label = (
+            f" (Positive label: {self.pos_label})" if self.pos_label is not None else ""
+        )
+
+        fig.update_layout(
+            xaxis_title=f"False Positive Rate{info_pos_label}",
+            yaxis_title=f"True Positive Rate{info_pos_label}",
+            xaxis=dict(range=[-0.01, 1.01]),
+            yaxis=dict(range=[-0.01, 1.01]),
+            showlegend=True,
+            legend=dict(x=1, y=0, xanchor="right", yanchor="bottom"),
+            width=600,
+            height=600,
+        )
+
+        self.ax_ = fig
+        self.figure_ = fig
+        return self
+
+    def plot(
+        self,
+        ax=None,
+        *,
+        name=None,
+        plot_chance_level=False,
+        chance_level_kw=None,
+        despine=False,
+        backend="matplotlib",
+        **kwargs,
+    ):
+        if backend == "matplotlib":
+            return self._plot_matplotlib(
+                ax=ax,
+                name=name,
+                plot_chance_level=plot_chance_level,
+                chance_level_kw=chance_level_kw,
+                despine=despine,
+                **kwargs,
+            )
+        elif backend == "plotly":
+            return self._plot_plotly(
+                ax=ax,
+                name=name,
+                plot_chance_level=plot_chance_level,
+                chance_level_kw=chance_level_kw,
+                despine=despine,
+                **kwargs,
+            )
+        else:
+            raise ValueError(f"Backend '{backend}' is not supported.")
+
+        return self

--- a/skore/src/skore/sklearn/_plot.py
+++ b/skore/src/skore/sklearn/_plot.py
@@ -1,5 +1,3 @@
-import inspect
-
 from sklearn.metrics import RocCurveDisplay
 
 
@@ -21,24 +19,14 @@ class RocCurveDisplay(RocCurveDisplay):
         despine=False,
         **kwargs,
     ):
-        # only in scikit-learn >= 1.6+
-        parent_plot = super().plot
-        plot_params = inspect.signature(parent_plot).parameters
-        plot_kwargs = {
-            "ax": ax,
-            "name": name,
-            "plot_chance_level": plot_chance_level,
-            "chance_level_kw": chance_level_kw,
-            **kwargs,
-        }
-
-        if "despine" in plot_params:
-            plot_kwargs["despine"] = despine
-            super().plot(**plot_kwargs)
-        else:
-            super().plot(**plot_kwargs)
-            if despine:
-                _despine_matplotlib_axis(self.ax_)
+        super().plot(
+            ax=ax,
+            name=name,
+            plot_chance_level=plot_chance_level,
+            chance_level_kw=chance_level_kw,
+        )
+        if despine:
+            _despine_matplotlib_axis(self.ax_)
 
         return self
 
@@ -131,5 +119,3 @@ class RocCurveDisplay(RocCurveDisplay):
             )
         else:
             raise ValueError(f"Backend '{backend}' is not supported.")
-
-        return self

--- a/skore/src/skore/sklearn/cross_validate.py
+++ b/skore/src/skore/sklearn/cross_validate.py
@@ -601,7 +601,12 @@ class _MetricsAccessor:
                 pos_label=pos_label,
             )
 
-            cache_key = (hash, pos_label, metric_name)
+            cache_key = (hash, metric_name)
+            metric_params = inspect.signature(metric_fn).parameters
+            if "pos_label" in metric_params:
+                cache_key += (pos_label,)
+            if "average" in metric_params:
+                cache_key += (metric_kwargs["average"],)
 
             if cache_key in self._parent._cache:
                 score = self._parent._cache[cache_key]

--- a/skore/tests/integration/test_cross_validate.py
+++ b/skore/tests/integration/test_cross_validate.py
@@ -14,6 +14,7 @@ from skore.item.cross_validation_item import (
     CrossValidationItem,
     plot_cross_validation,
 )
+from skore.sklearn import CrossValidationReporter
 
 
 @pytest.fixture
@@ -170,3 +171,26 @@ def test_aggregated_cross_validation(rf, in_memory_project):
         in_memory_project.item_repository.get_item("cross_validation_aggregated"),
         CrossValidationAggregationItem,
     )
+
+
+@pytest.mark.parametrize(
+    "cv_results, error_msg",
+    [
+        (
+            {},
+            "keys \\['estimator', 'indices'\\] are required"
+            ".*return_estimator=True, return_indices=True",
+        ),
+        (
+            {"estimator": [None, None]},
+            "keys \\['indices'\\] are required.*return_indices=True",
+        ),
+        (
+            {"indices": [None, None]},
+            "keys \\['estimator'\\] are required.*return_estimator=True",
+        ),
+    ],
+)
+def test_cross_validation_reporter_missing_keys(cv_results, error_msg):
+    with pytest.raises(RuntimeError, match=error_msg):
+        CrossValidationReporter(cv_results, None)


### PR DESCRIPTION
I give some thoughts to https://github.com/probabl-ai/skore/issues/731.

I wanted to see if I could come with an API that I would be happy with.

So here, this is a class implementing aggressive caching to avoid recomputation in line with the idea of the current `cross_validate`. Actually, it can go further because, we could make it work with custom scorer/metric where we would not require to recompute the model predictions if already in the cache.

In terms of API, I went on the pandas side with accessors. I find it quite need to extend upon the current scikit-learn display or metrics. In terms of feature, none of the current scikit-learn displays offer visualization for cross-validation. I implemented a dirty trick to show that we could go quite fast from today without the need to wait too much on the scikit-learn side. Once ready in scikit-learn, we could of course leverage the proposed design there.

Also, I used the `available_if` trick to expose methods that are only relevant with the estimators and target provided. If trying to access something not compatible, it will raise and explained why this is not supported.

So at this stage, there is no test and far to be the cleaner code ever but it allows to have discussion in terms of design and additional features.