### PR TITLE
[no ci]POC: use perspective as a datafram viewer

### DIFF
--- a/skore-ui/package-lock.json
+++ b/skore-ui/package-lock.json
@@ -8,6 +8,10 @@
       "name": "skore-ui",
       "version": "0.0.0",
       "dependencies": {
+        "@finos/perspective": "^3.1.6",
+        "@finos/perspective-viewer": "^3.1.6",
+        "@finos/perspective-viewer-d3fc": "^3.1.6",
+        "@finos/perspective-viewer-datagrid": "^3.1.6",
         "@floating-ui/vue": "^1.1.5",
         "@vscode/markdown-it-katex": "^1.1.0",
         "date-fns": "^3.6.0",
@@ -807,6 +811,248 @@
         "postcss-selector-parser": "^6.1.0"
       }
     },
+    "node_modules/@d3fc/d3fc-annotation": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-annotation/-/d3fc-annotation-3.0.16.tgz",
+      "integrity": "sha512-4tA7RHLUbj/i3KqWRqCVDOHi435qBRXbAFrAajVYM2juNzFdX5RCoF3opyXKOFncs339caxgeySGStTVfulO9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-data-join": "^6.0.3",
+        "@d3fc/d3fc-rebind": "^6.0.1",
+        "@d3fc/d3fc-series": "^6.1.3",
+        "@d3fc/d3fc-shape": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-scale": "*",
+        "d3-selection": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-axis": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-axis/-/d3fc-axis-3.0.7.tgz",
+      "integrity": "sha512-S4pILxkQUkD7WQmimWxIEHfXUYEonlXWuWvMP6iq3KXL3d+cj4flvwNqLYZvSVaQDdK990cKkjrK/ZAKnReGlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-data-join": "^6.0.3",
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-scale": "*",
+        "d3-selection": "*",
+        "d3-shape": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-brush": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-brush/-/d3fc-brush-3.0.3.tgz",
+      "integrity": "sha512-fc1XBuNWl6DQVFSnBdauI/WNRvtNaeUWwDiLEIMY+v0VlrmGOgWEGCB5otVepGZiL56cjgRtHdwYBdKCvgGBSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-data-join": "^6.0.3",
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-brush": "*",
+        "d3-dispatch": "*",
+        "d3-scale": "*",
+        "d3-selection": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-chart": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-chart/-/d3fc-chart-5.1.9.tgz",
+      "integrity": "sha512-xFO9lDUi2wAkjfyWlVZuFwSWEgnk0WOEagR2R9KzQ+uxeg3oZOPzwE+AZbpALyQbjjQ2uIxcOk56xnmnnayk3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-axis": "^3.0.7",
+        "@d3fc/d3fc-data-join": "^6.0.3",
+        "@d3fc/d3fc-element": "^6.2.0",
+        "@d3fc/d3fc-rebind": "^6.0.1",
+        "@d3fc/d3fc-series": "^6.1.3"
+      },
+      "peerDependencies": {
+        "d3-scale": "*",
+        "d3-selection": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-data-join": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-data-join/-/d3fc-data-join-6.0.3.tgz",
+      "integrity": "sha512-fd1D2Cl4YGjzl3gBhcrvTl/VxaSncY0ZcokWsN8ahtmk9DZK4DnAgHGrdecnXVLkOx+ANDcqxqscYz6MWXLbcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "d3-selection": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-discontinuous-scale": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-discontinuous-scale/-/d3fc-discontinuous-scale-4.1.1.tgz",
+      "integrity": "sha512-cyhtq4XPtK8RCSBtzctRAl4RkDyYJqJY0SJpi3QcfJz/OX9iB6At7UjITO7tAmJ7RUHb/xZvAVpJU8BM5gaQqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-scale": "*",
+        "d3-time": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-element": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-element/-/d3fc-element-6.2.0.tgz",
+      "integrity": "sha512-AvdZ3V4mVxF9dGYLiDCoqr3GhrFOUQEc1FcP20QEhQ3fJ3qYRwx7/uhL7G/L2xbe6k4delPgnLOvtoaDenhpZw==",
+      "license": "MIT"
+    },
+    "node_modules/@d3fc/d3fc-extent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-extent/-/d3fc-extent-4.0.2.tgz",
+      "integrity": "sha512-m7w7Dof6KAIDtgzIsTcprWTEoiqExJGsGoQbb97bF+EwIkuEZWRUl1jkoeNL00efpX1o6zSdqSr6lojoR0aI/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "d3-array": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-financial-feed": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-financial-feed/-/d3fc-financial-feed-7.1.0.tgz",
+      "integrity": "sha512-K8jktdRJQAiJepglErsuY2ZMKsm0YFWTeuhYnTFb8rWmyhwoPeem9QW+e6xBTiAvbElJm4yTrkal09KmO2cLlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "d3-fetch": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-group": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-group/-/d3fc-group-3.0.1.tgz",
+      "integrity": "sha512-GBUR6a4hkqfSo77iaFS4qPMS5tupH8hmJ8eniiD45GFmWQs69+Dlf8Uhx+GCCvQkE+px6rQyZWVCJKBq6gkz2Q==",
+      "license": "MIT"
+    },
+    "node_modules/@d3fc/d3fc-label-layout": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-label-layout/-/d3fc-label-layout-7.0.4.tgz",
+      "integrity": "sha512-4CCyOx6uQA/Eq1VHnNy9dpI5QE2sDd1EP4W0Nw2rwnhFtlQqv37V38b9y5zT4YcdFrEgJqSB81fXIt3ZK1yxSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-data-join": "^6.0.3",
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-array": "*",
+        "d3-scale": "*",
+        "d3-selection": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-pointer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-pointer/-/d3fc-pointer-3.0.3.tgz",
+      "integrity": "sha512-hXY7LqliDEJBH/do4YZusdLoikLYlWoN7efPC7YKYJ8igoEQFa48BqEHcANLs1qH+r7vzL2SS8V39MzgnJ1yQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-dispatch": "*",
+        "d3-selection": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-random-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-random-data/-/d3fc-random-data-4.0.2.tgz",
+      "integrity": "sha512-T7+PbG1n23jyVMOWIuHJjY12PhPcYeRShuF0MK0ohifcNmwslurFMQKLBWkZk4x19In6JX7lNR0lwsaUUrcZNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-random": "*",
+        "d3-time": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-rebind": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-rebind/-/d3fc-rebind-6.0.1.tgz",
+      "integrity": "sha512-+ryBZ53ALMffbADwnFAtTYQJcT7PE5BwpducGYS0X6Jux6ESnp+fP+cDQvBGbDBOVqaziGnfeLeJXjtMnZujmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@d3fc/d3fc-sample": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-sample/-/d3fc-sample-5.0.2.tgz",
+      "integrity": "sha512-+ZJu+TOL4MFzFvAYc+QqDKude9DS7x4uK+133vCknAlSxL/l8Sh6ecWFXTSaC8tqHGywT7SK1arf0DiYCyS3Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-array": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-series": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-series/-/d3fc-series-6.1.3.tgz",
+      "integrity": "sha512-OSbt60SohTIib1xihX9ufneyJY7s9Feg9hvXVyEBZEBkwNE1NaeesZJ4nkmslu39RWuwsvpK3apL/XuBw7i5WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-data-join": "^6.0.3",
+        "@d3fc/d3fc-rebind": "^6.0.1",
+        "@d3fc/d3fc-shape": "^6.0.1",
+        "@d3fc/d3fc-webgl": "^3.2.1"
+      },
+      "peerDependencies": {
+        "d3-array": "*",
+        "d3-scale": "*",
+        "d3-scale-chromatic": "*",
+        "d3-selection": "*",
+        "d3-shape": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-shape": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-shape/-/d3fc-shape-6.0.1.tgz",
+      "integrity": "sha512-/dD3S8BWrOjO2mSptUmwe38V7KG4Kw6liIE5NXZJjX/XidfZhuDu7WWuya3i90HeNYDZNcs6Z+4qM3FnvlZf8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "d3-path": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-technical-indicator": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-technical-indicator/-/d3fc-technical-indicator-8.1.1.tgz",
+      "integrity": "sha512-ci5q+/4jCbbnT9M/JnrsBoHJfNJI4HFeCGVT+sy221OTdaFnrLj+IELFKFUS2h0uEOSu+CYT3D1K0BcAnMooxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-array": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-webgl": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-webgl/-/d3fc-webgl-3.2.1.tgz",
+      "integrity": "sha512-yNYHW/tC05rrJs5fpVM5zdmInL8NH6UP09ZJ2tmKw62ELYHWySV8vuXOVZN3V/3WihPa60p2w23H0Hrp2b5qeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-scale": "*",
+        "d3-shape": "*"
+      }
+    },
+    "node_modules/@d3fc/d3fc-zoom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@d3fc/d3fc-zoom/-/d3fc-zoom-1.2.0.tgz",
+      "integrity": "sha512-NfY6gPfcatw1gUtZoWq17SA7LV00t7Rl3eq6Bgj17++7K1H77Gpsb1hFa3XhzF85RrODuUzQW33/IIMYPgim9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-rebind": "^6.0.1"
+      },
+      "peerDependencies": {
+        "d3-dispatch": "*",
+        "d3-selection": "*",
+        "d3-zoom": "*"
+      }
+    },
     "node_modules/@dual-bundle/import-meta-resolve": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
@@ -1261,6 +1507,54 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@finos/perspective": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@finos/perspective/-/perspective-3.1.6.tgz",
+      "integrity": "sha512-NBU+tBO85j0m0ZFi+ty1ugVFq4ez8b0DOSvAwIGz7P/Lf+cWf6vrP28UETEj+GvPS3DMmngmTf8A4atcmWs/4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "stoppable": "^1.1.0",
+        "ws": "^8.17.0"
+      }
+    },
+    "node_modules/@finos/perspective-viewer": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer/-/perspective-viewer-3.1.6.tgz",
+      "integrity": "sha512-/uguUY/8b55CvI+xjjQLPlBlTlPJCerggD1KP+Da5+BwPxrF4PazyXrQi844cKt40nwYTfYIjC+URO/3BZJ0Kg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@finos/perspective": "^3.1.6"
+      }
+    },
+    "node_modules/@finos/perspective-viewer-d3fc": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-d3fc/-/perspective-viewer-d3fc-3.1.6.tgz",
+      "integrity": "sha512-Dvt7Br1/mMl5yiAx9aewrbH2bJIdlsxwbmj6w5rv91CqybtiG4cChk2FkKRZCvx4masoRhHtn63BSnf3kQxbvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@finos/perspective": "^3.1.6",
+        "@finos/perspective-viewer": "^3.1.6",
+        "chroma-js": "^1.3.4",
+        "d3": "^7.8.0",
+        "d3-array": "^3.2.1",
+        "d3-selection": "^3.0.0",
+        "d3-svg-legend": "^2.25.6",
+        "d3fc": "^15.2.4",
+        "gradient-parser": "1.0.2"
+      }
+    },
+    "node_modules/@finos/perspective-viewer-datagrid": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-datagrid/-/perspective-viewer-datagrid-3.1.6.tgz",
+      "integrity": "sha512-E1QEVvP39XZMnXkP4rlu0lRxAgHaj3mwZs9PeNKgke+3dOGpsJkQmmwPxq60Au2FKPmpJxFS3qEq0w5v9iFHYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@finos/perspective": "^3.1.6",
+        "@finos/perspective-viewer": "^3.1.6",
+        "chroma-js": "^1.3.4",
+        "regular-table": "=0.6.4"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1862,6 +2156,12 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
       "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
       "dev": true
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.0.10.tgz",
+      "integrity": "sha512-mHICSFHpIwgTycsvgINYCwItk039eofbGRzVNdeUUtv0S2BD1vXFFUKaeMJN3ARbVl+hlsVOIwdzhzub5tjr6Q==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -3061,6 +3361,11 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chroma-js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-1.4.1.tgz",
+      "integrity": "sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ=="
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3303,11 +3608,51 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "peer": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -3315,11 +3660,65 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3328,7 +3727,6 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "peer": true,
       "dependencies": {
         "delaunator": "5"
       },
@@ -3340,7 +3738,19 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3349,7 +3759,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
       "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "peer": true,
       "dependencies": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -3374,16 +3783,35 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "peer": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
       "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -3397,7 +3825,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3406,7 +3833,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
       "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "peer": true,
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -3448,7 +3874,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3457,7 +3882,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -3469,7 +3893,15 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -3478,7 +3910,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -3487,7 +3927,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "peer": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -3503,7 +3942,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -3512,11 +3950,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "peer": true,
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -3524,11 +3970,120 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-svg-legend": {
+      "version": "2.25.6",
+      "resolved": "https://registry.npmjs.org/d3-svg-legend/-/d3-svg-legend-2.25.6.tgz",
+      "integrity": "sha512-6dueSjQr3+g9SlQ1SOzc4V58cCjjBeyo4WEcY8PW80i9XD/s562W/4xk05bpky0vzQx+i2XmXj3CYT+9KIRlnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/d3-selection": "1.0.10",
+        "d3-array": "1.0.1",
+        "d3-dispatch": "1.0.1",
+        "d3-format": "1.0.2",
+        "d3-scale": "1.0.3",
+        "d3-selection": "1.0.2",
+        "d3-transition": "1.0.3"
+      }
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.0.1.tgz",
+      "integrity": "sha512-VPS5OH5Xb43tkFkxHEc4r5yWhlDwST47zh1q+qvgTj7xB9xDXn+UEcofhvNC7s8gD55y9Q/MCSPSBUVvnzo3Dw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-dispatch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.1.tgz",
+      "integrity": "sha512-BRTp95mobTSKx8EtpOLbxXuYVtNNr0PmelkH9Uzg5cgcO5O1M0i3+2C0FeM2I95BwQoIlsuZXQTPIoIt5xOtmw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-format": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.0.2.tgz",
+      "integrity": "sha512-VHFdLLjGkeGrRL8T/rlIIDhI3vvVX/oOTM/GaDJfB1sIb4dU5ZgiEjg3EeidJdQ/70u60tM015TSWa1gqqLRhg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-scale": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.3.tgz",
+      "integrity": "sha512-ah2Xqywu96gau2iET3T0ZTsu0/X0gfoB8vDTuZ1OaG5F0SgGJLXreBVBknSZf2HKnxjenRvFok3qY2FgY4RpFg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-selection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.0.2.tgz",
+      "integrity": "sha512-nInNdsdhljkDqkU/83bdWwtiJ7xsX3l57YZMlqsAOMeQROeCv7osPqQgYnao0NmRZEGc11hNakY+EOkaIdsWpQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-svg-legend/node_modules/d3-transition": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.0.3.tgz",
+      "integrity": "sha512-Facxcbma0nA2GVrx7B/Mgnn5ju6SwUMzGa9YcYmQjpqmaIq1Zbp5vVJLjtH6b08Lu0vcX7O6a4z+AlLmdCxrCQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1",
+        "d3-dispatch": "1",
+        "d3-ease": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "1",
+        "d3-timer": "1"
+      }
+    },
     "node_modules/d3-time": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "peer": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -3540,7 +4095,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "peer": true,
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -3552,9 +4106,71 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3fc": {
+      "version": "15.2.13",
+      "resolved": "https://registry.npmjs.org/d3fc/-/d3fc-15.2.13.tgz",
+      "integrity": "sha512-wfBvY9TcoeV/bRxPjawlzDHS/r2y03STspyZc9ydiz4ANMt+y+ynL9oahTZ4aAbp5JK850VxWNkQ8jaaN/cDYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@d3fc/d3fc-annotation": "^3.0.16",
+        "@d3fc/d3fc-axis": "^3.0.7",
+        "@d3fc/d3fc-brush": "^3.0.3",
+        "@d3fc/d3fc-chart": "^5.1.9",
+        "@d3fc/d3fc-data-join": "^6.0.3",
+        "@d3fc/d3fc-discontinuous-scale": "^4.1.1",
+        "@d3fc/d3fc-element": "^6.2.0",
+        "@d3fc/d3fc-extent": "^4.0.2",
+        "@d3fc/d3fc-financial-feed": "^7.1.0",
+        "@d3fc/d3fc-group": "^3.0.1",
+        "@d3fc/d3fc-label-layout": "^7.0.4",
+        "@d3fc/d3fc-pointer": "^3.0.3",
+        "@d3fc/d3fc-random-data": "^4.0.2",
+        "@d3fc/d3fc-rebind": "^6.0.1",
+        "@d3fc/d3fc-sample": "^5.0.2",
+        "@d3fc/d3fc-series": "^6.1.3",
+        "@d3fc/d3fc-shape": "^6.0.1",
+        "@d3fc/d3fc-technical-indicator": "^8.1.1",
+        "@d3fc/d3fc-webgl": "^3.2.1",
+        "@d3fc/d3fc-zoom": "^1.2.0"
       }
     },
     "node_modules/data-urls": {
@@ -3674,7 +4290,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
       "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-      "peer": true,
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
@@ -4552,6 +5167,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gradient-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
+      "integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -4766,7 +5389,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6296,6 +6918,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/regular-table": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/regular-table/-/regular-table-0.6.4.tgz",
+      "integrity": "sha512-N53k0gMxK9X4pwc8/+UOqiigoLwANsUBTlfoPruLoU3248kDswgt2H1LpuK6RqKkTU9V9Gr1XOOOxK0rXAWsSQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6402,8 +7033,7 @@
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "peer": true
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
       "version": "4.22.4",
@@ -6485,8 +7115,7 @@
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "peer": true
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6711,6 +7340,16 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
       "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
       "dev": true
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -8549,7 +9188,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/skore-ui/package.json
+++ b/skore-ui/package.json
@@ -16,6 +16,10 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@finos/perspective": "^3.1.6",
+    "@finos/perspective-viewer": "^3.1.6",
+    "@finos/perspective-viewer-d3fc": "^3.1.6",
+    "@finos/perspective-viewer-datagrid": "^3.1.6",
     "@floating-ui/vue": "^1.1.5",
     "@vscode/markdown-it-katex": "^1.1.0",
     "date-fns": "^3.6.0",

--- a/skore-ui/src/assets/fixtures/row-oriented-dataframe.json
+++ b/skore-ui/src/assets/fixtures/row-oriented-dataframe.json
@@ -1,0 +1,602 @@
+[
+  {
+    "id": 0,
+    "date": "2023-01-09T00:00:00",
+    "random_string": "Zj2jVMDRqM",
+    "random_float": 94.4676341226
+  },
+  {
+    "id": 1,
+    "date": "2023-09-22T00:00:00",
+    "random_string": "L24Mx7hGbU",
+    "random_float": 58.9601756416
+  },
+  {
+    "id": 2,
+    "date": "2023-09-05T00:00:00",
+    "random_string": "g40CTEi6Ed",
+    "random_float": 79.979542557
+  },
+  {
+    "id": 3,
+    "date": "2023-02-09T00:00:00",
+    "random_string": "itPpdRJffK",
+    "random_float": 76.0611234097
+  },
+  {
+    "id": 4,
+    "date": "2023-09-28T00:00:00",
+    "random_string": "5K9UgCRbeK",
+    "random_float": 91.6079364063
+  },
+  {
+    "id": 5,
+    "date": "2023-09-04T00:00:00",
+    "random_string": "vzJqrMszky",
+    "random_float": 68.5231302746
+  },
+  {
+    "id": 6,
+    "date": "2023-01-16T00:00:00",
+    "random_string": "gJ9BdKZA51",
+    "random_float": 89.9667818433
+  },
+  {
+    "id": 7,
+    "date": "2023-12-02T00:00:00",
+    "random_string": "TRce1usg6i",
+    "random_float": 92.9204385093
+  },
+  {
+    "id": 8,
+    "date": "2023-08-18T00:00:00",
+    "random_string": "HA5vgcsb08",
+    "random_float": 53.1068891304
+  },
+  {
+    "id": 9,
+    "date": "2023-07-10T00:00:00",
+    "random_string": "IggJ7I2cvZ",
+    "random_float": 55.3866868343
+  },
+  {
+    "id": 10,
+    "date": "2023-01-14T00:00:00",
+    "random_string": "ngDQntruSA",
+    "random_float": 83.6773860683
+  },
+  {
+    "id": 11,
+    "date": "2023-07-07T00:00:00",
+    "random_string": "clDbArPq2H",
+    "random_float": 28.1834681728
+  },
+  {
+    "id": 12,
+    "date": "2023-08-06T00:00:00",
+    "random_string": "aMiSdk7mtQ",
+    "random_float": 38.2698754411
+  },
+  {
+    "id": 13,
+    "date": "2023-01-28T00:00:00",
+    "random_string": "A8o9Ytnzzw",
+    "random_float": 78.3586396313
+  },
+  {
+    "id": 14,
+    "date": "2023-09-29T00:00:00",
+    "random_string": "xIwVfhx5wd",
+    "random_float": 90.6876896264
+  },
+  {
+    "id": 15,
+    "date": "2023-06-09T00:00:00",
+    "random_string": "HlBRgZVp0I",
+    "random_float": 91.7142413999
+  },
+  {
+    "id": 16,
+    "date": "2023-12-29T00:00:00",
+    "random_string": "0isZ9XUQeu",
+    "random_float": 65.8146741957
+  },
+  {
+    "id": 17,
+    "date": "2023-10-11T00:00:00",
+    "random_string": "KkZPlEZwHP",
+    "random_float": 91.1208896189
+  },
+  {
+    "id": 18,
+    "date": "2023-12-02T00:00:00",
+    "random_string": "Ga4Qd7Dwtx",
+    "random_float": 43.2440337951
+  },
+  {
+    "id": 19,
+    "date": "2023-04-08T00:00:00",
+    "random_string": "LWw3A7vrJk",
+    "random_float": 85.6152365213
+  },
+  {
+    "id": 20,
+    "date": "2023-04-02T00:00:00",
+    "random_string": "HpjssaRkt1",
+    "random_float": 17.7084349092
+  },
+  {
+    "id": 21,
+    "date": "2023-08-23T00:00:00",
+    "random_string": "556hTsj0XP",
+    "random_float": 57.6782744283
+  },
+  {
+    "id": 22,
+    "date": "2023-10-27T00:00:00",
+    "random_string": "D78m7YXUYl",
+    "random_float": 39.8006112146
+  },
+  {
+    "id": 23,
+    "date": "2023-11-15T00:00:00",
+    "random_string": "zGmateWoT2",
+    "random_float": 15.3220503274
+  },
+  {
+    "id": 24,
+    "date": "2023-11-01T00:00:00",
+    "random_string": "Y0SXJ17cCI",
+    "random_float": 99.0044023223
+  },
+  {
+    "id": 25,
+    "date": "2023-08-31T00:00:00",
+    "random_string": "mZBgmSprU9",
+    "random_float": 28.0529143119
+  },
+  {
+    "id": 26,
+    "date": "2023-12-09T00:00:00",
+    "random_string": "ylObRdb5Qf",
+    "random_float": 70.5675797806
+  },
+  {
+    "id": 27,
+    "date": "2023-08-10T00:00:00",
+    "random_string": "k7axAd5NoA",
+    "random_float": 35.2469763919
+  },
+  {
+    "id": 28,
+    "date": "2023-08-15T00:00:00",
+    "random_string": "qMOdiMWwJp",
+    "random_float": 66.1440481008
+  },
+  {
+    "id": 29,
+    "date": "2023-11-28T00:00:00",
+    "random_string": "iF5SSa9N4F",
+    "random_float": 20.1132326489
+  },
+  {
+    "id": 30,
+    "date": "2023-09-06T00:00:00",
+    "random_string": "maWat6ovwD",
+    "random_float": 21.6165869255
+  },
+  {
+    "id": 31,
+    "date": "2023-01-21T00:00:00",
+    "random_string": "bppMG6RYxG",
+    "random_float": 58.6694491356
+  },
+  {
+    "id": 32,
+    "date": "2023-03-10T00:00:00",
+    "random_string": "xseqWagyH7",
+    "random_float": 98.8121401178
+  },
+  {
+    "id": 33,
+    "date": "2023-01-07T00:00:00",
+    "random_string": "x1TuHpHd3T",
+    "random_float": 74.6604365509
+  },
+  {
+    "id": 34,
+    "date": "2023-11-24T00:00:00",
+    "random_string": "SOM0NbaXoe",
+    "random_float": 10.4116804101
+  },
+  {
+    "id": 35,
+    "date": "2023-03-24T00:00:00",
+    "random_string": "ypGTPFtac3",
+    "random_float": 65.4525009374
+  },
+  {
+    "id": 36,
+    "date": "2023-07-09T00:00:00",
+    "random_string": "LIMYycC4JE",
+    "random_float": 48.1041531726
+  },
+  {
+    "id": 37,
+    "date": "2023-04-24T00:00:00",
+    "random_string": "OaUmEAI6IP",
+    "random_float": 19.4839066496
+  },
+  {
+    "id": 38,
+    "date": "2023-08-11T00:00:00",
+    "random_string": "8c4teyDGW6",
+    "random_float": 34.2868372564
+  },
+  {
+    "id": 39,
+    "date": "2023-05-04T00:00:00",
+    "random_string": "jIhOajwKr9",
+    "random_float": 83.3177941541
+  },
+  {
+    "id": 40,
+    "date": "2023-07-15T00:00:00",
+    "random_string": "bFLkxLJxWp",
+    "random_float": 69.0444845312
+  },
+  {
+    "id": 41,
+    "date": "2023-04-04T00:00:00",
+    "random_string": "Ny2Sd3tnal",
+    "random_float": 63.0062807621
+  },
+  {
+    "id": 42,
+    "date": "2023-02-09T00:00:00",
+    "random_string": "pzZepk2Ik2",
+    "random_float": 71.3199292605
+  },
+  {
+    "id": 43,
+    "date": "2023-06-01T00:00:00",
+    "random_string": "gjjtvu0jPc",
+    "random_float": 77.7215526361
+  },
+  {
+    "id": 44,
+    "date": "2023-10-17T00:00:00",
+    "random_string": "j2VSgUQxDj",
+    "random_float": 13.4240566819
+  },
+  {
+    "id": 45,
+    "date": "2023-06-13T00:00:00",
+    "random_string": "6rL5Xcwhi0",
+    "random_float": 87.5472860737
+  },
+  {
+    "id": 46,
+    "date": "2023-08-23T00:00:00",
+    "random_string": "IHcUMUBVxF",
+    "random_float": 87.5381025662
+  },
+  {
+    "id": 47,
+    "date": "2023-09-08T00:00:00",
+    "random_string": "cYvBMuZkxu",
+    "random_float": 20.7835331243
+  },
+  {
+    "id": 48,
+    "date": "2023-06-04T00:00:00",
+    "random_string": "oVWXzV7O5E",
+    "random_float": 51.1152815053
+  },
+  {
+    "id": 49,
+    "date": "2023-06-08T00:00:00",
+    "random_string": "UVvoDWiPvI",
+    "random_float": 71.4828064517
+  },
+  {
+    "id": 50,
+    "date": "2023-01-20T00:00:00",
+    "random_string": "oFJ34ijipW",
+    "random_float": 99.5351197623
+  },
+  {
+    "id": 51,
+    "date": "2023-02-27T00:00:00",
+    "random_string": "gsJs8lAHfQ",
+    "random_float": 97.7128625803
+  },
+  {
+    "id": 52,
+    "date": "2023-02-04T00:00:00",
+    "random_string": "q1YLkEMiit",
+    "random_float": 57.5129885611
+  },
+  {
+    "id": 53,
+    "date": "2023-08-09T00:00:00",
+    "random_string": "gjRyvXRZSi",
+    "random_float": 94.0632431138
+  },
+  {
+    "id": 54,
+    "date": "2023-04-25T00:00:00",
+    "random_string": "buzsn4wHFl",
+    "random_float": 22.1065314105
+  },
+  {
+    "id": 55,
+    "date": "2023-08-09T00:00:00",
+    "random_string": "1nJr9Appw0",
+    "random_float": 36.0354208783
+  },
+  {
+    "id": 56,
+    "date": "2023-01-08T00:00:00",
+    "random_string": "RgFACFhYA9",
+    "random_float": 73.0340672799
+  },
+  {
+    "id": 57,
+    "date": "2023-08-24T00:00:00",
+    "random_string": "9cnYgG1xfJ",
+    "random_float": 56.813730041
+  },
+  {
+    "id": 58,
+    "date": "2023-04-05T00:00:00",
+    "random_string": "9vDPGfwWFZ",
+    "random_float": 94.8545739443
+  },
+  {
+    "id": 59,
+    "date": "2023-05-28T00:00:00",
+    "random_string": "DBawmrRDoJ",
+    "random_float": 41.4593864039
+  },
+  {
+    "id": 60,
+    "date": "2023-08-05T00:00:00",
+    "random_string": "g9zPrhYug2",
+    "random_float": 97.8239549388
+  },
+  {
+    "id": 61,
+    "date": "2023-12-05T00:00:00",
+    "random_string": "C42nV666BT",
+    "random_float": 26.8833085208
+  },
+  {
+    "id": 62,
+    "date": "2023-02-21T00:00:00",
+    "random_string": "o7XsoIMxSd",
+    "random_float": 48.9337334907
+  },
+  {
+    "id": 63,
+    "date": "2023-01-15T00:00:00",
+    "random_string": "87WLHEmr0Q",
+    "random_float": 17.5518230752
+  },
+  {
+    "id": 64,
+    "date": "2023-03-08T00:00:00",
+    "random_string": "R7iOWhffq0",
+    "random_float": 89.0514531971
+  },
+  {
+    "id": 65,
+    "date": "2023-05-31T00:00:00",
+    "random_string": "vLNJiU8kql",
+    "random_float": 48.2625257371
+  },
+  {
+    "id": 66,
+    "date": "2023-06-05T00:00:00",
+    "random_string": "luorYrWM8N",
+    "random_float": 11.3621113872
+  },
+  {
+    "id": 67,
+    "date": "2023-01-22T00:00:00",
+    "random_string": "Utk7Hh6D5p",
+    "random_float": 80.7583178491
+  },
+  {
+    "id": 68,
+    "date": "2023-05-23T00:00:00",
+    "random_string": "A0A3ndsM27",
+    "random_float": 7.6171045705000004
+  },
+  {
+    "id": 69,
+    "date": "2023-11-19T00:00:00",
+    "random_string": "D09nVb0KJu",
+    "random_float": 94.055203588
+  },
+  {
+    "id": 70,
+    "date": "2023-10-10T00:00:00",
+    "random_string": "ExqIu2Aw7l",
+    "random_float": 26.9794099573
+  },
+  {
+    "id": 71,
+    "date": "2023-08-30T00:00:00",
+    "random_string": "UErmWUTRug",
+    "random_float": 28.2489226891
+  },
+  {
+    "id": 72,
+    "date": "2023-08-16T00:00:00",
+    "random_string": "ZAhUsRY2zV",
+    "random_float": 79.6042782668
+  },
+  {
+    "id": 73,
+    "date": "2023-10-24T00:00:00",
+    "random_string": "kSUqYiL5cl",
+    "random_float": 89.1141946543
+  },
+  {
+    "id": 74,
+    "date": "2023-09-28T00:00:00",
+    "random_string": "w1AxfcyxYp",
+    "random_float": 46.084090072
+  },
+  {
+    "id": 75,
+    "date": "2023-03-20T00:00:00",
+    "random_string": "QFG4fMDslG",
+    "random_float": 58.524443911
+  },
+  {
+    "id": 76,
+    "date": "2023-03-03T00:00:00",
+    "random_string": "XDvMsfWH8K",
+    "random_float": 53.9953364448
+  },
+  {
+    "id": 77,
+    "date": "2023-10-17T00:00:00",
+    "random_string": "A9BsRQtFG2",
+    "random_float": 69.3337476332
+  },
+  {
+    "id": 78,
+    "date": "2023-01-30T00:00:00",
+    "random_string": "jCPXMHgmTg",
+    "random_float": 75.0295713722
+  },
+  {
+    "id": 79,
+    "date": "2023-10-10T00:00:00",
+    "random_string": "pdMrXP2AAl",
+    "random_float": 85.1511406183
+  },
+  {
+    "id": 80,
+    "date": "2023-12-06T00:00:00",
+    "random_string": "J8WW3i8P3v",
+    "random_float": 3.220763864
+  },
+  {
+    "id": 81,
+    "date": "2023-09-14T00:00:00",
+    "random_string": "d2XfMzmpRG",
+    "random_float": 99.5699485587
+  },
+  {
+    "id": 82,
+    "date": "2023-11-18T00:00:00",
+    "random_string": "UxZtXLiyos",
+    "random_float": 21.588032939
+  },
+  {
+    "id": 83,
+    "date": "2023-08-11T00:00:00",
+    "random_string": "PaPMTSIT7B",
+    "random_float": 2.3408673156
+  },
+  {
+    "id": 84,
+    "date": "2023-12-19T00:00:00",
+    "random_string": "qZGqh0PMbm",
+    "random_float": 20.7846563093
+  },
+  {
+    "id": 85,
+    "date": "2023-11-16T00:00:00",
+    "random_string": "QVNH0VQVXr",
+    "random_float": 97.3814491541
+  },
+  {
+    "id": 86,
+    "date": "2023-12-06T00:00:00",
+    "random_string": "ZSy8CA4wVI",
+    "random_float": 44.0026169962
+  },
+  {
+    "id": 87,
+    "date": "2023-04-30T00:00:00",
+    "random_string": "kVcm7Vq37Q",
+    "random_float": 18.3122157996
+  },
+  {
+    "id": 88,
+    "date": "2023-04-28T00:00:00",
+    "random_string": "oVgB6cyGkZ",
+    "random_float": 72.3745346688
+  },
+  {
+    "id": 89,
+    "date": "2023-05-02T00:00:00",
+    "random_string": "AwwZblehky",
+    "random_float": 94.4957255651
+  },
+  {
+    "id": 90,
+    "date": "2023-09-04T00:00:00",
+    "random_string": "JbM4OpOTpi",
+    "random_float": 49.9270896457
+  },
+  {
+    "id": 91,
+    "date": "2023-02-10T00:00:00",
+    "random_string": "0HuDlST2zZ",
+    "random_float": 78.7278533167
+  },
+  {
+    "id": 92,
+    "date": "2023-08-08T00:00:00",
+    "random_string": "tYbSse4hbx",
+    "random_float": 39.2729596338
+  },
+  {
+    "id": 93,
+    "date": "2023-05-09T00:00:00",
+    "random_string": "8XDU5Dyh39",
+    "random_float": 59.4685162322
+  },
+  {
+    "id": 94,
+    "date": "2023-09-28T00:00:00",
+    "random_string": "6hGa20FrB5",
+    "random_float": 62.4388915026
+  },
+  {
+    "id": 95,
+    "date": "2023-09-05T00:00:00",
+    "random_string": "0XSsqWTwiF",
+    "random_float": 75.5093477856
+  },
+  {
+    "id": 96,
+    "date": "2023-11-18T00:00:00",
+    "random_string": "BxFaRsMPsn",
+    "random_float": 5.6468148472
+  },
+  {
+    "id": 97,
+    "date": "2023-07-06T00:00:00",
+    "random_string": "WYi7HcDKa3",
+    "random_float": 37.6606722247
+  },
+  {
+    "id": 98,
+    "date": "2023-01-20T00:00:00",
+    "random_string": "3pBdQEebeY",
+    "random_float": 83.2006740169
+  },
+  {
+    "id": 99,
+    "date": "2023-11-10T00:00:00",
+    "random_string": "PRUEMVGX2S",
+    "random_float": 40.1550293517
+  }
+]

--- a/skore-ui/src/components/PerspectiveWidget.vue
+++ b/skore-ui/src/components/PerspectiveWidget.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import "@finos/perspective-viewer";
+import "@finos/perspective-viewer-d3fc";
+import "@finos/perspective-viewer-datagrid";
+
+import { getPerspectiveWorker } from "@/workers";
+import { type Table } from "@finos/perspective";
+import { type HTMLPerspectiveViewerElement } from "@finos/perspective-viewer";
+import { onMounted, onUnmounted, useTemplateRef } from "vue";
+
+const props = defineProps<{ data: Record<string, unknown>[] }>();
+const viewer = useTemplateRef<HTMLPerspectiveViewerElement>("viewer");
+let table: Table;
+
+async function setupPerspective() {
+  const worker = await getPerspectiveWorker();
+  table = await worker.table(props.data);
+  if (viewer.value) {
+    await viewer.value.load(table);
+    viewer.value.restore({ settings: true });
+  }
+}
+
+onMounted(async () => {
+  await setupPerspective();
+});
+
+onUnmounted(async () => {
+  if (table) {
+    table.free();
+  }
+});
+</script>
+
+<template>
+  <div class="perspective">
+    <perspective-viewer ref="viewer"></perspective-viewer>
+  </div>
+</template>
+
+<style>
+@import url("@finos/perspective-styles/intl.css");
+@import url("@finos/perspective-styles/icons.css");
+@import url("@finos/perspective-styles/pro.css");
+
+perspective-viewer {
+  width: 100%;
+  height: 500px;
+}
+</style>

--- a/skore-ui/src/views/project/ProjectView.vue
+++ b/skore-ui/src/views/project/ProjectView.vue
@@ -3,11 +3,11 @@ import { formatDistance } from "date-fns";
 import Simplebar from "simplebar-vue";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 
-import DataFrameWidget from "@/components/DataFrameWidget.vue";
 import DraggableList from "@/components/DraggableList.vue";
 import HtmlSnippetWidget from "@/components/HtmlSnippetWidget.vue";
 import ImageWidget from "@/components/ImageWidget.vue";
 import MarkdownWidget from "@/components/MarkdownWidget.vue";
+import PerspectiveWidget from "@/components/PerspectiveWidget.vue";
 import PlotlyWidget from "@/components/PlotlyWidget.vue";
 import ProjectViewCard from "@/components/ProjectViewCard.vue";
 import SimpleButton from "@/components/SimpleButton.vue";
@@ -114,12 +114,9 @@ onBeforeUnmount(() => {
                 @card-removed="onCardRemoved(key)"
                 @update-selected="projectStore.setCurrentItemUpdateIndex(key, $event)"
               >
-                <DataFrameWidget
+                <PerspectiveWidget
                   v-if="mediaType === 'application/vnd.dataframe+json'"
-                  :columns="data.columns"
-                  :data="data.data"
-                  :index="data.index"
-                  :index-names="data.index_names"
+                  :data="data"
                 />
                 <ImageWidget
                   v-if="

--- a/skore-ui/src/workers.ts
+++ b/skore-ui/src/workers.ts
@@ -1,0 +1,11 @@
+import type { Client } from "@finos/perspective";
+import perspective from "@finos/perspective";
+
+let _perspectiveWorker: Client | null = null;
+
+export async function getPerspectiveWorker() {
+  if (_perspectiveWorker === null) {
+    _perspectiveWorker = await perspective.worker();
+  }
+  return _perspectiveWorker;
+}

--- a/skore-ui/vite.config.ts
+++ b/skore-ui/vite.config.ts
@@ -8,10 +8,23 @@ import vueDevTools from "vite-plugin-vue-devtools";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), vueDevTools()],
+  plugins: [
+    vue({
+      template: {
+        compilerOptions: {
+          isCustomElement: (tag) => ["perspective-viewer"].includes(tag),
+        },
+      },
+    }),
+    vueDevTools(),
+  ],
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "@finos/perspective": "@finos/perspective/dist/esm/perspective.inline.js",
+      "@finos/perspective-viewer":
+        "@finos/perspective-viewer/dist/esm/perspective-viewer.inline.js",
+      "@finos/perspective-styles": "@finos/perspective-viewer/dist/css",
     },
   },
   css: {
@@ -21,5 +34,13 @@ export default defineConfig({
   },
   test: {
     setupFiles: ["./vitest.setup.ts"],
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "es2022",
+    },
+  },
+  build: {
+    target: "es2022",
   },
 });

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -53,7 +53,7 @@ def __serialize_project(project: Project) -> SerializedProject:
                 value = item.array.tolist()
                 media_type = "text/markdown"
             elif isinstance(item, PandasDataFrameItem):
-                value = item.dataframe.to_dict(orient="tight")
+                value = item.dataframe.to_dict(orient="records")
                 media_type = "application/vnd.dataframe+json"
             elif isinstance(item, PandasSeriesItem):
                 value = item.series.to_list()


### PR DESCRIPTION
This draft PR repalces our dataframe widget with [perspective](https://github.com/finos/perspective).
Perspective adds tons of interactivity on user's data. But at a cost that is not covered for now.

- our frontend tests are broken because of a circular import in a sub dependency
- dark/light mode is not working perfectly, users cant switch. for now only light mode is available
- vite build target is now `es2022` instead of the default `modules` (not sure this is bad)
- skore ui now has a wasm dependency, it's lifecycle may trigger some side effect (need to do some research on the subject)

## UI preview

https://github.com/user-attachments/assets/449deaa2-57cd-435b-9709-e9f2046fece4

