### PR TITLE
ci: Fix sphinx building pipeline

### DIFF
--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -1,9 +1,14 @@
 # Minimal makefile for Sphinx documentation
 #
 
+# Ensures SPHINX_DOMAIN is not an empty string
+ifeq ($(SPHINX_DOMAIN),)
+	SPHINX_DOMAIN := skore.probabl.ai
+endif
+
 export SPHINX_VERSION ?= dev
 export SPHINX_RELEASE ?= 0.0.0+dev
-export SPHINX_DOMAIN ?= skore.probabl.ai
+export SPHINX_DOMAIN
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.


### PR DESCRIPTION
Fix sphinx building pipeline on forks where `vars.DOCUMENTATION_DOMAIN` is not provisioned.