### PR TITLE
ci: Temporarily fix the sphinx pipeline by downloading our own skrub cache

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -106,12 +106,19 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+      - shell: bash
+        run: wget -qO- "${SKRUB_DATA_URL}" | tar -zxvf - -C "${HOME}"
+        env:
+          SKRUB_DATA_URL: https://skore.probabl.ai/f355443be646d49eab1aa76e29dfd0a8/skrub-data.tar.gz
+          HOME: ${{ github.workspace }}
       - uses: ./.github/actions/sphinx/build
         timeout-minutes: 10
         with:
           SPHINX_VERSION: ${{ needs.sphinx-version.outputs.SPHINX_VERSION }}
           SPHINX_RELEASE: ${{ needs.sphinx-version.outputs.SPHINX_RELEASE }}
           SPHINX_DOMAIN: ${{ vars.DOCUMENTATION_DOMAIN }}
+        env:
+          HOME: ${{ github.workspace }}
       - uses: actions/upload-artifact@v4
         with:
           name: sphinx-html-artifact


### PR DESCRIPTION
Temporarily fix the sphinx pipeline by downloading the `skrub` cache, which i put directly on our bucket under a random directory.

`skrub` using the user home to cache data, i set the `home` envar.

![image](https://github.com/user-attachments/assets/b349937f-d3f5-41f2-9f40-f302203d6c1a)

---

Content of the archive:

```
skrub_data/
skrub_data/openml/
skrub_data/openml/employee_salaries.csv
skrub_data/openml/open_payments.csv
skrub_data/openml/openml/
skrub_data/openml/openml/openml.org/
skrub_data/openml/openml/openml.org/api/
skrub_data/openml/openml/openml.org/api/v1/
skrub_data/openml/openml/openml.org/api/v1/json/
skrub_data/openml/openml/openml.org/api/v1/json/data/
skrub_data/openml/openml/openml.org/api/v1/json/data/42125.gz
skrub_data/openml/openml/openml.org/api/v1/json/data/features/
skrub_data/openml/openml/openml.org/api/v1/json/data/features/42125.gz
skrub_data/openml/openml/openml.org/api/v1/json/data/features/42738.gz
skrub_data/openml/openml/openml.org/api/v1/json/data/qualities/
skrub_data/openml/openml/openml.org/api/v1/json/data/qualities/42125.gz
skrub_data/openml/openml/openml.org/api/v1/json/data/qualities/42738.gz
skrub_data/openml/openml/openml.org/api/v1/json/data/42738.gz
skrub_data/openml/openml/openml.org/data/
skrub_data/openml/openml/openml.org/data/v1/
skrub_data/openml/openml/openml.org/data/v1/download/
skrub_data/openml/openml/openml.org/data/v1/download/21718841.gz
skrub_data/openml/openml/openml.org/data/v1/download/22044787.gz
```