### PR TITLE
fix: Cache the pos_label=None when calling cache_predictions

### DIFF
--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -215,7 +215,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                     response_methods += ["predict_proba"]
                 if hasattr(self._estimator, "decision_function"):
                     response_methods += ["decision_function"]
-            pos_labels = self._estimator.classes_
+            pos_labels = self._estimator.classes_.tolist() + [None]
         else:
             if response_methods == "auto":
                 response_methods = ["predict"]

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -297,13 +297,13 @@ def test_estimator_report_repr(binary_classification_data):
 @pytest.mark.parametrize(
     "fixture_name, pass_train_data, expected_n_keys",
     [
-        ("binary_classification_data", True, 6),
-        ("binary_classification_data_svc", True, 6),
-        ("multiclass_classification_data", True, 8),
+        ("binary_classification_data", True, 8),
+        ("binary_classification_data_svc", True, 8),
+        ("multiclass_classification_data", True, 10),
         ("regression_data", True, 2),
-        ("binary_classification_data", False, 3),
-        ("binary_classification_data_svc", False, 3),
-        ("multiclass_classification_data", False, 4),
+        ("binary_classification_data", False, 4),
+        ("binary_classification_data_svc", False, 4),
+        ("multiclass_classification_data", False, 5),
         ("regression_data", False, 1),
     ],
 )


### PR DESCRIPTION
While coding an example, I realized that by default we can trigger the `pos_label=None` with binary classification and thus it should be cached as well.

I added amended the according test as well.