### PR TITLE
ci: Remove reference of the release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ jobs:
   tag-restriction:
     name: Tag must match semantic versioning pattern
     runs-on: ubuntu-latest
-    environment: release
     steps:
       - shell: bash
         run: |
@@ -19,7 +18,6 @@ jobs:
   build:
     name: Build package distributions
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: read
     needs: tag-restriction
@@ -65,7 +63,6 @@ jobs:
   publish:
     name: Publish package distributions to PyPI using trusted publisher
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       id-token: write
     needs: build
@@ -111,7 +108,6 @@ jobs:
   clean:
     name: Delete package distributions artifacts
     runs-on: ubuntu-latest
-    environment: release
     if: always()
     needs: publish
     steps:


### PR DESCRIPTION
We don't need to fill the `deployment` section of GH, as long as we do only releases.