### PR TITLE
chore(deps): Use scikit-learn <1.7 in skore dependencies

### DIFF
--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "plotly>=5,<6",
   "pyarrow",
   "rich",
-  "scikit-learn <1.6",  # ensure compatibility
+  "scikit-learn<1.7",
   "skops",
   "uvicorn",
 ]
@@ -76,7 +76,6 @@ test = [
   "pytest-order",
   "pytest-randomly",
   "ruff",
-  "scikit-learn <1.6",
   "skrub",
 ]
 
@@ -89,7 +88,6 @@ sphinx = [
   "polars",
   "kaleido",
   "pydata-sphinx-theme",
-  "scikit-learn <1.6",
   "sphinx",
   "sphinx-design",
   "sphinx-gallery",


### PR DESCRIPTION
`scikit-learn` is used in `/sklearn/cross_validation/` and `/sklearn/train_test_split/`.