### PR TITLE
feat: Hide progress bar after execution

### DIFF
--- a/skore/src/skore/utils/_progress_bar.py
+++ b/skore/src/skore/utils/_progress_bar.py
@@ -43,6 +43,7 @@ def progress_decorator(description):
                     ),
                     TextColumn("[orange1]{task.percentage:>3.0f}%"),
                     expand=False,
+                    transient=True
                 )
                 progress.start()
 


### PR DESCRIPTION
closes #1251 

Hide the progress bar after the execution to free some space in the output in notebook.