### PR TITLE
chore: Differentiate __repr__ and help for report and accessors

### DIFF
--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -70,10 +70,17 @@ class _HelpMixin:
 
         console.print(self._create_help_panel())
 
-    def __repr__(self):
+    def _rich_repr(self, class_name, help_method_name):
         """Return a string representation using rich."""
         console = Console(file=StringIO(), force_terminal=False)
-        console.print(self._create_help_panel())
+        console.print(
+            Panel(
+                f"Get guidance using the {help_method_name} method",
+                title=f"[cyan]{class_name}[/cyan]",
+                border_style="orange1",
+                expand=False,
+            )
+        )
         return console.file.getvalue()
 
 

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -819,6 +819,13 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
     def _get_help_tree_title(self):
         return "[bold cyan]reporter.metrics[/bold cyan]"
 
+    def __repr__(self):
+        """Return a string representation using rich."""
+        return self._rich_repr(
+            class_name="skore.EstimatorReport.metrics",
+            help_method_name="reporter.metrics.help()",
+        )
+
 
 ########################################################################################
 # Sub-accessors
@@ -1096,3 +1103,10 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
     def _get_help_tree_title(self):
         return "[bold cyan]reporter.metrics.plot[/bold cyan]"
+
+    def __repr__(self):
+        """Return a string representation using rich."""
+        return self._rich_repr(
+            class_name="skore.EstimatorReport.metrics.plot",
+            help_method_name="reporter.metrics.plot.help()",
+        )

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -255,3 +255,9 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         else:
             name = self._estimator.__class__.__name__
         return name
+
+    def __repr__(self):
+        """Return a string representation using rich."""
+        return self._rich_repr(
+            class_name="skore.EstimatorReport", help_method_name="reporter.help()"
+        )

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -286,6 +286,7 @@ def test_estimator_report_repr(binary_classification_data):
 
     repr_str = repr(report)
     assert "skore.EstimatorReport" in repr_str
+    assert "reporter.help()" in repr_str
 
 
 @pytest.mark.parametrize(
@@ -345,6 +346,7 @@ def test_estimator_report_plot_repr(binary_classification_data):
 
     repr_str = repr(report.metrics.plot)
     assert "skore.EstimatorReport.metrics.plot" in repr_str
+    assert "reporter.metrics.plot.help()" in repr_str
 
 
 def test_estimator_report_plot_roc(binary_classification_data):
@@ -484,6 +486,7 @@ def test_estimator_report_metrics_repr(binary_classification_data):
 
     repr_str = repr(report.metrics)
     assert "skore.EstimatorReport.metrics" in repr_str
+    assert "reporter.metrics.help()" in repr_str
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -285,7 +285,7 @@ def test_estimator_report_repr(binary_classification_data):
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
     repr_str = repr(report)
-    assert f"📓 Tools to diagnose estimator {estimator.__class__.__name__}" in repr_str
+    assert "skore.EstimatorReport" in repr_str
 
 
 @pytest.mark.parametrize(
@@ -344,7 +344,7 @@ def test_estimator_report_plot_repr(binary_classification_data):
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
     repr_str = repr(report.metrics.plot)
-    assert "🎨 Available plot methods" in repr_str
+    assert "skore.EstimatorReport.metrics.plot" in repr_str
 
 
 def test_estimator_report_plot_roc(binary_classification_data):
@@ -483,7 +483,7 @@ def test_estimator_report_metrics_repr(binary_classification_data):
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
     repr_str = repr(report.metrics)
-    assert "📏 Available metrics methods" in repr_str
+    assert "skore.EstimatorReport.metrics" in repr_str
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #1103 

As suggested in #1103, let's differentiate the output of `help` with the output of the `repr`. Let's have a concise output for `repr` to show where to get the information.