### PR TITLE
fix(UI): Trim all line feed from end of note

### DIFF
--- a/skore-ui/src/views/project/ItemNote.vue
+++ b/skore-ui/src/views/project/ItemNote.vue
@@ -32,7 +32,8 @@ async function onEditionEnd() {
   if (isEditing.value) {
     // stop listening to outside click
     document.removeEventListener("click", onClickOutside);
-    await projectStore.setNoteOnItem(props.name, innerNote.value.trimEnd());
+    innerNote.value = innerNote.value.replace(/\n+$/g, "");
+    await projectStore.setNoteOnItem(props.name, innerNote.value);
     isEditing.value = false;
     // actually wait for the editor to be closed to resatrt backend polling
     nextTick(() => {
@@ -105,8 +106,8 @@ onBeforeUnmount(() => {
         v-model:value="innerNote"
         :rows="4"
         @keyup.esc="onEditionEnd"
-        @keydown.shift.enter="onEditionEnd"
-        @keydown.meta.enter="onEditionEnd"
+        @keydown.shift.enter.prevent="onEditionEnd"
+        @keydown.meta.enter.prevent="onEditionEnd"
       />
     </div>
     <div class="preview" v-if="!isEditing" @click="onEdit">


### PR DESCRIPTION
When saving a note using <kbd>shift</kbd> + <kbd>enter</kbd> or <kbd>meta</kbd> + <kbd>enter</kbd> all line feed at the end will be removed (in frontend aswell as in backend).