### PR TITLE
ci: Temporarily deactivate coverage comments on PRs from fork

### DIFF
--- a/.github/workflows/skore-ui.yml
+++ b/.github/workflows/skore-ui.yml
@@ -40,7 +40,7 @@ jobs:
           npm install
           npm run test:unit:coverage
       - name: Report coverage
-        if: always()
+        if: ${{ always() && ! github.event.pull_request.head.repo.fork }}
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           working-directory: ./skore-ui

--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -61,6 +61,7 @@ jobs:
           # run coverage
           python -m pytest -n auto --junitxml=coverage.xml --cov=skore src/ tests/ | tee pytest-coverage.txt
       - name: Pytest coverage comment
+        if: ${{ ! github.event.pull_request.head.repo.fork }}
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./skore/pytest-coverage.txt


### PR DESCRIPTION
Temporarily deactivate coverage comments on PRs from fork, which don't have enough permissions.