### PR TITLE
feat: Private API to expose `data_source_hash` when computing metric

### DIFF
--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -157,7 +157,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 else:
                     metric_fn = partial(self._custom_metric, metric_function=metric)
                     if scoring_kwargs is None:
-                        metrics_kwargs = {"data_source_hash": data_source_hash}
+                        metrics_kwargs = {}
                     else:
                         # check if we should pass any parameters specific to the metric
                         # callable

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -52,6 +52,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         X=None,
         y=None,
         scoring=None,
+        scoring_name=None,
         pos_label=None,
         scoring_kwargs=None,
     ):
@@ -83,6 +84,9 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             same parameter name with different values), you can use scikit-learn scorers
             as provided by :func:`sklearn.metrics.make_scorer`.
 
+        scoring_name : list of str, default=None
+            Overwrite the name of the metrics.
+
         pos_label : int, float, bool or str, default=None
             The positive class.
 
@@ -94,41 +98,74 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The statistics for the metrics.
         """
+        if data_source == "X_y":
+            # optimization of the hash computation to avoid recomputing it
+            # FIXME: we are still recomputing the hash for all the metrics that we
+            # support in the report because we don't call `_compute_metric_scores`
+            # here. We should fix it.
+            X, y, data_source_hash = self._get_X_y_and_data_source_hash(
+                data_source=data_source, X=X, y=y
+            )
+        else:
+            data_source_hash = None
+
         if scoring is None:
             # Equivalent to _get_scorers_to_add
             if self._parent._ml_task == "binary-classification":
-                scoring = ["precision", "recall", "roc_auc"]
+                scoring = ["_precision", "_recall", "_roc_auc"]
                 if hasattr(self._parent._estimator, "predict_proba"):
-                    scoring.append("brier_score")
+                    scoring.append("_brier_score")
             elif self._parent._ml_task == "multiclass-classification":
-                scoring = ["precision", "recall"]
+                scoring = ["_precision", "_recall"]
                 if hasattr(self._parent._estimator, "predict_proba"):
-                    scoring += ["roc_auc", "log_loss"]
+                    scoring += ["_roc_auc", "_log_loss"]
             else:
-                scoring = ["r2", "rmse"]
+                scoring = ["_r2", "_rmse"]
 
         scores = []
 
-        for metric in scoring:
+        for metric_idx, metric in enumerate(scoring):
             # NOTE: we have to check specifically for `_BaseScorer` first because this
             # is also a callable but it has a special private API that we can leverage
             if isinstance(metric, _BaseScorer):
                 # scorers have the advantage to have scoped defined kwargs
                 metric_fn = partial(
-                    self.custom_metric,
+                    self._custom_metric,
                     metric_function=metric._score_func,
                     response_method=metric._response_method,
                 )
                 # forward the additional parameters specific to the scorer
                 metrics_kwargs = {**metric._kwargs}
+                if scoring_name is not None:
+                    metrics_kwargs["metric_name"] = scoring_name[metric_idx]
+                metrics_kwargs["data_source_hash"] = data_source_hash
+                metrics_params = inspect.signature(metric._score_func).parameters
+                if "pos_label" in metrics_params:
+                    metrics_kwargs["pos_label"] = pos_label
             elif isinstance(metric, str) or callable(metric):
                 if isinstance(metric, str):
+                    err_msg = (
+                        f"Invalid metric: {metric!r}. Please use a valid metric"
+                        " from the list of supported metrics: "
+                        f"{list(self._SCORE_OR_LOSS_ICONS.keys())}"
+                    )
+                    if (
+                        metric.startswith("_")
+                        and metric[1:] not in self._SCORE_OR_LOSS_ICONS
+                    ):
+                        raise ValueError(err_msg)
+                    if not metric.startswith("_"):
+                        if metric not in self._SCORE_OR_LOSS_ICONS:
+                            raise ValueError(err_msg)
+                        metric = f"_{metric}"
                     metric_fn = getattr(self, metric)
-                    metrics_kwargs = {}
+                    metrics_kwargs = {"data_source_hash": data_source_hash}
+                    if scoring_name is not None:
+                        metrics_kwargs["metric_name"] = scoring_name[metric_idx]
                 else:
-                    metric_fn = partial(self.custom_metric, metric_function=metric)
+                    metric_fn = partial(self._custom_metric, metric_function=metric)
                     if scoring_kwargs is None:
-                        metrics_kwargs = {}
+                        metrics_kwargs = {"data_source_hash": data_source_hash}
                     else:
                         # check if we should pass any parameters specific to the metric
                         # callable
@@ -138,6 +175,9 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                             for param in metric_callable_params
                             if param in scoring_kwargs
                         }
+                    if scoring_name is not None:
+                        metrics_kwargs["metric_name"] = scoring_name[metric_idx]
+                    metrics_kwargs["data_source_hash"] = data_source_hash
                 metrics_params = inspect.signature(metric_fn).parameters
                 if scoring_kwargs is not None:
                     for param in metrics_params:
@@ -151,7 +191,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 )
 
             scores.append(
-                metric_fn(data_source=data_source, X=X, y=y, **metrics_kwargs)
+                metric_fn(
+                    data_source=data_source,
+                    X=X,
+                    y=y,
+                    **metrics_kwargs,
+                )
             )
 
         has_multilevel = any(
@@ -184,25 +229,17 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         y_true,
         *,
         data_source="test",
+        data_source_hash=None,
         response_method,
         pos_label=None,
         metric_name=None,
         **metric_kwargs,
     ):
-        X, y_true, data_source_hash = self._get_X_y_and_data_source_hash(
-            data_source=data_source, X=X, y=y_true
-        )
+        if data_source_hash is None:
+            X, y_true, data_source_hash = self._get_X_y_and_data_source_hash(
+                data_source=data_source, X=X, y=y_true
+            )
 
-        y_pred = _get_cached_response_values(
-            cache=self._parent._cache,
-            estimator_hash=self._parent._hash,
-            estimator=self._parent.estimator,
-            X=X,
-            response_method=response_method,
-            pos_label=pos_label,
-            data_source=data_source,
-            data_source_hash=data_source_hash,
-        )
         cache_key = (self._parent._hash, metric_fn.__name__, data_source)
         if data_source_hash:
             cache_key += (data_source_hash,)
@@ -230,6 +267,17 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             kwargs = {**metric_kwargs}
             if "pos_label" in metric_params:
                 kwargs.update(pos_label=pos_label)
+
+            y_pred = _get_cached_response_values(
+                cache=self._parent._cache,
+                estimator_hash=self._parent._hash,
+                estimator=self._parent.estimator,
+                X=X,
+                response_method=response_method,
+                pos_label=pos_label,
+                data_source=data_source,
+                data_source_hash=data_source_hash,
+            )
 
             score = metric_fn(y_true, y_pred, **kwargs)
             self._parent._cache[cache_key] = score
@@ -262,9 +310,8 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                     names=["Metric", "Output"],
                 )
                 score = score.reshape(1, -1)
-        else:
-            # FIXME: clusterer would fall here.
-            columns = None
+        else:  # unknown task - try our best
+            columns = [metric_name] if score.shape[0] == 1 else None
         return pd.DataFrame(score, columns=columns, index=[self._parent.estimator_name])
 
     @available_if(
@@ -297,11 +344,16 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The accuracy score.
         """
+        return self._accuracy(data_source=data_source, data_source_hash=None, X=X, y=y)
+
+    def _accuracy(self, *, data_source="test", data_source_hash=None, X=None, y=None):
+        """Private interface of accuracy to be able to pass `data_source_hash`."""
         return self._compute_metric_scores(
             metrics.accuracy_score,
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method="predict",
             metric_name=f"Accuracy {self._SCORE_OR_LOSS_ICONS['accuracy']}",
         )
@@ -366,6 +418,26 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The precision score.
         """
+        return self._precision(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+            average=average,
+            pos_label=pos_label,
+        )
+
+    def _precision(
+        self,
+        *,
+        data_source="test",
+        data_source_hash=None,
+        X=None,
+        y=None,
+        average=None,
+        pos_label=None,
+    ):
+        """Private interface of precision to be able to pass `data_source_hash`."""
         if self._parent._ml_task == "binary-classification" and pos_label is not None:
             # if `pos_label` is specified by our user, then we can safely report only
             # the statistics of the positive class
@@ -376,6 +448,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method="predict",
             pos_label=pos_label,
             metric_name=f"Precision {self._SCORE_OR_LOSS_ICONS['precision']}",
@@ -443,6 +516,26 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The recall score.
         """
+        return self._recall(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+            average=average,
+            pos_label=pos_label,
+        )
+
+    def _recall(
+        self,
+        *,
+        data_source="test",
+        data_source_hash=None,
+        X=None,
+        y=None,
+        average=None,
+        pos_label=None,
+    ):
+        """Private interface of recall to be able to pass `data_source_hash`."""
         if self._parent._ml_task == "binary-classification" and pos_label is not None:
             # if `pos_label` is specified by our user, then we can safely report only
             # the statistics of the positive class
@@ -453,6 +546,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method="predict",
             pos_label=pos_label,
             metric_name=f"Recall {self._SCORE_OR_LOSS_ICONS['recall']}",
@@ -487,6 +581,17 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The Brier score.
         """
+        return self._brier_score(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+        )
+
+    def _brier_score(
+        self, *, data_source="test", data_source_hash=None, X=None, y=None
+    ):
+        """Private interface of brier_score to be able to pass `data_source_hash`."""
         # The Brier score in scikit-learn request `pos_label` to ensure that the
         # integral encoding of `y_true` corresponds to the probabilities of the
         # `pos_label`. Since we get the predictions with `get_response_method`, we
@@ -496,6 +601,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method="predict_proba",
             metric_name=f"Brier score {self._SCORE_OR_LOSS_ICONS['brier_score']}",
             pos_label=self._parent._estimator.classes_[-1],
@@ -567,11 +673,32 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The ROC AUC score.
         """
+        return self._roc_auc(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+            average=average,
+            multi_class=multi_class,
+        )
+
+    def _roc_auc(
+        self,
+        *,
+        data_source="test",
+        data_source_hash=None,
+        X=None,
+        y=None,
+        average=None,
+        multi_class="ovr",
+    ):
+        """Private interface of roc_auc to be able to pass `data_source_hash`."""
         return self._compute_metric_scores(
             metrics.roc_auc_score,
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method=["predict_proba", "decision_function"],
             metric_name=f"ROC AUC {self._SCORE_OR_LOSS_ICONS['roc_auc']}",
             average=average,
@@ -601,11 +728,28 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The log-loss.
         """
+        return self._log_loss(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+        )
+
+    def _log_loss(
+        self,
+        *,
+        data_source="test",
+        data_source_hash=None,
+        X=None,
+        y=None,
+    ):
+        """Private interface of log_loss to be able to pass `data_source_hash`."""
         return self._compute_metric_scores(
             metrics.log_loss,
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method="predict_proba",
             metric_name=f"Log loss {self._SCORE_OR_LOSS_ICONS['log_loss']}",
         )
@@ -616,6 +760,13 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
 
         Parameters
         ----------
+        data_source : {"test", "train", "X_y"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the reporter.
+            - "train" : use the train set provided when creating the reporter.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
         X : array-like of shape (n_samples, n_features), default=None
             New data on which to compute the metric. By default, we use the validation
             set provided when creating the reporter.
@@ -639,11 +790,29 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The R² score.
         """
+        return self._r2(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+            multioutput=multioutput,
+        )
+
+    def _r2(
+        self,
+        *,
+        data_source="test",
+        data_source_hash=None,
+        X=None,
+        y=None,
+        multioutput="raw_values",
+    ):
         return self._compute_metric_scores(
             metrics.r2_score,
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method="predict",
             metric_name=f"R² {self._SCORE_OR_LOSS_ICONS['r2']}",
             multioutput=multioutput,
@@ -655,6 +824,13 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
 
         Parameters
         ----------
+        data_source : {"test", "train", "X_y"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the reporter.
+            - "train" : use the train set provided when creating the reporter.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
         X : array-like of shape (n_samples, n_features), default=None
             New data on which to compute the metric. By default, we use the validation
             set provided when creating the reporter.
@@ -678,11 +854,30 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The root mean squared error.
         """
+        return self._rmse(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+            multioutput=multioutput,
+        )
+
+    def _rmse(
+        self,
+        *,
+        data_source="test",
+        data_source_hash=None,
+        X=None,
+        y=None,
+        multioutput="raw_values",
+    ):
+        """Private interface of rmse to be able to pass `data_source_hash`."""
         return self._compute_metric_scores(
             metrics.root_mean_squared_error,
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method="predict",
             metric_name=f"RMSE {self._SCORE_OR_LOSS_ICONS['rmse']}",
             multioutput=multioutput,
@@ -725,6 +920,13 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             The name of the metric. If not provided, it will be inferred from the
             metric function.
 
+        data_source : {"test", "train", "X_y"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the reporter.
+            - "train" : use the train set provided when creating the reporter.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
         X : array-like of shape (n_samples, n_features), default=None
             New data on which to compute the metric. By default, we use the validation
             set provided when creating the reporter.
@@ -741,11 +943,36 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         pd.DataFrame
             The custom metric.
         """
+        return self._custom_metric(
+            data_source=data_source,
+            data_source_hash=None,
+            X=X,
+            y=y,
+            metric_function=metric_function,
+            response_method=response_method,
+            metric_name=metric_name,
+            **kwargs,
+        )
+
+    def _custom_metric(
+        self,
+        *,
+        data_source="test",
+        data_source_hash=None,
+        X=None,
+        y=None,
+        metric_function=None,
+        response_method=None,
+        metric_name=None,
+        **kwargs,
+    ):
+        """Private interface of custom_metric to be able to pass `data_source_hash`."""
         return self._compute_metric_scores(
             metric_function,
             X=X,
             y_true=y,
             data_source=data_source,
+            data_source_hash=data_source_hash,
             response_method=response_method,
             metric_name=metric_name,
             **kwargs,

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -337,7 +337,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         return self._accuracy(data_source=data_source, data_source_hash=None, X=X, y=y)
 
     def _accuracy(self, *, data_source="test", data_source_hash=None, X=None, y=None):
-        """Private interface of accuracy to be able to pass `data_source_hash`."""
+        """Private interface of `accuracy` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         return self._compute_metric_scores(
             metrics.accuracy_score,
             X=X,
@@ -427,7 +432,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         average=None,
         pos_label=None,
     ):
-        """Private interface of precision to be able to pass `data_source_hash`."""
+        """Private interface of `precision` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         if self._parent._ml_task == "binary-classification" and pos_label is not None:
             # if `pos_label` is specified by our user, then we can safely report only
             # the statistics of the positive class
@@ -525,7 +535,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         average=None,
         pos_label=None,
     ):
-        """Private interface of recall to be able to pass `data_source_hash`."""
+        """Private interface of `recall` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         if self._parent._ml_task == "binary-classification" and pos_label is not None:
             # if `pos_label` is specified by our user, then we can safely report only
             # the statistics of the positive class
@@ -581,7 +596,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
     def _brier_score(
         self, *, data_source="test", data_source_hash=None, X=None, y=None
     ):
-        """Private interface of brier_score to be able to pass `data_source_hash`."""
+        """Private interface of `brier_score` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         # The Brier score in scikit-learn request `pos_label` to ensure that the
         # integral encoding of `y_true` corresponds to the probabilities of the
         # `pos_label`. Since we get the predictions with `get_response_method`, we
@@ -682,7 +702,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         average=None,
         multi_class="ovr",
     ):
-        """Private interface of roc_auc to be able to pass `data_source_hash`."""
+        """Private interface of `roc_auc` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         return self._compute_metric_scores(
             metrics.roc_auc_score,
             X=X,
@@ -733,7 +758,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         X=None,
         y=None,
     ):
-        """Private interface of log_loss to be able to pass `data_source_hash`."""
+        """Private interface of `log_loss` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         return self._compute_metric_scores(
             metrics.log_loss,
             X=X,
@@ -797,6 +827,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         y=None,
         multioutput="raw_values",
     ):
+        """Private interface of `r2` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         return self._compute_metric_scores(
             metrics.r2_score,
             X=X,
@@ -861,7 +897,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         y=None,
         multioutput="raw_values",
     ):
-        """Private interface of rmse to be able to pass `data_source_hash`."""
+        """Private interface of `rmse` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         return self._compute_metric_scores(
             metrics.root_mean_squared_error,
             X=X,
@@ -956,7 +997,12 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         metric_name=None,
         **kwargs,
     ):
-        """Private interface of custom_metric to be able to pass `data_source_hash`."""
+        """Private interface of `custom_metric` to be able to pass `data_source_hash`.
+
+        `data_source_hash` is either an `int` when we already computed the hash
+        and are able to pass it around or `None` and thus trigger its computation
+        in the underlying process.
+        """
         return self._compute_metric_scores(
             metric_function,
             X=X,

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -752,6 +752,18 @@ def test_estimator_report_custom_metric(regression_data):
     )
 
 
+@pytest.mark.parametrize("scoring", ["public_metric", "_private_metric"])
+def test_estimator_report_report_metrics_error_scoring_strings(
+    regression_data, scoring
+):
+    """Check that we raise an error if a scoring string is not a valid metric."""
+    estimator, X_test, y_test = regression_data
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    err_msg = re.escape(f"Invalid metric: {scoring!r}.")
+    with pytest.raises(ValueError, match=err_msg):
+        report.metrics.report_metrics(scoring=[scoring])
+
+
 def test_estimator_report_custom_function_kwargs_numpy_array(regression_data):
     """Check that we are able to store a hash of a numpy array in the cache when they
     are passed as kwargs.

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -10,7 +10,14 @@ from sklearn.cluster import KMeans
 from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression, LogisticRegression
-from sklearn.metrics import make_scorer, median_absolute_error, r2_score, rand_score
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    make_scorer,
+    median_absolute_error,
+    r2_score,
+    rand_score,
+)
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
@@ -870,6 +877,34 @@ def test_estimator_report_report_metrics_with_scorer(regression_data):
                 r2_score(y_test, estimator.predict(X_test)),
                 median_absolute_error(y_test, estimator.predict(X_test)),
                 custom_metric(y_test, estimator.predict(X_test), weights),
+            ]
+        ],
+    )
+
+
+def test_estimator_report_report_metrics_with_scorer_binary_classification(
+    binary_classification_data,
+):
+    """Check that we can pass scikit-learn scorer with different parameters to
+    the `report_metrics` method."""
+    estimator, X_test, y_test = binary_classification_data
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    f1_scorer = make_scorer(
+        f1_score, response_method="predict", average="macro", pos_label=1
+    )
+    result = report.metrics.report_metrics(
+        scoring=["accuracy", f1_scorer],
+    )
+    assert result.shape == (1, 2)
+    np.testing.assert_allclose(
+        result.to_numpy(),
+        [
+            [
+                accuracy_score(y_test, estimator.predict(X_test)),
+                f1_score(
+                    y_test, estimator.predict(X_test), average="macro", pos_label=1
+                ),
             ]
         ],
     )

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -572,8 +572,13 @@ def _check_results_report_metrics(result, expected_metrics, expected_nb_stats):
 
 
 @pytest.mark.parametrize("pos_label, nb_stats", [(None, 2), (1, 1)])
+@pytest.mark.parametrize("data_source", ["test", "X_y"])
 def test_estimator_report_report_metrics_binary(
-    binary_classification_data, binary_classification_data_svc, pos_label, nb_stats
+    binary_classification_data,
+    binary_classification_data_svc,
+    pos_label,
+    nb_stats,
+    data_source,
 ):
     """Check the behaviour of the `report_metrics` method with binary
     classification. We test both with an SVC that does not support `predict_proba` and a
@@ -581,7 +586,10 @@ def test_estimator_report_report_metrics_binary(
     """
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics(pos_label=pos_label)
+    kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
+    result = report.metrics.report_metrics(
+        pos_label=pos_label, data_source=data_source, **kwargs
+    )
     expected_metrics = ("precision", "recall", "roc_auc", "brier_score")
     # depending on `pos_label`, we report a stats for each class or not for
     # precision and recall
@@ -595,7 +603,10 @@ def test_estimator_report_report_metrics_binary(
     y_test = target_names[y_test]
     estimator = clone(estimator).fit(X_test, y_test)
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics(pos_label=pos_label_name)
+    kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
+    result = report.metrics.report_metrics(
+        pos_label=pos_label_name, data_source=data_source, **kwargs
+    )
     expected_metrics = ("precision", "recall", "roc_auc", "brier_score")
     # depending on `pos_label`, we report a stats for each class or not for
     # precision and recall
@@ -604,7 +615,10 @@ def test_estimator_report_report_metrics_binary(
 
     estimator, X_test, y_test = binary_classification_data_svc
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics(pos_label=pos_label)
+    kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
+    result = report.metrics.report_metrics(
+        pos_label=pos_label, data_source=data_source, **kwargs
+    )
     expected_metrics = ("precision", "recall", "roc_auc")
     # depending on `pos_label`, we report a stats for each class or not for
     # precision and recall
@@ -612,15 +626,17 @@ def test_estimator_report_report_metrics_binary(
     _check_results_report_metrics(result, expected_metrics, expected_nb_stats)
 
 
+@pytest.mark.parametrize("data_source", ["test", "X_y"])
 def test_estimator_report_report_metrics_multiclass(
-    multiclass_classification_data, multiclass_classification_data_svc
+    multiclass_classification_data, multiclass_classification_data_svc, data_source
 ):
     """Check the behaviour of the `report_metrics` method with multiclass
     classification.
     """
     estimator, X_test, y_test = multiclass_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics()
+    kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
+    result = report.metrics.report_metrics(data_source=data_source, **kwargs)
     expected_metrics = ("precision", "recall", "roc_auc", "log_loss")
     # since we are not averaging by default, we report 3 statistics for
     # precision, recall and roc_auc
@@ -629,7 +645,8 @@ def test_estimator_report_report_metrics_multiclass(
 
     estimator, X_test, y_test = multiclass_classification_data_svc
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics()
+    kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
+    result = report.metrics.report_metrics(data_source=data_source, **kwargs)
     expected_metrics = ("precision", "recall")
     # since we are not averaging by default, we report 3 statistics for
     # precision and recall
@@ -637,11 +654,13 @@ def test_estimator_report_report_metrics_multiclass(
     _check_results_report_metrics(result, expected_metrics, expected_nb_stats)
 
 
-def test_estimator_report_report_metrics_regression(regression_data):
+@pytest.mark.parametrize("data_source", ["test", "X_y"])
+def test_estimator_report_report_metrics_regression(regression_data, data_source):
     """Check the behaviour of the `report_metrics` method with regression."""
     estimator, X_test, y_test = regression_data
+    kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics()
+    result = report.metrics.report_metrics(data_source=data_source, **kwargs)
     expected_metrics = ("r2", "rmse")
     _check_results_report_metrics(result, expected_metrics, len(expected_metrics))
 


### PR DESCRIPTION
This PR exposes private metrics to expose the `data_source_hash` such we can compute it once and pass it around whenever possible. It is particularly interested because the hash might be expensive to compute on huge dataset.