### PR TITLE
fix(docs): Add an example for `skore.train_test_split`

### DIFF
--- a/examples/plot_03_cross_validate.py
+++ b/examples/plot_03_cross_validate.py
@@ -122,7 +122,6 @@ fig_plotly_clf = my_project.get_item("cross_validation").plot
 fig_plotly_clf
 
 # %%
-# |
 # Skore's :func:`~skore.cross_validate` advantages are the following:
 #
 # * By default, it computes several useful scores without the need for the user to

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -35,17 +35,143 @@ my_project = skore.create("my_project.skore", working_dir=temp_dir_path)
 #
 # Scikit-learn holds a function for splitting the data into a training and a testing
 # sets: :func:`sklearn.model_selection.train_test_split`.
-
+# Its signature is the following:
+#
+# .. code-block:: python
+#
+#     sklearn.model_selection.train_test_split(*arrays, test_size=None, train_size=None, random_state=None, shuffle=True, stratify=None)
+#
+# where ``*arrays`` is a Python *args (it allows you to pass a varying number of
+# positional arguments) and the scikit-learn doc indicates that it is ``a sequence of
+# indexables with same length / shape[0]``.
 
 # %%
-from skore import train_test_split
+# Let us construct a design matrix ``X`` and target ``y`` to illustrate our point:
 
+# %%
 import numpy as np
 
 X, y = np.arange(10).reshape((5, 2)), range(5)
+print(X, y)
 
-# Drop-in replacement for sklearn train_test_split
-X_train, X_test, y_train, y_test = train_test_split(
-    X, y, test_size=0.33, random_state=42
+# %%
+# In scikit-learn, the most common usage is the following:
+
+# %%
+from sklearn.model_selection import train_test_split as sklearn_train_test_split
+
+X_train, X_test, y_train, y_test = sklearn_train_test_split(
+    X, y, test_size=0.2, random_state=0
 )
-X_train
+print(X_train, y_train)
+print(X_test, y_test)
+
+# %%
+# Notice the shuffling that is done by default.
+
+# %%
+# In scikit-learn, the user can not explicitly set the design matrix ``X`` and
+# the target ``y``. The following:
+#
+# .. code-block:: python
+#
+#   X_train, X_test, y_train, y_test = sklearn_train_test_split(
+#       X=X, y=y, test_size=0.2, random_state=0)
+#
+# would return:
+#
+# .. code-block:: python
+#
+#   TypeError: got an unexpected keyword argument 'X'
+#
+# In general, in Python, positional arguments are useful to prevent typos such as:
+
+# %%
+X_train, X_test, y_train, y_test = sklearn_train_test_split(
+    y, X, test_size=0.2, random_state=0
+)
+
+# %%
+# where ``y`` and ``X`` are inverted in the arguments and no warning is returned.
+# This is where skore comes in handy.
+
+# %%
+# Train-test split in skore
+# =========================
+
+# %%
+# skore has its own :func:`skore.train_test_split` that wraps scikit-learn's
+# :func:`sklearn.model_selection.train_test_split`.
+
+# %%
+# Expliciting the positional arguments for ``X`` and ``y``
+# --------------------------------------------------------
+
+# %%
+# First of all, naturally, it can be used as a simple drop-in replacement for sklearn:
+
+# %%
+X_train, X_test, y_train, y_test = skore.train_test_split(
+    X, y, test_size=0.2, random_state=0
+)
+print(X_train, y_train)
+print(X_test, y_test)
+
+# %%
+# .. note::
+#
+#   The outputs of :func:`skore.train_test_split` are intentionally exactly the same as
+#   :func:`sklearn.model_selection.train_test_split`, so the user can just use the
+#   skore version as a drop-in replacement of scikit-learn.
+
+# %%
+# It allows users to explicit ``X`` and ``y``, making detection of issues easier:
+
+# %%
+X_train, X_test, y_train, y_test = skore.train_test_split(
+    X=X, y=y, test_size=0.2, random_state=0
+)
+print(X_train, y_train)
+print(X_test, y_test)
+
+# %%
+# Moreover, when passing ``X`` and ``y`` explicitly, ``X`` is always returned before
+# ``y``, even when they are inverted:
+
+# %%
+arr = np.arange(10).reshape((5, 2))
+arr_train, arr_test, X_train, X_test, y_train, y_test = skore.train_test_split(
+    arr, y=y, X=X, test_size=0.2, random_state=0
+)
+print(X_train, y_train)
+print(X_test, y_test)
+
+# %%
+# Automatic diagnostics: raising methodological warnings
+# ------------------------------------------------------
+#
+# In machine learning, class-imbalance (the classes in a dataset are not equally
+# represented) requires a specific modelling.
+# For example, in a dataset with 95% majority class and 5% minority class, a model that
+# always predicts the majority class will have a 95% accuracy, while it would be
+# useless for identifying the minority class.
+# Hence, it is important to detect when we have class-imbalance.
+#
+# Suppose that we have imbalanced data :
+
+# %%
+X = [[1]] * 4
+y = [0, 1, 1, 1]
+
+# %%
+# In that case, :func:`skore.train_test_split` raises a warning telling the user that
+# there is class imbalance:
+
+# %%
+X_train, X_test, y_train, y_test = skore.train_test_split(
+    X=X, y=y, test_size=0.2, random_state=0
+)
+
+# %%
+# Hence, skore recommends the users to take into account this class-imbalance, that
+# they might have missed, in their modelling strategy.

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -59,7 +59,8 @@ my_project = skore.create("my_project.skore", working_dir=temp_dir_path)
 import numpy as np
 
 X, y = np.arange(10).reshape((5, 2)), range(5)
-print(X, y)
+print(X)
+print(y)
 
 # %%
 # In scikit-learn, the most common usage is the following:

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -165,7 +165,7 @@ print(X_test, y_test)
 #
 # In machine learning, class-imbalance (the classes in a dataset are not equally
 # represented) requires a specific modelling.
-# For example, in a dataset with 95% majority class and 5% minority class, a model that
+# For example, in a dataset with 95% majority class and 5% minority class, a dummy model that
 # always predicts the majority class will have a 95% accuracy, while it would be
 # useless for identifying the minority class.
 # Hence, it is important to detect when we have class-imbalance.

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -33,7 +33,7 @@ my_project = skore.create("my_project.skore", working_dir=temp_dir_path)
 # Train-test split in scikit-learn
 # ================================
 #
-# Scikit-learn holds a function for splitting the data into a training and a testing
+# Scikit-learn has a function for splitting the data into train and test
 # sets: :func:`sklearn.model_selection.train_test_split`.
 # Its signature is the following:
 #

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -39,7 +39,14 @@ my_project = skore.create("my_project.skore", working_dir=temp_dir_path)
 #
 # .. code-block:: python
 #
-#     sklearn.model_selection.train_test_split(*arrays, test_size=None, train_size=None, random_state=None, shuffle=True, stratify=None)
+#     sklearn.model_selection.train_test_split(
+#         *arrays,
+#         test_size=None,
+#         train_size=None,
+#         random_state=None,
+#         shuffle=True,
+#         stratify=None
+#     )
 #
 # where ``*arrays`` is a Python *args (it allows you to pass a varying number of
 # positional arguments) and the scikit-learn doc indicates that it is ``a sequence of

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -1,0 +1,51 @@
+"""
+.. _example_train_test_split:
+
+==========================
+Enhancing train-test split
+==========================
+
+This example illustrates the motivation and the use of skore's
+:func:`skore.train_test_split` to get assistance when developing your
+ML/DS projects.
+"""
+
+# %%
+# Creating and loading the skore project
+# ======================================
+#
+# We start by creating a temporary directory to store our project such that we can
+# easily clean it after executing this example. If you want to keep the project, you
+# have to skip this section.
+
+# %%
+import tempfile
+from pathlib import Path
+
+import skore
+
+temp_dir = tempfile.TemporaryDirectory(prefix="skore_example_")
+temp_dir_path = Path(temp_dir.name)
+
+my_project = skore.create("my_project.skore", working_dir=temp_dir_path)
+
+# %%
+# Train-test split in scikit-learn
+# ================================
+#
+# Scikit-learn holds a function for splitting the data into a training and a testing
+# sets: :func:`sklearn.model_selection.train_test_split`.
+
+
+# %%
+from skore import train_test_split
+
+import numpy as np
+
+X, y = np.arange(10).reshape((5, 2)), range(5)
+
+# Drop-in replacement for sklearn train_test_split
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.33, random_state=42
+)
+X_train

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -71,8 +71,11 @@ from sklearn.model_selection import train_test_split as sklearn_train_test_split
 X_train, X_test, y_train, y_test = sklearn_train_test_split(
     X, y, test_size=0.2, random_state=0
 )
-print(X_train, y_train)
-print(X_test, y_test)
+print(X_train)
+print(y_train)
+
+print(X_test)
+print(y_test)
 
 # %%
 # Notice the shuffling that is done by default.

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -103,7 +103,7 @@ X_train, X_test, y_train, y_test = sklearn_train_test_split(
 )
 
 # %%
-# where ``y`` and ``X`` are inverted in the arguments and no warning is returned.
+# but Python will not catch this mistake for us.
 # This is where skore comes in handy.
 
 # %%

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -81,7 +81,7 @@ print(y_test)
 # Notice the shuffling that is done by default.
 
 # %%
-# In scikit-learn, the user can not explicitly set the design matrix ``X`` and
+# In scikit-learn, the user cannot explicitly set the design matrix ``X`` and
 # the target ``y``. The following:
 #
 # .. code-block:: python

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -108,7 +108,8 @@ X_train, X_test, y_train, y_test = sklearn_train_test_split(
 # --------------------------------------------------------
 
 # %%
-# First of all, naturally, it can be used as a simple drop-in replacement for sklearn:
+# First of all, naturally, it can be used as a simple drop-in replacement for
+# scikit-learn:
 
 # %%
 X_train, X_test, y_train, y_test = skore.train_test_split(
@@ -125,7 +126,8 @@ print(X_test, y_test)
 #   skore version as a drop-in replacement of scikit-learn.
 
 # %%
-# It allows users to explicit ``X`` and ``y``, making detection of issues easier:
+# Contrary to scikit-learn, skore allows users to explicit the``X`` and ``y``, making
+# detection of eventual issues easier:
 
 # %%
 X_train, X_test, y_train, y_test = skore.train_test_split(
@@ -135,8 +137,8 @@ print(X_train, y_train)
 print(X_test, y_test)
 
 # %%
-# Moreover, when passing ``X`` and ``y`` explicitly, ``X`` is always returned before
-# ``y``, even when they are inverted:
+# Moreover, when passing ``X`` and ``y`` explicitly, the ``X``'s are always returned
+# before the ``y``'s, even when they are inverted:
 
 # %%
 arr = np.arange(10).reshape((5, 2))
@@ -175,3 +177,4 @@ X_train, X_test, y_train, y_test = skore.train_test_split(
 # %%
 # Hence, skore recommends the users to take into account this class-imbalance, that
 # they might have missed, in their modelling strategy.
+# skore provides methodological checks.

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -95,7 +95,7 @@ print(y_test)
 #
 #   TypeError: got an unexpected keyword argument 'X'
 #
-# In general, in Python, positional arguments are useful to prevent typos such as:
+# In general, in Python, keyword arguments are useful to prevent typos. For example, in the following, ``X`` and ``y`` are reversed:
 
 # %%
 X_train, X_test, y_train, y_test = sklearn_train_test_split(

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -166,7 +166,7 @@ print(X_test, y_test)
 # In machine learning, class-imbalance (the classes in a dataset are not equally
 # represented) requires a specific modelling.
 # For example, in a dataset with 95% majority class and 5% minority class, a dummy model that
-# always predicts the majority class will have a 95% accuracy, while it would be
+# always predicts "class 1" will have a 95% accuracy, while it would be
 # useless for identifying the minority class.
 # Hence, it is important to detect when we have class-imbalance.
 #

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -59,8 +59,7 @@ my_project = skore.create("my_project.skore", working_dir=temp_dir_path)
 import numpy as np
 
 X, y = np.arange(10).reshape((5, 2)), range(5)
-print(X)
-print(y)
+print(X, "\n", y)
 
 # %%
 # In scikit-learn, the most common usage is the following:
@@ -71,11 +70,7 @@ from sklearn.model_selection import train_test_split as sklearn_train_test_split
 X_train, X_test, y_train, y_test = sklearn_train_test_split(
     X, y, test_size=0.2, random_state=0
 )
-print(X_train)
-print(y_train)
-
-print(X_test)
-print(y_test)
+print(X_train, "\n", y_train, "\n", X_test, "\n", y_test)
 
 # %%
 # Notice the shuffling that is done by default.
@@ -126,8 +121,7 @@ X_train, X_test, y_train, y_test = sklearn_train_test_split(
 X_train, X_test, y_train, y_test = skore.train_test_split(
     X, y, test_size=0.2, random_state=0
 )
-print(X_train, y_train)
-print(X_test, y_test)
+print(X_train, "\n", y_train, "\n", X_test, "\n", y_test)
 
 # %%
 # .. note::
@@ -137,15 +131,14 @@ print(X_test, y_test)
 #   skore version as a drop-in replacement of scikit-learn.
 
 # %%
-# Contrary to scikit-learn, skore allows users to explicit the``X`` and ``y``, making
+# Contrary to scikit-learn, skore allows users to explicit the ``X`` and ``y``, making
 # detection of eventual issues easier:
 
 # %%
 X_train, X_test, y_train, y_test = skore.train_test_split(
     X=X, y=y, test_size=0.2, random_state=0
 )
-print(X_train, y_train)
-print(X_test, y_test)
+print(X_train, "\n", y_train, "\n", X_test, "\n", y_test)
 
 # %%
 # Moreover, when passing ``X`` and ``y`` explicitly, the ``X``'s are always returned
@@ -156,8 +149,7 @@ arr = np.arange(10).reshape((5, 2))
 arr_train, arr_test, X_train, X_test, y_train, y_test = skore.train_test_split(
     arr, y=y, X=X, test_size=0.2, random_state=0
 )
-print(X_train, y_train)
-print(X_test, y_test)
+print(X_train, "\n", y_train, "\n", X_test, "\n", y_test)
 
 # %%
 # Automatic diagnostics: raising methodological warnings

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -165,9 +165,9 @@ print(X_test, y_test)
 #
 # In machine learning, class-imbalance (the classes in a dataset are not equally
 # represented) requires a specific modelling.
-# For example, in a dataset with 95% majority class and 5% minority class, a dummy model that
-# always predicts "class 1" will have a 95% accuracy, while it would be
-# useless for identifying examples of class 0.
+# For example, in a dataset with 95% majority class (class ``1``) and 5% minority class
+# (class ``0``), a dummy model that always predicts class ``1`` will have a 95%
+# accuracy, while it would be useless for identifying examples of class ``0``.
 # Hence, it is important to detect when we have class-imbalance.
 #
 # Suppose that we have imbalanced data :

--- a/examples/plot_05_train_test_split.py
+++ b/examples/plot_05_train_test_split.py
@@ -167,7 +167,7 @@ print(X_test, y_test)
 # represented) requires a specific modelling.
 # For example, in a dataset with 95% majority class and 5% minority class, a dummy model that
 # always predicts "class 1" will have a 95% accuracy, while it would be
-# useless for identifying the minority class.
+# useless for identifying examples of class 0.
 # Hence, it is important to detect when we have class-imbalance.
 #
 # Suppose that we have imbalanced data :

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -30,13 +30,16 @@ def train_test_split(
 ):
     """Perform train-test-split of data.
 
-    This is a wrapper over scikit-learn's `train_test_split https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html`_
-    helper function, enriching it with various warnings that can be saved in a Project.
+    This is a wrapper over scikit-learn's
+    :func:`sklearn.model_selection.train_test_split` helper function,
+    enriching it with various warnings that can be saved in a skore Project.
 
-    The signature is fully compatible with sklearn's `train_test_split`, and
+    The signature is fully compatible with sklearn's ``train_test_split``, and
     some keyword arguments are added to make the detection of issues more accurate.
-    For instance, argument `y` has been added to pass the target explicitly, which
+    For instance, argument ``y`` has been added to pass the target explicitly, which
     makes it easier to detect issues with the target.
+
+    See the :ref:`example_train_test_split` example.
 
     Parameters
     ----------
@@ -47,7 +50,7 @@ def train_test_split(
         If not None, will be appended to the list of arrays passed positionally.
     y : array-like, optional
         If not None, will be appended to the list of arrays passed positionally, after
-        `X`. If None, it is assumed that the last array in `arrays` is `y`.
+        ``X``. If None, it is assumed that the last array in ``arrays`` is ``y``.
     test_size : float or int, optional
         If float, should be between 0.0 and 1.0 and represent the proportion of
         the dataset to include in the test split. If int, represents the absolute number
@@ -75,17 +78,17 @@ def train_test_split(
     splitting : list
         List containing train-test split of inputs.
         The length of the list is twice the number of arrays passed, including
-        the X and y keyword arguments. If arrays are passed positionally as well
-        as through X and y, the output arrays are ordered as follows: first the
-        arrays passed positionally, in the order they were passed, then X if it
-        was passed, then y if it was passed.
+        the ``X`` and ``y`` keyword arguments. If arrays are passed positionally as well
+        as through ``X`` and ``y``, the output arrays are ordered as follows: first the
+        arrays passed positionally, in the order they were passed, then ``X`` if it
+        was passed, then ``y`` if it was passed.
 
     Examples
     --------
     >>> import numpy as np
     >>> X, y = np.arange(10).reshape((5, 2)), range(5)
 
-    # Drop-in replacement for sklearn train_test_split
+    >>> # Drop-in replacement for sklearn train_test_split
     >>> X_train, X_test, y_train, y_test = train_test_split(X, y,
     ...     test_size=0.33, random_state=42)
     >>> X_train
@@ -93,7 +96,7 @@ def train_test_split(
            [0, 1],
            [6, 7]])
 
-    # Explicit X and y, makes detection of problems easier
+    >>> # Explicit X and y, makes detection of problems easier
     >>> X_train, X_test, y_train, y_test = train_test_split(X=X, y=y,
     ...     test_size=0.33, random_state=42)
     >>> X_train
@@ -101,7 +104,7 @@ def train_test_split(
            [0, 1],
            [6, 7]])
 
-    # When passing X and y explicitly, X is returned before y
+    >>> # When passing X and y explicitly, X is returned before y
     >>> arr = np.arange(10).reshape((5, 2))
     >>> arr_train, arr_test, X_train, X_test, y_train, y_test = train_test_split(
     ...     arr, y=y, X=X, test_size=0.33, random_state=42)

--- a/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_warning.py
@@ -25,7 +25,7 @@ class HighClassImbalanceWarning(TrainTestSplitWarning):
     MSG = (
         "It seems that you have a classification problem with a high class "
         "imbalance. In this "
-        "case, using train_test_split may not be a good idea because of high  "
+        "case, using train_test_split may not be a good idea because of high "
         "variability in the scores obtained on the test set. "
         "To tackle this challenge we suggest to use skore's "
         "cross_validate function."

--- a/sphinx/api.rst
+++ b/sphinx/api.rst
@@ -37,3 +37,4 @@ These functions and classes enhance scikit-learn's ones.
     :nosignatures:
 
     cross_validate
+    train_test_split

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -9,7 +9,7 @@ With skore, data scientists can:
 #. Track and visualize their ML/DS results.
 #. Get assistance when developing their ML/DS projects.
 
-   - Scikit-learn compatible :func:`~skore.cross_validate` provides insights and checks on cross-validation.
+   - Scikit-learn compatible :func:`skore.cross_validate` and :func:`skore.train_test_split` provide insights and checks on cross-validation and train-test-split.
 
 These are only the initial features: skore is a work in progress and aims to be
 an end-to-end library for data scientists.


### PR DESCRIPTION
Fix #771