### PR TITLE
ci: Test with the 3 latest major versions of `scikit-learn`

### DIFF
--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -30,7 +30,8 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: "pip"
 
-      - uses: actions/cache/restore@v4
+      - name: Restore python-venv
+        uses: actions/cache/restore@v4
         id: cache-python-venv
         with:
           path: 'skore/venv'
@@ -53,22 +54,28 @@ jobs:
               echo "VIRTUAL_ENV=${GITHUB_WORKSPACE}\\skore\\venv" >> ${GITHUB_ENV}
           fi
 
-      - name: Install dependencies
+      - name: Install dependencies in python-venv
         working-directory: "skore/"
         if: steps.cache-python-venv.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade "pip"
           python -m pip install --upgrade "build"
           python -m pip install --upgrade "scikit-learn ==${{ matrix.scikit-learn }}"
+
+          # Install `skore` and its dependencies
           python -m pip install --upgrade ".[test]"
 
-      - uses: actions/cache/save@v4
+          # Uninstall the `skore` package itself
+          python -m pip uninstall -y "skore"
+
+      - name: Save python-venv
+        uses: actions/cache/save@v4
         if: steps.cache-python-venv.outputs.cache-hit != 'true'
         with:
           path: 'skore/venv'
           key: ${{ steps.cache-python-venv.outputs.cache-primary-key }}
 
-      - name:
+      - name: Lint and test
         timeout-minutes: 10
         working-directory: "skore/"
         run: |
@@ -78,7 +85,7 @@ jobs:
           # Build
           python -m build
 
-          # Install
+          # Install `skore` without its dependencies, which are present in the venv
           wheel=(dist/*.whl); python -m pip install --force-reinstall --no-deps "${wheel}"
 
           # Test

--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -5,30 +5,73 @@ on: [workflow_call]
 defaults:
   run:
     shell: "bash"
-    working-directory: "./skore"
 
 jobs:
   test-skore:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
+        scikit-learn: ["1.6"]
+        include:
+          - os: "ubuntu-latest"
+            python: "3.12"
+            scikit-learn: "1.4"
+          - os: "ubuntu-latest"
+            python: "3.12"
+            scikit-learn: "1.5"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
           cache: "pip"
+
+      - uses: actions/cache/restore@v4
+        id: cache-python-venv
+        with:
+          path: 'skore/venv'
+          key: python-venv-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.scikit-learn }}-${{ hashFiles('skore/pyproject.toml') }}
+
+      - name: Setup python-venv
+        working-directory: "skore/"
+        run: |
+          set -eu
+
+          # Ensure venv is created
+          python -m venv venv
+
+          # Activate venv for each step depending on the OS
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+              echo "${GITHUB_WORKSPACE}/skore/venv/bin" >> ${GITHUB_PATH}
+              echo "VIRTUAL_ENV=${GITHUB_WORKSPACE}/skore/venv" >> ${GITHUB_ENV}
+          else
+              echo "${GITHUB_WORKSPACE}\\skore\\venv\\Scripts" >> ${GITHUB_PATH}
+              echo "VIRTUAL_ENV=${GITHUB_WORKSPACE}\\skore\\venv" >> ${GITHUB_ENV}
+          fi
+
+      - name: Install dependencies
+        working-directory: "skore/"
+        if: steps.cache-python-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade "pip"
+          python -m pip install --upgrade "build"
+          python -m pip install --upgrade "scikit-learn ==${{ matrix.scikit-learn }}"
+          python -m pip install --upgrade ".[test]"
+
+      - uses: actions/cache/save@v4
+        if: steps.cache-python-venv.outputs.cache-hit != 'true'
+        with:
+          path: 'skore/venv'
+          key: ${{ steps.cache-python-venv.outputs.cache-primary-key }}
+
       - name:
         timeout-minutes: 10
+        working-directory: "skore/"
         run: |
-          # Install dependencies
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade pre-commit
-          python -m pip install --upgrade build
-
           # Lint
           pre-commit run --all-files ruff
 
@@ -36,7 +79,7 @@ jobs:
           python -m build
 
           # Install
-          wheel=(dist/*.whl); python -m pip install "${wheel}[test]"
+          wheel=(dist/*.whl); python -m pip install --force-reinstall --no-deps "${wheel}"
 
           # Test
           python -m pytest --no-cov src/ tests/ -n auto
@@ -51,6 +94,7 @@ jobs:
           python-version: 3.12
           cache: "pip"
       - name: pytest coverage
+        working-directory: "skore/"
         run: |
           # Install dependencies
           python -m pip install --upgrade pip

--- a/skore/src/skore/sklearn/cross_validation/cross_validation_helpers.py
+++ b/skore/src/skore/sklearn/cross_validation/cross_validation_helpers.py
@@ -58,7 +58,7 @@ def _get_scorers_to_add(estimator, y) -> dict[str, Any]:
     return {}
 
 
-def _add_scorers(scorers, scorers_to_add):
+def _add_scorers(scorers, scorers_to_add, estimator):
     """Expand `scorers` with more scorers.
 
     The type of the resulting scorers object is dependent on the type of the input
@@ -79,6 +79,8 @@ def _add_scorers(scorers, scorers_to_add):
         The scorer(s) to expand.
     scorers_to_add : dict[str, str]
         The scorers to be added.
+    estimator : estimator
+        A scikit-learn estimator.
 
     Returns
     -------
@@ -89,10 +91,12 @@ def _add_scorers(scorers, scorers_to_add):
         in `scorers`).
     """
     if scorers is None or isinstance(scorers, str):
-        new_scorers, added_scorers = _add_scorers({"score": scorers}, scorers_to_add)
+        new_scorers, added_scorers = _add_scorers(
+            {"score": scorers}, scorers_to_add, estimator
+        )
     elif isinstance(scorers, (list, tuple)):
         new_scorers, added_scorers = _add_scorers(
-            {s: s for s in scorers}, scorers_to_add
+            {s: s for s in scorers}, scorers_to_add, estimator
         )
     elif isinstance(scorers, dict):
         # User-defined metrics have priority
@@ -103,8 +107,11 @@ def _add_scorers(scorers, scorers_to_add):
         from sklearn.metrics._scorer import _MultimetricScorer
 
         internal_scorer = _MultimetricScorer(
+            # NOTE: we pass `estimator` to `check_scoring` for compatibility with
+            # scikit-learn 1.4. However, because `scoring` is never `None`, this
+            # estimator will not have any effect.
             scorers={
-                name: check_scoring(estimator=None, scoring=scoring)
+                name: check_scoring(estimator=estimator, scoring=scoring)
                 if isinstance(scoring, str)
                 else scoring
                 for name, scoring in scorers_to_add.items()

--- a/skore/src/skore/sklearn/cross_validation/cross_validation_reporter.py
+++ b/skore/src/skore/sklearn/cross_validation/cross_validation_reporter.py
@@ -134,7 +134,9 @@ class CrossValidationReporter:
 
         # Extend scorers with other relevant scorers
         scorers_to_add = _get_scorers_to_add(self.estimator, self.y)
-        self._scorers, added_scorers = _add_scorers(self.scorers, scorers_to_add)
+        self._scorers, added_scorers = _add_scorers(
+            self.scorers, scorers_to_add, self.estimator
+        )
 
         self._cv_results = sklearn.model_selection.cross_validate(
             *args,


### PR DESCRIPTION
Refactor `skore.yml` workflow:
- launch tests with the 3 latest major versions of `scikit-learn` on `os: "ubuntu-latest"` and `python: "3.12"`,
- speed-up tests by installing dependencies in `venv`and caching it.

And make `_add_scorers` compatible with `sklearn ==1.4`.