### PR TITLE
revert: Instantiate the default project when `create_app` is invoked by uvicorn from CLI

### DIFF
--- a/skore/src/skore/ui/app.py
+++ b/skore/src/skore/ui/app.py
@@ -15,9 +15,21 @@ from skore.ui.dependencies import get_static_path
 from skore.ui.project_routes import router as project_router
 
 
-def create_app(project: Project, lifespan: Optional[Lifespan] = None) -> FastAPI:
+def create_app(
+    project: Optional[Project] = None,
+    lifespan: Optional[Lifespan] = None,
+) -> FastAPI:
     """FastAPI factory used to create the API to interact with `stores`."""
     app = FastAPI(lifespan=lifespan)
+
+    # Give the app an access to the project, especially when invoking uvicorn in debug
+    # mode, directly from CLI. In such way, we can't directly pass to the function a
+    # project.
+    #
+    # If the project doesn't exist yet, it will be implicitly created.
+    if not project:
+        project = Project("project.skore", if_exists="load")
+
     app.state.project = project
 
     # Enable CORS support on all routes, for all origins and methods.


### PR DESCRIPTION
Follow-up for https://github.com/probabl-ai/skore/pull/1194 and the comment https://github.com/probabl-ai/skore/pull/1194#issuecomment-2622458300 of @rouk1.

