### PR TITLE
feat(NumpyArrayItem): Use `numpy.save` instead of `array.tolist()`

### DIFF
--- a/skore/src/skore/persistence/item/numpy_array_item.py
+++ b/skore/src/skore/persistence/item/numpy_array_item.py
@@ -36,7 +36,7 @@ class NumpyArrayItem(Item):
         Parameters
         ----------
         array_b64_str : str
-            The raw bytes of the array in the NumPy serialization format, encoded in 
+            The raw bytes of the array in the NumPy serialization format, encoded in
             bas64 string.
         created_at : str
             The creation timestamp in ISO format.

--- a/skore/src/skore/persistence/item/numpy_array_item.py
+++ b/skore/src/skore/persistence/item/numpy_array_item.py
@@ -35,8 +35,9 @@ class NumpyArrayItem(Item):
 
         Parameters
         ----------
-        array_b64_json : str
-            The JSON representation of the array.
+        array_b64_str : str
+            The raw bytes of the array in the NumPy serialization format, encoded in 
+            bas64 string.
         created_at : str
             The creation timestamp in ISO format.
         updated_at : str

--- a/skore/tests/unit/item/test_numpy_array_item.py
+++ b/skore/tests/unit/item/test_numpy_array_item.py
@@ -1,8 +1,10 @@
 import json
+from io import BytesIO
 
 import numpy
 import pytest
 from skore.persistence.item import ItemTypeError, NumpyArrayItem
+from skore.utils import bytes_to_b64_str
 
 
 class TestNumpyArrayItem:
@@ -17,22 +19,30 @@ class TestNumpyArrayItem:
     @pytest.mark.order(0)
     def test_factory(self, mock_nowstr):
         array = numpy.array([1, 2, 3])
-        array_json = json.dumps(array.tolist())
+        with BytesIO() as stream:
+            numpy.save(stream, array)
+
+            array_bytes = stream.getvalue()
+            array_b64_str = bytes_to_b64_str(array_bytes)
 
         item = NumpyArrayItem.factory(array)
 
-        assert item.array_json == array_json
+        assert item.array_b64_str == array_b64_str
         assert item.created_at == mock_nowstr
         assert item.updated_at == mock_nowstr
 
     @pytest.mark.order(1)
     def test_array(self, mock_nowstr):
         array = numpy.array([1, 2, 3])
-        array_json = json.dumps(array.tolist())
+        with BytesIO() as stream:
+            numpy.save(stream, array)
+
+            array_bytes = stream.getvalue()
+            array_b64_str = bytes_to_b64_str(array_bytes)
 
         item1 = NumpyArrayItem.factory(array)
         item2 = NumpyArrayItem(
-            array_json=array_json,
+            array_b64_str=array_b64_str,
             created_at=mock_nowstr,
             updated_at=mock_nowstr,
         )
@@ -40,11 +50,20 @@ class TestNumpyArrayItem:
         numpy.testing.assert_array_equal(item1.array, array)
         numpy.testing.assert_array_equal(item2.array, array)
 
+    def test_ensure_jsonable(self):
+        item = NumpyArrayItem.factory(numpy.array([1, 2, 3]))
+        item_parameters = item.__parameters__
+
+        json.dumps(item_parameters)
+
     @pytest.mark.order(1)
     def test_array_with_complex_object(self, mock_nowstr):
         array = numpy.array([object])
 
-        with pytest.raises(TypeError, match="type is not JSON serializable"):
+        with pytest.raises(
+            ValueError,
+            match="Object arrays cannot be saved when allow_pickle=False",
+        ):
             NumpyArrayItem.factory(array)
 
     def test_get_serializable_dict(self, mock_nowstr):


### PR DESCRIPTION
Only for storage for now; `array.tolist()` is still used for sending data to the UI.

The `allow_pickle=False` setting is used to keep the same behaviour for arrays.

Closes https://github.com/probabl-ai/skore/issues/1159
