### PR TITLE
feat(cli): Make `create` and `launch` parameters usable with `quickstart`

### DIFF
--- a/skore/src/skore/cli/cli.py
+++ b/skore/src/skore/cli/cli.py
@@ -62,8 +62,43 @@ def cli(args: list[str]):
         help="overwrite an existing project with the same name",
     )
 
-    subparsers.add_parser(
+    parser_quickstart = subparsers.add_parser(
         "quickstart", help='Create a "project.skore" file and start the UI'
+    )
+    parser_quickstart.add_argument(
+        "project_name",
+        nargs="?",
+        help="the name or path of the project to create (default: %(default)s)",
+        default="project",
+    )
+    parser_quickstart.add_argument(
+        "--working-dir",
+        type=pathlib.Path,
+        help=(
+            "the directory relative to which the project name will be interpreted; "
+            "default is the current working directory (mostly used for testing)"
+        ),
+        default=None,
+    )
+    parser_quickstart.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="overwrite an existing project with the same name",
+    )
+    parser_quickstart.add_argument(
+        "--port",
+        type=int,
+        help="the port at which to bind the UI server (default: %(default)s)",
+        default=22140,
+    )
+    parser_quickstart.add_argument(
+        "--open-browser",
+        action=argparse.BooleanOptionalAction,
+        help=(
+            "whether to automatically open a browser tab showing the web UI "
+            "(default: %(default)s)"
+        ),
+        default=True,
     )
 
     parsed_args: argparse.Namespace = parser.parse_args(args)
@@ -81,6 +116,12 @@ def cli(args: list[str]):
             overwrite=parsed_args.overwrite,
         )
     elif parsed_args.subcommand == "quickstart":
-        __quickstart()
+        __quickstart(
+            project_name=parsed_args.project_name,
+            working_dir=parsed_args.working_dir,
+            overwrite=parsed_args.overwrite,
+            port=parsed_args.port,
+            open_browser=parsed_args.open_browser,
+        )
     else:
         parser.print_help()

--- a/skore/src/skore/cli/quickstart_command.py
+++ b/skore/src/skore/cli/quickstart_command.py
@@ -1,32 +1,51 @@
 """Implement the "quickstart" command."""
 
+from pathlib import Path
+from typing import Optional, Union
+
 from skore.cli import logger
 from skore.cli.launch_dashboard import __launch
 from skore.exceptions import ProjectAlreadyExistsError
 from skore.project import create
 
 
-def __quickstart():
+def __quickstart(
+    project_name: Union[str, Path],
+    working_dir: Optional[Path],
+    overwrite: bool,
+    port: int,
+    open_browser: bool,
+):
     """Quickstart a Skore project.
 
     Create it if it does not exist, then launch the web UI.
 
     Parameters
     ----------
+    project_name : Path-like
+        Name of the project to be created, or a relative or absolute path.
+    working_dir : Path or None
+        If ``project_name`` is not an absolute path, it will be considered relative to
+        ``working_dir``. If `project_name` is an absolute path, ``working_dir`` will
+        have no effect. If set to ``None`` (the default), ``working_dir`` will be re-set
+        to the current working directory.
+    overwrite : bool
+        If ``True``, overwrite an existing project with the same name.
+        If ``False``, raise an error if a project with the same name already exists.
     port : int
         Port at which to bind the UI server.
+    open_browser : bool
+        Whether to automatically open a browser tab showing the UI.
     """
-    project_name = "project.skore"
-
     try:
-        create(project_name=project_name)
+        create(project_name=project_name, working_dir=working_dir, overwrite=overwrite)
     except ProjectAlreadyExistsError:
         logger.info(
             f"Project file '{project_name}' already exists. Skipping creation step."
         )
 
     __launch(
-        project_name="project.skore",
-        port=22140,
-        open_browser=True,
+        project_name=project_name,
+        port=port,
+        open_browser=open_browser,
     )

--- a/skore/tests/unit/cli/test_cli.py
+++ b/skore/tests/unit/cli/test_cli.py
@@ -26,6 +26,6 @@ def test_cli_launch(monkeypatch):
     assert not launch_open_browser
 
 
-def test_cli_launch_no_project_name(monkeypatch):
+def test_cli_launch_no_project_name():
     with pytest.raises(SystemExit):
         cli(["launch", "--port", 0, "--no-open-browser"])

--- a/skore/tests/unit/cli/test_quickstart.py
+++ b/skore/tests/unit/cli/test_quickstart.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from skore.cli.cli import cli
+
+
+def test_quickstart(monkeypatch):
+    """`quickstart` passes its arguments down to `create` and `launch`."""
+
+    create_project_name = None
+    create_working_dir = None
+    create_overwrite = None
+
+    def fake_create(project_name, working_dir, overwrite):
+        nonlocal create_project_name
+        nonlocal create_working_dir
+        nonlocal create_overwrite
+
+        create_project_name = project_name
+        create_working_dir = working_dir
+        create_overwrite = overwrite
+
+    monkeypatch.setattr("skore.cli.quickstart_command.create", fake_create)
+
+    launch_project_name = None
+    launch_port = None
+    launch_open_browser = None
+
+    def fake_launch(project_name, port, open_browser):
+        nonlocal launch_project_name
+        nonlocal launch_port
+        nonlocal launch_open_browser
+
+        launch_project_name = project_name
+        launch_port = port
+        launch_open_browser = open_browser
+
+    monkeypatch.setattr("skore.cli.quickstart_command.__launch", fake_launch)
+
+    cli(
+        [
+            "quickstart",
+            "my_project.skore",
+            "--overwrite",
+            "--working-dir",
+            "hello",
+            "--port",
+            "888",
+            "--no-open-browser",
+        ]
+    )
+
+    assert create_project_name == "my_project.skore"
+    assert create_working_dir == Path("hello")
+    assert create_overwrite is True
+
+    assert launch_project_name == "my_project.skore"
+    assert launch_port == 888
+    assert launch_open_browser is False


### PR DESCRIPTION
The PR contains a fair amount of code duplication, presumably because I'm missing something about `argparse`.

Closes #725

TODO:
- [x] Add automatic tests