### PR TITLE
docs: Stop showing typehints in API docs

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -48,6 +48,8 @@ default_role = "literal"
 autosummary_generate = True  # generate stubs for all classes
 templates_path = ["_templates"]
 
+autodoc_typehints = "none"
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 


### PR DESCRIPTION
Closes #1199

Screenshot:
![image](https://github.com/user-attachments/assets/8f4e8587-0525-4f02-a628-583df01d4725)
