### PR TITLE
chore: Upgrade vitest to patch CVE-2025-24964

### DIFF
--- a/skore-ui/package.json
+++ b/skore-ui/package.json
@@ -67,7 +67,7 @@
     "typescript": "~5.7.3",
     "vite": "^6.0.11",
     "vite-plugin-vue-devtools": "^7.7.1",
-    "vitest": "^3.0.4",
+    "vitest": "^3.0.5",
     "vitest-canvas-mock": "^0.3.3",
     "vue-tsc": "^2.2.0"
   }


### PR DESCRIPTION
See dependabot alert in the security tab of the repo.