### PR TITLE
fix: Avoid JSON parsing of object that are already parsed

### DIFF
--- a/skore-ui/src/stores/project.ts
+++ b/skore-ui/src/stores/project.ts
@@ -350,7 +350,7 @@ export const useProjectStore = defineStore("project", () => {
           if (isBase64 && !isImage) {
             data = atob(item.value);
           }
-          if (item.media_type.includes("+json")) {
+          if (typeof data === "string" && item.media_type.includes("+json")) {
             data = JSON.parse(data);
           }
           const createdAt = new Date(item.created_at);


### PR DESCRIPTION
I'm a bit puzzled by this. 
I think it's a regression linked to our latest refactor but I cant understand how it worked before.