### PR TITLE
ci: Change the username of Auguste in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.github/ @thomass-dev @rouk1 @augustebaum
+/.github/ @thomass-dev @rouk1 @auguste-probabl


### PR DESCRIPTION
Auguste has created a dedicated professional GH account.
This PR switches its account from personal to professional in the CODEOWNERS file.