### PR TITLE
feat(train_test_split): Add "time-based column" warning

### DIFF
--- a/skore/hatch/metadata.py
+++ b/skore/hatch/metadata.py
@@ -6,7 +6,9 @@ from hatchling.metadata.plugin.interface import MetadataHookInterface
 
 class MetadataHook(MetadataHookInterface):
     def update(self, metadata):
-        license = Path(self.root, self.config["license-file"]).read_text(encoding="utf-8")
+        license = Path(self.root, self.config["license-file"]).read_text(
+            encoding="utf-8"
+        )
         readme = Path(self.root, self.config["readme-file"]).read_text(encoding="utf-8")
         version = self.config["version-default"]
 

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -71,6 +71,7 @@ test = [
   "pandas",
   "pillow",
   "plotly",
+  "polars",
   "pre-commit",
   "pytest",
   "pytest-cov",

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -155,11 +155,9 @@ def train_test_split(
     )
 
     for warning_class in TRAIN_TEST_SPLIT_WARNINGS:
-        check = warning_class.check(**kwargs)
+        warning = warning_class.check(**kwargs)
 
-        if check is False:
-            warnings.warn(
-                message=warning_class.MSG, category=warning_class, stacklevel=1
-            )
+        if warning is not None:
+            warnings.warn(message=warning, category=warning_class, stacklevel=1)
 
     return output

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -129,6 +129,9 @@ def train_test_split(
         stratify=stratify,
     )
 
+    if X is None:
+        X = arrays[0] if len(arrays) == 1 else arrays[-2]
+
     if y is None and len(arrays) >= 2:
         y = arrays[-1]
 
@@ -148,6 +151,7 @@ def train_test_split(
         random_state=random_state,
         shuffle=shuffle,
         stratify=stratify,
+        X=X,
         y=y,
         y_test=y_test,
         y_labels=y_labels,

--- a/skore/src/skore/sklearn/train_test_split/warning/__init__.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/__init__.py
@@ -13,6 +13,7 @@ from .high_class_imbalance_warning import (
 from .random_state_unset_warning import RandomStateUnsetWarning
 from .shuffle_true_warning import ShuffleTrueWarning
 from .stratify_is_set_warning import StratifyWarning
+from .time_based_column_warning import TimeBasedColumnWarning
 
 TRAIN_TEST_SPLIT_WARNINGS = [
     HighClassImbalanceTooFewExamplesWarning,
@@ -20,6 +21,7 @@ TRAIN_TEST_SPLIT_WARNINGS = [
     StratifyWarning,
     RandomStateUnsetWarning,
     ShuffleTrueWarning,
+    TimeBasedColumnWarning,
 ]
 
 __all__ = [
@@ -29,4 +31,5 @@ __all__ = [
     "StratifyWarning",
     "RandomStateUnsetWarning",
     "ShuffleTrueWarning",
+    "TimeBasedColumnWarning",
 ]

--- a/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
@@ -1,4 +1,4 @@
-""""High class imbalance (too few examples) warning.
+"""'High class imbalance (too few examples)' warning.
 
 This warning is shown when some class in a dataset has too few examples in the test set.
 """
@@ -6,7 +6,7 @@ This warning is shown when some class in a dataset has too few examples in the t
 from __future__ import annotations
 
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from skore.sklearn.train_test_split.warning.train_test_split_warning import (
     TrainTestSplitWarning,
@@ -36,7 +36,7 @@ class HighClassImbalanceTooFewExamplesWarning(TrainTestSplitWarning):
         y_labels: Optional[ArrayLike],
         ml_task: MLTask,
         **kwargs,
-    ) -> bool:
+    ) -> Union[str, None]:
         """Check whether the test set has too few examples in one class.
 
         More precisely, we check whether some class in `y_labels` has
@@ -63,8 +63,8 @@ class HighClassImbalanceTooFewExamplesWarning(TrainTestSplitWarning):
 
         Returns
         -------
-        bool
-            True if the check passed, False otherwise.
+        warning
+            None if the check passed, otherwise the warning message.
         """
         if (
             stratify
@@ -72,8 +72,11 @@ class HighClassImbalanceTooFewExamplesWarning(TrainTestSplitWarning):
             or (y_labels is None or len(y_labels) == 0)
             or ("classification" not in ml_task)
         ):
-            return True
+            return None
 
         counts = Counter(y_test)
 
-        return all(counts.get(class_, 0) >= 100 for class_ in y_labels)
+        if all(counts.get(class_, 0) >= 100 for class_ in y_labels):
+            return None
+
+        return HighClassImbalanceTooFewExamplesWarning.MSG

--- a/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_warning.py
@@ -5,7 +5,7 @@ This warning is shown when a dataset exhibits a high class imbalance.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import pandas
 
@@ -37,7 +37,7 @@ class HighClassImbalanceWarning(TrainTestSplitWarning):
         stratify: Optional[ArrayLike],
         ml_task: MLTask,
         **kwargs,
-    ) -> bool:
+    ) -> Union[str, None]:
         """Check whether the test set has high class imbalance.
 
         More precisely, we check whether the most populated class in `y` has
@@ -58,12 +58,15 @@ class HighClassImbalanceWarning(TrainTestSplitWarning):
 
         Returns
         -------
-        bool
-            True if the check passed, False otherwise.
+        warning
+            None if the check passed, otherwise the warning message.
         """
         if stratify or (y is None or len(y) == 0) or ("classification" not in ml_task):
-            return True
+            return None
 
         class_counts = pandas.Series(y).value_counts()
 
-        return (max(class_counts) / min(class_counts)) < 3
+        if (max(class_counts) / min(class_counts)) < 3:
+            return None
+
+        return HighClassImbalanceWarning.MSG

--- a/skore/src/skore/sklearn/train_test_split/warning/random_state_unset_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/random_state_unset_warning.py
@@ -28,7 +28,7 @@ class RandomStateUnsetWarning(TrainTestSplitWarning):
         shuffle: bool,
         random_state: Optional[Union[int, RandomState]],
         **kwargs,
-    ) -> bool:
+    ) -> Union[str, None]:
         """Check whether ``random_state`` is set.
 
         Parameters
@@ -42,7 +42,8 @@ class RandomStateUnsetWarning(TrainTestSplitWarning):
 
         Returns
         -------
-        bool
-            True if the check passed, False otherwise.
+        warning
+            None if the check passed, otherwise the warning message.
         """
-        return not (shuffle and random_state is None)
+        if shuffle and random_state is None:
+            return RandomStateUnsetWarning.MSG

--- a/skore/src/skore/sklearn/train_test_split/warning/shuffle_true_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/shuffle_true_warning.py
@@ -5,6 +5,8 @@ This warning is shown when ``shuffle`` is set to True.
 
 from __future__ import annotations
 
+from typing import Union
+
 from skore.sklearn.train_test_split.warning.train_test_split_warning import (
     TrainTestSplitWarning,
 )
@@ -26,7 +28,7 @@ class ShuffleTrueWarning(TrainTestSplitWarning):
     def check(
         shuffle: bool,
         **kwargs,
-    ) -> bool:
+    ) -> Union[str, None]:
         """Check whether ``shuffle`` is set to ``True``.
 
         Parameters
@@ -36,7 +38,8 @@ class ShuffleTrueWarning(TrainTestSplitWarning):
 
         Returns
         -------
-        bool
-            True if the check passed, False otherwise.
+        warning
+            None if the check passed, otherwise the warning message.
         """
-        return shuffle is False
+        if shuffle is not False:
+            return ShuffleTrueWarning.MSG

--- a/skore/src/skore/sklearn/train_test_split/warning/stratify_is_set_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/stratify_is_set_warning.py
@@ -5,7 +5,7 @@ This warning is shown when `stratify` is set.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from skore.sklearn.train_test_split.warning.train_test_split_warning import (
     TrainTestSplitWarning,
@@ -26,7 +26,7 @@ class StratifyWarning(TrainTestSplitWarning):
     )
 
     @staticmethod
-    def check(stratify: Optional[ArrayLike], **kwargs) -> bool:
+    def check(stratify: Optional[ArrayLike], **kwargs) -> Union[str, None]:
         """Check whether stratify is set.
 
         Parameters
@@ -36,7 +36,8 @@ class StratifyWarning(TrainTestSplitWarning):
 
         Returns
         -------
-        bool
-            True if the check passed, False otherwise.
+        warning
+            None if the check passed, otherwise the warning message.
         """
-        return not stratify
+        if stratify:
+            return StratifyWarning.MSG

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -53,6 +53,8 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
             return None
 
         dtypes = [(col, X[col].dtype) for col in X.columns]
+        # NOTE: Searching by regex allows us to avoid depending explicitly
+        # on Pandas or Polars
         datetime_columns = [
             f'"{col}"'
             for col, dtype in dtypes

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -37,7 +37,7 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
 
     @staticmethod
     def check(X: ArrayLike, **kwargs) -> Union[str, None]:
-        """Check whether ``X`` contains a time-based column.
+        """Check whether the design matrix ``X`` contains a time-based column.
 
         Parameters
         ----------

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -29,10 +29,10 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
 
         return (
             f"We detected a time-based column {column_info} in your data. "
-            "We recommend using scikit-learn's TimeSeriesSplit instead of train_test_split. "
-            "Otherwise you might train on future data to predict the past, or get "
-            "inflated model performance evaluation because natural drift will not be "
-            "taken into account."
+            "We recommend using scikit-learn's TimeSeriesSplit instead of "
+            "train_test_split. Otherwise you might train on future data to "
+            "predict the past, or get inflated model performance evaluation "
+            "because natural drift will not be taken into account."
         )
 
     @staticmethod

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -20,15 +20,15 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
     """Check whether the design matrix ``X`` contains a time-based column."""
 
     @staticmethod
-    def _MSG(df_name, offending_column_name):
-        column_info = (
-            f"(column {offending_column_name}, dataframe {offending_column_name})"
-            if df_name is not None
-            else f"(column {offending_column_name})"
-        )
+    def _MSG(df_name: str, offending_column_names: list[str]) -> str:
+        s = "" if len(offending_column_names) == 1 else "s"
+
+        df_name_info = "" if df_name is None else f', dataframe "{df_name}"'
+
+        column_info = f"(column{s} {', '.join(offending_column_names)}{df_name_info})"
 
         return (
-            f"We detected a time-based column {column_info} in your data. "
+            f"We detected some time-based columns {column_info} in your data. "
             "We recommend using scikit-learn's TimeSeriesSplit instead of "
             "train_test_split. Otherwise you might train on future data to "
             "predict the past, or get inflated model performance evaluation "
@@ -54,10 +54,10 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
 
         dtypes = [(col, X[col].dtype) for col in X.columns]
         datetime_columns = [
-            col
+            f'"{col}"'
             for col, dtype in dtypes
             if re.search("date", str(type(dtype)), flags=re.IGNORECASE)
         ]
         if datetime_columns:
             df_name = X.name if hasattr(X, "name") else None
-            return TimeBasedColumnWarning._MSG(df_name, datetime_columns[0])
+            return TimeBasedColumnWarning._MSG(df_name, datetime_columns)

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -52,8 +52,12 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
         if not hasattr(X, "columns"):
             return None
 
-        # NOTE: Only works for pandas DataFrames currently
-        for col, dtype in X.dtypes.items():
-            if re.search("datetime", str(type(dtype)), flags=re.IGNORECASE):
-                df_name = X.name if hasattr(X, "name") else None
-                return TimeBasedColumnWarning._MSG(df_name, col)
+        dtypes = [(col, X[col].dtype) for col in X.columns]
+        datetime_columns = [
+            col
+            for col, dtype in dtypes
+            if re.search("datetime", str(type(dtype)), flags=re.IGNORECASE)
+        ]
+        if datetime_columns:
+            df_name = X.name if hasattr(X, "name") else None
+            return TimeBasedColumnWarning._MSG(df_name, datetime_columns[0])

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -29,7 +29,7 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
 
         return (
             f"We detected a time-based column {column_info} in your data. "
-            "We recommend using TimeSeriesSplit instead of train_test_split. "
+            "We recommend using scikit-learn's TimeSeriesSplit instead of train_test_split. "
             "Otherwise you might train on future data to predict the past, or get "
             "inflated model performance evaluation because natural drift will not be "
             "taken into account."

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class TimeBasedColumnWarning(TrainTestSplitWarning):
-    """Check whether ``X`` contains a time-based column."""
+    """Check whether the design matrix ``X`` contains a time-based column."""
 
     @staticmethod
     def _MSG(df_name, offending_column_name):

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -1,0 +1,59 @@
+"""'Time-based column' warning.
+
+This warning is shown when ``X`` contains a time-based column.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, Union
+
+from skore.sklearn.train_test_split.warning.train_test_split_warning import (
+    TrainTestSplitWarning,
+)
+
+if TYPE_CHECKING:
+    ArrayLike = Any
+
+
+class TimeBasedColumnWarning(TrainTestSplitWarning):
+    """Check whether ``X`` contains a time-based column."""
+
+    @staticmethod
+    def _MSG(df_name, offending_column_name):
+        column_info = (
+            f"(column {offending_column_name}, dataframe {offending_column_name})"
+            if df_name is not None
+            else f"(column {offending_column_name})"
+        )
+
+        return (
+            f"We detected a time-based column {column_info} in your data. "
+            "We recommend using TimeSeriesSplit instead of train_test_split. "
+            "Otherwise you might train on future data to predict the past, or get "
+            "inflated model performance evaluation because natural drift will not be "
+            "taken into account."
+        )
+
+    @staticmethod
+    def check(X: ArrayLike, **kwargs) -> Union[str, None]:
+        """Check whether ``X`` contains a time-based column.
+
+        Parameters
+        ----------
+        X : array-like or None
+            A data matrix that can contain datetime data, e.g. a DataFrame.
+
+        Returns
+        -------
+        warning
+            None if the check passed, otherwise the warning message.
+        """
+        if not hasattr(X, "columns"):
+            return None
+
+        # NOTE: Only works for pandas DataFrames currently
+        for col, dtype in X.dtypes.items():
+            if re.search("datetime", str(type(dtype)), flags=re.IGNORECASE):
+                df_name = X.name if hasattr(X, "name") else None
+                return TimeBasedColumnWarning._MSG(df_name, col)

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -56,7 +56,7 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
         datetime_columns = [
             col
             for col, dtype in dtypes
-            if re.search("datetime", str(type(dtype)), flags=re.IGNORECASE)
+            if re.search("date", str(type(dtype)), flags=re.IGNORECASE)
         ]
         if datetime_columns:
             df_name = X.name if hasattr(X, "name") else None

--- a/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/time_based_column_warning.py
@@ -1,6 +1,7 @@
 """'Time-based column' warning.
 
 This warning is shown when ``X`` contains a time-based column.
+Currently, only pandas and polars DataFrames are supported.
 """
 
 from __future__ import annotations
@@ -17,7 +18,10 @@ if TYPE_CHECKING:
 
 
 class TimeBasedColumnWarning(TrainTestSplitWarning):
-    """Check whether the design matrix ``X`` contains a time-based column."""
+    """Check whether the design matrix ``X`` contains a time-based column.
+
+    Currently, only pandas and polars DataFrames are supported.
+    """
 
     @staticmethod
     def _MSG(df_name: str, offending_column_names: list[str]) -> str:
@@ -38,6 +42,8 @@ class TimeBasedColumnWarning(TrainTestSplitWarning):
     @staticmethod
     def check(X: ArrayLike, **kwargs) -> Union[str, None]:
         """Check whether the design matrix ``X`` contains a time-based column.
+
+        Currently, only pandas and polars DataFrames are supported.
 
         Parameters
         ----------

--- a/skore/src/skore/sklearn/train_test_split/warning/train_test_split_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/train_test_split_warning.py
@@ -3,19 +3,19 @@
 This module defines an interface for warnings shown in :func:`~skore.train_test_split`.
 """
 
+from typing import Union
+
 
 class TrainTestSplitWarning(Warning):
     """Interface for a train-test-split warning."""
 
-    MSG: str
-
     @staticmethod
-    def check(*args, **kwargs) -> bool:
+    def check(*args, **kwargs) -> Union[str, None]:
         """Perform the check.
 
         Returns
         -------
-        bool
-            True if the check passed, False otherwise.
+        warning
+            None if the check passed, otherwise the warning message.
         """
         ...

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -76,6 +76,23 @@ def case_time_based_column():
     return args, kwargs, TimeBasedColumnWarning
 
 
+def case_time_based_columns_several():
+    """If a column has dtype "datetime", the warning should fire"""
+    X = pandas.DataFrame(
+        {
+            "ints": [0, 1],
+            "dates1": [datetime(2024, 11, 25), datetime(2024, 11, 26)],
+            # NOTE: Column name is an int
+            2: [datetime(2024, 11, 25), datetime(2024, 11, 26)],
+        }
+    )
+    # NOTE: DataFrame has a name
+    X.name = "my_df"
+    args = (X,)
+    kwargs = {}
+    return args, kwargs, TimeBasedColumnWarning
+
+
 def case_time_based_column_polars():
     X = polars.DataFrame(
         {"ints": [0, 1], "dates": [datetime(2024, 11, 25), datetime(2024, 11, 26)]}
@@ -107,6 +124,7 @@ def case_time_based_column_polars_dates():
         case_shuffle_true,
         case_shuffle_none,
         case_time_based_column,
+        case_time_based_columns_several,
         case_time_based_column_polars,
         case_time_based_column_polars_dates,
     ],

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -2,6 +2,7 @@ import warnings
 from datetime import datetime
 
 import pandas
+import polars
 import pytest
 from skore.sklearn.train_test_split.train_test_split import (
     train_test_split,
@@ -75,6 +76,15 @@ def case_time_based_column():
     return args, kwargs, TimeBasedColumnWarning
 
 
+def case_time_based_column_polars():
+    X = polars.DataFrame(
+        {"ints": [0, 1], "dates": [datetime(2024, 11, 25), datetime(2024, 11, 26)]}
+    )
+    args = (X,)
+    kwargs = {}
+    return args, kwargs, TimeBasedColumnWarning
+
+
 @pytest.mark.parametrize(
     "params",
     [
@@ -87,6 +97,7 @@ def case_time_based_column():
         case_shuffle_true,
         case_shuffle_none,
         case_time_based_column,
+        case_time_based_column_polars,
     ],
 )
 def test_train_test_split_warns(params):

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -1,5 +1,7 @@
 import warnings
+from datetime import datetime
 
+import pandas
 import pytest
 from skore.sklearn.train_test_split.train_test_split import (
     train_test_split,
@@ -10,6 +12,7 @@ from skore.sklearn.train_test_split.warning import (
     RandomStateUnsetWarning,
     ShuffleTrueWarning,
     StratifyWarning,
+    TimeBasedColumnWarning,
 )
 
 
@@ -62,6 +65,16 @@ def case_shuffle_none():
     return args, kwargs, ShuffleTrueWarning
 
 
+def case_time_based_column():
+    """If a column has dtype "datetime", the warning should fire"""
+    X = pandas.DataFrame(
+        {"ints": [0, 1], "dates": [datetime(2024, 11, 25), datetime(2024, 11, 26)]}
+    )
+    args = (X,)
+    kwargs = {}
+    return args, kwargs, TimeBasedColumnWarning
+
+
 @pytest.mark.parametrize(
     "params",
     [
@@ -73,6 +86,7 @@ def case_shuffle_none():
         case_random_state_unset,
         case_shuffle_true,
         case_shuffle_none,
+        case_time_based_column,
     ],
 )
 def test_train_test_split_warns(params):

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -85,6 +85,16 @@ def case_time_based_column_polars():
     return args, kwargs, TimeBasedColumnWarning
 
 
+def case_time_based_column_polars_dates():
+    X = polars.DataFrame(
+        {"ints": [0, 1], "dates": [datetime(2024, 11, 25), datetime(2024, 11, 26)]},
+        schema={"ints": polars.Int8, "dates": polars.Date},
+    )
+    args = (X,)
+    kwargs = {}
+    return args, kwargs, TimeBasedColumnWarning
+
+
 @pytest.mark.parametrize(
     "params",
     [
@@ -98,6 +108,7 @@ def case_time_based_column_polars():
         case_shuffle_none,
         case_time_based_column,
         case_time_based_column_polars,
+        case_time_based_column_polars_dates,
     ],
 )
 def test_train_test_split_warns(params):

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_too_few_examples_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_too_few_examples_warning.py
@@ -7,11 +7,11 @@ def test_check_high_class_imbalance_too_few_examples():
     y_test = [0] * 100
     y_labels = [0, 1]
 
-    check_passed = HighClassImbalanceTooFewExamplesWarning.check(
+    warning = HighClassImbalanceTooFewExamplesWarning.check(
         y_test=y_test,
         y_labels=y_labels,
         stratify=None,
         ml_task="multiclass-classification",
     )
 
-    assert not check_passed
+    assert warning is not None

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_too_few_examples_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_too_few_examples_warning.py
@@ -14,4 +14,4 @@ def test_check_high_class_imbalance_too_few_examples():
         ml_task="multiclass-classification",
     )
 
-    assert warning is not None
+    assert warning == HighClassImbalanceTooFewExamplesWarning.MSG

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_warning.py
@@ -17,10 +17,10 @@ target = [0] * 100 + [1] * 100 + [2] * 300
     ],
 )
 def test_check_high_class_imbalance(y):
-    check = HighClassImbalanceWarning.check(
+    warning = HighClassImbalanceWarning.check(
         y=y,
         stratify=None,
         ml_task="multiclass-classification",
     )
 
-    assert check is False
+    assert warning is not None

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_high_class_imbalance_warning.py
@@ -23,4 +23,4 @@ def test_check_high_class_imbalance(y):
         ml_task="multiclass-classification",
     )
 
-    assert warning is not None
+    assert warning == HighClassImbalanceWarning.MSG

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_stratify_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_stratify_warning.py
@@ -3,7 +3,7 @@ from skore.sklearn.train_test_split.warning import StratifyWarning
 
 def test_check_stratify():
     warning = StratifyWarning.check(stratify=[0] * 100)
-    assert warning is not None
+    assert warning == StratifyWarning.MSG
 
 
 def test_check_stratify_passes():

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_stratify_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_stratify_warning.py
@@ -2,10 +2,10 @@ from skore.sklearn.train_test_split.warning import StratifyWarning
 
 
 def test_check_stratify():
-    check_passed = StratifyWarning.check(stratify=[0] * 100)
-    assert not check_passed
+    warning = StratifyWarning.check(stratify=[0] * 100)
+    assert warning is not None
 
 
 def test_check_stratify_passes():
-    check_passed = StratifyWarning.check(stratify=None)
-    assert check_passed
+    warning = StratifyWarning.check(stratify=None)
+    assert warning is None

--- a/skore/tests/unit/sklearn/train_test_split/warning/test_time_based_column_warning.py
+++ b/skore/tests/unit/sklearn/train_test_split/warning/test_time_based_column_warning.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pandas
+import polars
+import pytest
+from skore.sklearn.train_test_split.warning import TimeBasedColumnWarning
+
+target = [0] * 100 + [1] * 100 + [2] * 300
+
+
+def case_time_based_column():
+    """If a column has dtype "datetime", the warning should fire"""
+    return pandas.DataFrame(
+        {"ints": [0, 1], "dates": [datetime(2024, 11, 25), datetime(2024, 11, 26)]}
+    )
+
+
+def case_time_based_columns_several():
+    """If a column has dtype "datetime", the warning should fire"""
+    X = pandas.DataFrame(
+        {
+            "ints": [0, 1],
+            "dates1": [datetime(2024, 11, 25), datetime(2024, 11, 26)],
+            # NOTE: Column name is an int
+            2: [datetime(2024, 11, 25), datetime(2024, 11, 26)],
+        }
+    )
+    # NOTE: DataFrame has a name
+    X.name = "my_df"
+    return X
+
+
+def case_time_based_column_polars():
+    return polars.DataFrame(
+        {"ints": [0, 1], "dates": [datetime(2024, 11, 25), datetime(2024, 11, 26)]}
+    )
+
+
+def case_time_based_column_polars_dates():
+    return polars.DataFrame(
+        {"ints": [0, 1], "dates": [datetime(2024, 11, 25), datetime(2024, 11, 26)]},
+        schema={"ints": polars.Int8, "dates": polars.Date},
+    )
+
+
+@pytest.mark.parametrize(
+    "X",
+    [
+        case_time_based_column,
+        case_time_based_columns_several,
+        case_time_based_column_polars,
+        case_time_based_column_polars_dates,
+    ],
+)
+def test_check_time_based_column(X):
+    warning = TimeBasedColumnWarning.check(X=X())
+
+    assert warning is not None


### PR DESCRIPTION
This implementation has been tested for pandas and polars dataframes, and checks whether the dtype of any column matches the string "date". Thus, we assume that the dtypes are accurate (no clever string parsing yet).

Because the new warning's message is dynamic (it includes the name or index of the first offending column), I took the opportunity to simplify the `TrainTestSplitWarning` interface: now, only the `check` method is expected, and it returns either `None` or a warning message string.

Addresses #684
