### PR TITLE
ci: Use GH environment variables to fill the documentation domain

### DIFF
--- a/.github/actions/sphinx/build/action.yml
+++ b/.github/actions/sphinx/build/action.yml
@@ -5,6 +5,8 @@ inputs:
     required: true
   SPHINX_RELEASE:
     required: true
+  SPHINX_DOMAIN:
+    required: true
 
 runs:
   using: composite
@@ -19,4 +21,5 @@ runs:
       run: >
         SPHINX_VERSION=${{ inputs.SPHINX_VERSION }}
         SPHINX_RELEASE=${{ inputs.SPHINX_RELEASE }}
+        SPHINX_DOMAIN=${{ inputs.SPHINX_DOMAIN }}
         make html

--- a/.github/workflows/pr-serve-documentation-preview.yml
+++ b/.github/workflows/pr-serve-documentation-preview.yml
@@ -49,5 +49,5 @@ jobs:
           number: ${{ steps.acquire-pr-context.outputs.pr-number }}
           header: documentation-preview
           message: >-
-            [Documentation preview](${{ vars.DOCUMENTATION_PREVIEW_URL }}/${{ steps.acquire-pr-context.outputs.pr-number }})
+            [Documentation preview](https://${{ vars.DOCUMENTATION_PREVIEW_DOMAIN }}/${{ steps.acquire-pr-context.outputs.pr-number }})
             @ ${{ steps.acquire-pr-context.outputs.pr-head-sha }}

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           SPHINX_VERSION: ${{ needs.sphinx-version.outputs.SPHINX_VERSION }}
           SPHINX_RELEASE: ${{ needs.sphinx-version.outputs.SPHINX_RELEASE }}
+          SPHINX_DOMAIN: ${{ vars.DOCUMENTATION_DOMAIN }}
       - uses: actions/upload-artifact@v4
         with:
           name: sphinx-html-artifact
@@ -163,9 +164,9 @@ jobs:
             import operator
             import json
 
-            url = os.environ["URL"]
             version = os.environ["SPHINX_VERSION"]
             release = os.environ["SPHINX_RELEASE"]
+            url = os.environ["SPHINX_URL"]
 
             # Retrieve history
             response = requests.get(f"{url}/versions.json")
@@ -208,9 +209,9 @@ jobs:
                   """
               )
         env:
-          URL: ${{ vars.DOCUMENTATION_URL }}
           SPHINX_VERSION: ${{ needs.sphinx-version.outputs.SPHINX_VERSION }}
           SPHINX_RELEASE: ${{ needs.sphinx-version.outputs.SPHINX_RELEASE }}
+          SPHINX_URL: https://${{ vars.DOCUMENTATION_DOMAIN }}
       - uses: ./.github/actions/sphinx/deploy
         with:
           CONFIGURATION: ${{ secrets.RCLONE_CONFIG_DOCS }}

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -3,6 +3,7 @@
 
 export SPHINX_VERSION ?= dev
 export SPHINX_RELEASE ?= 0.0.0+dev
+export SPHINX_DOMAIN ?= skore.probabl.ai
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -21,6 +21,7 @@ copyright = "2024, Probabl"
 author = "Probabl"
 version = os.environ["SPHINX_VERSION"]
 release = os.environ["SPHINX_RELEASE"]
+domain = os.environ["SPHINX_DOMAIN"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -66,6 +67,7 @@ subsections_order = [
     "../examples/model_evaluation",
 ]
 
+
 # Augment the dpi of matplotlib figures in Sphinx examples
 # https://sphinx-gallery.github.io/stable/advanced.html#resetting-before-each-example
 def reset_mpl(gallery_conf, fname):
@@ -78,7 +80,7 @@ def reset_mpl(gallery_conf, fname):
 sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to example scripts
     "gallery_dirs": "auto_examples",  # path to gallery generated output
-    "subsection_order": ExplicitOrder(subsections_order),  # sorting gallery subsections,
+    "subsection_order": ExplicitOrder(subsections_order),  # sorting gallery subsections
     # see https://sphinx-gallery.github.io/stable/configuration.html#sub-gallery-order
     "within_subsection_order": "ExampleTitleSortKey",  # See https://sphinx-gallery.github.io/stable/configuration.html#sorting-gallery-examples for alternatives
     "show_memory": False,
@@ -147,7 +149,7 @@ html_theme_options = {
         },
     ],
     "switcher": {
-        "json_url": "https://skore.probabl.ai/versions.json",
+        "json_url": f"https://{domain}/versions.json",
         "version_match": release,
     },
     "check_switcher": True,
@@ -160,7 +162,7 @@ html_theme_options = {
 # Plausible Analytics
 html_theme_options["analytics"] = {
     # The domain you'd like to use for this analytics instance
-    "plausible_analytics_domain": "skore.probabl.ai",
+    "plausible_analytics_domain": domain,
     # The analytics script that is served by Plausible
     "plausible_analytics_url": "https://plausible.io/js/script.js",
 }


### PR DESCRIPTION
Use GH environment variables to fill the documentation domain.
In order to be resilient to any domain name changes, centralize the domain name in GH settings.

![image](https://github.com/user-attachments/assets/bfa18b98-847d-4a61-8b03-b5bb0aeff01a)
