### PR TITLE
docs: Reset figure DPI before each example

### DIFF
--- a/examples/getting_started/plot_skore_product_tour.py
+++ b/examples/getting_started/plot_skore_product_tour.py
@@ -131,7 +131,7 @@ df[["param_alpha", "rmse"]].head()
 # %%
 import matplotlib.pyplot as plt
 
-fig = plt.figure(layout="constrained", dpi=200)
+fig = plt.figure(layout="constrained")
 plt.plot(df["param_alpha"], df["rmse"])
 plt.xscale("log")
 plt.xlabel("Alpha hyperparameter")

--- a/examples/getting_started/plot_working_with_projects.py
+++ b/examples/getting_started/plot_working_with_projects.py
@@ -231,7 +231,7 @@ import matplotlib.pyplot as plt
 
 x = np.linspace(0, 2, 100)
 
-fig, ax = plt.subplots(layout="constrained", dpi=200)
+fig, ax = plt.subplots(layout="constrained")
 ax.plot(x, x, label="linear")
 ax.plot(x, x**2, label="quadratic")
 ax.plot(x, x**3, label="cubic")

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -65,6 +65,14 @@ examples_ordered = [
     "../examples/model_evaluation/plot_cross_validate",
 ]
 
+
+# https://sphinx-gallery.github.io/stable/advanced.html#resetting-before-each-example
+def reset_mpl(gallery_conf, fname):
+    import matplotlib
+
+    matplotlib.rcParams["figure.dpi"] = 200
+
+
 # sphinx_gallery options
 sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to example scripts
@@ -80,6 +88,7 @@ sphinx_gallery_conf = {
     "backreferences_dir": "generated",
     "doc_module": "skore",
     "default_thumb_file": "./_static/images/Logo_Skore_Light@2x.svg",
+    "reset_modules": (reset_mpl, "seaborn"),
 }
 
 # intersphinx configuration


### PR DESCRIPTION
I followed the [sphinx-gallery docs](https://sphinx-gallery.github.io/stable/advanced.html#resetting-before-each-example).

I tried to place `reset_mpl` in a different module in the hopes of removing the warning about sphinx not being able to cache `sphinx_gallery_conf`, but I couldn't manage to make the import work. I noticed sklearn declares a function in `conf.py` as well so I don't think it's too big a deal.

Closes #675
