### PR TITLE
feat(UI): Simpler drag'n'drop UX

### DIFF
--- a/skore-ui/src/components/ProjectViewCard.vue
+++ b/skore-ui/src/components/ProjectViewCard.vue
@@ -56,7 +56,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="card" ref="root">
-    <div class="header">
+    <div class="header" data-drag-image-selector>
       <div class="titles">
         <div class="title">{{ props.title }}</div>
         <div class="subtitle" v-if="props.subtitle">

--- a/skore-ui/src/views/ComponentsView.vue
+++ b/skore-ui/src/views/ComponentsView.vue
@@ -1315,7 +1315,7 @@ const richText = ref(
           >
             <template #item="{ name: id, color, content }">
               <div :style="{ backgroundColor: color, color: 'white' }">
-                <span>ID: {{ id }}</span>
+                <div data-drag-image-selector :style="{ backgroundColor: color }">ID: {{ id }}</div>
                 <ul>
                   <li v-for="(c, i) in content" :key="i">{{ c }}</li>
                 </ul>
@@ -1483,7 +1483,7 @@ main {
 }
 
 .draggable-list-container {
-  max-height: 80vh;
+  max-height: 60vh;
   margin-top: 10px;
 }
 


### PR DESCRIPTION
This PR tries to simplify user experience when moving items.

- When dragging there is no more concept of going up or down. Feedback is now always at the same position. 
- Space to fit the dragged item is not reserved anymore making it easier to move it.
- A new option has been added to the component. If a draggable element contains a node with a `data-drag-image-selector` attribute only this element will be rasterize and used for d'n'd feedback.

Hopefully this makes it easier to move long item around.

UI preview:

https://github.com/user-attachments/assets/c5bf9234-c244-4621-aef6-2deaf2f0349e


