### PR TITLE
fix(cross-validation plot): Fix hover on horizontal lines

### DIFF
--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -66,7 +66,7 @@ def plot_cross_validation(cv_results: dict) -> plotly.graph_objects.Figure:
         bar_color = plotly.colors.qualitative.Plotly[
             col_i % len(plotly.colors.qualitative.Plotly)
         ]
-        bar_x = [min(df.index) - 0.5, max(df.index) + 0.5]
+        bar_x = numpy.linspace(min(df.index) - 0.5, max(df.index) + 0.5, num=10)
 
         common_kwargs = dict(
             visible=True if col_i == 0 else "legendonly",
@@ -104,7 +104,7 @@ def plot_cross_validation(cv_results: dict) -> plotly.graph_objects.Figure:
                 # Mean line
                 go.Scatter(
                     x=bar_x,
-                    y=[avg_value, avg_value],
+                    y=[avg_value] * 10,
                     name=f"Average {metric_name}",
                     line=dict(dash="dash", color=bar_color),
                     showlegend=False,
@@ -114,7 +114,7 @@ def plot_cross_validation(cv_results: dict) -> plotly.graph_objects.Figure:
                 # +1 std line
                 go.Scatter(
                     x=bar_x,
-                    y=[avg_value + std_value, avg_value + std_value],
+                    y=[avg_value + std_value] * 10,
                     name=f"Average + 1 std. dev. {metric_name}",
                     line=dict(dash="dot", color=bar_color),
                     showlegend=False,
@@ -124,7 +124,7 @@ def plot_cross_validation(cv_results: dict) -> plotly.graph_objects.Figure:
                 # -1 std line
                 go.Scatter(
                     x=bar_x,
-                    y=[avg_value - std_value, avg_value - std_value],
+                    y=[avg_value - std_value] * 10,
                     name=f"Average - 1 std. dev. {metric_name}",
                     line=dict(dash="dot", color=bar_color),
                     showlegend=False,


### PR DESCRIPTION
Previously the tooltip was only shown when hovering on the extreme right or left of the plot.

Addresses #686


https://github.com/user-attachments/assets/c75ffeff-dc85-4526-bc6b-93d8afa119fe

