### PR TITLE
ci: Fix `sphinx-deploy-root-files` on high minor versions

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -188,7 +188,7 @@ jobs:
             # Sort history, and always keep "dev" at the beginning
             history = sorted(
                 history.items(),
-                key=lambda item: float(item[0]) if item[0] != "dev" else float('inf'),
+                key=lambda item: tuple(map(float, item[0].split("."))) if item[0] != "dev" else (float('inf'), 0),
                 reverse=True
             )
 


### PR DESCRIPTION
Currently, we compare `X.Y` using float casting. It will be wrong on a comparison between `0.6` and `0.10`.

```
In [1]: history = {
   ...:     "dev": "0.0.0+dev",
   ...:     "0.15": "0.15.5",
   ...:     "0.5": "0.5.1",
   ...:     "0.4": "0.4.0",
   ...: }
   ...: 
   ...: # before
   ...: print(
   ...:     sorted(
   ...:         history.items(),
   ...:         key=lambda item: float(item[0]) if item[0] != "dev" else float('inf'),
   ...:         reverse=True
   ...:     )
   ...: )
   ...: 
   ...: # after
   ...: print(
   ...:     sorted(
   ...:         history.items(),
   ...:         key=lambda item: tuple(map(float, item[0].split("."))) if item[0] != "dev" else (float('inf'), 0),
   ...:         reverse=True
   ...:     )
   ...: )
   ...: 
[('dev', '0.0.0+dev'), ('0.5', '0.5.1'), ('0.4', '0.4.0'), ('0.15', '0.15.5')]
[('dev', '0.0.0+dev'), ('0.15', '0.15.5'), ('0.5', '0.5.1'), ('0.4', '0.4.0')]
```