### PR TITLE
docs: Minor changes in the examples (about `open`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can find information on the latest version [here](https://anaconda.org/conda
 1. From your Python code, create and load a skore project:
     ```python
     import skore
-    my_project = skore.open("my_project")
+    my_project = skore.open("my_project", create=True)
     ```
     This will create a skore project directory named `my_project.skore` in your current working directory.
 

--- a/examples/getting_started/plot_quick_start.py
+++ b/examples/getting_started/plot_quick_start.py
@@ -16,9 +16,7 @@ my_project = skore.open("my_project", create=True)
 
 # %%
 # This will create a skore project directory named ``quick_start.skore`` in your
-# current working directory. Note that `overwrite=True` will overwrite any pre-existing
-# project with the same path (which you might not want to do that depending on your use
-# case).
+# current working directory.
 
 # %%
 # Evaluate your model using skore's :class:`~skore.CrossValidationReport`:


### PR DESCRIPTION
specify `create=True` on `open`

- [x] In the README, for the quick start, explicit `create=True` although it is the default value, so that a new user can quickly understand what is going on
- [x] In the quick start example, we no longer have `overwrite=True`, so adapt the description.