### PR TITLE
fix: Persist base64 string instead of bytes to ensure items are JSONable

### DIFF
--- a/skore/src/skore/persistence/item/altair_chart_item.py
+++ b/skore/src/skore/persistence/item/altair_chart_item.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from .item import Item, ItemTypeError
-from .media_item import lazy_is_instance
+from skore.persistence.item.item import Item, ItemTypeError
+from skore.persistence.item.media_item import lazy_is_instance
+from skore.utils import bytes_to_b64_str
 
 if TYPE_CHECKING:
     from altair.vegalite.v5.schema.core import TopLevelSpec as AltairChart
@@ -71,10 +72,8 @@ class AltairChartItem(Item):
 
     def as_serializable_dict(self):
         """Convert item to a JSON-serializable dict to used by frontend."""
-        import base64
-
         chart_bytes = self.chart_str.encode("utf-8")
-        chart_b64_str = base64.b64encode(chart_bytes).decode()
+        chart_b64_str = bytes_to_b64_str(chart_bytes)
 
         return super().as_serializable_dict() | {
             "media_type": "application/vnd.vega.v5+json;base64",

--- a/skore/src/skore/persistence/item/matplotlib_figure_item.py
+++ b/skore/src/skore/persistence/item/matplotlib_figure_item.py
@@ -5,14 +5,14 @@ This module defines the MatplotlibFigureItem class, used to persist Matplotlib f
 
 from __future__ import annotations
 
-from base64 import b64encode
 from io import BytesIO
 from typing import TYPE_CHECKING, Optional
 
 import joblib
 
-from .item import Item, ItemTypeError
-from .media_item import lazy_is_instance
+from skore.persistence.item.item import Item, ItemTypeError
+from skore.persistence.item.media_item import lazy_is_instance
+from skore.utils import b64_str_to_bytes, bytes_to_b64_str
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -23,7 +23,7 @@ class MatplotlibFigureItem(Item):
 
     def __init__(
         self,
-        figure_bytes: str,
+        figure_b64_str: str,
         created_at: Optional[str] = None,
         updated_at: Optional[str] = None,
         note: Optional[str] = None,
@@ -33,7 +33,7 @@ class MatplotlibFigureItem(Item):
 
         Parameters
         ----------
-        figure_bytes : bytes
+        figure_b64_str : str
             The raw bytes of the Matplotlib figure pickled representation.
         created_at : str, optional
             The creation timestamp in ISO format.
@@ -44,7 +44,7 @@ class MatplotlibFigureItem(Item):
         """
         super().__init__(created_at, updated_at, note)
 
-        self.figure_bytes = figure_bytes
+        self.figure_b64_str = figure_b64_str
 
     @classmethod
     def factory(cls, figure: Figure, /, **kwargs) -> MatplotlibFigureItem:
@@ -67,12 +67,17 @@ class MatplotlibFigureItem(Item):
         with BytesIO() as stream:
             joblib.dump(figure, stream)
 
-            return cls(stream.getvalue(), **kwargs)
+            figure_bytes = stream.getvalue()
+            figure_b64_str = bytes_to_b64_str(figure_bytes)
+
+            return cls(figure_b64_str, **kwargs)
 
     @property
     def figure(self) -> Figure:
         """The figure from the persistence."""
-        with BytesIO(self.figure_bytes) as stream:
+        figure_bytes = b64_str_to_bytes(self.figure_b64_str)
+
+        with BytesIO(figure_bytes) as stream:
             return joblib.load(stream)
 
     def as_serializable_dict(self) -> dict:
@@ -81,7 +86,7 @@ class MatplotlibFigureItem(Item):
             self.figure.savefig(stream, format="svg", bbox_inches="tight")
 
             figure_bytes = stream.getvalue()
-            figure_b64_str = b64encode(figure_bytes).decode()
+            figure_b64_str = bytes_to_b64_str(figure_bytes)
 
             return super().as_serializable_dict() | {
                 "media_type": "image/svg+xml;base64",

--- a/skore/src/skore/persistence/item/plotly_figure_item.py
+++ b/skore/src/skore/persistence/item/plotly_figure_item.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from .item import Item, ItemTypeError
-from .media_item import lazy_is_instance
+from skore.persistence.item.item import Item, ItemTypeError
+from skore.persistence.item.media_item import lazy_is_instance
+from skore.utils import bytes_to_b64_str
 
 if TYPE_CHECKING:
     import plotly.basedatatypes
@@ -29,7 +30,7 @@ class PlotlyFigureItem(Item):
 
         Parameters
         ----------
-        figure_str : bytes
+        figure_str : str
             The JSON str of the Plotly figure.
         created_at : str, optional
             The creation timestamp in ISO format.
@@ -78,10 +79,8 @@ class PlotlyFigureItem(Item):
 
     def as_serializable_dict(self):
         """Convert item to a JSON-serializable dict to used by frontend."""
-        import base64
-
         figure_bytes = self.figure_str.encode("utf-8")
-        figure_b64_str = base64.b64encode(figure_bytes).decode()
+        figure_b64_str = bytes_to_b64_str(figure_bytes)
 
         return super().as_serializable_dict() | {
             "media_type": "application/vnd.plotly.v1+json;base64",

--- a/skore/src/skore/utils/__init__.py
+++ b/skore/src/skore/utils/__init__.py
@@ -1,1 +1,19 @@
 """Various utilities to help with development."""
+
+from base64 import b64decode, b64encode
+
+
+def bytes_to_b64_str(literal: bytes) -> str:
+    """Encode the bytes-like object `literal` in a Base64 str."""
+    return b64encode(literal).decode("utf-8")
+
+
+def b64_str_to_bytes(literal: str) -> bytes:
+    """Decode the Base64 str object `literal` in a bytes."""
+    return b64decode(literal.encode("utf-8"))
+
+
+__all__ = [
+    "bytes_to_b64_str",
+    "b64_str_to_bytes",
+]

--- a/skore/tests/unit/item/test_altair_chart_item.py
+++ b/skore/tests/unit/item/test_altair_chart_item.py
@@ -1,4 +1,5 @@
 import base64
+import json
 
 import altair
 import pytest
@@ -21,6 +22,14 @@ class TestAltairChartItem:
     def test_factory_exception(self):
         with pytest.raises(ItemTypeError):
             AltairChartItem.factory(None)
+
+    def test_ensure_jsonable(self):
+        chart = altair.Chart().mark_point()
+
+        item = AltairChartItem.factory(chart)
+        item_parameters = item.__parameters__
+
+        json.dumps(item_parameters)
 
     def test_chart(self):
         chart = altair.Chart().mark_point()

--- a/skore/tests/unit/item/test_cross_validation_reporter_item.py
+++ b/skore/tests/unit/item/test_cross_validation_reporter_item.py
@@ -1,5 +1,6 @@
 import dataclasses
 import io
+import json
 
 import joblib
 import numpy
@@ -15,6 +16,7 @@ from skore.sklearn.cross_validation import CrossValidationReporter
 from skore.sklearn.cross_validation.cross_validation_reporter import (
     CrossValidationPlots,
 )
+from skore.utils import bytes_to_b64_str
 
 
 class FakeEstimator:
@@ -89,10 +91,19 @@ class TestCrossValidationReporterItem:
             joblib.dump(reporter, stream)
 
             reporter_bytes = stream.getvalue()
+            reporter_b64_str = bytes_to_b64_str(reporter_bytes)
 
-        assert item.reporter_bytes == reporter_bytes
+        assert item.reporter_b64_str == reporter_b64_str
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
+
+    def test_ensure_jsonable(self):
+        reporter = FakeCrossValidationReporter()
+
+        item = CrossValidationReporterItem.factory(reporter)
+        item_parameters = item.__parameters__
+
+        json.dumps(item_parameters)
 
     def test_reporter(self, mock_nowstr):
         reporter = FakeCrossValidationReporter()
@@ -101,10 +112,11 @@ class TestCrossValidationReporterItem:
             joblib.dump(reporter, stream)
 
             reporter_bytes = stream.getvalue()
+            reporter_b64_str = bytes_to_b64_str(reporter_bytes)
 
         item1 = CrossValidationReporterItem.factory(reporter)
         item2 = CrossValidationReporterItem(
-            reporter_bytes=reporter_bytes,
+            reporter_b64_str=reporter_b64_str,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,
         )

--- a/skore/tests/unit/item/test_matplotlib_figure_item.py
+++ b/skore/tests/unit/item/test_matplotlib_figure_item.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import json
 
 import joblib
 import pytest
@@ -7,6 +8,7 @@ from matplotlib.figure import Figure
 from matplotlib.pyplot import subplots
 from matplotlib.testing.compare import compare_images
 from skore.persistence.item import ItemTypeError, MatplotlibFigureItem
+from skore.utils import b64_str_to_bytes, bytes_to_b64_str
 
 
 class FakeFigure(Figure):
@@ -29,7 +31,7 @@ class TestMatplotlibFigureItem:
         # we can't compare figure bytes directly
 
         figure.savefig(tmp_path / "figure.png")
-        with io.BytesIO(item.figure_bytes) as stream:
+        with io.BytesIO(b64_str_to_bytes(item.figure_b64_str)) as stream:
             joblib.load(stream).savefig(tmp_path / "item.png")
 
         assert compare_images(tmp_path / "figure.png", tmp_path / "item.png", 0) is None
@@ -40,6 +42,15 @@ class TestMatplotlibFigureItem:
         with pytest.raises(ItemTypeError):
             MatplotlibFigureItem.factory(None)
 
+    def test_ensure_jsonable(self):
+        figure, ax = subplots()
+        ax.plot([1, 2, 3, 4], [1, 4, 2, 3])
+
+        item = MatplotlibFigureItem.factory(figure)
+        item_parameters = item.__parameters__
+
+        json.dumps(item_parameters)
+
     def test_figure(self, tmp_path):
         figure, ax = subplots()
         ax.plot([1, 2, 3, 4], [1, 4, 2, 3])
@@ -48,9 +59,10 @@ class TestMatplotlibFigureItem:
             joblib.dump(figure, stream)
 
             figure_bytes = stream.getvalue()
+            figure_b64_str = bytes_to_b64_str(figure_bytes)
 
         item1 = MatplotlibFigureItem.factory(figure)
-        item2 = MatplotlibFigureItem(figure_bytes)
+        item2 = MatplotlibFigureItem(figure_b64_str)
 
         figure.savefig(tmp_path / "figure.png")
         item1.figure.savefig(tmp_path / "item1.png")

--- a/skore/tests/unit/item/test_pickle_item.py
+++ b/skore/tests/unit/item/test_pickle_item.py
@@ -1,8 +1,10 @@
 import io
+import json
 
 import joblib
 import pytest
 from skore.persistence.item import PickleItem
+from skore.utils import bytes_to_b64_str
 
 
 class TestPickleItem:
@@ -17,21 +19,29 @@ class TestPickleItem:
         with io.BytesIO() as stream:
             joblib.dump(object, stream)
 
-            object_bytes = stream.getvalue()
+            pickle_bytes = stream.getvalue()
+            pickle_b64_str = bytes_to_b64_str(pickle_bytes)
 
-        assert item.pickle_bytes == object_bytes
+        assert item.pickle_b64_str == pickle_b64_str
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
+
+    def test_ensure_jsonable(self):
+        item = PickleItem.factory(object)
+        item_parameters = item.__parameters__
+
+        json.dumps(item_parameters)
 
     def test_object(self, mock_nowstr):
         with io.BytesIO() as stream:
             joblib.dump(int, stream)
 
-            int_bytes = stream.getvalue()
+            pickle_bytes = stream.getvalue()
+            pickle_b64_str = bytes_to_b64_str(pickle_bytes)
 
         item1 = PickleItem.factory(int)
         item2 = PickleItem(
-            pickle_bytes=int_bytes,
+            pickle_b64_str=pickle_b64_str,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,
         )

--- a/skore/tests/unit/item/test_plotly_figure_item.py
+++ b/skore/tests/unit/item/test_plotly_figure_item.py
@@ -1,4 +1,5 @@
 import base64
+import json
 
 import plotly.graph_objects
 import plotly.io
@@ -23,6 +24,15 @@ class TestPlotlyFigureItem:
     def test_factory_exception(self):
         with pytest.raises(ItemTypeError):
             PlotlyFigureItem.factory(None)
+
+    def test_ensure_jsonable(self):
+        bar = plotly.graph_objects.Bar(x=[1, 2, 3], y=[1, 3, 2])
+        figure = plotly.graph_objects.Figure(data=[bar])
+
+        item = PlotlyFigureItem.factory(figure)
+        item_parameters = item.__parameters__
+
+        json.dumps(item_parameters)
 
     def test_figure(self):
         bar = plotly.graph_objects.Bar(x=[1, 2, 3], y=[1, 3, 2])

--- a/skore/tests/unit/item/test_sklearn_base_estimator_item.py
+++ b/skore/tests/unit/item/test_sklearn_base_estimator_item.py
@@ -1,7 +1,10 @@
+import json
+
 import pytest
 import sklearn.svm
 import skops.io
 from skore.persistence.item import ItemTypeError, SklearnBaseEstimatorItem
+from skore.utils import bytes_to_b64_str
 
 
 class Estimator(sklearn.svm.SVC):
@@ -21,14 +24,17 @@ class TestSklearnBaseEstimatorItem:
     def test_factory(self, monkeypatch, mock_nowstr):
         estimator = sklearn.svm.SVC()
         estimator_html_repr = "<estimator_html_repr>"
-        estimator_skops = "<estimator_skops>"
+        estimator_skops_bytes = b"<estimator_skops>"
+        estimator_skops_b64_str = bytes_to_b64_str(b"<estimator_skops>")
         estimator_skops_untrusted_types = "<estimator_skops_untrusted_types>"
 
         monkeypatch.setattr(
             "sklearn.utils.estimator_html_repr",
             lambda *args, **kwargs: estimator_html_repr,
         )
-        monkeypatch.setattr("skops.io.dumps", lambda *args, **kwargs: estimator_skops)
+        monkeypatch.setattr(
+            "skops.io.dumps", lambda *args, **kwargs: estimator_skops_bytes
+        )
         monkeypatch.setattr(
             "skops.io.get_untrusted_types",
             lambda *args, **kwargs: estimator_skops_untrusted_types,
@@ -37,23 +43,32 @@ class TestSklearnBaseEstimatorItem:
         item = SklearnBaseEstimatorItem.factory(estimator)
 
         assert item.estimator_html_repr == estimator_html_repr
-        assert item.estimator_skops == estimator_skops
+        assert item.estimator_skops_b64_str == estimator_skops_b64_str
         assert item.estimator_skops_untrusted_types == estimator_skops_untrusted_types
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
 
+    def test_ensure_jsonable(self):
+        estimator = sklearn.svm.SVC()
+
+        item = SklearnBaseEstimatorItem.factory(estimator)
+        item_parameters = item.__parameters__
+
+        json.dumps(item_parameters)
+
     @pytest.mark.order(1)
     def test_estimator(self, mock_nowstr):
         estimator = sklearn.svm.SVC()
-        estimator_skops = skops.io.dumps(estimator)
+        estimator_skops_bytes = skops.io.dumps(estimator)
+        estimator_skops_b64_str = bytes_to_b64_str(estimator_skops_bytes)
         estimator_skops_untrusted_types = skops.io.get_untrusted_types(
-            data=estimator_skops
+            data=estimator_skops_bytes
         )
 
         item1 = SklearnBaseEstimatorItem.factory(estimator)
         item2 = SklearnBaseEstimatorItem(
             estimator_html_repr=None,
-            estimator_skops=estimator_skops,
+            estimator_skops_b64_str=estimator_skops_b64_str,
             estimator_skops_untrusted_types=estimator_skops_untrusted_types,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,
@@ -65,9 +80,10 @@ class TestSklearnBaseEstimatorItem:
     @pytest.mark.order(1)
     def test_estimator_untrusted(self, mock_nowstr):
         estimator = Estimator()
-        estimator_skops = skops.io.dumps(estimator)
+        estimator_skops_bytes = skops.io.dumps(estimator)
+        estimator_skops_b64_str = bytes_to_b64_str(estimator_skops_bytes)
         estimator_skops_untrusted_types = skops.io.get_untrusted_types(
-            data=estimator_skops
+            data=estimator_skops_bytes
         )
 
         if not estimator_skops_untrusted_types:
@@ -82,7 +98,7 @@ class TestSklearnBaseEstimatorItem:
         item1 = SklearnBaseEstimatorItem.factory(estimator)
         item2 = SklearnBaseEstimatorItem(
             estimator_html_repr=None,
-            estimator_skops=estimator_skops,
+            estimator_skops_b64_str=estimator_skops_b64_str,
             estimator_skops_untrusted_types=estimator_skops_untrusted_types,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,


### PR DESCRIPTION
This PR intends to persist b64 string inplace of bytes.
The latest isn't JSONable, so items can't be easily persisted without a pickle backend.