### PR TITLE
fix: Correct serialization of CrossValidationItem for UI

### DIFF
--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import copy
 import importlib
+import json
 import operator
 import re
 import statistics
@@ -136,7 +137,7 @@ def __cross_validation_item_as_serializable(item: CrossValidationItem) -> dict:
         "plots": [
             {
                 "name": "cross-validation results",
-                "value": item.plot,
+                "value": json.loads(item.plot_bytes.decode("utf-8")),
             }
         ],
         "sections": [

--- a/skore/tests/integration/ui/test_ui.py
+++ b/skore/tests/integration/ui/test_ui.py
@@ -179,7 +179,6 @@ def test_serialize_cross_validation_item(
     fake_cross_validate,
 ):
     monkeypatch.setattr("skore.item.item.datetime", MockDatetime)
-    monkeypatch.setattr("skore.ui.project_routes.CrossValidationItem.plot", {})
 
     def prepare_cv():
         from sklearn import datasets, linear_model
@@ -194,12 +193,17 @@ def test_serialize_cross_validation_item(
     reporter = CrossValidationReporter(model, X, y, cv=KFold(3))
     in_memory_project.put("cv", reporter)
 
+    # Mock the item to make the plot empty
+    item = in_memory_project.get_item("cv")
+    item.plot_bytes = b"{}"
+    in_memory_project.put_item("cv_mocked", item)
+
     response = client.get("/api/project/items")
     assert response.status_code == 200
 
     project = response.json()
     expected = {
-        "name": "cv",
+        "name": "cv_mocked",
         "media_type": "application/vnd.skore.cross_validation+json",
         "value": {
             "scalar_results": [
@@ -259,7 +263,7 @@ def test_serialize_cross_validation_item(
         "updated_at": mock_nowstr,
         "created_at": mock_nowstr,
     }
-    actual = project["items"]["cv"][0]
+    actual = project["items"]["cv_mocked"][0]
     assert expected == actual
 
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/probabl-ai/skore/pull/964/ where the plot was outputted to a non-serializable object
