### PR TITLE
docs: Group the left menu of APIs

### DIFF
--- a/sphinx/api.rst
+++ b/sphinx/api.rst
@@ -17,14 +17,10 @@ These functions and classes are meant for managing a Project.
 .. autosummary::
     :toctree: generated/
     :template: base.rst
+    :caption: Managing a project
 
     Project
     item.primitive_item.PrimitiveItem
-
-.. autosummary::
-    :toctree: generated/
-    :template: base.rst
-
     create
     load
 
@@ -36,12 +32,8 @@ These functions and classes enhance scikit-learn's ones.
 .. autosummary::
     :toctree: generated/
     :template: base.rst
+    :caption: ML Assistance
 
     train_test_split
-
-.. autosummary::
-    :toctree: generated/
-    :template: base.rst
-
     CrossValidationReporter
     item.cross_validation_item.CrossValidationItem


### PR DESCRIPTION
Adds sections in the navigation bar as requested in https://github.com/probabl-ai/skore/issues/836.  

![Capture d’écran du 2024-12-23 19-29-06](https://github.com/user-attachments/assets/4c65dc19-7501-4a21-8d2d-e61afb450ada)

in we want toggle menus instead, we can add `"show_nav_level": 0,` in html_theme_options dict.
