### PR TITLE
chore: Improve error message when if_exist='raise'

### DIFF
--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -80,7 +80,10 @@ class Project:
         self.path = self.path.resolve()
 
         if if_exists == "raise" and self.path.exists():
-            raise FileExistsError(f"Project '{str(path)}' already exists.")
+            raise FileExistsError(
+                f"Project '{str(path)}' already exists. Set `if_exists` to 'load' to "
+                "only load the project."
+            )
 
         item_storage_dirpath = self.path / "items"
         view_storage_dirpath = self.path / "views"


### PR DESCRIPTION
Follow-up for #1194 

Related to a question from @rouk1 https://github.com/probabl-ai/skore/pull/1194#issuecomment-2622256091

I think that we should improve the error message, whatever the default value is.