### PR TITLE
fix: Make skore.show_versions() robust to version specifiers in requirements

### DIFF
--- a/skore/src/skore/utils/_show_versions.py
+++ b/skore/src/skore/utils/_show_versions.py
@@ -6,6 +6,7 @@ adapted from :func:`sklearn.show_versions`
 
 import importlib
 import platform
+import re
 import sys
 
 
@@ -47,7 +48,9 @@ def _get_deps_info():
 
     requirements = importlib.metadata.requires("skore")
     for requirement in filter(lambda r: "; extra" not in r, requirements):
-        deps.append(requirement)
+        # Extract just the package name before any version specifiers
+        package_name = re.split(r"[<>=~!]", requirement)[0].strip()
+        deps.append(package_name)
 
     deps_info = {
         "skore": version("skore"),

--- a/skore/tests/unit/utils/test_show_versions.py
+++ b/skore/tests/unit/utils/test_show_versions.py
@@ -18,11 +18,28 @@ def test_get_deps_info():
 
 
 def test_show_versions(capfd):
+    """Check that we have the expected packages in the output of `show_versions()`.
+
+    We use `:` in the assertion to be sure that we are robust to package
+    version specifiers.
+
+    Non-regression test for:
+    https://github.com/probabl-ai/skore/issues/987
+    """
     show_versions()
     captured = capfd.readouterr()
-    assert "python" in captured.out
-    assert "executable" in captured.out
-    assert "machine" in captured.out
-    assert "pip" in captured.out
-    assert "setuptools" in captured.out
-    assert "skore" in captured.out
+    assert "python:" in captured.out
+    assert "executable:" in captured.out
+    assert "machine:" in captured.out
+    assert "skore:" in captured.out
+    assert "pip:" in captured.out
+    assert "setuptools:" in captured.out
+    assert "diskcache:" in captured.out
+    assert "fastapi:" in captured.out
+    assert "numpy:" in captured.out
+    assert "plotly:" in captured.out
+    assert "pyarrow:" in captured.out
+    assert "rich:" in captured.out
+    assert "scikit-learn:" in captured.out
+    assert "skops:" in captured.out
+    assert "uvicorn:" in captured.out


### PR DESCRIPTION
closes #987 

Make `skore.show_vertsions()` robust to version specifiers in the requirements defined in `pyproject.toml`.