### PR TITLE
fix: Include the LICENSE file in tar.gz source

### DIFF
--- a/skore/hatch/metadata.py
+++ b/skore/hatch/metadata.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from contextlib import suppress
 
@@ -6,9 +7,8 @@ from hatchling.metadata.plugin.interface import MetadataHookInterface
 
 class MetadataHook(MetadataHookInterface):
     def update(self, metadata):
-        license = Path(self.root, self.config["license-file"]).read_text(
-            encoding="utf-8"
-        )
+        license_path = Path(self.root, self.config["license-file"])
+        license = license_path.read_text(encoding="utf-8")
         readme = Path(self.root, self.config["readme-file"]).read_text(encoding="utf-8")
         version = self.config["version-default"]
 
@@ -18,3 +18,6 @@ class MetadataHook(MetadataHookInterface):
         metadata["license"] = {"text": license, "content-type": "text/plain"}
         metadata["readme"] = {"text": readme, "content-type": "text/markdown"}
         metadata["version"] = version
+
+        license_dest = Path(self.root, license_path.name)
+        shutil.copy2(license_path, license_dest)


### PR DESCRIPTION
closes #743 

It is a fix to include the LICENSE file into the `tar.gz`.