### PR TITLE
fix: Fix the error message regarding immutable attribute

### DIFF
--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -218,7 +218,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     def X_train(self, value):
         raise AttributeError(
             "The X_train attribute is immutable. "
-            "Please use the `from_unfitted_estimator` method to create a new report."
+            f"Call the constructor of {self.__class__.__name__} to create a new report."
         )
 
     @property
@@ -229,7 +229,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     def y_train(self, value):
         raise AttributeError(
             "The y_train attribute is immutable. "
-            "Please use the `from_unfitted_estimator` method to create a new report."
+            f"Call the constructor of {self.__class__.__name__} to create a new report."
         )
 
     @property


### PR DESCRIPTION
Fixing some outdated information from previous iteration.
`unfitted_estimator` and `fitted_estimator` are not available anymore because we use the constructor directly.