### PR TITLE
chore(CI): Remove PYTHONUTF8 from the CI 

### DIFF
--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -66,8 +66,6 @@ jobs:
 
           # Test
           python -m pytest src/ tests/
-        env:
-          PYTHONUTF8: 1
 
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As tests should run on a default encoding.