### PR TITLE
fix(train_test_split): Make behaviour the same when passing `y` by keyword

### DIFF
--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -129,12 +129,15 @@ def train_test_split(
         stratify=stratify,
     )
 
-    y_labels = None
-    y_test = None
     if y is None and len(arrays) >= 2:
         y = arrays[-1]
+
+    if y is not None:
         y_labels = np.unique(y)
         y_test = output[-1]
+    else:
+        y_labels = None
+        y_test = None
 
     ml_task = _find_ml_task(y)
 

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -24,6 +24,18 @@ def case_high_class_imbalance_too_few_examples():
     return args, kwargs, HighClassImbalanceTooFewExamplesWarning
 
 
+def case_high_class_imbalance_too_few_examples_kwargs():
+    args = ()
+    kwargs = dict(X=[[1]] * 4, y=[0, 1, 1, 1])
+    return args, kwargs, HighClassImbalanceTooFewExamplesWarning
+
+
+def case_high_class_imbalance_too_few_examples_kwargs_mixed():
+    args = ([[1]] * 4,)
+    kwargs = dict(y=[0, 1, 1, 1])
+    return args, kwargs, HighClassImbalanceTooFewExamplesWarning
+
+
 def case_stratify():
     args = ([0] * 10 + [1] * 10,)
     kwargs = dict(stratify=[0] * 10 + [1] * 10)
@@ -42,6 +54,8 @@ def case_random_state_unset():
     [
         case_high_class_imbalance,
         case_high_class_imbalance_too_few_examples,
+        case_high_class_imbalance_too_few_examples_kwargs,
+        case_high_class_imbalance_too_few_examples_kwargs_mixed,
         case_stratify,
         case_random_state_unset,
     ],


### PR DESCRIPTION
This fixes an issue where a warning was raised when X and y were passed positionally, but not when they were passed by keyword.
