### PR TITLE
feat: Implement note-related methods

### DIFF
--- a/docs/design/0003-use-union-rather-than-pipe.md
+++ b/docs/design/0003-use-union-rather-than-pipe.md
@@ -1,0 +1,17 @@
+---
+date: 2025-01-14
+decision-makers: ["@augustebaum", "@thomass-dev"]
+---
+
+# Use `typing.Union` rather than `|` in type hints
+
+## Context and Problem Statement
+
+This ADR originates from a discussion in [this PR comment](https://github.com/probabl-ai/skore/pull/1084#discussion_r1914402895).
+
+Writing a union type using `|` is [only available from Python 3.10](https://docs.python.org/3.12/library/typing.html#typing.Union), while we currently intend to support Python 3.9.
+Even though we do not formally check type-hints using automatic tools like `mypy`, we still strive for consistency for style issues of this kind.
+
+## Decision Outcome
+
+Use `typing.Union` rather than `|` in type hints.

--- a/skore/src/skore/externals/_sklearn_compat.py
+++ b/skore/src/skore/externals/_sklearn_compat.py
@@ -18,7 +18,7 @@ import platform
 import sys
 import types
 from dataclasses import dataclass, field
-from typing import Callable, Literal
+from typing import Callable, Literal, Union
 
 import sklearn
 from sklearn.utils.fixes import parse_version
@@ -775,11 +775,11 @@ if sklearn_version < parse_version("1.6"):
             The input data(X) tags.
         """
 
-        estimator_type: str | None
+        estimator_type: Union[str, None]
         target_tags: TargetTags
-        transformer_tags: TransformerTags | None = None
-        classifier_tags: ClassifierTags | None = None
-        regressor_tags: RegressorTags | None = None
+        transformer_tags: Union[TransformerTags, None] = None
+        classifier_tags: Union[ClassifierTags, None] = None
+        regressor_tags: Union[RegressorTags, None] = None
         array_api_support: bool = False
         no_validation: bool = False
         non_deterministic: bool = False
@@ -808,10 +808,10 @@ if sklearn_version < parse_version("1.6"):
         generate_only=False,
         *,
         legacy: bool = True,
-        expected_failed_checks: dict[str, str] | None = None,
-        on_skip: Literal["warn"] | None = "warn",
-        on_fail: Literal["raise", "warn"] | None = "raise",
-        callback: Callable | None = None,
+        expected_failed_checks: Union[dict[str, str], None] = None,
+        on_skip: Union[Literal["warn"], None] = "warn",
+        on_fail: Union[Literal["raise", "warn"], None] = "raise",
+        callback: Union[Callable, None] = None,
     ):
         # legacy, on_skip, on_fail, and callback are not supported and ignored
         from sklearn.utils.estimator_checks import check_estimator
@@ -825,7 +825,7 @@ if sklearn_version < parse_version("1.6"):
         estimators,
         *,
         legacy: bool = True,
-        expected_failed_checks: Callable | None = None,
+        expected_failed_checks: Union[Callable, None] = None,
     ):
         # legacy is not supported and ignored
         from sklearn.utils.estimator_checks import parametrize_with_checks

--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -14,7 +14,7 @@ import json
 import re
 import statistics
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
 
 import numpy
 import plotly.graph_objects
@@ -136,12 +136,12 @@ class CrossValidationItem(Item):
         cv_results_serialized: dict,
         estimator_info: EstimatorInfo,
         X_info: dict,
-        y_info: dict | None,
+        y_info: Union[dict, None],
         plots_bytes: dict[str, bytes],
         cv_info: dict,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a CrossValidationItem.
@@ -167,7 +167,7 @@ class CrossValidationItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -141,6 +141,7 @@ class CrossValidationItem(Item):
         cv_info: dict,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a CrossValidationItem.
@@ -166,8 +167,10 @@ class CrossValidationItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.cv_results_serialized = cv_results_serialized
         self.estimator_info = estimator_info

--- a/skore/src/skore/item/cross_validation_item.py
+++ b/skore/src/skore/item/cross_validation_item.py
@@ -14,7 +14,7 @@ import json
 import re
 import statistics
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 import numpy
 import plotly.graph_objects
@@ -136,11 +136,11 @@ class CrossValidationItem(Item):
         cv_results_serialized: dict,
         estimator_info: EstimatorInfo,
         X_info: dict,
-        y_info: Union[dict, None],
+        y_info: dict | None,
         plots_bytes: dict[str, bytes],
         cv_info: dict,
-        created_at: Union[str, None] = None,
-        updated_at: Union[str, None] = None,
+        created_at: str | None = None,
+        updated_at: str | None = None,
     ):
         """
         Initialize a CrossValidationItem.

--- a/skore/src/skore/item/item.py
+++ b/skore/src/skore/item/item.py
@@ -34,6 +34,8 @@ class Item(ABC):
         The creation timestamp of the item. If None, the current time is used.
     updated_at : str | None, optional
         The last update timestamp of the item. If None, the current time is used.
+    note : str | None
+        An optional note.
 
     Attributes
     ----------
@@ -41,17 +43,21 @@ class Item(ABC):
         The creation timestamp of the item.
     updated_at : str
         The last update timestamp of the item.
+    note : str | None
+        An optional note.
     """
 
     def __init__(
         self,
         created_at: Optional[str] = None,
         updated_at: Optional[str] = None,
+        note: Optional[str] = None,
     ):
         now = datetime.now(tz=timezone.utc).isoformat()
 
         self.created_at = created_at or now
         self.updated_at = updated_at or now
+        self.note = note
 
     @classmethod
     @abstractmethod
@@ -120,4 +126,5 @@ class Item(ABC):
         return {
             "updated_at": self.updated_at,
             "created_at": self.created_at,
+            "note": self.note,
         }

--- a/skore/src/skore/item/item.py
+++ b/skore/src/skore/item/item.py
@@ -30,11 +30,11 @@ class Item(ABC):
 
     Parameters
     ----------
-    created_at : str | None, optional
+    created_at : Union[str, None], optional
         The creation timestamp of the item. If None, the current time is used.
-    updated_at : str | None, optional
+    updated_at : Union[str, None], optional
         The last update timestamp of the item. If None, the current time is used.
-    note : str | None
+    note : Union[str, None]
         An optional note.
 
     Attributes
@@ -43,7 +43,7 @@ class Item(ABC):
         The creation timestamp of the item.
     updated_at : str
         The last update timestamp of the item.
-    note : str | None
+    note : Union[str, None]
         An optional note.
     """
 

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -153,3 +153,72 @@ class ItemRepository:
             A list of all keys in the storage.
         """
         return list(self.storage.keys())
+
+    def set_item_note(self, key: str, message: str, *, version=-1):
+        """Attach a note to key ``key``.
+
+        Parameters
+        ----------
+        key : str
+            The key of the item to annotate.
+            May be qualified with a version number through the ``version`` argument.
+        message : str
+            The message to be attached.
+        version : int, default=-1
+            The version of the key to annotate. Default is the latest version.
+
+        Raises
+        ------
+        KeyError
+            If the ``(key, version)`` couple does not exist.
+        """
+        try:
+            self.storage[key][version]["item"]["note"] = message
+        except IndexError as e:
+            raise KeyError((key, version)) from e
+
+    def get_item_note(self, key: str, *, version=-1) -> str | None:
+        """Retrieve a note previously attached to key ``key``.
+
+        Parameters
+        ----------
+        key : str
+            The key of the annotated item.
+            May be qualified with a version number through the ``version`` argument.
+        version : int, default=-1
+            The version of the annotated key. Default is the latest version.
+
+        Returns
+        -------
+        The attached note, or None if no note is attached.
+
+        Raises
+        ------
+        KeyError
+            If no note is attached to the ``(key, version)`` couple.
+        """
+        try:
+            return self.storage[key][version]["item"]["note"]
+        except IndexError as e:
+            raise KeyError((key, version)) from e
+
+    def delete_item_note(self, key: str, *, version=-1):
+        """Delete a note previously attached to key ``key``.
+
+        Parameters
+        ----------
+        key : str
+            The key of the annotated item.
+            May be qualified with a version number through the ``version`` argument.
+        version : int, default=-1
+            The version of the annotated key. Default is the latest version.
+
+        Raises
+        ------
+        KeyError
+            If no note is attached to the ``(key, version)`` couple.
+        """
+        try:
+            self.storage[key][version]["item"]["note"] = None
+        except IndexError as e:
+            raise KeyError((key, version)) from e

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -171,7 +171,14 @@ class ItemRepository:
         ------
         KeyError
             If the ``(key, version)`` couple does not exist.
+        TypeError
+            If ``key`` or ``message`` is not a string.
         """
+        if not isinstance(key, str):
+            raise TypeError(f"Key should be a string; got {type(key)}")
+        if not isinstance(message, str):
+            raise TypeError(f"Message should be a string; got {type(message)}")
+
         try:
             self.storage[key][version]["item"]["note"] = message
         except IndexError as e:

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -6,7 +6,7 @@ storing, retrieving, and deleting items in a storage system.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from skore.item.item import Item

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -184,7 +184,7 @@ class ItemRepository:
         except IndexError as e:
             raise KeyError((key, version)) from e
 
-    def get_item_note(self, key: str, *, version=-1) -> str | None:
+    def get_item_note(self, key: str, *, version=-1) -> Union[str, None]:
         """Retrieve a note previously attached to key ``key``.
 
         Parameters

--- a/skore/src/skore/item/media_item.py
+++ b/skore/src/skore/item/media_item.py
@@ -39,6 +39,7 @@ class MediaItem(Item):
         media_type: str,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a MediaItem.
@@ -55,8 +56,10 @@ class MediaItem(Item):
             The creation timestamp in ISO format.
         updated_at : str, optional
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.media_bytes = media_bytes
         self.media_encoding = media_encoding

--- a/skore/src/skore/item/media_item.py
+++ b/skore/src/skore/item/media_item.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import base64
 from io import BytesIO
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from skore.item.item import Item, ItemTypeError
 
@@ -37,9 +37,9 @@ class MediaItem(Item):
         media_bytes: bytes,
         media_encoding: str,
         media_type: str,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a MediaItem.
@@ -56,7 +56,7 @@ class MediaItem(Item):
             The creation timestamp in ISO format.
         updated_at : str, optional
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/numpy_array_item.py
+++ b/skore/src/skore/item/numpy_array_item.py
@@ -27,6 +27,7 @@ class NumpyArrayItem(Item):
         array_json: str,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a NumpyArrayItem.
@@ -39,8 +40,10 @@ class NumpyArrayItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.array_json = array_json
 

--- a/skore/src/skore/item/numpy_array_item.py
+++ b/skore/src/skore/item/numpy_array_item.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from functools import cached_property
 from json import dumps, loads
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from skore.item.item import Item, ItemTypeError
 
@@ -25,9 +25,9 @@ class NumpyArrayItem(Item):
     def __init__(
         self,
         array_json: str,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a NumpyArrayItem.
@@ -40,7 +40,7 @@ class NumpyArrayItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/pandas_dataframe_item.py
+++ b/skore/src/skore/item/pandas_dataframe_item.py
@@ -7,7 +7,7 @@ which represents a pandas DataFrame item.
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from skore.item.item import Item, ItemTypeError
 
@@ -29,9 +29,9 @@ class PandasDataFrameItem(Item):
         self,
         index_json: str,
         dataframe_json: str,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a PandasDataFrameItem.
@@ -46,7 +46,7 @@ class PandasDataFrameItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/pandas_dataframe_item.py
+++ b/skore/src/skore/item/pandas_dataframe_item.py
@@ -31,6 +31,7 @@ class PandasDataFrameItem(Item):
         dataframe_json: str,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a PandasDataFrameItem.
@@ -45,8 +46,10 @@ class PandasDataFrameItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.index_json = index_json
         self.dataframe_json = dataframe_json

--- a/skore/src/skore/item/pandas_series_item.py
+++ b/skore/src/skore/item/pandas_series_item.py
@@ -7,7 +7,7 @@ which represents a pandas Series item.
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from skore.item.item import Item, ItemTypeError
 
@@ -29,9 +29,9 @@ class PandasSeriesItem(Item):
         self,
         index_json: str,
         series_json: str,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a PandasSeriesItem.
@@ -46,7 +46,7 @@ class PandasSeriesItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/pandas_series_item.py
+++ b/skore/src/skore/item/pandas_series_item.py
@@ -31,6 +31,7 @@ class PandasSeriesItem(Item):
         series_json: str,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a PandasSeriesItem.
@@ -45,8 +46,10 @@ class PandasSeriesItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.index_json = index_json
         self.series_json = series_json

--- a/skore/src/skore/item/polars_dataframe_item.py
+++ b/skore/src/skore/item/polars_dataframe_item.py
@@ -32,6 +32,7 @@ class PolarsDataFrameItem(Item):
         dataframe_json: str,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a PolarsDataFrameItem.
@@ -44,8 +45,10 @@ class PolarsDataFrameItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.dataframe_json = dataframe_json
 

--- a/skore/src/skore/item/polars_dataframe_item.py
+++ b/skore/src/skore/item/polars_dataframe_item.py
@@ -7,7 +7,7 @@ which represents a polars DataFrame item.
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from skore.item.item import Item, ItemTypeError
 
@@ -30,9 +30,9 @@ class PolarsDataFrameItem(Item):
     def __init__(
         self,
         dataframe_json: str,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a PolarsDataFrameItem.
@@ -45,7 +45,7 @@ class PolarsDataFrameItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/polars_series_item.py
+++ b/skore/src/skore/item/polars_series_item.py
@@ -28,6 +28,7 @@ class PolarsSeriesItem(Item):
         series_json: str,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a PolarsSeriesItem.
@@ -40,8 +41,10 @@ class PolarsSeriesItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.series_json = series_json
 

--- a/skore/src/skore/item/polars_series_item.py
+++ b/skore/src/skore/item/polars_series_item.py
@@ -7,7 +7,7 @@ which represents a polars Series item.
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from skore.item.item import Item, ItemTypeError
 
@@ -26,9 +26,9 @@ class PolarsSeriesItem(Item):
     def __init__(
         self,
         series_json: str,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a PolarsSeriesItem.
@@ -41,7 +41,7 @@ class PolarsSeriesItem(Item):
             The creation timestamp in ISO format.
         updated_at : str
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/primitive_item.py
+++ b/skore/src/skore/item/primitive_item.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
         str,
         list["Primitive"],
         tuple["Primitive"],
-        dict[str | int | float, "Primitive"],
+        dict[Union[str, int, float], "Primitive"],
     ]
 
 
@@ -48,9 +48,9 @@ class PrimitiveItem(Item):
     def __init__(
         self,
         primitive: Primitive,
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a PrimitiveItem.
@@ -63,7 +63,7 @@ class PrimitiveItem(Item):
             The creation timestamp as ISO format.
         updated_at : str, optional
             The last update timestamp as ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/primitive_item.py
+++ b/skore/src/skore/item/primitive_item.py
@@ -50,6 +50,7 @@ class PrimitiveItem(Item):
         primitive: Primitive,
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a PrimitiveItem.
@@ -62,8 +63,10 @@ class PrimitiveItem(Item):
             The creation timestamp as ISO format.
         updated_at : str, optional
             The last update timestamp as ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.primitive = primitive
 

--- a/skore/src/skore/item/sklearn_base_estimator_item.py
+++ b/skore/src/skore/item/sklearn_base_estimator_item.py
@@ -7,7 +7,7 @@ which represents a scikit-learn BaseEstimator item.
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from skore.item.item import Item, ItemTypeError
 
@@ -28,9 +28,9 @@ class SklearnBaseEstimatorItem(Item):
         estimator_html_repr: str,
         estimator_skops: bytes,
         estimator_skops_untrusted_types: list[str],
-        created_at: str | None = None,
-        updated_at: str | None = None,
-        note: str | None = None,
+        created_at: Union[str, None] = None,
+        updated_at: Union[str, None] = None,
+        note: Union[str, None] = None,
     ):
         """
         Initialize a SklearnBaseEstimatorItem.
@@ -47,7 +47,7 @@ class SklearnBaseEstimatorItem(Item):
             The creation timestamp in ISO format.
         updated_at : str, optional
             The last update timestamp in ISO format.
-        note : str | None
+        note : Union[str, None]
             An optional note.
         """
         super().__init__(created_at, updated_at, note)

--- a/skore/src/skore/item/sklearn_base_estimator_item.py
+++ b/skore/src/skore/item/sklearn_base_estimator_item.py
@@ -30,6 +30,7 @@ class SklearnBaseEstimatorItem(Item):
         estimator_skops_untrusted_types: list[str],
         created_at: str | None = None,
         updated_at: str | None = None,
+        note: str | None = None,
     ):
         """
         Initialize a SklearnBaseEstimatorItem.
@@ -46,8 +47,10 @@ class SklearnBaseEstimatorItem(Item):
             The creation timestamp in ISO format.
         updated_at : str, optional
             The last update timestamp in ISO format.
+        note : str | None
+            An optional note.
         """
-        super().__init__(created_at, updated_at)
+        super().__init__(created_at, updated_at, note)
 
         self.estimator_html_repr = estimator_html_repr
         self.estimator_skops = estimator_skops

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -1,7 +1,7 @@
 """Define a Project."""
 
 import logging
-from typing import Any
+from typing import Any, Union
 
 from skore.item import (
     CrossValidationItem,

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -280,6 +280,8 @@ class Project:
         ------
         KeyError
             If the ``(key, version)`` couple does not exist.
+        TypeError
+            If ``key`` or ``message`` is not a string.
 
         Examples
         --------

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -262,3 +262,89 @@ class Project:
             The list of view keys. The list is empty if there is no view.
         """
         return self.view_repository.keys()
+
+    def set_note(self, key: str, message: str, *, version=-1):
+        """Attach a note to key ``key``.
+
+        Parameters
+        ----------
+        key : str
+            The key of the item to annotate.
+            May be qualified with a version number through the ``version`` argument.
+        message : str
+            The message to be attached.
+        version : int, default=-1
+            The version of the key to annotate. Default is the latest version.
+
+        Raises
+        ------
+        KeyError
+            If the ``(key, version)`` couple does not exist.
+
+        Examples
+        --------
+        # Annotate latest version of key "key"
+        >>> project.set_note("key", "message")  # doctest: +SKIP
+
+        # Annotate first version of key "key"
+        >>> project.set_note("key", "message", version=0)  # doctest: +SKIP
+        """
+        pass
+
+    def get_note(self, key: str, *, version=-1) -> Union[str, None]:
+        """Retrieve a note previously attached to key ``key``.
+
+        Parameters
+        ----------
+        key : str
+            The key of the annotated item.
+            May be qualified with a version number through the ``version`` argument.
+        version : int, default=-1
+            The version of the annotated key. Default is the latest version.
+
+        Returns
+        -------
+        The attached note, or None if no note is attached.
+
+        Raises
+        ------
+        KeyError
+            If the ``(key, version)`` couple does not exist.
+
+        Examples
+        --------
+        # Retrieve note attached to latest version of key "key"
+        >>> project.get_note("key")  # doctest: +SKIP
+
+        # Retrieve note attached to first version of key "key"
+        >>> project.get_note("key", version=0)  # doctest: +SKIP
+        """
+        pass
+
+    def delete_note(self, key: str, *, version=-1):
+        """Delete a note previously attached to key ``key``.
+
+        If no note is attached, does nothing.
+
+        Parameters
+        ----------
+        key : str
+            The key of the annotated item.
+            May be qualified with a version number through the ``version`` argument.
+        version : int, default=-1
+            The version of the annotated key. Default is the latest version.
+
+        Raises
+        ------
+        KeyError
+            If the ``(key, version)`` couple does not exist.
+
+        Examples
+        --------
+        # Delete note attached to latest version of key "key"
+        >>> project.delete_note("key")  # doctest: +SKIP
+
+        # Delete note attached to first version of key "key"
+        >>> project.delete_note("key", version=0)  # doctest: +SKIP
+        """
+        pass

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -289,7 +289,9 @@ class Project:
         # Annotate first version of key "key"
         >>> project.set_note("key", "message", version=0)  # doctest: +SKIP
         """
-        pass
+        return self.item_repository.set_item_note(
+            key=key, message=message, version=version
+        )
 
     def get_note(self, key: str, *, version=-1) -> Union[str, None]:
         """Retrieve a note previously attached to key ``key``.
@@ -319,7 +321,7 @@ class Project:
         # Retrieve note attached to first version of key "key"
         >>> project.get_note("key", version=0)  # doctest: +SKIP
         """
-        pass
+        return self.item_repository.get_item_note(key=key, version=version)
 
     def delete_note(self, key: str, *, version=-1):
         """Delete a note previously attached to key ``key``.
@@ -347,4 +349,4 @@ class Project:
         # Delete note attached to first version of key "key"
         >>> project.delete_note("key", version=0)  # doctest: +SKIP
         """
-        pass
+        return self.item_repository.delete_item_note(key=key, version=version)

--- a/skore/tests/unit/item/test_item_repository.py
+++ b/skore/tests/unit/item/test_item_repository.py
@@ -44,6 +44,7 @@ class TestItemRepository:
             media_type="application/octet-stream",
             created_at=now,
             updated_at=now,
+            note=None,
         )
 
         storage = {}
@@ -60,6 +61,7 @@ class TestItemRepository:
                         "media_type": "application/octet-stream",
                         "created_at": now,
                         "updated_at": now,
+                        "note": None,
                     },
                 }
             ]
@@ -72,6 +74,7 @@ class TestItemRepository:
             media_type="application/octet-stream",
             created_at=now2,
             updated_at=now2,
+            note=None,
         )
 
         repository.put_item("key", item2)
@@ -86,6 +89,7 @@ class TestItemRepository:
                         "media_type": "application/octet-stream",
                         "created_at": now,
                         "updated_at": now,
+                        "note": None,
                     },
                 },
                 {
@@ -96,6 +100,7 @@ class TestItemRepository:
                         "media_type": "application/octet-stream",
                         "created_at": now,
                         "updated_at": now2,
+                        "note": None,
                     },
                 },
             ]

--- a/skore/tests/unit/item/test_media_item.py
+++ b/skore/tests/unit/item/test_media_item.py
@@ -96,6 +96,7 @@ class TestMediaItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "text/markdown",
             "value": "<content>",
         }

--- a/skore/tests/unit/item/test_numpy_array_item.py
+++ b/skore/tests/unit/item/test_numpy_array_item.py
@@ -55,6 +55,7 @@ class TestNumpyArrayItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "text/markdown",
             "value": array.tolist(),
         }

--- a/skore/tests/unit/item/test_pandas_dataframe_item.py
+++ b/skore/tests/unit/item/test_pandas_dataframe_item.py
@@ -88,6 +88,7 @@ class TestPandasDataFrameItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "application/vnd.dataframe",
             "value": dataframe.fillna("NaN").to_dict(orient="tight"),
         }

--- a/skore/tests/unit/item/test_pandas_series_item.py
+++ b/skore/tests/unit/item/test_pandas_series_item.py
@@ -88,6 +88,7 @@ class TestPandasSeriesItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "text/markdown",
             "value": series.to_list(),
         }

--- a/skore/tests/unit/item/test_polars_dataframe_item.py
+++ b/skore/tests/unit/item/test_polars_dataframe_item.py
@@ -54,6 +54,7 @@ class TestPolarsDataFrameItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "application/vnd.dataframe",
             "value": dataframe.to_pandas().fillna("NaN").to_dict(orient="tight"),
         }

--- a/skore/tests/unit/item/test_polars_series_item.py
+++ b/skore/tests/unit/item/test_polars_series_item.py
@@ -56,6 +56,7 @@ class TestPolarsSeriesItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "text/markdown",
             "value": series.to_list(),
         }

--- a/skore/tests/unit/item/test_primitive_item.py
+++ b/skore/tests/unit/item/test_primitive_item.py
@@ -50,6 +50,7 @@ class TestPrimitiveItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "text/markdown",
             "value": primitive,
         }

--- a/skore/tests/unit/item/test_sklearn_base_estimator_item.py
+++ b/skore/tests/unit/item/test_sklearn_base_estimator_item.py
@@ -99,6 +99,7 @@ class TestSklearnBaseEstimatorItem:
         assert serializable == {
             "updated_at": mock_nowstr,
             "created_at": mock_nowstr,
+            "note": None,
             "media_type": "application/vnd.sklearn.estimator+html",
             "value": item.estimator_html_repr,
         }

--- a/skore/tests/unit/project/test_notes.py
+++ b/skore/tests/unit/project/test_notes.py
@@ -1,0 +1,51 @@
+"""Test the item notes API."""
+
+import pytest
+
+
+def test_set_note(in_memory_project):
+    in_memory_project.put("key", "hello")
+    in_memory_project.set_note("key", "message")
+    assert in_memory_project.get_note("key") == "message"
+
+
+def test_set_note_version(in_memory_project):
+    """By default, `set_note` only attaches a message to the latest version
+    of a key."""
+    in_memory_project.put("key", "hello")
+    in_memory_project.put("key", "goodbye")
+    in_memory_project.set_note("key", "message")
+    assert in_memory_project.get_note("key", version=-1) == "message"
+    assert in_memory_project.get_note("key", version=0) is None
+
+
+def test_set_note_no_key(in_memory_project):
+    with pytest.raises(KeyError):
+        in_memory_project.set_note("key", "hello")
+
+    in_memory_project.put("key", "hello")
+
+    with pytest.raises(KeyError):
+        in_memory_project.set_note("key", "hello", version=10)
+
+
+def test_delete_note(in_memory_project):
+    in_memory_project.put("key", "hello")
+    in_memory_project.set_note("key", "message")
+    in_memory_project.delete_note("key")
+    assert in_memory_project.get_note("key") is None
+
+
+def test_delete_note_no_key(in_memory_project):
+    with pytest.raises(KeyError):
+        in_memory_project.delete_note("key")
+
+    in_memory_project.put("key", "hello")
+
+    with pytest.raises(KeyError):
+        in_memory_project.set_note("key", "hello", version=10)
+
+
+def test_delete_note_no_note(in_memory_project):
+    in_memory_project.put("key", "hello")
+    assert in_memory_project.get_note("key") is None

--- a/skore/tests/unit/project/test_notes.py
+++ b/skore/tests/unit/project/test_notes.py
@@ -29,6 +29,15 @@ def test_set_note_no_key(in_memory_project):
         in_memory_project.set_note("key", "hello", version=10)
 
 
+def test_set_note_not_strings(in_memory_project):
+    """If key or message is not a string, raise a TypeError."""
+    with pytest.raises(TypeError):
+        in_memory_project.set_note(1, "hello")
+
+    with pytest.raises(TypeError):
+        in_memory_project.set_note("key", 1)
+
+
 def test_delete_note(in_memory_project):
     in_memory_project.put("key", "hello")
     in_memory_project.set_note("key", "message")


### PR DESCRIPTION
New methods have been added to `Project`:

```python
# The default is to act on the latest version
project.set_note(key, message, version=-1)

project.get_note(key, message, version=-1)

project.delete_note(key, message, version=-1)
```

To this end,
- `Item` now has an additional attribute, `note`, which is a `str | None`
- `ItemRepository` has similar methods

The note related methods fail with a KeyError when the key-version combination does not exist, but:
- `get_note` returns `None` if the note is `None` (no error)
- `delete_note` never errors if the key-version combination exists (even if the note is already `None`, it will be set to `None` again)

`set_note` fails with a TypeError if `key` or `message` is not a string.

Addresses part of #1041 

