### PR TITLE
refactor: Prepend with  name of variable that we modify

### DIFF
--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -88,7 +88,7 @@ class _BaseReport(_HelpMixin):
     def _get_help_panel_title(self):
         return (
             f"[bold cyan]Tools to diagnose estimator "
-            f"{self.estimator_name}[/bold cyan]"
+            f"{self.estimator_name_}[/bold cyan]"
         )
 
     def _get_help_legend(self):
@@ -230,7 +230,7 @@ class _BaseAccessor(_HelpMixin):
             The hash of the data source. None when we are able to track the data, and
             thus relying on X_train, y_train, X_test, y_test.
         """
-        is_cluster = is_clusterer(self._parent.estimator)
+        is_cluster = is_clusterer(self._parent.estimator_)
         if data_source == "test":
             if not (X is None or y is None):
                 raise ValueError("X and y must be None when data_source is test.")

--- a/skore/src/skore/sklearn/_base.pyi
+++ b/skore/src/skore/sklearn/_base.pyi
@@ -46,7 +46,8 @@ def _get_cached_response_values(
 
 class _BaseReport(_HelpMixin):
     _ACCESSOR_CONFIG: dict[str, dict[str, str]]
-    estimator_name: str
+    estimator_: BaseEstimator
+    estimator_name_: str
     _X_test: Optional[np.ndarray]
     _y_test: Optional[np.ndarray]
     _X_train: Optional[np.ndarray]

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -316,7 +316,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             y_pred = _get_cached_response_values(
                 cache=self._parent._cache,
                 estimator_hash=self._parent._hash,
-                estimator=self._parent.estimator,
+                estimator=self._parent.estimator_,
                 X=X,
                 response_method=response_method,
                 pos_label=pos_label,
@@ -357,7 +357,9 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 score = score.reshape(1, -1)
         else:  # unknown task - try our best
             columns = [metric_name] if score.shape[0] == 1 else None
-        return pd.DataFrame(score, columns=columns, index=[self._parent.estimator_name])
+        return pd.DataFrame(
+            score, columns=columns, index=[self._parent.estimator_name_]
+        )
 
     @available_if(
         _check_supported_ml_task(
@@ -1472,7 +1474,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
             y_pred = _get_cached_response_values(
                 cache=self._parent._cache,
                 estimator_hash=self._parent._hash,
-                estimator=self._parent.estimator,
+                estimator=self._parent.estimator_,
                 X=X,
                 response_method=response_method,
                 data_source=data_source,
@@ -1483,8 +1485,8 @@ class _PlotMetricsAccessor(_BaseAccessor):
             display = display_class._from_predictions(
                 y,
                 y_pred,
-                estimator=self._parent.estimator,
-                estimator_name=self._parent.estimator_name,
+                estimator=self._parent.estimator_,
+                estimator_name=self._parent.estimator_name_,
                 ml_task=self._parent._ml_task,
                 data_source=data_source,
                 **display_kwargs,

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -48,6 +48,12 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
 
     Attributes
     ----------
+    estimator_ : estimator object
+        The cloned or copied estimator.
+
+    estimator_name_ : str
+        The name of the estimator.
+
     metrics : _MetricsAccessor
         Accessor for metrics-related operations.
 
@@ -243,11 +249,11 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
             progress.update(task, advance=1, refresh=True)
 
     @property
-    def estimator(self):
+    def estimator_(self):
         return self._estimator
 
-    @estimator.setter
-    def estimator(self, value):
+    @estimator_.setter
+    def estimator_(self, value):
         raise AttributeError(
             "The estimator attribute is immutable. "
             f"Call the constructor of {self.__class__.__name__} to create a new report."
@@ -294,7 +300,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         self._initialize_state()
 
     @property
-    def estimator_name(self):
+    def estimator_name_(self):
         if isinstance(self._estimator, Pipeline):
             name = self._estimator[-1].__class__.__name__
         else:

--- a/skore/src/skore/sklearn/_estimator/utils.py
+++ b/skore/src/skore/sklearn/_estimator/utils.py
@@ -3,7 +3,7 @@ from sklearn.pipeline import Pipeline
 
 def _check_supported_estimator(supported_estimators):
     def check(accessor):
-        estimator = accessor._parent.estimator
+        estimator = accessor._parent.estimator_
         if isinstance(estimator, Pipeline):
             estimator = estimator.steps[-1][1]
         supported_estimator = isinstance(estimator, supported_estimators)

--- a/skore/tests/unit/sklearn/test_base.py
+++ b/skore/tests/unit/sklearn/test_base.py
@@ -186,7 +186,7 @@ class MockReport:
         self._y_test = y_test
 
     @property
-    def estimator(self):
+    def estimator_(self):
         return self._estimator
 
     @property

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -113,7 +113,7 @@ def test_check_supported_estimator():
 
     class MockParent:
         def __init__(self, estimator):
-            self.estimator = estimator
+            self.estimator_ = estimator
 
     class MockAccessor:
         def __init__(self, parent):
@@ -170,8 +170,8 @@ def test_estimator_report_from_unfitted_estimator(fit):
         y_test=y_test,
     )
 
-    check_is_fitted(report.estimator)
-    assert report.estimator is not estimator  # the estimator should be cloned
+    check_is_fitted(report.estimator_)
+    assert report.estimator_ is not estimator  # the estimator should be cloned
 
     assert report.X_train is X_train
     assert report.y_train is y_train
@@ -180,7 +180,7 @@ def test_estimator_report_from_unfitted_estimator(fit):
 
     err_msg = "attribute is immutable"
     with pytest.raises(AttributeError, match=err_msg):
-        report.estimator = LinearRegression()
+        report.estimator_ = LinearRegression()
     with pytest.raises(AttributeError, match=err_msg):
         report.X_train = X_train
     with pytest.raises(AttributeError, match=err_msg):
@@ -194,8 +194,8 @@ def test_estimator_report_from_fitted_estimator(binary_classification_data, fit)
     estimator, X, y = binary_classification_data
     report = EstimatorReport(estimator, fit=fit, X_test=X, y_test=y)
 
-    check_is_fitted(report.estimator)
-    assert isinstance(report.estimator, RandomForestClassifier)
+    check_is_fitted(report.estimator_)
+    assert isinstance(report.estimator_, RandomForestClassifier)
     assert report.X_train is None
     assert report.y_train is None
     assert report.X_test is X
@@ -203,7 +203,7 @@ def test_estimator_report_from_fitted_estimator(binary_classification_data, fit)
 
     err_msg = "attribute is immutable"
     with pytest.raises(AttributeError, match=err_msg):
-        report.estimator = LinearRegression()
+        report.estimator_ = LinearRegression()
     with pytest.raises(AttributeError, match=err_msg):
         report.X_train = X
     with pytest.raises(AttributeError, match=err_msg):
@@ -217,9 +217,9 @@ def test_estimator_report_from_fitted_pipeline(binary_classification_data_pipeli
     estimator, X, y = binary_classification_data_pipeline
     report = EstimatorReport(estimator, X_test=X, y_test=y)
 
-    check_is_fitted(report.estimator)
-    assert isinstance(report.estimator, Pipeline)
-    assert report.estimator_name == estimator[-1].__class__.__name__
+    check_is_fitted(report.estimator_)
+    assert isinstance(report.estimator_, Pipeline)
+    assert report.estimator_name_ == estimator[-1].__class__.__name__
     assert report.X_train is None
     assert report.y_train is None
     assert report.X_test is X
@@ -1140,9 +1140,9 @@ def test_estimator_has_side_effects(prefit_estimator):
         y_test=y_test,
     )
 
-    predictions_before = report.estimator.predict_proba(X_test)
+    predictions_before = report.estimator_.predict_proba(X_test)
     estimator.fit(X_test, y_test)
-    predictions_after = report.estimator.predict_proba(X_test)
+    predictions_after = report.estimator_.predict_proba(X_test)
     np.testing.assert_array_equal(predictions_before, predictions_after)
 
 


### PR DESCRIPTION
closes #1118 

As proposed in #1118. Add `_` at the end of the variables that we alter in the constructor to follow the scikit-learn convention.