### PR TITLE
fix(notes api): Make ItemRepository save notes properly

### DIFF
--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -204,7 +204,7 @@ class ItemRepository:
         Raises
         ------
         KeyError
-            If no note is attached to the ``(key, version)`` couple.
+            If the ``(key, version)`` couple does not exist.
         """
         try:
             return self.storage[key][version]["item"]["note"]
@@ -225,7 +225,7 @@ class ItemRepository:
         Raises
         ------
         KeyError
-            If no note is attached to the ``(key, version)`` couple.
+            If the ``(key, version)`` couple does not exist.
         """
         try:
             old = self.storage[key]

--- a/skore/src/skore/item/item_repository.py
+++ b/skore/src/skore/item/item_repository.py
@@ -180,7 +180,9 @@ class ItemRepository:
             raise TypeError(f"Message should be a string; got {type(message)}")
 
         try:
-            self.storage[key][version]["item"]["note"] = message
+            old = self.storage[key]
+            old[version]["item"]["note"] = message
+            self.storage[key] = old
         except IndexError as e:
             raise KeyError((key, version)) from e
 
@@ -226,6 +228,8 @@ class ItemRepository:
             If no note is attached to the ``(key, version)`` couple.
         """
         try:
-            self.storage[key][version]["item"]["note"] = None
+            old = self.storage[key]
+            old[version]["item"]["note"] = None
+            self.storage[key] = old
         except IndexError as e:
             raise KeyError((key, version)) from e

--- a/skore/tests/conftest.py
+++ b/skore/tests/conftest.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
+import skore
 from skore.item.item_repository import ItemRepository
 from skore.persistence.in_memory_storage import InMemoryStorage
 from skore.project import Project
@@ -44,6 +45,12 @@ def in_memory_project():
         item_repository=item_repository,
         view_repository=view_repository,
     )
+
+
+@pytest.fixture
+def on_disk_project(tmp_path):
+    project = skore.open(tmp_path / "project")
+    return project
 
 
 @pytest.fixture(scope="function")

--- a/skore/tests/unit/project/test_notes.py
+++ b/skore/tests/unit/project/test_notes.py
@@ -3,76 +3,95 @@
 import pytest
 
 
-def test_set_note(in_memory_project):
-    in_memory_project.put("key", "hello")
-    in_memory_project.set_note("key", "message")
-    assert in_memory_project.get_note("key") == "message"
+@pytest.mark.parametrize(
+    "project_fixture",
+    [
+        "in_memory_project",
+        "on_disk_project",
+    ],
+)
+class TestNotes:
+    def test_set_note(self, project_fixture, request):
+        project = request.getfixturevalue(project_fixture)
 
+        project.put("key", "hello")
+        project.set_note("key", "message")
+        assert project.get_note("key") == "message"
 
-def test_set_note_version(in_memory_project):
-    """By default, `set_note` only attaches a message to the latest version
-    of a key."""
-    in_memory_project.put("key", "hello")
-    in_memory_project.put("key", "goodbye")
-    in_memory_project.set_note("key", "message")
-    assert in_memory_project.get_note("key", version=-1) == "message"
-    assert in_memory_project.get_note("key", version=0) is None
+    def test_set_note_version(self, project_fixture, request):
+        """By default, `set_note` only attaches a message to the latest version
+        of a key."""
+        project = request.getfixturevalue(project_fixture)
 
+        project.put("key", "hello")
+        project.put("key", "goodbye")
+        project.set_note("key", "message")
+        assert project.get_note("key", version=-1) == "message"
+        assert project.get_note("key", version=0) is None
 
-def test_set_note_no_key(in_memory_project):
-    with pytest.raises(KeyError):
-        in_memory_project.set_note("key", "hello")
+    def test_set_note_no_key(self, project_fixture, request):
+        project = request.getfixturevalue(project_fixture)
 
-    in_memory_project.put("key", "hello")
+        with pytest.raises(KeyError):
+            project.set_note("key", "hello")
 
-    with pytest.raises(KeyError):
-        in_memory_project.set_note("key", "hello", version=10)
+        project.put("key", "hello")
 
+        with pytest.raises(KeyError):
+            project.set_note("key", "hello", version=10)
 
-def test_set_note_not_strings(in_memory_project):
-    """If key or message is not a string, raise a TypeError."""
-    with pytest.raises(TypeError):
-        in_memory_project.set_note(1, "hello")
+    def test_set_note_not_strings(self, project_fixture, request):
+        """If key or message is not a string, raise a TypeError."""
+        project = request.getfixturevalue(project_fixture)
 
-    with pytest.raises(TypeError):
-        in_memory_project.set_note("key", 1)
+        with pytest.raises(TypeError):
+            project.set_note(1, "hello")
 
+        with pytest.raises(TypeError):
+            project.set_note("key", 1)
 
-def test_delete_note(in_memory_project):
-    in_memory_project.put("key", "hello")
-    in_memory_project.set_note("key", "message")
-    in_memory_project.delete_note("key")
-    assert in_memory_project.get_note("key") is None
+    def test_delete_note(self, project_fixture, request):
+        project = request.getfixturevalue(project_fixture)
 
+        project.put("key", "hello")
+        project.set_note("key", "message")
+        project.delete_note("key")
+        assert project.get_note("key") is None
 
-def test_delete_note_no_key(in_memory_project):
-    with pytest.raises(KeyError):
-        in_memory_project.delete_note("key")
+    def test_delete_note_no_key(self, project_fixture, request):
+        project = request.getfixturevalue(project_fixture)
 
-    in_memory_project.put("key", "hello")
+        with pytest.raises(KeyError):
+            project.delete_note("key")
 
-    with pytest.raises(KeyError):
-        in_memory_project.set_note("key", "hello", version=10)
+        project.put("key", "hello")
 
+        with pytest.raises(KeyError):
+            project.set_note("key", "hello", version=10)
 
-def test_delete_note_no_note(in_memory_project):
-    in_memory_project.put("key", "hello")
-    assert in_memory_project.get_note("key") is None
+    def test_delete_note_no_note(self, project_fixture, request):
+        project = request.getfixturevalue(project_fixture)
 
+        project.put("key", "hello")
+        assert project.get_note("key") is None
 
-def test_put_with_note(in_memory_project):
-    in_memory_project.put("key", "hello", note="note")
-    assert in_memory_project.get_note("key") == "note"
+    def test_put_with_note(self, project_fixture, request):
+        project = request.getfixturevalue(project_fixture)
 
+        project.put("key", "hello", note="note")
+        assert project.get_note("key") == "note"
 
-def test_put_with_note_annotates_latest(in_memory_project):
-    """Adding the `note` argument annotates the latest version of the item."""
-    in_memory_project.put("key", "hello")
-    in_memory_project.put("key", "goodbye", note="note")
-    assert in_memory_project.get_note("key", version=0) is None
+    def test_put_with_note_annotates_latest(self, project_fixture, request):
+        """Adding the `note` argument annotates the latest version of the item."""
+        project = request.getfixturevalue(project_fixture)
 
+        project.put("key", "hello")
+        project.put("key", "goodbye", note="note")
+        assert project.get_note("key", version=0) is None
 
-def test_put_with_note_wrong_type(in_memory_project):
-    """Adding the `note` argument annotates the latest version of the item."""
-    with pytest.raises(TypeError):
-        in_memory_project.put("key", "hello", note=0)
+    def test_put_with_note_wrong_type(self, project_fixture, request):
+        """Adding the `note` argument annotates the latest version of the item."""
+        project = request.getfixturevalue(project_fixture)
+
+        with pytest.raises(TypeError):
+            project.put("key", "hello", note=0)


### PR DESCRIPTION
The storage API was not used correctly which resulted in not saving the notes properly; this affected `set_note` and `delete_note`.
The issue was not detected in unit tests because they relied on an in-memory project, not a "real" on-disk project.
