### PR TITLE
fix: Make reports pickable out-of-the-box

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -103,7 +103,9 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         cv_splitter=None,
         n_jobs=None,
     ):
-        self._parent_progress = None  # used for the different progress bars
+        # used to know if a parent launch a progress bar manager
+        self._parent_progress = None
+
         self._estimator = clone(estimator)
 
         # private storage to be able to invalidate the cache when the user alters

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -109,7 +109,8 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         X_test=None,
         y_test=None,
     ):
-        self._parent_progress = None  # used to display progress bar
+        # used to know if a parent launch a progress bar manager
+        self._parent_progress = None
 
         if fit == "auto":
             try:
@@ -128,8 +129,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         self._y_train = y_train
         self._X_test = X_test
         self._y_test = y_test
-
-        self._parent_progress = None
 
         self._initialize_state()
 

--- a/skore/src/skore/utils/_progress_bar.py
+++ b/skore/src/skore/utils/_progress_bar.py
@@ -68,6 +68,9 @@ def progress_decorator(description):
                             task, completed=progress.tasks[task].total, refresh=True
                         )
                     progress.stop()
+                # clean up to make object pickable
+                self_obj._parent_progress = None
+                self_obj._progress_info = None
 
         return wrapper
 

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -204,7 +204,7 @@ def test_cross_validation_report_cache_predictions(
 
 
 def test_cross_validation_report_pickle(tmp_path, binary_classification_data):
-    """Check that we can pickle an estimator report.
+    """Check that we can pickle an cross-validation report.
 
     In particular, the progress bar from rich are pickable, therefore we trigger
     the progress bar to be able to test that the progress bar is pickable.

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -1,5 +1,6 @@
 import re
 
+import joblib
 import numpy as np
 import pandas as pd
 import pytest
@@ -182,7 +183,7 @@ def test_cross_validation_report_repr(binary_classification_data):
     ],
 )
 @pytest.mark.parametrize("n_jobs", [None, 1, 2])
-def test_estimator_report_cache_predictions(
+def test_cross_validation_report_cache_predictions(
     request, fixture_name, expected_n_keys, n_jobs
 ):
     """Check that calling cache_predictions fills the cache."""
@@ -200,6 +201,18 @@ def test_estimator_report_cache_predictions(
     assert report._cache == {}
     for estimator_report in report.estimator_reports_:
         assert estimator_report._cache == {}
+
+
+def test_cross_validation_report_pickle(tmp_path, binary_classification_data):
+    """Check that we can pickle an estimator report.
+
+    In particular, the progress bar from rich are pickable, therefore we trigger
+    the progress bar to be able to test that the progress bar is pickable.
+    """
+    estimator, X, y = binary_classification_data
+    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report.cache_predictions()
+    joblib.dump(report, tmp_path / "report.joblib")
 
 
 ########################################################################################
@@ -265,7 +278,7 @@ def test_cross_validation_report_display_regression(pyplot, regression_data, dis
 ########################################################################################
 
 
-def test_estimator_report_metrics_help(capsys, binary_classification_data):
+def test_cross_validation_report_metrics_help(capsys, binary_classification_data):
     """Check that the help method writes to the console."""
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
@@ -275,7 +288,7 @@ def test_estimator_report_metrics_help(capsys, binary_classification_data):
     assert "Available metrics methods" in captured.out
 
 
-def test_estimator_report_metrics_repr(binary_classification_data):
+def test_cross_validation_report_metrics_repr(binary_classification_data):
     """Check that __repr__ returns a string starting with the expected prefix."""
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
@@ -618,7 +631,7 @@ def test_cross_validation_report_report_metrics_error_scoring_strings(
         report.metrics.report_metrics(scoring=[scoring])
 
 
-def test_estimator_report_report_metrics_with_scorer(regression_data):
+def test_cross_validation_report_report_metrics_with_scorer(regression_data):
     """Check that we can pass scikit-learn scorer with different parameters to
     the `report_metrics` method."""
     estimator, X, y = regression_data

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -330,6 +330,18 @@ def test_estimator_report_cache_predictions(
     assert report._cache.keys() == stored_cache.keys()
 
 
+def test_estimator_report_pickle(tmp_path, binary_classification_data):
+    """Check that we can pickle an estimator report.
+
+    In particular, the progress bar from rich are pickable, therefore we trigger
+    the progress bar to be able to test that the progress bar is pickable.
+    """
+    estimator, X_test, y_test = binary_classification_data
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    report.cache_predictions()
+    joblib.dump(report, tmp_path / "report.joblib")
+
+
 ########################################################################################
 # Check the plot methods
 ########################################################################################


### PR DESCRIPTION
This PR makes sure that the `EstimatorReport` and `CrossValidationReport` are pickable object.

Right now, because we kept the step of the `Progress` from rich that has a lock, the object are not pickable. I reset the `_parent_progress` and `_progress_info` to `None` in the finally of the decorator.

An alternative is to change the `set_state` but here I think that we can just applied this clean-up instead.