### PR TITLE
chore: Move base.py outside from _estimator module

### DIFF
--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -327,10 +327,12 @@ def _get_cached_response_values(
     else:
         cache_key = (estimator_hash, prediction_method, data_source)
 
-    if data_source_hash is None and data_source == "X_y":
-        data_source_hash = joblib.hash(X)
-        cache_key += (data_source_hash,)
-    elif data_source_hash is not None:
+    if data_source == "X_y":
+        if data_source_hash is None:
+            # Only trigger hash computation if it was not previously done.
+            # If data_source_hash is not None, we internally computed ourself the hash
+            # and it is trustful
+            data_source_hash = joblib.hash(X)
         cache_key += (data_source_hash,)
 
     if cache_key in cache:

--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -327,8 +327,10 @@ def _get_cached_response_values(
     else:
         cache_key = (estimator_hash, prediction_method, data_source)
 
-    if data_source == "X_y":
+    if data_source_hash is None and data_source == "X_y":
         data_source_hash = joblib.hash(X)
+        cache_key += (data_source_hash,)
+    elif data_source_hash is not None:
         cache_key += (data_source_hash,)
 
     if cache_key in cache:

--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -5,6 +5,7 @@ import joblib
 from rich.console import Console, Group
 from rich.panel import Panel
 from rich.tree import Tree
+from sklearn.utils._response import _check_response_method, _get_response_values
 
 from skore.externals._sklearn_compat import is_clusterer
 
@@ -74,6 +75,102 @@ class _HelpMixin:
         console = Console(file=StringIO(), force_terminal=False)
         console.print(self._create_help_panel())
         return console.file.getvalue()
+
+
+class _BaseReport(_HelpMixin):
+    def _get_help_panel_title(self):
+        return (
+            f"[bold cyan]:notebook: Tools to diagnose estimator "
+            f"{self.estimator_name}[/bold cyan]"
+        )
+
+    def _get_help_legend(self):
+        return (
+            "[cyan](↗︎)[/cyan] higher is better [orange1](↘︎)[/orange1] lower is better"
+        )
+
+    def _get_attributes_for_help(self):
+        """Get the public attributes to display in help."""
+        attributes = []
+        xy_attributes = []
+
+        for name in dir(self):
+            # Skip private attributes, callables, and accessors
+            if (
+                name.startswith("_")
+                or callable(getattr(self, name))
+                or isinstance(getattr(self, name), _BaseAccessor)
+            ):
+                continue
+
+            # Group X and y attributes separately
+            value = getattr(self, name)
+            if name.startswith(("X_", "y_")):
+                if value is not None:  # Only include non-None X/y attributes
+                    xy_attributes.append(name)
+            else:
+                attributes.append(name)
+
+        # Sort X/y attributes to keep them grouped
+        xy_attributes.sort()
+        attributes.sort()
+
+        # Return X/y attributes first, followed by other attributes
+        return xy_attributes + attributes
+
+    def _create_help_tree(self):
+        """Create a rich Tree with the available tools and accessor methods."""
+        tree = Tree("reporter")
+
+        # Add accessor methods first
+        for accessor_attr, config in self._ACCESSOR_CONFIG.items():
+            accessor = getattr(self, accessor_attr)
+            branch = tree.add(
+                f"[bold cyan].{config['name']} {config['icon']}[/bold cyan]"
+            )
+
+            # Add main accessor methods first
+            methods = accessor._get_methods_for_help()
+            methods = accessor._sort_methods_for_help(methods)
+
+            # Add methods
+            for name, method in methods:
+                displayed_name = accessor._format_method_name(name)
+                description = accessor._get_method_description(method)
+                branch.add(f".{displayed_name} - {description}")
+
+            # Add sub-accessors after main methods
+            for sub_attr, sub_obj in inspect.getmembers(accessor):
+                if isinstance(sub_obj, _BaseAccessor) and not sub_attr.startswith("_"):
+                    sub_branch = branch.add(
+                        f"[bold cyan].{sub_attr} {sub_obj._icon}[/bold cyan]"
+                    )
+
+                    # Add sub-accessor methods
+                    sub_methods = sub_obj._get_methods_for_help()
+                    sub_methods = sub_obj._sort_methods_for_help(sub_methods)
+
+                    for name, method in sub_methods:
+                        displayed_name = sub_obj._format_method_name(name)
+                        description = sub_obj._get_method_description(method)
+                        sub_branch.add(f".{displayed_name.ljust(25)} - {description}")
+
+        # Add base methods
+        base_methods = self._get_methods_for_help()
+        base_methods = self._sort_methods_for_help(base_methods)
+
+        for name, method in base_methods:
+            description = self._get_method_description(method)
+            tree.add(f".{name}(...)".ljust(34) + f" - {description}")
+
+        # Add attributes section
+        attributes = self._get_attributes_for_help()
+        if attributes:
+            attr_branch = tree.add("[bold cyan]Attributes[/bold cyan]")
+            for attr in attributes:
+                attr_branch.add(f".{attr}")
+
+        return tree
 
 
 class _BaseAccessor(_HelpMixin):
@@ -172,3 +269,78 @@ class _BaseAccessor(_HelpMixin):
                 f"Invalid data source: {data_source}. Possible values are: "
                 "test, train, X_y."
             )
+
+
+def _get_cached_response_values(
+    *,
+    cache,
+    estimator_hash,
+    estimator,
+    X,
+    response_method,
+    pos_label=None,
+    data_source="test",
+    data_source_hash=None,
+):
+    """Compute or load from local cache the response values.
+
+    Parameters
+    ----------
+    cache : dict
+        The cache to use.
+
+    estimator_hash : int
+        A hash associated with the estimator such that we can retrieve the data from
+        the cache.
+
+    estimator : estimator object
+        The estimator.
+
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        The data.
+
+    response_method : str
+        The response method.
+
+    pos_label : str, default=None
+        The positive label.
+
+    data_source : {"test", "train", "X_y"}, default="test"
+        The data source to use.
+        - "test" : use the test set provided when creating the reporter.
+        - "train" : use the train set provided when creating the reporter.
+        - "X_y" : use the provided `X` and `y` to compute the metric.
+
+    data_source_hash : int or None
+        The hash of the data source when `data_source` is "X_y".
+
+    Returns
+    -------
+    array-like of shape (n_samples,) or (n_samples, n_outputs)
+        The response values.
+    """
+    prediction_method = _check_response_method(estimator, response_method).__name__
+    if prediction_method in ("predict_proba", "decision_function"):
+        # pos_label is only important in classification and with probabilities
+        # and decision functions
+        cache_key = (estimator_hash, pos_label, prediction_method, data_source)
+    else:
+        cache_key = (estimator_hash, prediction_method, data_source)
+
+    if data_source == "X_y":
+        data_source_hash = joblib.hash(X)
+        cache_key += (data_source_hash,)
+
+    if cache_key in cache:
+        return cache[cache_key]
+
+    predictions, _ = _get_response_values(
+        estimator,
+        X=X,
+        response_method=prediction_method,
+        pos_label=pos_label,
+        return_response_method_used=False,
+    )
+    cache[cache_key] = predictions
+
+    return predictions

--- a/skore/src/skore/sklearn/_base.pyi
+++ b/skore/src/skore/sklearn/_base.pyi
@@ -1,8 +1,9 @@
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Union
 
 import numpy as np
 from rich.panel import Panel
 from rich.tree import Tree
+from sklearn.base import BaseEstimator
 
 class _HelpMixin:
     def _get_methods_for_help(self) -> list[tuple[str, Any]]: ...
@@ -31,3 +32,28 @@ class _BaseAccessor(_HelpMixin):
         X: Optional[np.ndarray] = None,
         y: Optional[np.ndarray] = None,
     ) -> tuple[Optional[np.ndarray], Optional[np.ndarray], Optional[str]]: ...
+
+def _get_cached_response_values(
+    *,
+    cache: dict,
+    estimator_hash: int,
+    estimator: BaseEstimator,
+    X: np.ndarray,
+    response_method: Union[str, list[str]],
+    pos_label: Optional[Union[str, int]] = None,
+    data_source: Literal["test", "train", "X_y"] = "test",
+    data_source_hash: Optional[str] = None,
+) -> np.ndarray: ...
+
+class _BaseReport(_HelpMixin):
+    _ACCESSOR_CONFIG: dict[str, dict[str, str]]
+    estimator_name: str
+    _X_test: Optional[np.ndarray]
+    _y_test: Optional[np.ndarray]
+    _X_train: Optional[np.ndarray]
+    _y_train: Optional[np.ndarray]
+
+    def _get_help_panel_title(self) -> str: ...
+    def _get_help_legend(self) -> str: ...
+    def _get_attributes_for_help(self) -> list[str]: ...
+    def _create_help_tree(self) -> Tree: ...

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -9,7 +9,7 @@ from sklearn.metrics._scorer import _BaseScorer
 from sklearn.utils.metaestimators import available_if
 
 from skore.externals._pandas_accessors import DirNamesMixin
-from skore.sklearn._estimator.base import _BaseAccessor
+from skore.sklearn._base import _BaseAccessor, _get_cached_response_values
 from skore.sklearn._plot import (
     PrecisionRecallCurveDisplay,
     PredictionErrorDisplay,
@@ -193,7 +193,8 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             data_source=data_source, X=X, y=y_true
         )
 
-        y_pred = self._parent._get_cached_response_values(
+        y_pred = _get_cached_response_values(
+            cache=self._parent._cache,
             estimator_hash=self._parent._hash,
             estimator=self._parent.estimator,
             X=X,
@@ -889,7 +890,8 @@ class _PlotMetricsAccessor(_BaseAccessor):
             display = self._parent._cache[cache_key]
             display.plot(**display_plot_kwargs)
         else:
-            y_pred = self._parent._get_cached_response_values(
+            y_pred = _get_cached_response_values(
+                cache=self._parent._cache,
                 estimator_hash=self._parent._hash,
                 estimator=self._parent.estimator,
                 X=X,

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.pyi
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.pyi
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import PrecisionRecallDisplay, RocCurveDisplay
 
-from skore.sklearn._estimator.base import _BaseAccessor
+from skore.sklearn._base import _BaseAccessor
 from skore.sklearn._plot import PredictionErrorDisplay
 
 class _PlotMetricsAccessor(_BaseAccessor):

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import time
 import warnings
 from itertools import product
@@ -7,20 +6,18 @@ from itertools import product
 import joblib
 import numpy as np
 from rich.progress import track
-from rich.tree import Tree
 from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 from sklearn.pipeline import Pipeline
-from sklearn.utils._response import _check_response_method, _get_response_values
 from sklearn.utils.validation import check_is_fitted
 
 from skore.externals._pandas_accessors import DirNamesMixin
 from skore.externals._sklearn_compat import is_clusterer
-from skore.sklearn._estimator.base import _BaseAccessor, _HelpMixin
+from skore.sklearn._base import _BaseReport, _get_cached_response_values
 from skore.sklearn.find_ml_task import _find_ml_task
 
 
-class EstimatorReport(_HelpMixin, DirNamesMixin):
+class EstimatorReport(_BaseReport, DirNamesMixin):
     """Report for a fitted estimator.
 
     This class provides a set of tools to quickly validate and inspect a scikit-learn
@@ -180,7 +177,8 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
 
         parallel = joblib.Parallel(n_jobs=n_jobs, return_as="generator_unordered")
         generator = parallel(
-            joblib.delayed(self._get_cached_response_values)(
+            joblib.delayed(_get_cached_response_values)(
+                cache=self._cache,
                 estimator_hash=self._hash,
                 estimator=self._estimator,
                 X=X,
@@ -259,173 +257,3 @@ class EstimatorReport(_HelpMixin, DirNamesMixin):
         else:
             name = self._estimator.__class__.__name__
         return name
-
-    def _get_cached_response_values(
-        self,
-        *,
-        estimator_hash,
-        estimator,
-        X,
-        response_method,
-        pos_label=None,
-        data_source="test",
-        data_source_hash=None,
-    ):
-        """Compute or load from local cache the response values.
-
-        Parameters
-        ----------
-        estimator_hash : int
-            A hash associated with the estimator such that we can retrieve the data from
-            the cache.
-
-        estimator : estimator object
-            The estimator.
-
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            The data.
-
-        response_method : str
-            The response method.
-
-        pos_label : str, default=None
-            The positive label.
-
-        data_source : {"test", "train", "X_y"}, default="test"
-            The data source to use.
-
-            - "test" : use the test set provided when creating the reporter.
-            - "train" : use the train set provided when creating the reporter.
-            - "X_y" : use the provided `X` and `y` to compute the metric.
-
-        data_source_hash : int or None
-            The hash of the data source when `data_source` is "X_y".
-
-        Returns
-        -------
-        array-like of shape (n_samples,) or (n_samples, n_outputs)
-            The response values.
-        """
-        prediction_method = _check_response_method(estimator, response_method).__name__
-        if prediction_method in ("predict_proba", "decision_function"):
-            # pos_label is only important in classification and with probabilities
-            # and decision functions
-            cache_key = (estimator_hash, pos_label, prediction_method, data_source)
-        else:
-            cache_key = (estimator_hash, prediction_method, data_source)
-
-        if data_source == "X_y":
-            data_source_hash = joblib.hash(X)
-            cache_key += (data_source_hash,)
-
-        if cache_key in self._cache:
-            return self._cache[cache_key]
-
-        predictions, _ = _get_response_values(
-            estimator,
-            X=X,
-            response_method=prediction_method,
-            pos_label=pos_label,
-            return_response_method_used=False,
-        )
-        self._cache[cache_key] = predictions
-
-        return predictions
-
-    ####################################################################################
-    # Methods related to the help tree
-    ####################################################################################
-
-    def _get_help_panel_title(self):
-        return (
-            f"[bold cyan]:notebook: Tools to diagnose estimator "
-            f"{self.estimator_name}[/bold cyan]"
-        )
-
-    def _get_help_legend(self):
-        return (
-            "[cyan](↗︎)[/cyan] higher is better [orange1](↘︎)[/orange1] lower is better"
-        )
-
-    def _get_attributes_for_help(self):
-        """Get the public attributes to display in help."""
-        attributes = []
-        xy_attributes = []
-
-        for name in dir(self):
-            # Skip private attributes, callables, and accessors
-            if (
-                name.startswith("_")
-                or callable(getattr(self, name))
-                or isinstance(getattr(self, name), _BaseAccessor)
-            ):
-                continue
-
-            # Group X and y attributes separately
-            value = getattr(self, name)
-            if name.startswith(("X_", "y_")):
-                if value is not None:  # Only include non-None X/y attributes
-                    xy_attributes.append(name)
-            else:
-                attributes.append(name)
-
-        # Sort X/y attributes to keep them grouped
-        xy_attributes.sort()
-        attributes.sort()
-
-        # Return X/y attributes first, followed by other attributes
-        return xy_attributes + attributes
-
-    def _create_help_tree(self):
-        """Create a rich Tree with the available tools and accessor methods."""
-        tree = Tree("reporter")
-
-        # Add accessor methods first
-        for accessor_attr, config in self._ACCESSOR_CONFIG.items():
-            accessor = getattr(self, accessor_attr)
-            branch = tree.add(
-                f"[bold cyan].{config['name']} {config['icon']}[/bold cyan]"
-            )
-
-            # Add main accessor methods first
-            methods = accessor._get_methods_for_help()
-            methods = accessor._sort_methods_for_help(methods)
-
-            # Add methods
-            for name, method in methods:
-                displayed_name = accessor._format_method_name(name)
-                description = accessor._get_method_description(method)
-                branch.add(f".{displayed_name} - {description}")
-
-            # Add sub-accessors after main methods
-            for sub_attr, sub_obj in inspect.getmembers(accessor):
-                if isinstance(sub_obj, _BaseAccessor) and not sub_attr.startswith("_"):
-                    sub_branch = branch.add(
-                        f"[bold cyan].{sub_attr} {sub_obj._icon}[/bold cyan]"
-                    )
-
-                    # Add sub-accessor methods
-                    sub_methods = sub_obj._get_methods_for_help()
-                    sub_methods = sub_obj._sort_methods_for_help(sub_methods)
-
-                    for name, method in sub_methods:
-                        displayed_name = sub_obj._format_method_name(name)
-                        description = sub_obj._get_method_description(method)
-                        sub_branch.add(f".{displayed_name.ljust(25)} - {description}")
-
-        # Add base methods
-        base_methods = self._get_methods_for_help()
-        base_methods = self._sort_methods_for_help(base_methods)
-
-        for name, method in base_methods:
-            description = self._get_method_description(method)
-            tree.add(f".{name}(...)".ljust(34) + f" - {description}")
-
-        # Add attributes section
-        attributes = self._get_attributes_for_help()
-        if attributes:
-            attr_branch = tree.add("[bold cyan]Attributes[/bold cyan]")
-            for attr in attributes:
-                attr_branch.add(f".{attr}")
-
-        return tree

--- a/skore/src/skore/sklearn/_estimator/report.pyi
+++ b/skore/src/skore/sklearn/_estimator/report.pyi
@@ -3,7 +3,7 @@ from typing import Any, Literal, Optional, Union
 import numpy as np
 from sklearn.base import BaseEstimator
 
-from skore.sklearn._estimator.base import _HelpMixin
+from skore.sklearn._base import _HelpMixin
 from skore.sklearn._estimator.metrics_accessor import _MetricsAccessor
 
 class EstimatorReport(_HelpMixin):
@@ -56,16 +56,5 @@ class EstimatorReport(_HelpMixin):
     def y_test(self, value: Optional[np.ndarray]) -> None: ...
     @property
     def estimator_name(self) -> str: ...
-    def _get_cached_response_values(
-        self,
-        *,
-        estimator_hash: int,
-        estimator: BaseEstimator,
-        X: np.ndarray,
-        response_method: Union[str, list[str]],
-        pos_label: Optional[Union[str, int]] = None,
-        data_source: Literal["test", "train", "X_y"] = "test",
-        data_source_hash: Optional[str] = None,
-    ) -> np.ndarray: ...
     def _get_help_panel_title(self) -> str: ...
     def _create_help_tree(self) -> Any: ...  # Returns rich.tree.Tree

--- a/skore/tests/unit/sklearn/test_base.py
+++ b/skore/tests/unit/sklearn/test_base.py
@@ -1,0 +1,157 @@
+import numpy as np
+import pytest
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+from skore.sklearn._base import _get_cached_response_values
+
+
+class MockClassifier(ClassifierMixin, BaseEstimator):
+    def __init__(
+        self, n_call_predict=0, n_call_predict_proba=0, n_call_decision_function=0
+    ):
+        self.n_call_predict = n_call_predict
+        self.n_call_predict_proba = n_call_predict_proba
+        self.n_call_decision_function = n_call_decision_function
+
+    def fit(self, X, y):
+        self.classes_ = np.array([0, 1])
+        self.fitted_ = True
+        return self
+
+    def predict(self, X):
+        self.n_call_predict += 1
+        return np.ones(X.shape[0])
+
+    def predict_proba(self, X):
+        self.n_call_predict_proba += 1
+        return np.ones((X.shape[0], len(self.classes_)))
+
+    def decision_function(self, X):
+        self.n_call_decision_function += 1
+        return np.ones(X.shape[0])
+
+
+class MockRegressor(RegressorMixin, BaseEstimator):
+    def __init__(self, n_call_predict=0):
+        self.n_call_predict = n_call_predict
+
+    def fit(self, X, y):
+        self.fitted_ = True
+        return self
+
+    def predict(self, X):
+        self.n_call_predict += 1
+        return np.ones(X.shape[0])
+
+
+@pytest.mark.parametrize(
+    "Estimator, response_method, pos_label_sensitive",
+    [
+        (MockClassifier, "predict", False),
+        (MockClassifier, "predict_proba", True),
+        (MockClassifier, "decision_function", True),
+        (MockRegressor, "predict", False),
+    ],
+)
+@pytest.mark.parametrize("data_source", ["train", "test", "X_y"])
+@pytest.mark.parametrize("pos_label", [0, 1])
+def test_get_cached_response_values(
+    Estimator,
+    response_method,
+    pos_label_sensitive,
+    data_source,
+    pos_label,
+):
+    """Check the general behavior of the `_get_cached_response_values` function."""
+    X = np.array([[1, 2], [3, 4]])
+    y = np.array([0, 1])
+    cache = {}
+    estimator = Estimator().fit(X, y)
+
+    params = {
+        "estimator_hash": 123,
+        "estimator": estimator,
+        "X": X,
+        "response_method": response_method,
+        "pos_label": pos_label,
+        "data_source": data_source,
+        "data_source_hash": None if data_source == "test" else 456,
+    }
+
+    # trigger the computation
+    response_values = _get_cached_response_values(cache=cache, **params)
+
+    assert response_values.shape == y.shape
+    initial_calls = getattr(estimator, f"n_call_{response_method}")
+    assert (
+        initial_calls == 1
+    ), f"Expected 1 call for {response_method}, got {initial_calls}"
+
+    # Reload from the cache
+    response_values = _get_cached_response_values(cache=cache, **params)
+    assert response_values.shape == y.shape
+    current_calls = getattr(estimator, f"n_call_{response_method}")
+    assert current_calls == initial_calls, (
+        f"Cache was not used for {response_method} "
+        f"(calls: {current_calls} != {initial_calls})"
+    )
+
+    # Change pos_label
+    # It should trigger recomputation for predict_proba and decision_function only
+    params["pos_label"] = 1 - pos_label
+    response_values = _get_cached_response_values(cache=cache, **params)
+    assert response_values.shape == y.shape
+    current_calls = getattr(estimator, f"n_call_{response_method}")
+    expected_calls = initial_calls + (1 if pos_label_sensitive else 0)
+    assert (
+        current_calls == expected_calls
+    ), f"Unexpected number of calls for different pos_label in {response_method}"
+
+    # Should reload completely from the cache
+    response_values = _get_cached_response_values(cache=cache, **params)
+    assert response_values.shape == y.shape
+    current_calls = getattr(estimator, f"n_call_{response_method}")
+    assert (
+        current_calls == expected_calls
+    ), f"Unexpected number of calls for different pos_label in {response_method}"
+
+
+@pytest.mark.parametrize(
+    "Estimator, response_method",
+    [
+        (MockClassifier, "predict"),
+        (MockClassifier, "predict_proba"),
+        (MockClassifier, "decision_function"),
+        (MockRegressor, "predict"),
+    ],
+)
+def test_get_cached_response_values_different_data_source_hash(
+    Estimator, response_method
+):
+    """Test that different data source hashes trigger new computations."""
+    X = np.array([[1, 2], [3, 4]])
+    y = np.array([0, 1])
+    cache = {}
+    estimator = Estimator().fit(X, y)
+
+    params = {
+        "estimator_hash": 123,
+        "estimator": estimator,
+        "X": X,
+        "response_method": response_method,
+        "pos_label": 1,
+        "data_source": "X_y",
+        "data_source_hash": 456,
+    }
+    response_values = _get_cached_response_values(cache=cache, **params)
+    assert response_values.shape == y.shape
+    initial_calls = getattr(estimator, f"n_call_{response_method}")
+
+    # Second call with different hash should trigger new computation
+    params["data_source_hash"] = 789
+    response_values = _get_cached_response_values(cache=cache, **params)
+    assert response_values.shape == y.shape
+    current_calls = getattr(estimator, f"n_call_{response_method}")
+    assert current_calls == initial_calls + 1, (
+        f"Different data source hash should trigger new "
+        f"computation for {response_method}"
+    )


### PR DESCRIPTION
It is a refactor to ease the review in #1091.


It is only moving the file from `sklearn/_estimator/base.py` to `sklearn/_base.py` since some base class will be in common between the `EstimatorReport` and `CrossValidationReport`.

In addition, I factor out an additional base class link to the help of the `*Report` class and the `_get_cached_response_values` that will also be used in the `CrossValidationReport`.

So in short, there is no new code here.