### PR TITLE
fix: Exclude `skore/LICENSE` from tracked files after #948

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ examples/plot_*.png
 
 # Include excluded directories from github-actions
 !/.github/**/build/
+
+# Exclude hatch artifacts
+skore/LICENSE


### PR DESCRIPTION
```
# sdist

[...]
skore-0.0.0+unknown/.gitignore
skore-0.0.0+unknown/LICENSE
skore-0.0.0+unknown/pyproject.toml
skore-0.0.0+unknown/PKG-INFO

# wheel

[...]
skore-0.0.0+unknown.dist-info/METADATA
skore-0.0.0+unknown.dist-info/WHEEL
skore-0.0.0+unknown.dist-info/entry_points.txt
skore-0.0.0+unknown.dist-info/licenses/LICENSE
skore-0.0.0+unknown.dist-info/RECORD
```