### PR TITLE
feat: Hide view functions from project

### DIFF
--- a/skore/src/skore/project/create.py
+++ b/skore/src/skore/project/create.py
@@ -143,7 +143,7 @@ def create(
         ) from e
 
     p = load(project_directory)
-    p.put_view("default", View(layout=[]))
+    p._put_view("default", View(layout=[]))
 
     logger.info(f"Project file '{project_directory}' was successfully created.")
     return p

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -252,11 +252,11 @@ class Project:
         """
         self.item_repository.delete_item(key)
 
-    def put_view(self, key: str, view: View):
+    def _put_view(self, key: str, view: View):
         """Add a view to the Project."""
         self.view_repository.put_view(key, view)
 
-    def get_view(self, key: str) -> View:
+    def _get_view(self, key: str) -> View:
         """Get the view corresponding to ``key`` from the Project.
 
         Parameters
@@ -276,7 +276,7 @@ class Project:
         """
         return self.view_repository.get_view(key)
 
-    def delete_view(self, key: str):
+    def _delete_view(self, key: str):
         """Delete the view corresponding to ``key`` from the Project.
 
         Parameters
@@ -291,7 +291,7 @@ class Project:
         """
         return self.view_repository.delete_view(key)
 
-    def list_view_keys(self) -> list[str]:
+    def _list_view_keys(self) -> list[str]:
         """List all view keys in the Project.
 
         Returns

--- a/skore/src/skore/ui/project_routes.py
+++ b/skore/src/skore/ui/project_routes.py
@@ -54,7 +54,7 @@ def __project_as_serializable(project: Project) -> SerializableProject:
         for key in project.list_item_keys()
     }
 
-    views = {key: project.get_view(key).layout for key in project.list_view_keys()}
+    views = {key: project._get_view(key).layout for key in project._list_view_keys()}
 
     return SerializableProject(
         items=items,
@@ -78,7 +78,7 @@ async def put_view(request: Request, key: str, layout: Layout):
     project: Project = request.app.state.project
 
     view = View(layout=layout)
-    project.put_view(key, view)
+    project._put_view(key, view)
 
     return __project_as_serializable(project)
 
@@ -89,7 +89,7 @@ async def delete_view(request: Request, key: str):
     project: Project = request.app.state.project
 
     try:
-        project.delete_view(key)
+        project._delete_view(key)
     except KeyError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="View not found"

--- a/skore/tests/integration/ui/test_ui.py
+++ b/skore/tests/integration/ui/test_ui.py
@@ -59,7 +59,7 @@ def test_put_view_layout(client):
 
 
 def test_delete_view(client, in_memory_project):
-    in_memory_project.put_view("hello", View(layout=[]))
+    in_memory_project._put_view("hello", View(layout=[]))
     response = client.delete("/api/project/views?key=hello")
     assert response.status_code == 202
 

--- a/skore/tests/unit/test_project.py
+++ b/skore/tests/unit/test_project.py
@@ -234,15 +234,15 @@ def test_view(in_memory_project):
 
     view = View(layout=layout)
 
-    in_memory_project.put_view("view", view)
-    assert in_memory_project.get_view("view") == view
+    in_memory_project._put_view("view", view)
+    assert in_memory_project._get_view("view") == view
 
 
 def test_list_view_keys(in_memory_project):
     view = View(layout=[])
 
-    in_memory_project.put_view("view", view)
-    assert in_memory_project.list_view_keys() == ["view"]
+    in_memory_project._put_view("view", view)
+    assert in_memory_project._list_view_keys() == ["view"]
 
 
 def test_put_several_happy_path(in_memory_project):


### PR DESCRIPTION
We have functions about views in project which are documented & public, while we offer no specific feature related to a view. So far, it's something we want to deal with internally.  
Suggesting this solution, but not sure it's the best since the view functions still appear in the autocomplete. Also, there is still the "view_repository" as one of the parameters of Project while it would be best to be hidden.  

![Capture d’écran du 2024-12-23 17-35-26](https://github.com/user-attachments/assets/1b6ecdcb-da15-4093-9b15-15648060dbb2)
