### PR TITLE
fix(API): Do not use base64 for text types

### DIFF
--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -79,7 +79,7 @@ def __serialize_project(project: Project) -> SerializedProject:
                 media_type = "application/vnd.sklearn.estimator+html"
             elif isinstance(item, MediaItem):
                 if "text" in item.media_type:
-                    value = item.media_bytes.decode()
+                    value = item.media_bytes.decode(encoding=item.media_encoding)
                     media_type = f"{item.media_type}"
                 else:
                     value = base64.b64encode(item.media_bytes).decode()

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -78,8 +78,12 @@ def __serialize_project(project: Project) -> SerializedProject:
                 value = item.estimator_html_repr
                 media_type = "application/vnd.sklearn.estimator+html"
             elif isinstance(item, MediaItem):
-                value = base64.b64encode(item.media_bytes).decode()
-                media_type = f"{item.media_type};base64"
+                if "text" in item.media_type:
+                    value = item.media_bytes.decode()
+                    media_type = f"{item.media_type}"
+                else:
+                    value = base64.b64encode(item.media_bytes).decode()
+                    media_type = f"{item.media_type};base64"
             elif isinstance(
                 item, (CrossValidationItem, CrossValidationAggregationItem)
             ):

--- a/skore/tests/integration/ui/test_ui.py
+++ b/skore/tests/integration/ui/test_ui.py
@@ -114,7 +114,7 @@ def test_serialize_numpy_array(client, in_memory_project):
     assert len(project["items"]["np array"][0]["value"]) == 4
 
 
-def test_serilialize_sklearn_estimator(client, in_memory_project):
+def test_serialize_sklearn_estimator(client, in_memory_project):
     estimator = Lasso()
     in_memory_project.put("estimator", estimator)
 

--- a/skore/tests/integration/ui/test_ui.py
+++ b/skore/tests/integration/ui/test_ui.py
@@ -1,7 +1,11 @@
+import numpy
 import pandas
 import polars
 import pytest
 from fastapi.testclient import TestClient
+from PIL import Image
+from sklearn.linear_model import Lasso
+from skore.item.media_item import MediaItem
 from skore.ui.app import create_app
 from skore.view.view import View
 
@@ -98,3 +102,42 @@ def test_serialize_polars_series_with_missing_values(client, in_memory_project):
     assert response.status_code == 200
     project = response.json()
     assert len(project["items"]["🐻‍❄️"][0]["value"]) == 6
+
+
+def test_serialize_numpy_array(client, in_memory_project):
+    np_array = numpy.array([1, 2, 3, 4])
+    in_memory_project.put("np array", np_array)
+
+    response = client.get("/api/project/items")
+    assert response.status_code == 200
+    project = response.json()
+    assert len(project["items"]["np array"][0]["value"]) == 4
+
+
+def test_serilialize_sklearn_estimator(client, in_memory_project):
+    estimator = Lasso()
+    in_memory_project.put("estimator", estimator)
+
+    response = client.get("/api/project/items")
+    assert response.status_code == 200
+    project = response.json()
+    assert project["items"]["estimator"][0]["value"] is not None
+
+
+def test_serialize_media_item(client, in_memory_project):
+    imarray = numpy.random.rand(100, 100, 3) * 255
+    img = Image.fromarray(imarray.astype("uint8")).convert("RGBA")
+    in_memory_project.put("img", img)
+
+    html = "<h1>éàªªUœALDXIWDŸΩΩ</h1>"
+    in_memory_project.put("html", html)
+    in_memory_project.put_item(
+        "media html", MediaItem.factory_str(html, media_type="text/html")
+    )
+
+    response = client.get("/api/project/items")
+    assert response.status_code == 200
+    project = response.json()
+    assert "image" in project["items"]["img"][0]["media_type"]
+    assert project["items"]["html"][0]["value"] == html
+    assert project["items"]["media html"][0]["value"] == html


### PR DESCRIPTION
Fixes #853.
![Screenshot 2024-12-03 at 13 56 30](https://github.com/user-attachments/assets/019680fb-19f9-47dc-a576-02fa096c2b5a)

Bonus: projects_routes.py coverage is now higher.

 