### PR TITLE
ci: Add timeout to sphinx building pipeline

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -107,6 +107,7 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
       - uses: ./.github/actions/sphinx/build
+        timeout-minutes: 10
         with:
           SPHINX_VERSION: ${{ needs.sphinx-version.outputs.SPHINX_VERSION }}
           SPHINX_RELEASE: ${{ needs.sphinx-version.outputs.SPHINX_RELEASE }}


### PR DESCRIPTION
To avoid endless pipeline, add a timeout when building sphinx documentation.

![image](https://github.com/user-attachments/assets/6ec5ff2d-7ec5-426d-abee-c60a3a9158b0)
