### PR TITLE
feat: Make sure CrossValidationItem creation comes from CrossValidationReporter

### DIFF
--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -8,12 +8,12 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import numpy as np
 from numpy.random import RandomState
 
-from skore.project import Project
 from skore.sklearn.find_ml_task import _find_ml_task
 from skore.sklearn.train_test_split.warning import TRAIN_TEST_SPLIT_WARNINGS
 
 if TYPE_CHECKING:
     ArrayLike = Any
+    from skore.project import Project
 
 
 def train_test_split(

--- a/skore/tests/unit/item/test_cross_validation_item.py
+++ b/skore/tests/unit/item/test_cross_validation_item.py
@@ -1,7 +1,31 @@
+from dataclasses import dataclass
+
 import numpy
 import plotly.graph_objects
 import pytest
-from skore.item import CrossValidationItem, ItemTypeError
+from skore.item.cross_validation_item import (
+    CrossValidationItem,
+    ItemTypeError,
+    _hash_numpy,
+)
+
+
+class FakeEstimator:
+    def get_params(self):
+        return {}
+
+
+@dataclass
+class FakeCrossValidationReporter:
+    _cv_results = {
+        "test_score": numpy.array([1, 2, 3]),
+        "estimator": [FakeEstimator(), FakeEstimator(), FakeEstimator()],
+        "fit_time": [1, 2, 3],
+    }
+    estimator = FakeEstimator()
+    X = numpy.array([[1.0]])
+    y = numpy.array([1])
+    plot = plotly.graph_objects.Figure()
 
 
 class TestCrossValidationItem:
@@ -11,39 +35,25 @@ class TestCrossValidationItem:
 
     def test_factory_exception(self):
         with pytest.raises(ItemTypeError):
-            CrossValidationItem.factory(
-                cv_results=None,
-                estimator=None,
-                X=None,
-                y=None,
-                plot=None,
-            )
+            CrossValidationItem.factory(None)
 
     def test_factory(self, monkeypatch, mock_nowstr):
         monkeypatch.setattr(
-            "skore.item.cross_validation_item._hash_numpy", lambda x: ""
+            "skore.item.cross_validation_item.CrossValidationReporter",
+            FakeCrossValidationReporter,
         )
 
-        class MyEstimator:
-            def get_params(self):
-                return {}
-
-        item = CrossValidationItem.factory(
-            cv_results={
-                "test_score": numpy.array([1, 2, 3]),
-                "estimator": [MyEstimator(), MyEstimator(), MyEstimator()],
-                "fit_time": [1, 2, 3],
-            },
-            estimator=MyEstimator(),
-            X=[[1.0]],
-            y=[1],
-            plot=plotly.graph_objects.Figure()
-        )
+        reporter = FakeCrossValidationReporter()
+        item = CrossValidationItem.factory(reporter)
 
         assert item.cv_results_serialized == {"test_score": [1, 2, 3]}
-        assert item.estimator_info == {"name": "MyEstimator", "params": "{}"}
-        assert item.X_info == {"nb_cols": 1, "nb_rows": 1, "hash": ""}
-        assert item.y_info == {"hash": ""}
+        assert item.estimator_info == {"name": "FakeEstimator", "params": "{}"}
+        assert item.X_info == {
+            "nb_cols": 1,
+            "nb_rows": 1,
+            "hash": _hash_numpy(FakeCrossValidationReporter.X),
+        }
+        assert item.y_info == {"hash": _hash_numpy(FakeCrossValidationReporter.y)}
         assert isinstance(item.plot_bytes, bytes)
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr


### PR DESCRIPTION
Part of https://github.com/probabl-ai/skore/issues/886.

As a user will never instanciate a `CrossValidationItem` himself, make sure `CrossValidationItem` creation comes from `CrossValidationReporter`, so the `object_to_item` fallback is not triggered by a simple dictionary (and remains meaningful).

- In `CrossValidationItem`, test class with `isinstance` by fixing circular imports
- In `CrossValidationItem`, remove the possibility to use factory other than with a `CrossValidationReporter`.