### PR TITLE
fix(EstimatorReport): Make a deep copy of fitted estimator in constructor to avoid side-effect

### DIFF
--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -29,7 +29,8 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
     Parameters
     ----------
     estimator : estimator object
-        Estimator to make report from.
+        Estimator to make the report from. When the estimator is not fitted,
+        it is deep-copied to avoid side-effects. If it is fitted, it is cloned instead.
 
     fit : {"auto", True, False}, default="auto"
         Whether to fit the estimator on the training data. If "auto", the estimator
@@ -94,25 +95,13 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
         if fit == "auto":
             try:
                 check_is_fitted(estimator)
-                self._estimator = estimator
+                self._estimator = self._copy_estimator(estimator)
             except NotFittedError:
                 self._estimator = self._fit_estimator(estimator, X_train, y_train)
         elif fit is True:
             self._estimator = self._fit_estimator(estimator, X_train, y_train)
         else:  # fit is False
-            self._estimator = estimator
-
-        try:
-            self._estimator = copy.deepcopy(self._estimator)
-        except Exception as e:
-            warnings.warn(
-                "Deepcopy failed; using estimator as-is. "
-                "Be aware that modifying the estimator outside of "
-                f"{self.__class__.__name__} will modify the internal estimator. "
-                "Consider using a FrozenEstimator from scikit-learn to prevent this. "
-                f"Original error: {e}",
-                stacklevel=1,
-            )
+            self._estimator = self._copy_estimator(estimator)
 
         # private storage to be able to invalidate the cache when the user alters
         # those attributes
@@ -131,6 +120,19 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
         )
         self._cache = {}
         self._ml_task = _find_ml_task(self._y_test, estimator=self._estimator)
+
+    def _copy_estimator(self, estimator):
+        try:
+            return copy.deepcopy(estimator)
+        except Exception as e:
+            warnings.warn(
+                "Deepcopy failed; using estimator as-is. "
+                "Be aware that modifying the estimator outside of "
+                f"{self.__class__.__name__} will modify the internal estimator. "
+                "Consider using a FrozenEstimator from scikit-learn to prevent this. "
+                f"Original error: {e}",
+                stacklevel=1,
+            )
 
     # NOTE:
     # For the moment, we do not allow to alter the estimator and the training data.

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -1,5 +1,7 @@
+import copy
 import inspect
 import time
+import warnings
 from itertools import product
 
 import joblib
@@ -99,6 +101,18 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
             self._estimator = self._fit_estimator(estimator, X_train, y_train)
         else:  # fit is False
             self._estimator = estimator
+
+        try:
+            self._estimator = copy.deepcopy(self._estimator)
+        except Exception as e:
+            warnings.warn(
+                "Deepcopy failed; using estimator as-is. "
+                "Be aware that modifying the estimator outside of "
+                f"{self.__class__.__name__} will modify the internal estimator. "
+                "Consider using a FrozenEstimator from scikit-learn to prevent this. "
+                f"Original error: {e}",
+                stacklevel=1,
+            )
 
         # private storage to be able to invalidate the cache when the user alters
         # those attributes

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -82,6 +82,21 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
             )
         return clone(estimator).fit(X_train, y_train)
 
+    @classmethod
+    def _copy_estimator(cls, estimator):
+        try:
+            return copy.deepcopy(estimator)
+        except Exception as e:
+            warnings.warn(
+                "Deepcopy failed; using estimator as-is. "
+                "Be aware that modifying the estimator outside of "
+                f"{cls.__name__} will modify the internal estimator. "
+                "Consider using a FrozenEstimator from scikit-learn to prevent this. "
+                f"Original error: {e}",
+                stacklevel=1,
+            )
+        return estimator
+
     def __init__(
         self,
         estimator,
@@ -120,19 +135,6 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
         )
         self._cache = {}
         self._ml_task = _find_ml_task(self._y_test, estimator=self._estimator)
-
-    def _copy_estimator(self, estimator):
-        try:
-            return copy.deepcopy(estimator)
-        except Exception as e:
-            warnings.warn(
-                "Deepcopy failed; using estimator as-is. "
-                "Be aware that modifying the estimator outside of "
-                f"{self.__class__.__name__} will modify the internal estimator. "
-                "Consider using a FrozenEstimator from scikit-learn to prevent this. "
-                f"Original error: {e}",
-                stacklevel=1,
-            )
 
     # NOTE:
     # For the moment, we do not allow to alter the estimator and the training data.

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -929,14 +929,17 @@ def test_estimator_report_get_X_y_and_data_source_hash(data_source):
         assert data_source_hash == joblib.hash((X_test, y_test))
 
 
-def test_estimator_has_side_effects():
+@pytest.mark.parametrize("prefit_estimator", [True, False])
+def test_estimator_has_side_effects(prefit_estimator):
     """Re-fitting the estimator outside the EstimatorReport
-    should not have an effect on the EstimatorReport's internal estimator"""
+    should not have an effect on the EstimatorReport's internal estimator."""
     X, y = make_classification(n_classes=2, random_state=42)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    X_train2, _, y_train2, _ = train_test_split(X, y, random_state=420)
 
-    estimator = LogisticRegression().fit(X_train, y_train)
+    estimator = LogisticRegression()
+    if prefit_estimator:
+        estimator.fit(X_train, y_train)
+
     report = EstimatorReport(
         estimator,
         X_train=X_train,
@@ -952,6 +955,8 @@ def test_estimator_has_side_effects():
 
 
 def test_estimator_has_no_deep_copy():
+    """Check that we raise a warning if the deep copy failed with a fitted
+    estimator."""
     X, y = make_classification(n_classes=2, random_state=42)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
 

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -946,11 +946,8 @@ def test_estimator_has_side_effects():
     )
 
     predictions_before = report.estimator.predict_proba(X_test)
-
-    estimator.fit(X_train2, y_train2)
-
+    estimator.fit(X_test, y_test)
     predictions_after = report.estimator.predict_proba(X_test)
-
     np.testing.assert_array_equal(predictions_before, predictions_after)
 
 


### PR DESCRIPTION
Closes #1081

When initializing the `EstimatorReport`, we now `deepcopy` the input estimator unless it is `cloned`.
This way, if the user re-fits their estimator after giving it as input to `EstimatorReport`, this will have no impact on the report itself.

If `deepcopy` doesn't succeed, we keep the previous behaviour and issue a warning about the potential side-effects.
