### PR TITLE
fix: Dissociate help() and repr in displays

### DIFF
--- a/skore/src/skore/sklearn/_plot/utils.py
+++ b/skore/src/skore/sklearn/_plot/utils.py
@@ -82,7 +82,14 @@ class HelpDisplayMixin:
     def __repr__(self):
         """Return a string representation using rich."""
         console = Console(file=StringIO(), force_terminal=False)
-        console.print(self._create_help_panel())
+        console.print(
+            Panel(
+                "Get guidance using the display.help() method",
+                title=f"[cyan]{self.__class__.__name__}[/cyan]",
+                border_style="orange1",
+                expand=False,
+            )
+        )
         return console.file.getvalue()
 
 

--- a/skore/tests/unit/sklearn/plot/test_common.py
+++ b/skore/tests/unit/sklearn/plot/test_common.py
@@ -52,7 +52,8 @@ def test_display_repr(pyplot, plot_func, estimator, dataset):
     display = getattr(report.metrics.plot, plot_func)()
 
     repr_str = repr(display)
-    assert f"📊 {display.__class__.__name__}" in repr_str
+    assert f"{display.__class__.__name__}" in repr_str
+    assert "display.help()" in repr_str
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is similar to https://github.com/probabl-ai/skore/pull/1113 by splitting `help` from `__repr__` to have a more compact `repr` redirecting to `help`

Here we tackle the displays specifically. 