### PR TITLE
ci: Fix timeout by upgrading scikit-learn to latest bugfix

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -127,6 +127,11 @@ jobs:
           # Install `skore` without its dependencies, which are present in the venv
           wheel=(dist/*.whl); python -m pip install --force-reinstall --no-deps "${wheel}"
 
+      - name: Show dependencies versions
+        working-directory: skore/
+        run: |
+          python -c "import skore; skore.show_versions()"
+
       - name: Test without coverage
         if: ${{ ! matrix.coverage }}
         timeout-minutes: 10

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -131,7 +131,7 @@ jobs:
         if: ${{ ! matrix.coverage }}
         timeout-minutes: 10
         working-directory: skore/
-        run: python -m pytest -n 3 src/ tests/ --no-cov
+        run: python -m pytest src/ tests/ --no-cov
 
       - name: Test with coverage
         if: ${{ matrix.coverage }}
@@ -139,7 +139,7 @@ jobs:
         working-directory: skore/
         run: |
           mkdir coverage
-          python -m pytest -n 3 src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
+          python -m pytest src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
 
       - name: Upload coverage reports
         if: ${{ matrix.coverage && (github.event_name == 'pull_request') }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -49,17 +49,17 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.9", "3.10", "3.11", "3.12"]
-        scikit-learn: ["1.6"]
+        scikit-learn: ["1.6.1"]
         include:
           - os: "ubuntu-latest"
             python: "3.12"
-            scikit-learn: "1.4"
+            scikit-learn: "1.4.2"
           - os: "ubuntu-latest"
             python: "3.12"
-            scikit-learn: "1.5"
+            scikit-learn: "1.5.2"
           - os: "ubuntu-latest"
             python: "3.12"
-            scikit-learn: "1.6"
+            scikit-learn: "1.6.1"
             coverage: true
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -131,7 +131,7 @@ jobs:
         if: ${{ ! matrix.coverage }}
         timeout-minutes: 10
         working-directory: skore/
-        run: python -m pytest -n auto src/ tests/ --no-cov
+        run: python -m pytest -n 3 src/ tests/ --no-cov
 
       - name: Test with coverage
         if: ${{ matrix.coverage }}
@@ -139,7 +139,7 @@ jobs:
         working-directory: skore/
         run: |
           mkdir coverage
-          python -m pytest src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
+          python -m pytest -n 3 src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
 
       - name: Upload coverage reports
         if: ${{ matrix.coverage && (github.event_name == 'pull_request') }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -102,6 +102,8 @@ jobs:
         run: |
           python -m pip install --upgrade "pip"
           python -m pip install --upgrade "build"
+          # adding `.*` to the version ensures that we install the latest version of
+          # scikit-learn that is compatible with the specified version
           python -m pip install --upgrade "scikit-learn ==${{ matrix.scikit-learn }}.*"
 
           # Install `skore` and its dependencies

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -49,17 +49,17 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.9", "3.10", "3.11", "3.12"]
-        scikit-learn: ["1.6.1"]
+        scikit-learn: ["1.6"]
         include:
           - os: "ubuntu-latest"
             python: "3.12"
-            scikit-learn: "1.4.2"
+            scikit-learn: "1.4"
           - os: "ubuntu-latest"
             python: "3.12"
-            scikit-learn: "1.5.2"
+            scikit-learn: "1.5"
           - os: "ubuntu-latest"
             python: "3.12"
-            scikit-learn: "1.6.1"
+            scikit-learn: "1.6"
             coverage: true
     runs-on: ${{ matrix.os }}
     steps:
@@ -102,7 +102,7 @@ jobs:
         run: |
           python -m pip install --upgrade "pip"
           python -m pip install --upgrade "build"
-          python -m pip install --upgrade "scikit-learn~=${{ matrix.scikit-learn }}"
+          python -m pip install --upgrade "scikit-learn~=${{ matrix.scikit-learn }}.0"
 
           # Install `skore` and its dependencies
           python -m pip install --upgrade ".[test]"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           python -m pip install --upgrade "pip"
           python -m pip install --upgrade "build"
-          python -m pip install --upgrade "scikit-learn~=${{ matrix.scikit-learn }}.0"
+          python -m pip install --upgrade "scikit-learn ==${{ matrix.scikit-learn }}.*"
 
           # Install `skore` and its dependencies
           python -m pip install --upgrade ".[test]"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           python -m pip install --upgrade "pip"
           python -m pip install --upgrade "build"
-          python -m pip install --upgrade "scikit-learn ==${{ matrix.scikit-learn }}"
+          python -m pip install --upgrade "scikit-learn~=${{ matrix.scikit-learn }}"
 
           # Install `skore` and its dependencies
           python -m pip install --upgrade ".[test]"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -138,7 +138,7 @@ jobs:
         if: ${{ ! matrix.coverage }}
         timeout-minutes: 10
         working-directory: skore/
-        run: python -m pytest src/ tests/ --no-cov
+        run: python -m pytest -n auto src/ tests/ --no-cov
 
       - name: Test with coverage
         if: ${{ matrix.coverage }}
@@ -146,7 +146,7 @@ jobs:
         working-directory: skore/
         run: |
           mkdir coverage
-          python -m pytest src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
+          python -m pytest -n auto src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
 
       - name: Upload coverage reports
         if: ${{ matrix.coverage && (github.event_name == 'pull_request') }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -107,7 +107,7 @@ jobs:
           python -m pip install --upgrade "scikit-learn ==${{ matrix.scikit-learn }}.*"
 
           # Install `skore` and its dependencies
-          python -m pip install --upgrade ".[test]"
+          python -m pip install --upgrade --upgrade-strategy=eager ".[test]"
 
           # Uninstall the `skore` package itself
           python -m pip uninstall -y "skore"


### PR DESCRIPTION
Looking a bit more, it seems not only the `coverage` job is problematic. So since we are using `-n auto`, it means that we potentially allocate too many cores (logical + physical) and potentially some test allocate even more parallel jobs (usually I tried some jobs with `n_jobs=2`). So we could have a problem of over-subscription and not problem of deadlocks.

Let see if we have the same issue by limiting the number of worker.