### PR TITLE
feat(CrossValidationReporter): Catch exceptions during cross-validation

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -32,7 +32,9 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     Upon initialization, CrossValidationReport will clone ``estimator`` according to
     ``cv_splitter`` and fit the generated estimators. The fitting is done in parallel,
     and can be interrupted: the estimators that have been fitted can be accessed even if
-    the full cross-validation process did not complete.
+    the full cross-validation process did not complete. In particular,
+    `KeyboardInterrupt` exceptions are swallowed and will only interrupt the
+    cross-validation process, rather than the entire program.
 
     Parameters
     ----------

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -173,34 +173,27 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             for report in generator:
                 estimator_reports.append(report)
                 progress.update(task, advance=1, refresh=True)
-        except KeyboardInterrupt:
+        except (Exception, KeyboardInterrupt) as e:
             from skore import console  # avoid circular import
 
-            console.print(
-                Panel(
-                    title="Cross-validation interrupted",
-                    renderable=(
-                        "Cross-validation process was interrupted manually before all "
-                        "estimators could be fitted; CrossValidationReport object "
-                        "might not contain all the expected results."
-                    ),
-                    style="orange1",
-                    border_style="cyan",
+            if isinstance(e, KeyboardInterrupt):
+                message = (
+                    "Cross-validation process was interrupted manually before all "
+                    "estimators could be fitted; CrossValidationReport object "
+                    "might not contain all the expected results."
                 )
-            )
-
-        except Exception as e:
-            from skore import console  # avoid circular import
+            else:
+                message = (
+                    "Cross-validation process was interrupted by an error before "
+                    "all estimators could be fitted; CrossValidationReport object "
+                    "might not contain all the expected results. "
+                    f"Traceback: \n{e}"
+                )
 
             console.print(
                 Panel(
                     title="Cross-validation interrupted",
-                    renderable=(
-                        "Cross-validation process was interrupted by an error before "
-                        "all estimators could be fitted; CrossValidationReport object "
-                        "might not contain all the expected results. "
-                        f"Traceback: \n{e}"
-                    ),
+                    renderable=message,
                     style="orange1",
                     border_style="cyan",
                 )

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -28,6 +28,11 @@ def _generate_estimator_report(estimator, X, y, train_indices, test_indices):
 class CrossValidationReport(_BaseReport, DirNamesMixin):
     """Report for cross-validation results.
 
+    Upon initialization, CrossValidationReport will clone ``estimator`` according to
+    ``cv_splitter`` and fit the generated estimators. The fitting is done in parallel,
+    and can be interrupted: the estimators that have been fitted can be accessed even if
+    the full cross-validation process did not complete.
+
     Parameters
     ----------
     estimator : estimator object

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -2,6 +2,7 @@ import time
 
 import joblib
 import numpy as np
+from rich.panel import Panel
 from sklearn.base import clone, is_classifier
 from sklearn.model_selection import check_cv
 from sklearn.pipeline import Pipeline
@@ -172,8 +173,38 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             for report in generator:
                 estimator_reports.append(report)
                 progress.update(task, advance=1, refresh=True)
-        except (Exception, KeyboardInterrupt):
-            pass
+        except KeyboardInterrupt:
+            from skore import console  # avoid circular import
+
+            console.print(
+                Panel(
+                    title="Cross-validation interrupted",
+                    renderable=(
+                        "Cross-validation process was interrupted manually before all "
+                        "estimators could be fitted; CrossValidationReport object "
+                        "might not contain all the expected results."
+                    ),
+                    style="orange1",
+                    border_style="cyan",
+                )
+            )
+
+        except Exception as e:
+            from skore import console  # avoid circular import
+
+            console.print(
+                Panel(
+                    title="Cross-validation interrupted",
+                    renderable=(
+                        "Cross-validation process was interrupted by an error before "
+                        "all estimators could be fitted; CrossValidationReport object "
+                        "might not contain all the expected results. "
+                        f"Traceback: \n{e}"
+                    ),
+                    style="orange1",
+                    border_style="cyan",
+                )
+            )
 
         return estimator_reports
 

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -163,9 +163,12 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         )
 
         estimator_reports = []
-        for report in generator:
-            estimator_reports.append(report)
-            progress.update(task, advance=1, refresh=True)
+        try:
+            for report in generator:
+                estimator_reports.append(report)
+                progress.update(task, advance=1, refresh=True)
+        except (Exception, KeyboardInterrupt):
+            pass
 
         return estimator_reports
 

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -29,7 +29,7 @@ def _generate_estimator_report(estimator, X, y, train_indices, test_indices):
 class CrossValidationReport(_BaseReport, DirNamesMixin):
     """Report for cross-validation results.
 
-    Upon initialization, CrossValidationReport will clone ``estimator`` according to
+    Upon initialization, `CrossValidationReport` will clone ``estimator`` according to
     ``cv_splitter`` and fit the generated estimators. The fitting is done in parallel,
     and can be interrupted: the estimators that have been fitted can be accessed even if
     the full cross-validation process did not complete. In particular,

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -737,3 +737,39 @@ def test_cross_validation_report_custom_metric(binary_classification_data):
     )
     assert result.shape == (2, 1)
     assert result.columns == ["accuracy_score"]
+
+
+@pytest.fixture
+def fake_clone(monkeypatch):
+    """Mock `clone` function which raises an Exception when called too many times.
+
+    This allows us to interrupt the cross-validation process early, since each
+    cross-validation split is performed on a different `clone`d estimator.
+    """
+    nb_calls = 0
+
+    def failing_clone(estimator):
+        from sklearn.base import clone
+
+        nonlocal nb_calls
+        nb_calls += 1
+        if nb_calls > 2:
+            raise Exception("clone called more than twice")
+
+        return clone(estimator)
+
+    monkeypatch.setattr("skore.sklearn._cross_validation.report.clone", failing_clone)
+
+
+def test_cross_validation_report_interrupted(fake_clone, binary_classification_data):
+    """Check that we can interrupt cross-validation without losing all
+    data."""
+    estimator, X, y = binary_classification_data
+    report = CrossValidationReport(estimator, X, y, cv_splitter=10)
+
+    result = report.metrics.custom_metric(
+        metric_function=accuracy_score,
+        response_method="predict",
+    )
+    assert result.shape == (1, 1)
+    assert result.columns == ["accuracy_score"]


### PR DESCRIPTION
Exceptions in `CrossValidationReport._fit_estimator_reports` no longer cause the previously computed estimators to be thrown away.

Here is a manual test using the following snippet: 
```python
import time
from sklearn.datasets import make_classification
from sklearn.linear_model import LogisticRegression
from skore import CrossValidationReport

class SlowEstimator(LogisticRegression):
    def __init__(self):
        super().__init__()

    def fit(self, X, y):
        time.sleep(0.5)
        super().fit(X, y)
        return self

X, y = make_classification(random_state=42)
estimator = SlowEstimator()

# This will block and show you the progress bar.
#
# If you interrupt the fitting (e.g. with Ctrl-C), you can still access `report`
# which means you can compute metrics, etc. on the intermediate estimators that were
# fitted (even if not all of them were).
#
# Just don't interrupt too early, or there will not be time to fit even one estimator!
report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=5)
```

Closes #1024
