### PR TITLE
fix: Use tight bounding box for matplotlib item

### DIFF
--- a/skore/src/skore/item/media_item.py
+++ b/skore/src/skore/item/media_item.py
@@ -193,7 +193,7 @@ class MediaItem(Item):
             A new MediaItem instance.
         """
         with BytesIO() as stream:
-            media.savefig(stream, format="svg")
+            media.savefig(stream, format="svg", bbox_inches="tight")
             media_bytes = stream.getvalue()
 
             return cls(


### PR DESCRIPTION
Matplotlib plots now use "tight" bounding box.

![Screenshot 2024-12-11 at 17 40 06](https://github.com/user-attachments/assets/a255d290-5867-43ee-85ec-c85155c23ab0)
