### PR TITLE
feat(project): Add first-class support for polars dataframes

### DIFF
--- a/docs/design/0000-adr-template.md
+++ b/docs/design/0000-adr-template.md
@@ -1,0 +1,74 @@
+---
+# These are optional metadata elements. Feel free to remove any of them.
+status: "{proposed | rejected | accepted | deprecated | … | superseded by ADR-0123"
+date: {YYYY-MM-DD when the decision was last updated}
+decision-makers: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+---
+
+# {short title, representative of solved problem and found solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because {justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+### Confirmation
+
+{Describe how the implementation of/compliance with the ADR can/will be confirmed. Are the design that was decided for and its implementation in line with the decision made? E.g., a design/code review or a test with a library such as ArchUnit can help validate this. Not that although we classify this element as optional, it is included in many ADRs.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how the decision should be realized and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}

--- a/docs/design/0001-postpone-narwhals.md
+++ b/docs/design/0001-postpone-narwhals.md
@@ -1,0 +1,39 @@
+---
+# These are optional metadata elements. Feel free to remove any of them.
+status: "accepted"
+date: 2024-11-26
+decision-makers: @augustebaum @tuscland
+---
+
+# Postone usage of generic DataFrame library
+
+## Context and Problem Statement
+
+skore projects natively support inserting `pandas` DataFrames, and with PR [#792](https://github.com/probabl-ai/skore/pull/792) it will also support `polars` DataFrames.
+The question arises as to whether skore should use the `narwhals` library under the hood, or any another generic DataFrame library, as skore could then support many more DataFrame objects with little extra effort to integrate them. 
+
+## Considered Options
+
+* Postpone usage of generic DataFrame library
+* Use `narwhals`
+* Use `arrow`
+
+## Decision Outcome
+
+Chosen option: "Postpone usage of generic DataFrame library" 
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because there is not enough foresight to know which generic library serves our needs the best
+    - It is likely that we will explore generic formats in the near future in any case, for example:
+        - If the storage backend for skore changes from `diskcache` to something else
+        - if JSON as an exchange format is not robust enough for large data
+    - Since we don't have experience with `narwhals` or `arrow`, integrating one of them might result in unexpected roadblocks which would take time to resolve
+* Bad, because in the short term, adding support for a new DataFrame object will take more work
+    - At the same time, it might be unlikely that support for another DataFrame implementation will be requested in the short term.
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+This decision is being taken while reviewing PR [#792](https://github.com/probabl-ai/skore/pull/792), whose objective is to support inserting `polars` DataFrames.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,23 @@
+# Skore Architecture Decision Records (ADRs)
+
+Welcome to the Architecture Decision Records (ADR) for Skore.
+
+## What Are ADRs?
+
+Architecture Decision Records document the architectural and technical decisions made in a project. They help:
+
+* Preserve the reasoning behind key choices.
+* Guide new contributors in understanding the project's direction.
+* Enable revisiting or revising decisions as the project evolves in an open way.
+
+## How to Use This Folder
+
+Each ADR is stored as a markdown file and follows a sequential numbering system. The ADRs are organized to address different aspects of the backend architecture. New contributors and stakeholders can start by reviewing the decisions below to understand the foundational choices.
+
+## Updating ADRs
+
+If you propose a new decision or change an existing one:
+
+* Write a new ADR, referencing the previous one it supersedes (if applicable).
+* Follow the [established ADR template](https://github.com/adr/madr/blob/4.0.0/template/adr-template.md), [local version available](./0000-adr-template.md).
+* Submit it for team review and approval.

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -71,6 +71,7 @@ test = [
   "pandas",
   "pillow",
   "plotly",
+  "polars",
   "pre-commit",
   "pytest",
   "pytest-cov",

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "diskcache",
   "fastapi",
   "plotly>=5,<6",
+  "pyarrow",
   "rich",
   "skops",
   "uvicorn",

--- a/skore/src/skore/item/__init__.py
+++ b/skore/src/skore/item/__init__.py
@@ -12,6 +12,8 @@ from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
 from skore.item.pandas_dataframe_item import PandasDataFrameItem
 from skore.item.pandas_series_item import PandasSeriesItem
+from skore.item.polars_dataframe_item import PolarsDataFrameItem
+from skore.item.polars_series_item import PolarsSeriesItem
 from skore.item.primitive_item import PrimitiveItem
 from skore.item.sklearn_base_estimator_item import SklearnBaseEstimatorItem
 
@@ -22,6 +24,8 @@ def object_to_item(object: Any) -> Item:
         PrimitiveItem,
         PandasDataFrameItem,
         PandasSeriesItem,
+        PolarsDataFrameItem,
+        PolarsSeriesItem,
         NumpyArrayItem,
         SklearnBaseEstimatorItem,
         MediaItem,
@@ -47,6 +51,8 @@ __all__ = [
     "NumpyArrayItem",
     "PandasDataFrameItem",
     "PandasSeriesItem",
+    "PolarsDataFrameItem",
+    "PolarsSeriesItem",
     "PrimitiveItem",
     "SklearnBaseEstimatorItem",
     "object_to_item",

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -21,6 +21,8 @@ from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
 from skore.item.pandas_dataframe_item import PandasDataFrameItem
 from skore.item.pandas_series_item import PandasSeriesItem
+from skore.item.polars_dataframe_item import PolarsDataFrameItem
+from skore.item.polars_series_item import PolarsSeriesItem
 from skore.item.primitive_item import PrimitiveItem
 from skore.item.sklearn_base_estimator_item import SklearnBaseEstimatorItem
 
@@ -40,6 +42,8 @@ class ItemRepository:
         "NumpyArrayItem": NumpyArrayItem,
         "PandasDataFrameItem": PandasDataFrameItem,
         "PandasSeriesItem": PandasSeriesItem,
+        "PolarsDataFrameItem": PolarsDataFrameItem,
+        "PolarsSeriesItem": PolarsSeriesItem,
         "PrimitiveItem": PrimitiveItem,
         "CrossValidationItem": CrossValidationItem,
         "CrossValidationAggregationItem": CrossValidationAggregationItem,

--- a/skore/src/skore/item/polars_dataframe_item.py
+++ b/skore/src/skore/item/polars_dataframe_item.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     import polars
 
 
+class PolarsToJSONError(Exception):
+    """Something happened while converting a polars DataFrame to JSON."""
+
+
 class PolarsDataFrameItem(Item):
     """
     A class to represent a polars DataFrame item.
@@ -86,4 +90,9 @@ class PolarsDataFrameItem(Item):
         if not isinstance(dataframe, polars.DataFrame):
             raise ItemTypeError(f"Type '{dataframe.__class__}' is not supported.")
 
-        return cls(dataframe_json=dataframe.write_json())
+        try:
+            dataframe_json = dataframe.write_json()
+        except Exception as e:
+            raise PolarsToJSONError("Conversion to JSON failed") from e
+
+        return cls(dataframe_json=dataframe_json)

--- a/skore/src/skore/item/polars_dataframe_item.py
+++ b/skore/src/skore/item/polars_dataframe_item.py
@@ -1,0 +1,123 @@
+"""PolarsDataFrameItem.
+
+This module defines the PolarsDataFrameItem class,
+which represents a polars DataFrame item.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from skore.item.item import Item, ItemTypeError
+
+if TYPE_CHECKING:
+    import polars
+
+
+class PolarsDataFrameItem(Item):
+    """
+    A class to represent a polars DataFrame item.
+
+    This class encapsulates a polars DataFrame along with its
+    creation and update timestamps.
+    """
+
+    ORIENT = "split"
+
+    def __init__(
+        self,
+        index_json: str,
+        dataframe_json: str,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+    ):
+        """
+        Initialize a PolarsDataFrameItem.
+
+        Parameters
+        ----------
+        index_json : str
+            The JSON representation of the dataframe's index.
+        dataframe_json : str
+            The JSON representation of the dataframe, without its index.
+        created_at : str
+            The creation timestamp in ISO format.
+        updated_at : str
+            The last update timestamp in ISO format.
+        """
+        super().__init__(created_at, updated_at)
+
+        self.index_json = index_json
+        self.dataframe_json = dataframe_json
+
+    @cached_property
+    def dataframe(self) -> polars.DataFrame:
+        """
+        The polars DataFrame from the persistence.
+
+        Its content can differ from the original dataframe because it has been
+        serialized using polars' `to_json` function and not pickled, in order to be
+        environment-independent.
+        """
+        import io
+
+        import polars
+
+        with io.StringIO(self.dataframe_json) as df_stream:
+            dataframe = polars.read_json(df_stream, dtype=False)
+            return dataframe
+
+    @classmethod
+    def factory(cls, dataframe: polars.DataFrame) -> PolarsDataFrameItem:
+        """
+        Create a new PolarsDataFrameItem instance from a polars DataFrame.
+
+        Parameters
+        ----------
+        dataframe : pd.DataFrame
+            The polars DataFrame to store.
+
+        Returns
+        -------
+        PolarsDataFrameItem
+            A new PolarsDataFrameItem instance.
+
+        Notes
+        -----
+        The dataframe must be JSON serializable.
+        """
+        import polars
+
+        if not isinstance(dataframe, polars.DataFrame):
+            raise ItemTypeError(f"Type '{dataframe.__class__}' is not supported.")
+
+        # Two native methods are available to serialize dataframe with multi-index,
+        # while keeping the index names:
+        #
+        # 1. Using table orientation with JSON serializer:
+        #    ```python
+        #    json = dataframe.to_json(orient="table")
+        #    dataframe = polars.read_json(json, orient="table", dtype=False)
+        #    ```
+        #
+        #    This method fails when an index/column name is an integer.
+        #
+        # 2. Using record orientation with indexes as columns:
+        #    ```python
+        #    dataframe = dataframe.reset_index()
+        #    json = dataframe.to_json(orient="records")
+        #    dataframe = polars.read_json(json, orient="records", dtype=False)
+        #    ```
+        #
+        #    This method fails when the index has the same name as one of the columns.
+        #
+        # None of those methods being compatible, we decide to store indexes separately.
+
+        index = dataframe.index.to_frame(index=False)
+        dataframe = dataframe.reset_index(drop=True)
+
+        return cls(
+            index_json=index.to_json(orient=PolarsDataFrameItem.ORIENT),
+            dataframe_json=dataframe.write_json(),
+        )

--- a/skore/src/skore/item/polars_series_item.py
+++ b/skore/src/skore/item/polars_series_item.py
@@ -1,0 +1,122 @@
+"""PolarsSeriesItem.
+
+This module defines the PolarsSeriesItem class,
+which represents a polars Series item.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from skore.item.item import Item, ItemTypeError
+
+if TYPE_CHECKING:
+    import polars
+
+
+class PolarsSeriesItem(Item):
+    """
+    A class to represent a polars Series item.
+
+    This class encapsulates a polars Series along with its
+    creation and update timestamps.
+    """
+
+    ORIENT = "split"
+
+    def __init__(
+        self,
+        index_json: str,
+        series_json: str,
+        created_at: str | None = None,
+        updated_at: str | None = None,
+    ):
+        """
+        Initialize a PolarsSeriesItem.
+
+        Parameters
+        ----------
+        index_json : str
+            The JSON representation of the series's index.
+        series_json : str
+            The JSON representation of the series, without its index.
+        created_at : str
+            The creation timestamp in ISO format.
+        updated_at : str
+            The last update timestamp in ISO format.
+        """
+        super().__init__(created_at, updated_at)
+
+        self.index_json = index_json
+        self.series_json = series_json
+
+    @cached_property
+    def series(self) -> polars.Series:
+        """
+        The polars Series from the persistence.
+
+        Its content can differ from the original series because it has been serialized
+        using polars' `to_json` function and not pickled, in order to be
+        environment-independent.
+        """
+        import io
+
+        import polars
+
+        with (
+            io.StringIO(self.index_json) as index_stream,
+            io.StringIO(self.series_json) as series_stream,
+        ):
+            index = polars.read_json(index_stream, orient=self.ORIENT, dtype=False)
+            index = index.set_index(list(index.columns))
+            series = polars.read_json(
+                series_stream,
+                typ="series",
+                orient=self.ORIENT,
+                dtype=False,
+            )
+            series.index = index.index
+
+            return series
+
+    @classmethod
+    def factory(cls, series: polars.Series) -> PolarsSeriesItem:
+        """
+        Create a new PolarsSeriesItem instance from a polars Series.
+
+        Parameters
+        ----------
+        series : pd.Series
+            The polars Series to store.
+
+        Returns
+        -------
+        PolarsSeriesItem
+            A new PolarsSeriesItem instance.
+        """
+        import polars
+
+        if not isinstance(series, polars.Series):
+            raise ItemTypeError(f"Type '{series.__class__}' is not supported.")
+
+        # One native method is available to serialize series with multi-index,
+        # while keeping the index names:
+        #
+        # Using table orientation with JSON serializer:
+        #    ```python
+        #    json = series.to_json(orient="table")
+        #    series = polars.read_json(json, typ="series", orient="table", dtype=False)
+        #    ```
+        #
+        #    This method fails when an index name is an integer.
+        #
+        # None of those methods being compatible, we store indexes separately.
+
+        index = series.index.to_frame(index=False)
+        series = series.reset_index(drop=True)
+
+        return cls(
+            index_json=index.to_json(orient=PolarsSeriesItem.ORIENT),
+            series_json=series.to_json(orient=PolarsSeriesItem.ORIENT),
+        )

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -160,7 +160,7 @@ class Project:
 
         Parameters
         ----------
-        key: str
+        key : str
             The key corresponding to the item to get.
 
         Returns

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -11,6 +11,8 @@ from skore.item import (
     NumpyArrayItem,
     PandasDataFrameItem,
     PandasSeriesItem,
+    PolarsDataFrameItem,
+    PolarsSeriesItem,
     PrimitiveItem,
     SklearnBaseEstimatorItem,
     object_to_item,
@@ -139,6 +141,10 @@ class Project:
         elif isinstance(item, PandasDataFrameItem):
             return item.dataframe
         elif isinstance(item, PandasSeriesItem):
+            return item.series
+        elif isinstance(item, PolarsDataFrameItem):
+            return item.dataframe
+        elif isinstance(item, PolarsSeriesItem):
             return item.series
         elif isinstance(item, SklearnBaseEstimatorItem):
             return item.estimator

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -15,6 +15,8 @@ from skore.item.media_item import MediaItem
 from skore.item.numpy_array_item import NumpyArrayItem
 from skore.item.pandas_dataframe_item import PandasDataFrameItem
 from skore.item.pandas_series_item import PandasSeriesItem
+from skore.item.polars_dataframe_item import PolarsDataFrameItem
+from skore.item.polars_series_item import PolarsSeriesItem
 from skore.item.primitive_item import PrimitiveItem
 from skore.item.sklearn_base_estimator_item import SklearnBaseEstimatorItem
 from skore.project import Project
@@ -56,6 +58,12 @@ def __serialize_project(project: Project) -> SerializedProject:
                 value = item.dataframe.to_dict(orient="tight")
                 media_type = "application/vnd.dataframe+json"
             elif isinstance(item, PandasSeriesItem):
+                value = item.series.to_list()
+                media_type = "text/markdown"
+            elif isinstance(item, PolarsDataFrameItem):
+                value = item.dataframe.to_pandas().to_dict(orient="tight")
+                media_type = "application/vnd.dataframe+json"
+            elif isinstance(item, PolarsSeriesItem):
                 value = item.series.to_list()
                 media_type = "text/markdown"
             elif isinstance(item, SklearnBaseEstimatorItem):

--- a/skore/tests/unit/item/test_pandas_dataframe_item.py
+++ b/skore/tests/unit/item/test_pandas_dataframe_item.py
@@ -53,7 +53,8 @@ class TestPandasDataFrameItem:
         dataframe = DataFrame([{"key": np.array([1])}], Index([0], name="myIndex"))
         item = PandasDataFrameItem.factory(dataframe)
 
-        assert isinstance(item.dataframe["key"].iloc[0], list)
+        # NOTE: isinstance would not work because numpy.array is an instance of list
+        assert type(item.dataframe["key"].iloc[0]) is list
 
     @pytest.mark.order(1)
     def test_dataframe_with_integer_columns_name_and_multiindex(self, mock_nowstr):

--- a/skore/tests/unit/item/test_pandas_dataframe_item.py
+++ b/skore/tests/unit/item/test_pandas_dataframe_item.py
@@ -53,7 +53,7 @@ class TestPandasDataFrameItem:
         dataframe = DataFrame([{"key": np.array([1])}], Index([0], name="myIndex"))
         item = PandasDataFrameItem.factory(dataframe)
 
-        assert type(item.dataframe["key"].iloc[0]) is list
+        assert isinstance(item.dataframe["key"].iloc[0], list)
 
     @pytest.mark.order(1)
     def test_dataframe_with_integer_columns_name_and_multiindex(self, mock_nowstr):

--- a/skore/tests/unit/item/test_pandas_series_item.py
+++ b/skore/tests/unit/item/test_pandas_series_item.py
@@ -53,7 +53,8 @@ class TestPandasSeriesItem:
         series = Series([np.array([1])], Index([0], name="myIndex"))
         item = PandasSeriesItem.factory(series)
 
-        assert isinstance(item.series.iloc[0], list)
+        # NOTE: isinstance would not work because numpy.array is an instance of list
+        assert type(item.series.iloc[0]) is list
 
     @pytest.mark.order(1)
     def test_series_with_integer_indexes_name_and_multiindex(self, mock_nowstr):

--- a/skore/tests/unit/item/test_pandas_series_item.py
+++ b/skore/tests/unit/item/test_pandas_series_item.py
@@ -53,7 +53,7 @@ class TestPandasSeriesItem:
         series = Series([np.array([1])], Index([0], name="myIndex"))
         item = PandasSeriesItem.factory(series)
 
-        assert type(item.series.iloc[0]) is list
+        assert isinstance(item.series.iloc[0], list)
 
     @pytest.mark.order(1)
     def test_series_with_integer_indexes_name_and_multiindex(self, mock_nowstr):

--- a/skore/tests/unit/item/test_polars_dataframe_item.py
+++ b/skore/tests/unit/item/test_polars_dataframe_item.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+from polars import DataFrame, Index, MultiIndex
+from polars.testing import assert_frame_equal
+from skore.item import ItemTypeError, PolarsDataFrameItem
+
+
+class TestPolarsDataFrameItem:
+    @pytest.fixture(autouse=True)
+    def monkeypatch_datetime(self, monkeypatch, MockDatetime):
+        monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
+
+    def test_factory_exception(self):
+        with pytest.raises(ItemTypeError):
+            PolarsDataFrameItem.factory(None)
+
+    @pytest.mark.order(0)
+    def test_factory(self, mock_nowstr):
+        dataframe = DataFrame([{"key": "value"}], Index([0], name="myIndex"))
+
+        orient = PolarsDataFrameItem.ORIENT
+        index_json = dataframe.index.to_frame(index=False).to_json(orient=orient)
+        dataframe_json = dataframe.reset_index(drop=True).to_json(orient=orient)
+
+        item = PolarsDataFrameItem.factory(dataframe)
+
+        assert item.index_json == index_json
+        assert item.dataframe_json == dataframe_json
+        assert item.created_at == mock_nowstr
+        assert item.updated_at == mock_nowstr
+
+    @pytest.mark.order(1)
+    def test_dataframe(self, mock_nowstr):
+        dataframe = DataFrame([{"key": "value"}], Index([0], name="myIndex"))
+
+        orient = PolarsDataFrameItem.ORIENT
+        index_json = dataframe.index.to_frame(index=False).to_json(orient=orient)
+        dataframe_json = dataframe.reset_index(drop=True).to_json(orient=orient)
+
+        item1 = PolarsDataFrameItem.factory(dataframe)
+        item2 = PolarsDataFrameItem(
+            index_json=index_json,
+            dataframe_json=dataframe_json,
+            created_at=mock_nowstr,
+            updated_at=mock_nowstr,
+        )
+
+        assert_frame_equal(item1.dataframe, dataframe)
+        assert_frame_equal(item2.dataframe, dataframe)
+
+    @pytest.mark.order(1)
+    def test_dataframe_with_complex_object(self, mock_nowstr):
+        dataframe = DataFrame([{"key": np.array([1])}], Index([0], name="myIndex"))
+        item = PolarsDataFrameItem.factory(dataframe)
+
+        assert type(item.dataframe["key"].iloc[0]) is list
+
+    @pytest.mark.order(1)
+    def test_dataframe_with_integer_columns_name_and_multiindex(self, mock_nowstr):
+        dataframe = DataFrame(
+            [[">70", "1M", "M", 1], [">70", "2F", "F", 2]],
+            MultiIndex.from_arrays(
+                [["france", "usa"], ["paris", "nyc"], ["1", "1"]],
+                names=("country", "city", "district"),
+            ),
+        )
+
+        orient = PolarsDataFrameItem.ORIENT
+        index_json = dataframe.index.to_frame(index=False).to_json(orient=orient)
+        dataframe_json = dataframe.reset_index(drop=True).to_json(orient=orient)
+
+        item1 = PolarsDataFrameItem.factory(dataframe)
+        item2 = PolarsDataFrameItem(
+            index_json=index_json,
+            dataframe_json=dataframe_json,
+            created_at=mock_nowstr,
+            updated_at=mock_nowstr,
+        )
+
+        assert_frame_equal(item1.dataframe, dataframe)
+        assert_frame_equal(item2.dataframe, dataframe)

--- a/skore/tests/unit/item/test_polars_dataframe_item.py
+++ b/skore/tests/unit/item/test_polars_dataframe_item.py
@@ -3,6 +3,7 @@ import pytest
 from polars import DataFrame
 from polars.testing import assert_frame_equal
 from skore.item import ItemTypeError, PolarsDataFrameItem
+from skore.item.polars_dataframe_item import PolarsToJSONError
 
 
 class TestPolarsDataFrameItem:
@@ -42,6 +43,6 @@ class TestPolarsDataFrameItem:
 
     def test_dataframe_with_complex_object(self, mock_nowstr):
         dataframe = DataFrame([{"key": np.array([1, 2])}])
-        item = PolarsDataFrameItem.factory(dataframe)
 
-        assert isinstance(item.dataframe["key"].iloc[0], list)
+        with pytest.raises(PolarsToJSONError):
+            PolarsDataFrameItem.factory(dataframe)

--- a/skore/tests/unit/item/test_polars_series_item.py
+++ b/skore/tests/unit/item/test_polars_series_item.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+from polars import Index, MultiIndex, Series
+from polars.testing import assert_series_equal
+from skore.item import ItemTypeError, PolarsSeriesItem
+
+
+class TestPolarsSeriesItem:
+    @pytest.fixture(autouse=True)
+    def monkeypatch_datetime(self, monkeypatch, MockDatetime):
+        monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
+
+    def test_factory_exception(self):
+        with pytest.raises(ItemTypeError):
+            PolarsSeriesItem.factory(None)
+
+    @pytest.mark.order(0)
+    def test_factory(self, mock_nowstr):
+        series = Series([0, 1, 2], Index([0, 1, 2], name="myIndex"))
+
+        orient = PolarsSeriesItem.ORIENT
+        index_json = series.index.to_frame(index=False).to_json(orient=orient)
+        series_json = series.reset_index(drop=True).to_json(orient=orient)
+
+        item = PolarsSeriesItem.factory(series)
+
+        assert item.index_json == index_json
+        assert item.series_json == series_json
+        assert item.created_at == mock_nowstr
+        assert item.updated_at == mock_nowstr
+
+    @pytest.mark.order(1)
+    def test_series(self, mock_nowstr):
+        series = Series([0, 1, 2], Index([0, 1, 2], name="myIndex"))
+
+        orient = PolarsSeriesItem.ORIENT
+        index_json = series.index.to_frame(index=False).to_json(orient=orient)
+        series_json = series.reset_index(drop=True).to_json(orient=orient)
+
+        item1 = PolarsSeriesItem.factory(series)
+        item2 = PolarsSeriesItem(
+            index_json=index_json,
+            series_json=series_json,
+            created_at=mock_nowstr,
+            updated_at=mock_nowstr,
+        )
+
+        assert_series_equal(item1.series, series)
+        assert_series_equal(item2.series, series)
+
+    @pytest.mark.order(1)
+    def test_series_with_complex_object(self, mock_nowstr):
+        series = Series([np.array([1])], Index([0], name="myIndex"))
+        item = PolarsSeriesItem.factory(series)
+
+        assert type(item.series.iloc[0]) is list
+
+    @pytest.mark.order(1)
+    def test_series_with_integer_indexes_name_and_multiindex(self, mock_nowstr):
+        series = Series(
+            [">70", ">70"],
+            MultiIndex.from_arrays(
+                [["france", "usa"], ["paris", "nyc"], ["1", "1"]],
+                names=(0, "city", "district"),
+            ),
+        )
+
+        orient = PolarsSeriesItem.ORIENT
+        index_json = series.index.to_frame(index=False).to_json(orient=orient)
+        series_json = series.reset_index(drop=True).to_json(orient=orient)
+
+        item1 = PolarsSeriesItem.factory(series)
+        item2 = PolarsSeriesItem(
+            index_json=index_json,
+            series_json=series_json,
+            created_at=mock_nowstr,
+            updated_at=mock_nowstr,
+        )
+
+        assert_series_equal(item1.series, series)
+        assert_series_equal(item2.series, series)

--- a/skore/tests/unit/item/test_polars_series_item.py
+++ b/skore/tests/unit/item/test_polars_series_item.py
@@ -47,22 +47,4 @@ class TestPolarsSeriesItem:
         series = Series([np.array([1, 2])])
         item = PolarsSeriesItem.factory(series)
 
-        assert isinstance(item.series[0], Series)
-
-    @pytest.mark.order(1)
-    def test_series_with_integer_indexes_name_and_multiindex(self, mock_nowstr):
-        series = Series(
-            [">70", ">70"],
-        )
-
-        series_json = series.to_frame().write_json()
-
-        item1 = PolarsSeriesItem.factory(series)
-        item2 = PolarsSeriesItem(
-            series_json=series_json,
-            created_at=mock_nowstr,
-            updated_at=mock_nowstr,
-        )
-
-        assert_series_equal(item1.series, series)
-        assert_series_equal(item2.series, series)
+        assert_series_equal(item.series, series, check_dtypes=False)

--- a/skore/tests/unit/item/test_polars_series_item.py
+++ b/skore/tests/unit/item/test_polars_series_item.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from polars import Index, MultiIndex, Series
+from polars import Series
 from polars.testing import assert_series_equal
 from skore.item import ItemTypeError, PolarsSeriesItem
 
@@ -16,30 +16,24 @@ class TestPolarsSeriesItem:
 
     @pytest.mark.order(0)
     def test_factory(self, mock_nowstr):
-        series = Series([0, 1, 2], Index([0, 1, 2], name="myIndex"))
+        series = Series([0, 1, 2])
 
-        orient = PolarsSeriesItem.ORIENT
-        index_json = series.index.to_frame(index=False).to_json(orient=orient)
-        series_json = series.reset_index(drop=True).to_json(orient=orient)
+        series_json = series.to_frame().write_json()
 
         item = PolarsSeriesItem.factory(series)
 
-        assert item.index_json == index_json
         assert item.series_json == series_json
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
 
     @pytest.mark.order(1)
     def test_series(self, mock_nowstr):
-        series = Series([0, 1, 2], Index([0, 1, 2], name="myIndex"))
+        series = Series([0, 1, 2])
 
-        orient = PolarsSeriesItem.ORIENT
-        index_json = series.index.to_frame(index=False).to_json(orient=orient)
-        series_json = series.reset_index(drop=True).to_json(orient=orient)
+        series_json = series.to_frame().write_json()
 
         item1 = PolarsSeriesItem.factory(series)
         item2 = PolarsSeriesItem(
-            index_json=index_json,
             series_json=series_json,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,
@@ -50,28 +44,21 @@ class TestPolarsSeriesItem:
 
     @pytest.mark.order(1)
     def test_series_with_complex_object(self, mock_nowstr):
-        series = Series([np.array([1])], Index([0], name="myIndex"))
+        series = Series([np.array([1, 2])])
         item = PolarsSeriesItem.factory(series)
 
-        assert type(item.series.iloc[0]) is list
+        assert isinstance(item.series[0], Series)
 
     @pytest.mark.order(1)
     def test_series_with_integer_indexes_name_and_multiindex(self, mock_nowstr):
         series = Series(
             [">70", ">70"],
-            MultiIndex.from_arrays(
-                [["france", "usa"], ["paris", "nyc"], ["1", "1"]],
-                names=(0, "city", "district"),
-            ),
         )
 
-        orient = PolarsSeriesItem.ORIENT
-        index_json = series.index.to_frame(index=False).to_json(orient=orient)
-        series_json = series.reset_index(drop=True).to_json(orient=orient)
+        series_json = series.to_frame().write_json()
 
         item1 = PolarsSeriesItem.factory(series)
         item2 = PolarsSeriesItem(
-            index_json=index_json,
             series_json=series_json,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,

--- a/skore/tests/unit/test_project.py
+++ b/skore/tests/unit/test_project.py
@@ -6,6 +6,7 @@ import numpy
 import numpy.testing
 import pandas
 import pandas.testing
+import polars
 import pytest
 from matplotlib import pyplot as plt
 from PIL import Image
@@ -76,6 +77,27 @@ def test_put_pandas_series(in_memory_project):
     series = pandas.Series([0, 1, 2], index=pandas.Index([0, 1, 2], name="myIndex"))
     in_memory_project.put("pandas_series", series)
     pandas.testing.assert_series_equal(in_memory_project.get("pandas_series"), series)
+
+
+def test_put_polars_dataframe(in_memory_project):
+    dataframe = polars.DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": [4, 5, 6],
+            "C": [7, 8, 9],
+        },
+    )
+
+    in_memory_project.put("polars_dataframe", dataframe)
+    polars.testing.assert_frame_equal(
+        in_memory_project.get("polars_dataframe"), dataframe
+    )
+
+
+def test_put_polars_series(in_memory_project):
+    series = polars.Series("my_series", [0, 1, 2])
+    in_memory_project.put("polars_series", series)
+    polars.testing.assert_series_equal(in_memory_project.get("polars_series"), series)
 
 
 def test_put_numpy_array(in_memory_project):

--- a/skore/tests/unit/test_project.py
+++ b/skore/tests/unit/test_project.py
@@ -7,6 +7,7 @@ import numpy.testing
 import pandas
 import pandas.testing
 import polars
+import polars.testing
 import pytest
 from matplotlib import pyplot as plt
 from PIL import Image


### PR DESCRIPTION
- Copy-pasted all the pre-existing code concerning pandas into its polars equivalent
- Adapted as needed
	- For instance, polars dataframes don't have an Index, so I deleted all mentions of it in the polars version
	- Unlike pandas, polars raises a `ComputeError` when serializing a DataFrame that contains a complex object, e.g. a numpy array.
- Added the Polars Items to the UI routes
	- Used `to_pandas` which requires `pyarrow`


It was [suggested](https://github.com/probabl-ai/skore/pull/792#issuecomment-2498980110) that we might use narwhals for the implementation. For this PR I went without it, for these reasons:
- I wanted to avoid adding a dependency (unfortunately, I still ended up adding pyarrow for the specific case of transferring data from a Project to skore-ui).
- I have never used narwhals and wanted to avoid a situation where I spend time prototyping only to realize that it doesn't perfectly fit the use-case (for example, I see that narwhals does not expose a `to_json` method).
- We can always reconsider this if we implement support for another DataFrame library.

Closes #758

TODO:
- [x] Write ADR about narwhals
- [x] Deal with complex objects in polars dataframes