### PR TITLE
chore: Allow to run tests in parallel using pytest-xdist

### DIFF
--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -39,7 +39,7 @@ jobs:
           wheel=(dist/*.whl); python -m pip install "${wheel}[test]"
 
           # Test
-          python -m pytest --no-cov src/ tests/
+          python -m pytest --no-cov src/ tests/ -n auto
 
   coverage-skore:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
           python -m pip install -e .[test]
 
           # run coverage
-          python -m pytest --junitxml=coverage.xml --cov=skore src/ tests/ | tee pytest-coverage.txt
+          python -m pytest --junitxml=coverage.xml --cov=skore src/ tests/ | tee pytest-coverage.txt -n auto
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -59,7 +59,7 @@ jobs:
           python -m pip install -e .[test]
 
           # run coverage
-          python -m pytest --junitxml=coverage.xml --cov=skore src/ tests/ | tee pytest-coverage.txt -n auto
+          python -m pytest -n auto --junitxml=coverage.xml --cov=skore src/ tests/ | tee pytest-coverage.txt
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -76,6 +76,7 @@ test = [
   "pytest-cov",
   "pytest-order",
   "pytest-randomly",
+  "pytest-xdist",
   "ruff",
   "skrub",
 ]


### PR DESCRIPTION
`pytest-xdist` allows to run the test in parallel.
As the test suite will grow, it might be handy for little cost in terms of maintenance.