### PR TITLE
chore: More readable version to create variable to iterate on in cache_predictions

### DIFF
--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -158,22 +158,20 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         """
         if self._ml_task in ("binary-classification", "multiclass-classification"):
             if response_methods == "auto":
-                response_methods = ("predict",)
+                response_methods = ["predict"]
                 if hasattr(self._estimator, "predict_proba"):
-                    response_methods += ("predict_proba",)
+                    response_methods += ["predict_proba"]
                 if hasattr(self._estimator, "decision_function"):
-                    response_methods += ("decision_function",)
+                    response_methods += ["decision_function"]
             pos_labels = self._estimator.classes_
         else:
             if response_methods == "auto":
-                response_methods = ("predict",)
+                response_methods = ["predict"]
             pos_labels = [None]
 
-        data_sources = ("test",)
-        Xs = (self._X_test,)
+        data_sources = [("test", self._X_test)]
         if self._X_train is not None:
-            data_sources += ("train",)
-            Xs += (self._X_train,)
+            data_sources += [("train", self._X_train)]
 
         parallel = joblib.Parallel(n_jobs=n_jobs, return_as="generator_unordered")
         generator = parallel(
@@ -187,7 +185,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 data_source=data_source,
             )
             for response_method, pos_label, (data_source, X) in product(
-                response_methods, pos_labels, zip(data_sources, Xs)
+                response_methods, pos_labels, data_sources
             )
         )
         # trigger the computation


### PR DESCRIPTION
I might slight refactor such that we concatenate list instead of tuple and associate the `data_source` and `X` to make more straightforward.

There is no change in the tests because the outcome is equivalent.