### PR TITLE
chore: Allow for 5 menus on the top bar of docs

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -109,7 +109,7 @@ html_theme_options = {
             "name": "Probabl website",
         },
     ],
-    "header_links_before_dropdown": 4,
+    "header_links_before_dropdown": 5,
     "icon_links": [
         {
             "name": "Twitter",


### PR DESCRIPTION
I found it ugly to have a "more" button for just one submenu.  
We can switch back to only 4 main menus shown once we have several things to put in the submenu.  
![Capture d’écran du 2024-12-23 18-15-00](https://github.com/user-attachments/assets/dc6630d7-1b86-4f9e-b6e7-97645ec52d90)
