### PR TITLE
docs: Fix the type of  parameter

### DIFF
--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -83,7 +83,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             same parameter name with different values), you can use scikit-learn scorers
             as provided by :func:`sklearn.metrics.make_scorer`.
 
-        pos_label : int, default=None
+        pos_label : int, float, bool or str, default=None
             The positive class.
 
         scoring_kwargs : dict, default=None
@@ -357,7 +357,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 only the statistics of the positive class (i.e. equivalent to
                 `average="binary"`).
 
-        pos_label : int, default=None
+        pos_label : int, float, bool or str, default=None
             The positive class.
 
         Returns
@@ -434,7 +434,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 only the statistics of the positive class (i.e. equivalent to
                 `average="binary"`).
 
-        pos_label : int, default=None
+        pos_label : int, float, bool or str, default=None
             The positive class.
 
         Returns
@@ -938,7 +938,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
             New target on which to compute the metric. By default, we use the target
             provided when creating the reporter.
 
-        pos_label : str, default=None
+        pos_label : int, float, bool or str, default=None
             The positive class.
 
         ax : matplotlib.axes.Axes, default=None
@@ -995,7 +995,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
             New target on which to compute the metric. By default, we use the target
             provided when creating the reporter.
 
-        pos_label : str, default=None
+        pos_label : int, float, bool or str, default=None
             The positive class.
 
         ax : matplotlib.axes.Axes, default=None

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -288,7 +288,7 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
         response_method : str
             The response method.
 
-        pos_label : str, default=None
+        pos_label : int, float, bool or str, default=None
             The positive label.
 
         data_source : {"test", "train", "X_y"}, default="test"

--- a/skore/src/skore/sklearn/_plot/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/roc_curve.py
@@ -56,7 +56,7 @@ class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
     estimator_name : str
         Name of the estimator.
 
-    pos_label : str, default=None
+    pos_label : int, float, bool or str, default=None
         The class considered as positive. Only meaningful for binary classification.
 
     data_source : {"train", "test", "X_y"}, default=None


### PR DESCRIPTION


Fixing the type of `pos_label` in the different docstrings.
Here, it is the most consistent types that are accepted.