### PR TITLE
fix: Fix rendering in ipywidget by injecting CSS rule asap

### DIFF
--- a/skore/src/skore/utils/_patch.py
+++ b/skore/src/skore/utils/_patch.py
@@ -2,12 +2,11 @@ import os
 
 from rich import jupyter
 
-# original_display = jupyter.display
 _original_render_segments = jupyter._render_segments
 
 
 def patched_render_segments(segments):
-    """Patched version of rich.jupyter.display that includes VS Code styling.
+    """Patched version of rich.jupyter._render_segments that includes VS Code styling.
 
     This is to make sure that the CSS style exposed by jupyter notebook and used
     by ipywidgets is applied to rich output.
@@ -38,5 +37,4 @@ def patched_render_segments(segments):
 
 def setup_jupyter_display():
     """Configure the jupyter display to work properly in VS Code."""
-    # jupyter.display = patched_display
     jupyter._render_segments = patched_render_segments

--- a/skore/src/skore/utils/_patch.py
+++ b/skore/src/skore/utils/_patch.py
@@ -2,10 +2,11 @@ import os
 
 from rich import jupyter
 
-original_display = jupyter.display
+# original_display = jupyter.display
+_original_render_segments = jupyter._render_segments
 
 
-def patched_display(segments, text):
+def patched_render_segments(segments):
     """Patched version of rich.jupyter.display that includes VS Code styling.
 
     This is to make sure that the CSS style exposed by jupyter notebook and used
@@ -16,13 +17,9 @@ def patched_display(segments, text):
     https://github.com/microsoft/vscode-jupyter/issues/7161
 
     """
-    # Call the original display function first
-    original_display(segments, text)
-
+    html = _original_render_segments(segments)
     # Apply VS Code styling if we're in VS Code
     if "VSCODE_PID" in os.environ:
-        from IPython.display import HTML, display
-
         css = """
         <style>
         .cell-output-ipywidget-background {
@@ -34,9 +31,12 @@ def patched_display(segments, text):
         }
         </style>
         """
-        display(HTML(css))
+        html += css
+
+    return html
 
 
 def setup_jupyter_display():
     """Configure the jupyter display to work properly in VS Code."""
-    jupyter.display = patched_display
+    # jupyter.display = patched_display
+    jupyter._render_segments = patched_render_segments


### PR DESCRIPTION
closes #1132

The current patch was clean but not optimal: it was patching a public class. However, it involves calling `display()` once to create the ipywidget and then once for injection the CSS rule. I assume that the timing between the two displays call was actually the blinking observe.

This PR patch the function creating the HTML code block for the widget and concatenate the CSS rule and thus involve a single call to display and remove the blinking.