### PR TITLE
feat: Use friendly verbose and colorish

### DIFF
--- a/skore/src/skore/__init__.py
+++ b/skore/src/skore/__init__.py
@@ -2,7 +2,8 @@
 
 import logging
 
-import rich.logging
+from rich.console import Console
+from rich.theme import Theme
 
 from skore.project import Project, create, load
 from skore.sklearn import CrossValidationReporter, train_test_split
@@ -17,26 +18,16 @@ __all__ = [
     "train_test_split",
 ]
 
-
-class Handler(rich.logging.RichHandler):
-    """A logging handler that renders output with Rich."""
-
-    def get_level_text(self, record: rich.logging.LogRecord) -> rich.logging.Text:
-        """Get the logger name and levelname from the record."""
-        levelname = record.levelname
-        name = record.name
-        txt = f"<Logger {name} ({levelname})>"
-
-        return rich.logging.Text.styled(
-            txt.ljust(8),
-            f"logging.level.{levelname.lower()}",
-        )
-
-
-formatter = logging.Formatter("%(message)s")
-handler = Handler(markup=True)
-handler.setFormatter(formatter)
-
 logger = logging.getLogger(__name__)
-logger.addHandler(handler)
+logger.addHandler(logging.NullHandler())  # Default to no output
 logger.setLevel(logging.INFO)
+
+skore_console_theme = Theme(
+    {
+        "repr.str": "bold cyan",
+        "rule.line": "orange1",
+        "repr.url": "orange1",
+    }
+)
+
+console = Console(theme=skore_console_theme)

--- a/skore/src/skore/cli/__init__.py
+++ b/skore/src/skore/cli/__init__.py
@@ -2,12 +2,7 @@
 
 import logging
 
-formatter = logging.Formatter("%(message)s")
-
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.INFO)
-console_handler.setFormatter(formatter)
-
 logger = logging.getLogger(__name__)
-logger.addHandler(console_handler)
+logger.addHandler(logging.NullHandler())  # Default to no output
+logger.setLevel(logging.INFO)
 logger.propagate = False

--- a/skore/src/skore/cli/cli.py
+++ b/skore/src/skore/cli/cli.py
@@ -16,6 +16,9 @@ def cli(args: list[str]):
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {version('skore')}"
     )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Increase logging verbosity"
+    )
 
     subparsers = parser.add_subparsers(dest="subcommand")
 
@@ -108,12 +111,14 @@ def cli(args: list[str]):
             project_name=parsed_args.project_name,
             port=parsed_args.port,
             open_browser=parsed_args.open_browser,
+            verbose=parsed_args.verbose,
         )
     elif parsed_args.subcommand == "create":
         create(
             project_name=parsed_args.project_name,
             working_dir=parsed_args.working_dir,
             overwrite=parsed_args.overwrite,
+            verbose=parsed_args.verbose,
         )
     elif parsed_args.subcommand == "quickstart":
         __quickstart(
@@ -122,6 +127,7 @@ def cli(args: list[str]):
             overwrite=parsed_args.overwrite,
             port=parsed_args.port,
             open_browser=parsed_args.open_browser,
+            verbose=parsed_args.verbose,
         )
     else:
         parser.print_help()

--- a/skore/src/skore/cli/launch_dashboard.py
+++ b/skore/src/skore/cli/launch_dashboard.py
@@ -11,9 +11,13 @@ from fastapi import FastAPI
 from skore.cli import logger
 from skore.project import load
 from skore.ui.app import create_app
+from skore.utils._logger import with_logging
 
 
-def __launch(project_name: Union[str, Path], port: int, open_browser: bool):
+@with_logging(logger)
+def __launch(
+    project_name: Union[str, Path], port: int, open_browser: bool, verbose: bool = False
+):
     """Launch the UI to visualize a project.
 
     Parameters
@@ -24,7 +28,11 @@ def __launch(project_name: Union[str, Path], port: int, open_browser: bool):
         Port at which to bind the UI server.
     open_browser: bool
         Whether to automatically open a browser tab showing the UI.
+    verbose: bool
+        Whether to display info logs to the user.
     """
+    from skore import console  # avoid circular import
+
     project = load(project_name)
 
     @asynccontextmanager
@@ -37,9 +45,10 @@ def __launch(project_name: Union[str, Path], port: int, open_browser: bool):
 
     try:
         # TODO: check port is free
-        logger.info(
+        console.rule("[bold cyan]skore-UI[/bold cyan]")
+        console.print(
             f"Running skore UI from '{project_name}' at URL http://localhost:{port}"
         )
         uvicorn.run(app, port=port, log_level="error")
     except KeyboardInterrupt:
-        logger.info("Closing skore UI")
+        console.print("Closing skore UI")

--- a/skore/src/skore/cli/quickstart_command.py
+++ b/skore/src/skore/cli/quickstart_command.py
@@ -7,14 +7,17 @@ from skore.cli import logger
 from skore.cli.launch_dashboard import __launch
 from skore.exceptions import ProjectAlreadyExistsError
 from skore.project import create
+from skore.utils._logger import with_logging
 
 
+@with_logging(logger)
 def __quickstart(
     project_name: Union[str, Path],
     working_dir: Optional[Path],
     overwrite: bool,
     port: int,
     open_browser: bool,
+    verbose: bool = False,
 ):
     """Quickstart a Skore project.
 

--- a/skore/src/skore/project/create.py
+++ b/skore/src/skore/project/create.py
@@ -13,6 +13,7 @@ from skore.exceptions import (
 )
 from skore.project.load import load
 from skore.project.project import Project, logger
+from skore.utils._logger import with_logging
 from skore.view.view import View
 
 
@@ -57,10 +58,12 @@ def _validate_project_name(project_name: str) -> tuple[bool, Optional[Exception]
     return True, None
 
 
+@with_logging(logger)
 def create(
     project_name: Union[str, Path],
     working_dir: Optional[Path] = None,
     overwrite: bool = False,
+    verbose: bool = False,
 ) -> Project:
     """Create a project file named according to ``project_name``.
 
@@ -76,11 +79,15 @@ def create(
     overwrite : bool
         If ``True``, overwrite an existing project with the same name.
         If ``False``, raise an error if a project with the same name already exists.
+    verbose : bool
+        Whether or not to display info logs to the user.
 
     Returns
     -------
     The created project
     """
+    from skore import console  # avoid circular import
+
     project_path = Path(project_name)
 
     # Remove trailing ".skore" if it exists to check the name is valid
@@ -145,5 +152,6 @@ def create(
     p = load(project_directory)
     p.put_view("default", View(layout=[]))
 
-    logger.info(f"Project file '{project_directory}' was successfully created.")
+    console.rule("[bold cyan]skore[/bold cyan]")
+    console.print(f"Project file '{project_directory}' was successfully created.")
     return p

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -21,6 +21,8 @@ from skore.view.view import View
 from skore.view.view_repository import ViewRepository
 
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())  # Default to no output
+logger.setLevel(logging.INFO)
 
 
 MISSING = object()

--- a/skore/src/skore/utils/_logger.py
+++ b/skore/src/skore/utils/_logger.py
@@ -1,0 +1,43 @@
+"""Module to handle the verbosity of a given logger."""
+
+import logging
+from functools import wraps
+
+from rich.logging import LogRecord, RichHandler, Text
+
+
+class Handler(RichHandler):
+    """A logging handler that renders output with Rich."""
+
+    def get_level_text(self, record: LogRecord) -> Text:
+        """Get the logger name and levelname from the record."""
+        levelname = record.levelname
+        name = record.name
+        txt = f"<Logger {name} ({levelname})>"
+
+        return Text.styled(
+            txt.ljust(8),
+            f"logging.level.{levelname.lower()}",
+        )
+
+
+def with_logging(logger):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, verbose=False, **kwargs):
+            if verbose:
+                formatter = logging.Formatter("%(message)s")
+                console_handler = Handler(markup=True)
+                console_handler.setFormatter(formatter)
+                logger.addHandler(console_handler)
+
+            try:
+                result = func(*args, **kwargs)
+                return result
+            finally:
+                if verbose:
+                    logger.handlers.pop()
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
closes #959 

This PR proposes to:

- use a default `logger` that does not show any information by default
- introduce a `--verbose` option for the CLI or `verbose` parameter for the functions
- a decorator that register a rich handler depending of the `verbose` parameter
- introduce a `rich` console with cyan/orange colors (as the default `skore` theme) for showing the pertinent information.