### PR TITLE
ci: Use `scikit-learn <1.6` temporarily

### DIFF
--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "plotly>=5,<6",
   "pyarrow",
   "rich",
+  "scikit-learn <1.6",  # ensure compatibility
   "skops",
   "uvicorn",
 ]
@@ -75,7 +76,7 @@ test = [
   "pytest-order",
   "pytest-randomly",
   "ruff",
-  "scikit-learn",
+  "scikit-learn <1.6",
   "skrub",
 ]
 
@@ -88,7 +89,7 @@ sphinx = [
   "polars",
   "kaleido",
   "pydata-sphinx-theme",
-  "scikit-learn",
+  "scikit-learn <1.6",
   "sphinx",
   "sphinx-design",
   "sphinx-gallery",


### PR DESCRIPTION
It seems that we are not compatible with `scikit-learn ==1.6`.

```
Unexpected failing examples (2):

    ../examples/01_track/plot_01_overview_skore_project.py failed leaving traceback:

    Traceback (most recent call last):
      File "/home/runner/work/skore/skore/examples/01_track/plot_01_overview_skore_project.py", line 348, in <module>
        my_project.put("my_model", my_model)
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/project/project.py", line 130, in put
        self.__put_one(key, value)
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/project/project.py", line 147, in __put_one
        item = object_to_item(value)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/item/__init__.py", line 45, in object_to_item
        return cls.factory(object)
               ^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/item/cross_validation_item.py", line 114, in factory
        return cls.factory_raw(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: CrossValidationItem.factory_raw() missing 4 required positional arguments: 'estimator', 'X', 'y', and 'plot'

    ../examples/00_getting_started/plot_01_getting_started.py failed leaving traceback:

    Traceback (most recent call last):
      File "/home/runner/work/skore/skore/examples/00_getting_started/plot_01_getting_started.py", line 142, in <module>
        my_project.put("my_gs_cv", gs_cv)
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/project/project.py", line 130, in put
        self.__put_one(key, value)
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/project/project.py", line 147, in __put_one
        item = object_to_item(value)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/item/__init__.py", line 45, in object_to_item
        return cls.factory(object)
               ^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/skore/item/cross_validation_item.py", line 114, in factory
        return cls.factory_raw(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: CrossValidationItem.factory_raw() missing 4 required positional arguments: 'estimator', 'X', 'y', and 'plot'
```