### PR TITLE
ci: Run backend workflow after any change on `skore/`

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,11 +3,8 @@ name: backend
 on:
   pull_request:
     paths:
-      - 'skore/src/**'
-      - 'skore/tests/**'
-      - 'skore/pyproject.toml'
-      - 'skore/requirements*.txt'
       - '.github/workflows/backend.yml'
+      - 'skore/**'
   push:
     branches:
       - main

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,8 +3,8 @@ name: frontend
 on:
   pull_request:
     paths:
-      - 'skore-ui/**'
       - '.github/workflows/frontend.yml'
+      - 'skore-ui/**'
   push:
     branches:
       - main


### PR DESCRIPTION
Following https://github.com/probabl-ai/skore/pull/1238.

Currently, any change on `skore/hatch/`, `skore/ci/` or `skore/*.*` doesn't trigger the backend worflow.
This can lead to undetected bug.