### PR TITLE
feat(project.put): Add `note` argument

### DIFF
--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -1,7 +1,7 @@
 """Define a Project."""
 
 import logging
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from skore.item import (
     CrossValidationItem,
@@ -77,7 +77,7 @@ class Project:
         self.item_repository = item_repository
         self.view_repository = view_repository
 
-    def put(self, key: str, value: Any):
+    def put(self, key: str, value: Any, *, note: Optional[str] = None):
         """Add a key-value pair to the Project.
 
         If an item with the same key already exists, its value is replaced by the new
@@ -89,6 +89,8 @@ class Project:
             The key to associate with ``value`` in the Project.
         value : Any
             The value to associate with ``key`` in the Project.
+        note : str or None, optional
+            A note to attach with the item.
 
         Raises
         ------
@@ -101,7 +103,14 @@ class Project:
         if not isinstance(key, str):
             raise TypeError(f"Key must be a string (found '{type(key)}')")
 
-        self.item_repository.put_item(key, object_to_item(value))
+        item = object_to_item(value)
+
+        if note is not None:
+            if not isinstance(note, str):
+                raise TypeError(f"Note must be a string (found '{type(note)}')")
+            item.note = note
+
+        self.item_repository.put_item(key, item)
 
     def put_item(self, key: str, item: Item):
         """Add an Item to the Project."""

--- a/skore/tests/unit/project/test_notes.py
+++ b/skore/tests/unit/project/test_notes.py
@@ -58,3 +58,21 @@ def test_delete_note_no_key(in_memory_project):
 def test_delete_note_no_note(in_memory_project):
     in_memory_project.put("key", "hello")
     assert in_memory_project.get_note("key") is None
+
+
+def test_put_with_note(in_memory_project):
+    in_memory_project.put("key", "hello", note="note")
+    assert in_memory_project.get_note("key") == "note"
+
+
+def test_put_with_note_annotates_latest(in_memory_project):
+    """Adding the `note` argument annotates the latest version of the item."""
+    in_memory_project.put("key", "hello")
+    in_memory_project.put("key", "goodbye", note="note")
+    assert in_memory_project.get_note("key", version=0) is None
+
+
+def test_put_with_note_wrong_type(in_memory_project):
+    """Adding the `note` argument annotates the latest version of the item."""
+    with pytest.raises(TypeError):
+        in_memory_project.put("key", "hello", note=0)


### PR DESCRIPTION
Implementation notes:

At first I used `set_note` directly, to delegate the type-checking process, but that meant touching the storage 2 times instead of 1.

