### PR TITLE
feat: Add `HighClassImbalanceTooFewExamples` warning to `train_test_split`

### DIFF
--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -9,7 +9,7 @@ from numpy.random import RandomState
 
 from skore.project import Project
 from skore.sklearn.find_ml_task import _find_ml_task
-from skore.sklearn.train_test_split.warning.high_class_imbalance_warning import (
+from skore.sklearn.train_test_split.warning import (
     HighClassImbalanceWarning,
 )
 

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+import numpy as np
 from numpy.random import RandomState
 
 from skore.project import Project
 from skore.sklearn.find_ml_task import _find_ml_task
 from skore.sklearn.train_test_split.warning import (
+    HighClassImbalanceTooFewExamplesWarning,
     HighClassImbalanceWarning,
 )
 
@@ -132,6 +134,8 @@ def train_test_split(
 
     if y is None and len(arrays) >= 2:
         y = arrays[-1]
+        y_labels = np.unique(y)
+        y_test = output[-1]
 
     ml_task = _find_ml_task(y)
 
@@ -143,10 +147,15 @@ def train_test_split(
         shuffle=shuffle,
         stratify=stratify,
         y=y,
+        y_test=y_test,
+        y_labels=y_labels,
         ml_task=ml_task,
     )
 
-    for warning_class in [HighClassImbalanceWarning]:
+    for warning_class in [
+        HighClassImbalanceWarning,
+        HighClassImbalanceTooFewExamplesWarning,
+    ]:
         check = warning_class.check(**kwargs)
 
         if check is False:

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -132,6 +132,8 @@ def train_test_split(
         stratify=stratify,
     )
 
+    y_labels = None
+    y_test = None
     if y is None and len(arrays) >= 2:
         y = arrays[-1]
         y_labels = np.unique(y)

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -10,10 +10,7 @@ from numpy.random import RandomState
 
 from skore.project import Project
 from skore.sklearn.find_ml_task import _find_ml_task
-from skore.sklearn.train_test_split.warning import (
-    HighClassImbalanceTooFewExamplesWarning,
-    HighClassImbalanceWarning,
-)
+from skore.sklearn.train_test_split.warning import TRAIN_TEST_SPLIT_WARNINGS
 
 if TYPE_CHECKING:
     ArrayLike = Any
@@ -154,10 +151,7 @@ def train_test_split(
         ml_task=ml_task,
     )
 
-    for warning_class in [
-        HighClassImbalanceWarning,
-        HighClassImbalanceTooFewExamplesWarning,
-    ]:
+    for warning_class in TRAIN_TEST_SPLIT_WARNINGS:
         check = warning_class.check(**kwargs)
 
         if check is False:

--- a/skore/src/skore/sklearn/train_test_split/warning/__init__.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/__init__.py
@@ -11,7 +11,13 @@ from .high_class_imbalance_warning import (
     HighClassImbalanceWarning,
 )
 
+TRAIN_TEST_SPLIT_WARNINGS = [
+    HighClassImbalanceTooFewExamplesWarning,
+    HighClassImbalanceWarning,
+]
+
 __all__ = [
+    "TRAIN_TEST_SPLIT_WARNINGS",
     HighClassImbalanceTooFewExamplesWarning.__name__,
     HighClassImbalanceWarning.__name__,
 ]

--- a/skore/src/skore/sklearn/train_test_split/warning/__init__.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/__init__.py
@@ -4,10 +4,14 @@ This module implements the warnings that can be reported to the user when using
 `train_test_split`.
 """
 
+from .high_class_imbalance_too_few_examples_warning import (
+    HighClassImbalanceTooFewExamplesWarning,
+)
 from .high_class_imbalance_warning import (
     HighClassImbalanceWarning,
 )
 
 __all__ = [
+    HighClassImbalanceTooFewExamplesWarning.__name__,
     HighClassImbalanceWarning.__name__,
 ]

--- a/skore/src/skore/sklearn/train_test_split/warning/__init__.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/__init__.py
@@ -18,6 +18,6 @@ TRAIN_TEST_SPLIT_WARNINGS = [
 
 __all__ = [
     "TRAIN_TEST_SPLIT_WARNINGS",
-    HighClassImbalanceTooFewExamplesWarning.__name__,
-    HighClassImbalanceWarning.__name__,
+    "HighClassImbalanceTooFewExamplesWarning",
+    "HighClassImbalanceWarning",
 ]

--- a/skore/src/skore/sklearn/train_test_split/warning/__init__.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/__init__.py
@@ -3,3 +3,11 @@
 This module implements the warnings that can be reported to the user when using
 `train_test_split`.
 """
+
+from .high_class_imbalance_warning import (
+    HighClassImbalanceWarning,
+)
+
+__all__ = [
+    HighClassImbalanceWarning.__name__,
+]

--- a/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
@@ -1,0 +1,79 @@
+""""High class imbalance (too few examples) warning.
+
+This warning is shown when some class in a dataset has too few examples in the test set.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Any, Optional
+
+from skore.sklearn.train_test_split.warning.train_test_split_warning import (
+    TrainTestSplitWarning,
+)
+
+if TYPE_CHECKING:
+    from skore.sklearn.cross_validate import MLTask
+
+    ArrayLike = Any
+
+
+class HighClassImbalanceTooFewExamplesWarning(TrainTestSplitWarning):
+    """Check whether the test set has too few examples in one class."""
+
+    MSG = (
+        "It seems that you have a classification problem with at least one class with "
+        "fewer than 100 examples in the test set. In this case, using train_test_split "
+        "may not be a good idea because of high variability in the scores obtained on "
+        "the test set. We suggest three options to tackle this challenge: you can "
+        "increase test_size, collect more data, or use skore's cross_validate function."
+    )
+
+    @staticmethod
+    def check(
+        y_test: Optional[ArrayLike],
+        stratify: Optional[ArrayLike],
+        y_labels: Optional[ArrayLike],
+        ml_task: MLTask,
+        **kwargs,
+    ) -> bool:
+        """Check whether the test set has too few examples in one class.
+
+        More precisely, we check whether some class in `y_labels` has
+        fewer than 100 examples in `y_test`.
+        The other arguments are needed to see if the check is relevant. For
+        example, if `y_test` is used for a regression task, then the check should
+        be skipped.
+
+        Parameters
+        ----------
+        y_test : array-like or None
+            A 1-dimensional target vector, as a list, numpy array, scipy sparse array,
+            or pandas dataframe.
+        stratify : array-like or None
+            An 1-dimensional target array to be used for stratification.
+        y_labels: array-like or None
+            A 1-dimensional array containing the class labels
+            (e.g. [0, 1] if the task is binary classification),
+            if the task is classification.
+            This is needed in the case where `y_test` contains zero examples
+            for some class.
+        ml_task : MLTask
+            The type of machine-learning tasks being performed.
+
+        Returns
+        -------
+        bool
+            True if the check passed, False otherwise.
+        """
+        if (
+            stratify
+            or (y_test is None or len(y_test) == 0)
+            or (y_labels is None or len(y_test) == 0)
+            or ("classification" not in ml_task)
+        ):
+            return True
+
+        counts = Counter(y_test)
+
+        return all(counts.get(class_, 0) >= 100 for class_ in y_labels)

--- a/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
@@ -69,7 +69,7 @@ class HighClassImbalanceTooFewExamplesWarning(TrainTestSplitWarning):
         if (
             stratify
             or (y_test is None or len(y_test) == 0)
-            or (y_labels is None or len(y_test) == 0)
+            or (y_labels is None or len(y_labels) == 0)
             or ("classification" not in ml_task)
         ):
             return True

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -10,21 +10,33 @@ from skore.sklearn.train_test_split.warning import (
 )
 
 
-def test_train_test_split_warns():
+def case_high_class_imbalance():
+    args = ([[1]] * 4, [0, 1, 1, 1])
+    kwargs = {}
+    return args, kwargs, HighClassImbalanceWarning
+
+
+def case_high_class_imbalance_too_few_examples():
+    args = ([[1]] * 4, [0, 1, 1, 1])
+    kwargs = {}
+    return args, kwargs, HighClassImbalanceTooFewExamplesWarning
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        case_high_class_imbalance,
+        case_high_class_imbalance_too_few_examples,
+    ],
+)
+def test_train_test_split_warns(params):
+    """When train_test_split is called with these args and kwargs, the corresponding
+    warning should fire."""
     warnings.simplefilter("ignore")
+    args, kwargs, warning_cls = params()
 
-    with pytest.warns(HighClassImbalanceWarning, match=HighClassImbalanceWarning.MSG):
-        train_test_split([[1]] * 4, [0, 1, 1, 1])
-
-
-def test_train_test_split_too_few_examples_warns():
-    warnings.simplefilter("ignore")
-
-    with pytest.warns(
-        HighClassImbalanceTooFewExamplesWarning,
-        match=HighClassImbalanceTooFewExamplesWarning.MSG,
-    ):
-        train_test_split([[1]] * 4, [0, 1, 1, 1])
+    with pytest.warns(warning_cls):
+        train_test_split(*args, **kwargs)
 
 
 def test_train_test_split_no_y():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -10,6 +10,18 @@ from skore.sklearn.train_test_split.warning import (
 )
 
 
+def test_check_high_class_imbalance_too_few_examples():
+    y_test = [0] * 100
+    y_labels = [0, 1]
+    check_passed = HighClassImbalanceTooFewExamplesWarning.check(
+        y_test=y_test,
+        y_labels=y_labels,
+        stratify=None,
+        ml_task="multiclass-classification",
+    )
+
+    assert not check_passed
+
 
 def test_train_test_split_warns():
     with pytest.warns(HighClassImbalanceWarning, match=HighClassImbalanceWarning.MSG):

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -10,19 +10,6 @@ from skore.sklearn.train_test_split.warning import (
 )
 
 
-def test_check_high_class_imbalance_too_few_examples():
-    y_test = [0] * 100
-    y_labels = [0, 1]
-    check_passed = HighClassImbalanceTooFewExamplesWarning.check(
-        y_test=y_test,
-        y_labels=y_labels,
-        stratify=None,
-        ml_task="multiclass-classification",
-    )
-
-    assert not check_passed
-
-
 def test_train_test_split_warns():
     with pytest.warns(HighClassImbalanceWarning, match=HighClassImbalanceWarning.MSG):
         train_test_split([[1]] * 4, [0, 1, 1, 1])

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -53,3 +53,16 @@ def test_train_test_split_no_warn():
     warnings.simplefilter("error")
 
     train_test_split([[1]] * 2000, [0] * 1000 + [1] * 1000, random_state=0)
+
+
+def test_train_test_split_kwargs():
+    """Passing data by keyword arguments should produce the same results as passing
+    them by position."""
+    warnings.simplefilter("ignore")
+
+    X = [[1]] * 20
+    y = [0] * 10 + [1] * 10
+    output1 = train_test_split(X, y, random_state=0)
+    output2 = train_test_split(X=X, y=y, random_state=0)
+
+    assert output1 == output2

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -1,32 +1,14 @@
 import contextlib
 
-import numpy
-import pandas
 import pytest
 from skore.sklearn.train_test_split.train_test_split import (
-    HighClassImbalanceWarning,
     train_test_split,
 )
-
-target = [0] * 100 + [1] * 100 + [2] * 300
-
-
-@pytest.mark.parametrize(
-    "y",
-    [
-        pytest.param(target, id="list"),
-        pytest.param(pandas.Series(target), id="pandas-series"),
-        pytest.param(numpy.array(target), id="numpy"),
-    ],
+from skore.sklearn.train_test_split.warning import (
+    HighClassImbalanceTooFewExamplesWarning,
+    HighClassImbalanceWarning,
 )
-def test_check_high_class_imbalance(y):
-    check = HighClassImbalanceWarning.check(
-        y=y,
-        stratify=None,
-        ml_task="multiclass-classification",
-    )
 
-    assert check is False
 
 
 def test_train_test_split_warns():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -1,4 +1,3 @@
-import contextlib
 import warnings
 
 import pytest
@@ -31,12 +30,14 @@ def test_train_test_split_too_few_examples_warns():
 def test_train_test_split_no_y():
     """When calling `train_test_split` with one array argument,
     this array is assumed to be `X` and not `y`."""
-    with contextlib.nullcontext():
-        train_test_split([[1]] * 4)
+    warnings.simplefilter("error")
+
+    # Since the array is `X` and we do no checks on it, this should produce no
+    # warning
+    train_test_split([[1]] * 4)
 
 
 def test_train_test_split_no_warn():
     warnings.simplefilter("error")
 
-    with contextlib.nullcontext():
-        train_test_split([[1]] * 2000, [0] * 1000 + [1] * 1000, random_state=0)
+    train_test_split([[1]] * 2000, [0] * 1000 + [1] * 1000, random_state=0)

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -20,6 +20,7 @@ def test_train_test_split_warns():
 
 def test_train_test_split_too_few_examples_warns():
     warnings.simplefilter("ignore")
+
     with pytest.warns(
         HighClassImbalanceTooFewExamplesWarning,
         match=HighClassImbalanceTooFewExamplesWarning.MSG,

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -15,6 +15,14 @@ def test_train_test_split_warns():
         train_test_split([[1]] * 4, [0, 1, 1, 1])
 
 
+def test_train_test_split_too_few_examples_warns():
+    with pytest.warns(
+        HighClassImbalanceTooFewExamplesWarning,
+        match=HighClassImbalanceTooFewExamplesWarning.MSG,
+    ):
+        train_test_split([[1]] * 4, [0, 1, 1, 1])
+
+
 def test_train_test_split_no_y():
     """When calling `train_test_split` with one array argument,
     this array is assumed to be `X` and not `y`."""

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -1,4 +1,5 @@
 import contextlib
+import warnings
 
 import pytest
 from skore.sklearn.train_test_split.train_test_split import (
@@ -11,11 +12,14 @@ from skore.sklearn.train_test_split.warning import (
 
 
 def test_train_test_split_warns():
+    warnings.simplefilter("ignore")
+
     with pytest.warns(HighClassImbalanceWarning, match=HighClassImbalanceWarning.MSG):
         train_test_split([[1]] * 4, [0, 1, 1, 1])
 
 
 def test_train_test_split_too_few_examples_warns():
+    warnings.simplefilter("ignore")
     with pytest.warns(
         HighClassImbalanceTooFewExamplesWarning,
         match=HighClassImbalanceTooFewExamplesWarning.MSG,
@@ -31,5 +35,7 @@ def test_train_test_split_no_y():
 
 
 def test_train_test_split_no_warn():
+    warnings.simplefilter("error")
+
     with contextlib.nullcontext():
-        train_test_split([[1]] * 4, [0, 0, 1, 1])
+        train_test_split([[1]] * 2000, [0] * 1000 + [1] * 1000, random_state=0)

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_too_few_examples_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_too_few_examples_warning.py
@@ -1,0 +1,17 @@
+from skore.sklearn.train_test_split.warning import (
+    HighClassImbalanceTooFewExamplesWarning,
+)
+
+
+def test_check_high_class_imbalance_too_few_examples():
+    y_test = [0] * 100
+    y_labels = [0, 1]
+
+    check_passed = HighClassImbalanceTooFewExamplesWarning.check(
+        y_test=y_test,
+        y_labels=y_labels,
+        stratify=None,
+        ml_task="multiclass-classification",
+    )
+
+    assert not check_passed

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_warning.py
@@ -1,0 +1,26 @@
+import numpy
+import pandas
+import pytest
+from skore.sklearn.train_test_split.warning import (
+    HighClassImbalanceWarning,
+)
+
+target = [0] * 100 + [1] * 100 + [2] * 300
+
+
+@pytest.mark.parametrize(
+    "y",
+    [
+        pytest.param(target, id="list"),
+        pytest.param(pandas.Series(target), id="pandas-series"),
+        pytest.param(numpy.array(target), id="numpy"),
+    ],
+)
+def test_check_high_class_imbalance(y):
+    check = HighClassImbalanceWarning.check(
+        y=y,
+        stratify=None,
+        ml_task="multiclass-classification",
+    )
+
+    assert check is False


### PR DESCRIPTION
- Export train_test_split warnings through `train_test_split.warning` module
- refactor tests to mirror src
- Add new warning

Would welcome suggestions for a shorter name ^^' 

Addresses #684 