### PR TITLE
fix(UI): Dataframe widget does not use consistent text color

### DIFF
--- a/skore-ui/src/components/DataFrameWidget.vue
+++ b/skore-ui/src/components/DataFrameWidget.vue
@@ -206,6 +206,7 @@ watch(
       & tr {
         position: relative;
         padding: var(--spacing-4);
+        color: var(--color-text-secondary);
 
         & td {
           padding: var(--spacing-4);

--- a/skore-ui/src/components/TextInput.vue
+++ b/skore-ui/src/components/TextInput.vue
@@ -53,6 +53,7 @@ onMounted(() => {
 
   .icon {
     margin: 0 var(--spacing-10);
+    color: var(--color-text-primary);
   }
 
   input {
@@ -60,10 +61,14 @@ onMounted(() => {
     min-width: 0;
     border: none;
     background-color: transparent;
-    color: inherit;
+    color: var(--color-text-primary);
 
     &:focus {
       outline: none;
+    }
+
+    &::placeholder {
+      color: var(--color-text-secondary);
     }
   }
 


### PR DESCRIPTION
Especially in  in dark mode.

It now looks like: 
![Screenshot 2025-01-29 at 19 03 35](https://github.com/user-attachments/assets/4924e6af-57da-4938-bb0f-55cda7e0922a)
