### PR TITLE
feat(_find_ml_task): Refine ML task detection logic

### DIFF
--- a/skore/src/skore/sklearn/find_ml_task.py
+++ b/skore/src/skore/sklearn/find_ml_task.py
@@ -40,10 +40,11 @@ def _find_ml_task(y, estimator=None) -> MLTask:
     # Discrete values, not sequential
     >>> _find_ml_task(numpy.array([1, 5, 9]))
     'regression'
+
     # Discrete values, not sequential, containing 0
     >>> _find_ml_task(numpy.array([0, 1, 5, 9]))
     'regression'
-    
+
     # Discrete sequential values, containing 0
     >>> _find_ml_task(numpy.array([0, 1, 2]))
     'multiclass-classification'

--- a/skore/src/skore/sklearn/find_ml_task.py
+++ b/skore/src/skore/sklearn/find_ml_task.py
@@ -40,7 +40,10 @@ def _find_ml_task(y, estimator=None) -> MLTask:
     # Discrete values, not sequential
     >>> _find_ml_task(numpy.array([1, 5, 9]))
     'regression'
-
+    # Discrete values, not sequential, containing 0
+    >>> _find_ml_task(numpy.array([0, 1, 5, 9]))
+    'regression'
+    
     # Discrete sequential values, containing 0
     >>> _find_ml_task(numpy.array([0, 1, 2]))
     'multiclass-classification'

--- a/skore/src/skore/sklearn/find_ml_task.py
+++ b/skore/src/skore/sklearn/find_ml_task.py
@@ -8,8 +8,18 @@ from skore.externals._sklearn_compat import is_clusterer
 from skore.sklearn.types import MLTask
 
 
+def _is_sequential(y) -> bool:
+    """Check whether ``y`` is vector of sequential integer values."""
+    y_values = np.sort(np.unique(y))
+    sequential = np.arange(y_values[0], y_values[-1] + 1)
+    return np.array_equal(y_values, sequential)
+
+
 def _find_ml_task(y, estimator=None) -> MLTask:
     """Guess the ML task being addressed based on a target array and an estimator.
+
+    This relies first on the estimator characteristics, and falls back on
+    analyzing ``y``. Check the examples for some of the heuristics relied on.
 
     Parameters
     ----------
@@ -22,6 +32,22 @@ def _find_ml_task(y, estimator=None) -> MLTask:
     -------
     MLTask
         The guess of the kind of ML task being performed.
+
+    Examples
+    --------
+    >>> import numpy
+
+    # Discrete values, not sequential
+    >>> _find_ml_task(numpy.array([1, 5, 9]))
+    'regression'
+
+    # Discrete sequential values, containing 0
+    >>> _find_ml_task(numpy.array([0, 1, 2]))
+    'multiclass-classification'
+
+    # Discrete sequential values, not containing 0
+    >>> _find_ml_task(numpy.array([1, 3, 2]))
+    'regression'
     """
     if estimator is not None:
         # checking the estimator is more robust and faster than checking the type of
@@ -45,7 +71,12 @@ def _find_ml_task(y, estimator=None) -> MLTask:
                 if target_type == "binary":
                     return "binary-classification"
                 if target_type == "multiclass":
-                    return "multiclass-classification"
+                    # If y is a vector of integers, type_of_target considers
+                    # the task to be multiclass-classification.
+                    # We refine this analysis a bit here.
+                    if _is_sequential(y) and 0 in y:
+                        return "multiclass-classification"
+                    return "regression"
             return "unsupported"
         return "unsupported"
     else:
@@ -60,5 +91,10 @@ def _find_ml_task(y, estimator=None) -> MLTask:
         if target_type == "binary":
             return "binary-classification"
         if target_type == "multiclass":
-            return "multiclass-classification"
+            # If y is a vector of integers, type_of_target considers
+            # the task to be multiclass-classification.
+            # We refine this analysis a bit here.
+            if _is_sequential(y) and 0 in y:
+                return "multiclass-classification"
+            return "regression"
         return "unsupported"

--- a/skore/tests/unit/sklearn/test_utils.py
+++ b/skore/tests/unit/sklearn/test_utils.py
@@ -1,3 +1,4 @@
+import numpy
 import pytest
 from sklearn.cluster import KMeans
 from sklearn.datasets import (
@@ -53,6 +54,9 @@ def test_find_ml_task_with_estimator(X, y, estimator, expected_task, should_fit)
         (make_regression(n_samples=100, random_state=42)[1], "regression"),
         (None, "clustering"),
         (make_multilabel_classification(random_state=42)[1], "unsupported"),
+        (numpy.array([1, 5, 9]), "regression"),
+        (numpy.array([0, 1, 2]), "multiclass-classification"),
+        (numpy.array([1, 2, 3]), "regression"),
     ],
 )
 def test_find_ml_task_without_estimator(target, expected_task):

--- a/skore/tests/unit/sklearn/test_utils.py
+++ b/skore/tests/unit/sklearn/test_utils.py
@@ -57,6 +57,7 @@ def test_find_ml_task_with_estimator(X, y, estimator, expected_task, should_fit)
         (numpy.array([1, 5, 9]), "regression"),
         (numpy.array([0, 1, 2]), "multiclass-classification"),
         (numpy.array([1, 2, 3]), "regression"),
+        (numpy.array([0, 1, 5, 9]), "regression"),
     ],
 )
 def test_find_ml_task_without_estimator(target, expected_task):


### PR DESCRIPTION
Closes #1080

Adds more logic in the case where `y` is detected as multiclass classification: we now additionally check whether `y` is a vector or sequential values that contains 0 (if so, we output "multiclass-classification", otherwise "regression"). This heuristic is suggested by @koaning.