### PR TITLE
docs: Remove images/gif that are not used anymore, in any documentation version

### DIFF
--- a/sphinx/_static/images/2024_12_12_skore_activity_feed.png
+++ b/sphinx/_static/images/2024_12_12_skore_activity_feed.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80c4570c5793d23672d4811501c3f158e3539de746f4de41ccb3f0734a131852
-size 181254

--- a/sphinx/_static/images/2024_12_12_skore_cross_val.png
+++ b/sphinx/_static/images/2024_12_12_skore_cross_val.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb2cba43a5d800eafff8689df016691b5be387a234b35aec25e54ead954cdf18
-size 221882

--- a/sphinx/_static/images/2024_12_12_skore_cross_val_clf.png
+++ b/sphinx/_static/images/2024_12_12_skore_cross_val_clf.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:970c28954d769ee040615d5e0a98405816cd47b3247abea0def64421c9ee6ddf
-size 244474

--- a/sphinx/_static/images/2024_12_12_skore_demo_comp.gif
+++ b/sphinx/_static/images/2024_12_12_skore_demo_comp.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc96fbedc3cc013738e3077141bbc4d8d636f844e9baa58830e7c73477fa6b02
-size 1560064

--- a/sphinx/_static/images/2024_12_12_skore_tracking_comp.gif
+++ b/sphinx/_static/images/2024_12_12_skore_tracking_comp.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a0a1196dfd596f40251f9aec12c72a96bd949c7129195fba603c7c4244f9e20
-size 300930


### PR DESCRIPTION
Fix #1189 