### PR TITLE
fix: Have shorter repr for display and longer str

### DIFF
--- a/skore/src/skore/sklearn/_plot/utils.py
+++ b/skore/src/skore/sklearn/_plot/utils.py
@@ -79,7 +79,7 @@ class HelpDisplayMixin:
 
         console.print(self._create_help_panel())
 
-    def __repr__(self):
+    def __str__(self):
         """Return a string representation using rich."""
         console = Console(file=StringIO(), force_terminal=False)
         console.print(
@@ -90,6 +90,12 @@ class HelpDisplayMixin:
                 expand=False,
             )
         )
+        return console.file.getvalue()
+
+    def __repr__(self):
+        """Return a string representation using rich."""
+        console = Console(file=StringIO(), force_terminal=False)
+        console.print(f"[cyan]skore.{self.__class__.__name__}(...)[/cyan]")
         return console.file.getvalue()
 
 

--- a/skore/tests/unit/sklearn/plot/test_common.py
+++ b/skore/tests/unit/sklearn/plot/test_common.py
@@ -43,6 +43,31 @@ def test_display_help(pyplot, capsys, plot_func, estimator, dataset):
         ("prediction_error", LinearRegression(), make_regression(random_state=42)),
     ],
 )
+def test_display_str(pyplot, plot_func, estimator, dataset):
+    """Check that __str__ returns a string starting with the expected prefix."""
+    X_train, X_test, y_train, y_test = train_test_split(*dataset, random_state=42)
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+    display = getattr(report.metrics.plot, plot_func)()
+
+    str_str = str(display)
+    assert f"{display.__class__.__name__}" in str_str
+    assert "display.help()" in str_str
+
+
+@pytest.mark.parametrize(
+    "plot_func, estimator, dataset",
+    [
+        ("roc", LogisticRegression(), make_classification(random_state=42)),
+        (
+            "precision_recall",
+            LogisticRegression(),
+            make_classification(random_state=42),
+        ),
+        ("prediction_error", LinearRegression(), make_regression(random_state=42)),
+    ],
+)
 def test_display_repr(pyplot, plot_func, estimator, dataset):
     """Check that __repr__ returns a string starting with the expected prefix."""
     X_train, X_test, y_train, y_test = train_test_split(*dataset, random_state=42)
@@ -52,8 +77,7 @@ def test_display_repr(pyplot, plot_func, estimator, dataset):
     display = getattr(report.metrics.plot, plot_func)()
 
     repr_str = repr(display)
-    assert f"{display.__class__.__name__}" in repr_str
-    assert "display.help()" in repr_str
+    assert f"skore.{display.__class__.__name__}(...)" in repr_str
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #1150 

This changes proposed to have a conventional `repr` for display to avoid to interfere too much with the output and have a richer `str`.