### PR TITLE
fix(api): Remove the plot sub-accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can find information on the latest version [here](https://anaconda.org/conda
 
     ```python
     # Display the ROC curve that was generated for you:
-    roc_plot = cv_report.metrics.plot.roc()
+    roc_plot = cv_report.metrics.roc()
     roc_plot
     ```
 

--- a/examples/getting_started/plot_quick_start.py
+++ b/examples/getting_started/plot_quick_start.py
@@ -43,7 +43,7 @@ df_cv_report_metrics
 # %%
 import matplotlib.pyplot as plt
 
-roc_plot = cv_report.metrics.plot.roc()
+roc_plot = cv_report.metrics.roc()
 roc_plot
 plt.tight_layout()
 

--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -76,7 +76,7 @@ df_est_report_metrics
 # %%
 import matplotlib.pyplot as plt
 
-roc_plot = est_report.metrics.plot.roc()
+roc_plot = est_report.metrics.roc()
 roc_plot
 plt.tight_layout()
 
@@ -116,7 +116,7 @@ df_cv_report_metrics
 # We display the ROC curves for each fold:
 
 # %%
-roc_plot_cv = cv_report.metrics.plot.roc()
+roc_plot_cv = cv_report.metrics.roc()
 roc_plot_cv
 plt.tight_layout()
 

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -96,9 +96,6 @@ report.help()
 report.metrics.help()
 
 # %%
-report.metrics.plot.help()
-
-# %%
 #
 # Metrics computation with aggressive caching
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -332,12 +329,12 @@ report.metrics.report_metrics(scoring=[f1_scorer, operational_decision_cost_scor
 # The :class:`skore.EstimatorReport` class also provides a plotting interface that
 # allows to plot *defacto* the most common plots. As for the metrics, we only
 # provide the meaningful set of plots for the provided estimator.
-report.metrics.plot.help()
+report.metrics.help()
 
 # %%
 #
 # Let's start by plotting the ROC curve for our binary classification task.
-display = report.metrics.plot.roc(pos_label=pos_label)
+display = report.metrics.roc(pos_label=pos_label)
 plt.tight_layout()
 
 # %%
@@ -365,7 +362,7 @@ plt.tight_layout()
 # performance gain we can get.
 start = time.time()
 # we already trigger the computation of the predictions in a previous call
-report.metrics.plot.roc(pos_label=pos_label)
+report.metrics.roc(pos_label=pos_label)
 plt.tight_layout()
 end = time.time()
 
@@ -379,7 +376,7 @@ report.clear_cache()
 
 # %%
 start = time.time()
-report.metrics.plot.roc(pos_label=pos_label)
+report.metrics.roc(pos_label=pos_label)
 plt.tight_layout()
 end = time.time()
 

--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -218,7 +218,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 import matplotlib.pyplot as plt
 
 start = time.time()
-display = report.metrics.plot.roc(pos_label="allowed")
+display = report.metrics.roc(pos_label="allowed")
 end = time.time()
 plt.tight_layout()
 
@@ -229,7 +229,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 #
 # The second plot is instant because it uses cached data:
 start = time.time()
-display = report.metrics.plot.roc(pos_label="allowed")
+display = report.metrics.roc(pos_label="allowed")
 end = time.time()
 plt.tight_layout()
 

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -313,7 +313,7 @@ for split_idx, (ax, estimator_report) in enumerate(
     if estimator_report is None:
         ax.axis("off")
         continue
-    estimator_report.metrics.plot.prediction_error(kind="actual_vs_predicted", ax=ax)
+    estimator_report.metrics.prediction_error(kind="actual_vs_predicted", ax=ax)
     ax.set_title(f"Split #{split_idx + 1}")
     ax.legend(loc="lower right")
 plt.tight_layout()

--- a/skore/src/skore/sklearn/_cross_validation/__init__.py
+++ b/skore/src/skore/sklearn/_cross_validation/__init__.py
@@ -1,16 +1,9 @@
 from skore.externals._pandas_accessors import _register_accessor
-from skore.sklearn._cross_validation.metrics_accessor import (
-    _MetricsAccessor,
-    _PlotMetricsAccessor,
-)
+from skore.sklearn._cross_validation.metrics_accessor import _MetricsAccessor
 from skore.sklearn._cross_validation.report import (
     CrossValidationReport,
 )
 
-# add the metrics accessor to the estimator report
 _register_accessor("metrics", CrossValidationReport)(_MetricsAccessor)
-
-# add the plot accessor to the metrics accessor
-_register_accessor("plot", _MetricsAccessor)(_PlotMetricsAccessor)
 
 __all__ = ["CrossValidationReport"]

--- a/skore/src/skore/sklearn/_estimator/__init__.py
+++ b/skore/src/skore/sklearn/_estimator/__init__.py
@@ -1,14 +1,7 @@
 from skore.externals._pandas_accessors import _register_accessor
-from skore.sklearn._estimator.metrics_accessor import (
-    _MetricsAccessor,
-    _PlotMetricsAccessor,
-)
+from skore.sklearn._estimator.metrics_accessor import _MetricsAccessor
 from skore.sklearn._estimator.report import EstimatorReport
 
-# add the metrics accessor to the estimator report
 _register_accessor("metrics", EstimatorReport)(_MetricsAccessor)
-
-# add the plot accessor to the metrics accessor
-_register_accessor("plot", _MetricsAccessor)(_PlotMetricsAccessor)
 
 __all__ = ["EstimatorReport"]

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -17,10 +17,6 @@ from skore.sklearn._plot import (
 )
 from skore.utils._accessor import _check_supported_ml_task
 
-###############################################################################
-# Metrics accessor
-###############################################################################
-
 
 class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
     """Accessor for metrics-related operations.
@@ -1351,7 +1347,10 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         """Override format method for metrics-specific naming."""
         method_name = f"{name}(...)"
         method_name = method_name.ljust(22)
-        if self._SCORE_OR_LOSS_ICONS[name] in ("(↗︎)", "(↘︎)"):
+        if name in self._SCORE_OR_LOSS_ICONS and self._SCORE_OR_LOSS_ICONS[name] in (
+            "(↗︎)",
+            "(↘︎)",
+        ):
             if self._SCORE_OR_LOSS_ICONS[name] == "(↗︎)":
                 method_name += f"[cyan]{self._SCORE_OR_LOSS_ICONS[name]}[/cyan]"
                 return method_name.ljust(43)
@@ -1365,22 +1364,6 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         """Override to exclude the plot accessor from methods list."""
         methods = super()._get_methods_for_help()
         return [(name, method) for name, method in methods if name != "plot"]
-
-    def _create_help_tree(self):
-        """Override to include plot methods in a separate branch."""
-        tree = super()._create_help_tree()
-
-        # Add plot methods in a separate branch
-        plot_branch = tree.add("[bold cyan].plot[/bold cyan]")
-        plot_methods = self.plot._get_methods_for_help()
-        plot_methods = self.plot._sort_methods_for_help(plot_methods)
-
-        for name, method in plot_methods:
-            displayed_name = self.plot._format_method_name(name)
-            description = self.plot._get_method_description(method)
-            plot_branch.add(f".{displayed_name}".ljust(27) + f"- {description}")
-
-        return tree
 
     def _get_help_panel_title(self):
         return "[bold cyan]Available metrics methods[/bold cyan]"
@@ -1400,19 +1383,9 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             help_method_name="report.metrics.help()",
         )
 
-
-########################################################################################
-# Sub-accessors
-# Plotting
-########################################################################################
-
-
-class _PlotMetricsAccessor(_BaseAccessor):
-    """Plotting methods for the metrics accessor."""
-
-    def __init__(self, parent):
-        super().__init__(parent._parent)
-        self._metrics_parent = parent
+    ####################################################################################
+    # Methods related to displays
+    ####################################################################################
 
     def _get_display(
         self,
@@ -1549,7 +1522,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
         ...     X_test=X_test,
         ...     y_test=y_test,
         ... )
-        >>> display = report.metrics.plot.roc()
+        >>> display = report.metrics.roc()
         >>> display.plot(roc_curve_kwargs={"color": "tab:red"})
         """
         response_method = ("predict_proba", "decision_function")
@@ -1626,7 +1599,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
         ...     X_test=X_test,
         ...     y_test=y_test,
         ... )
-        >>> display = report.metrics.plot.precision_recall()
+        >>> display = report.metrics.precision_recall()
         >>> display.plot(pr_curve_kwargs={"color": "tab:red"})
         """
         response_method = ("predict_proba", "decision_function")
@@ -1721,7 +1694,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
         ...     X_test=X_test,
         ...     y_test=y_test,
         ... )
-        >>> display = report.metrics.plot.prediction_error(
+        >>> display = report.metrics.prediction_error(
         ...     kind="actual_vs_predicted"
         ... )
         >>> display.plot(line_kwargs={"color": "tab:red"})
@@ -1736,17 +1709,4 @@ class _PlotMetricsAccessor(_BaseAccessor):
             display_class=PredictionErrorDisplay,
             display_kwargs=display_kwargs,
             display_plot_kwargs=display_plot_kwargs,
-        )
-
-    def _get_help_panel_title(self):
-        return "[bold cyan]Available plot methods[/bold cyan]"
-
-    def _get_help_tree_title(self):
-        return "[bold cyan]report.metrics.plot[/bold cyan]"
-
-    def __repr__(self):
-        """Return a string representation using rich."""
-        return self._rich_repr(
-            class_name="skore.EstimatorReport.metrics.plot",
-            help_method_name="report.metrics.plot.help()",
         )

--- a/skore/src/skore/sklearn/_plot/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/precision_recall_curve.py
@@ -18,7 +18,7 @@ class PrecisionRecallCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin
     """Precision Recall visualization.
 
     An instance of this class is should created by
-    `EstimatorReport.metrics.plot.precision_recall()`. You should not create an
+    `EstimatorReport.metrics.precision_recall()`. You should not create an
     instance of this class directly.
 
 
@@ -97,7 +97,7 @@ class PrecisionRecallCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin
     ...     X_test=X_test,
     ...     y_test=y_test,
     ... )
-    >>> display = report.metrics.plot.precision_recall()
+    >>> display = report.metrics.precision_recall()
     >>> display.plot(pr_curve_kwargs={"color": "tab:red"})
     """
 
@@ -180,7 +180,7 @@ class PrecisionRecallCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin
         ...     X_test=X_test,
         ...     y_test=y_test,
         ... )
-        >>> display = report.metrics.plot.precision_recall()
+        >>> display = report.metrics.precision_recall()
         >>> display.plot(pr_curve_kwargs={"color": "tab:red"})
         """
         self.ax_, self.figure_, estimator_name = self._validate_plot_params(

--- a/skore/src/skore/sklearn/_plot/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/prediction_error.py
@@ -21,7 +21,7 @@ class PredictionErrorDisplay(HelpDisplayMixin):
     preferably on held-out data points.
 
     An instance of this class is should created by
-    `EstimatorReport.metrics.plot.prediction_error()`.
+    `EstimatorReport.metrics.prediction_error()`.
     You should not create an instance of this class directly.
 
     Parameters
@@ -74,7 +74,7 @@ class PredictionErrorDisplay(HelpDisplayMixin):
     ...     X_test=X_test,
     ...     y_test=y_test,
     ... )
-    >>> display = report.metrics.plot.prediction_error()
+    >>> display = report.metrics.prediction_error()
     >>> display.plot(kind="actual_vs_predicted")
     """
 
@@ -151,7 +151,7 @@ class PredictionErrorDisplay(HelpDisplayMixin):
         ...     X_test=X_test,
         ...     y_test=y_test,
         ... )
-        >>> display = report.metrics.plot.prediction_error()
+        >>> display = report.metrics.prediction_error()
         >>> display.plot(kind="actual_vs_predicted")
         """
         expected_kind = ("actual_vs_predicted", "residual_vs_predicted")

--- a/skore/src/skore/sklearn/_plot/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/roc_curve.py
@@ -17,7 +17,7 @@ from skore.sklearn._plot.utils import (
 class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
     """ROC Curve visualization.
 
-    An instance of this class is should created by `EstimatorReport.metrics.plot.roc()`.
+    An instance of this class is should created by `EstimatorReport.metrics.roc()`.
     You should not create an instance of this class directly.
 
     Parameters
@@ -98,7 +98,7 @@ class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
     ...     X_test=X_test,
     ...     y_test=y_test,
     ... )
-    >>> display = report.metrics.plot.roc()
+    >>> display = report.metrics.roc()
     >>> display.plot(roc_curve_kwargs={"color": "tab:red"})
     """
 
@@ -179,7 +179,7 @@ class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
         ...     X_test=X_test,
         ...     y_test=y_test,
         ... )
-        >>> display = report.metrics.plot.roc()
+        >>> display = report.metrics.roc()
         >>> display.plot(roc_curve_kwargs={"color": "tab:red"})
         """
         self.ax_, self.figure_, estimator_name = self._validate_plot_params(

--- a/skore/tests/unit/sklearn/plot/test_common.py
+++ b/skore/tests/unit/sklearn/plot/test_common.py
@@ -24,7 +24,7 @@ def test_display_help(pyplot, capsys, plot_func, estimator, dataset):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = getattr(report.metrics.plot, plot_func)()
+    display = getattr(report.metrics, plot_func)()
 
     display.help()
     captured = capsys.readouterr()
@@ -49,7 +49,7 @@ def test_display_str(pyplot, plot_func, estimator, dataset):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = getattr(report.metrics.plot, plot_func)()
+    display = getattr(report.metrics, plot_func)()
 
     str_str = str(display)
     assert f"{display.__class__.__name__}" in str_str
@@ -74,7 +74,7 @@ def test_display_repr(pyplot, plot_func, estimator, dataset):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = getattr(report.metrics.plot, plot_func)()
+    display = getattr(report.metrics, plot_func)()
 
     repr_str = repr(display)
     assert f"skore.{display.__class__.__name__}(...)" in repr_str
@@ -98,7 +98,7 @@ def test_display_provide_ax(pyplot, plot_func, estimator, dataset):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = getattr(report.metrics.plot, plot_func)()
+    display = getattr(report.metrics, plot_func)()
 
     _, ax = pyplot.subplots()
     display.plot(ax=ax)

--- a/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
@@ -45,7 +45,7 @@ def test_precision_recall_curve_display_binary_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     assert isinstance(display, PrecisionRecallCurveDisplay)
 
     # check the structure of the attributes
@@ -89,7 +89,7 @@ def test_precision_recall_curve_cross_validation_display_binary_classification(
     """
     (estimator, X, y), cv = binary_classification_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     assert isinstance(display, PrecisionRecallCurveDisplay)
 
     # check the structure of the attributes
@@ -135,12 +135,10 @@ def test_precision_recall_curve_display_data_source(pyplot, binary_classificatio
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall(data_source="train")
+    display = report.metrics.precision_recall(data_source="train")
     assert display.lines_[0].get_label() == "Train set (AP = 1.00)"
 
-    display = report.metrics.plot.precision_recall(
-        data_source="X_y", X=X_train, y=y_train
-    )
+    display = report.metrics.precision_recall(data_source="X_y", X=X_train, y=y_train)
     assert display.lines_[0].get_label() == "AP = 1.00"
 
 
@@ -154,7 +152,7 @@ def test_precision_recall_curve_display_multiclass_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     assert isinstance(display, PrecisionRecallCurveDisplay)
 
     # check the structure of the attributes
@@ -199,7 +197,7 @@ def test_precision_recall_curve_cross_validation_display_multiclass_classificati
     """
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     assert isinstance(display, PrecisionRecallCurveDisplay)
 
     # check the structure of the attributes
@@ -248,7 +246,7 @@ def test_precision_recall_curve_display_pr_curve_kwargs(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     for pr_curve_kwargs in ({"color": "red"}, [{"color": "red"}]):
         display.plot(pr_curve_kwargs=pr_curve_kwargs)
 
@@ -258,7 +256,7 @@ def test_precision_recall_curve_display_pr_curve_kwargs(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     display.plot(
         pr_curve_kwargs=[dict(color="red"), dict(color="blue"), dict(color="green")],
     )
@@ -281,7 +279,7 @@ def test_precision_recall_curve_display_plot_error_wrong_pr_curve_kwargs(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     err_msg = (
         "You intend to plot a single precision-recall curve and provide multiple "
         "precision-recall curve keyword arguments"
@@ -293,7 +291,7 @@ def test_precision_recall_curve_display_plot_error_wrong_pr_curve_kwargs(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     err_msg = "You intend to plot multiple precision-recall curves."
     with pytest.raises(ValueError, match=err_msg):
         display.plot(pr_curve_kwargs=[{}, {}])
@@ -315,7 +313,7 @@ def test_pr_curve_display_cross_validation_multiple_roc_curve_kwargs_error(
     (estimator, X, y), cv = request.getfixturevalue(fixture_name), 3
 
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.precision_recall()
+    display = report.metrics.precision_recall()
     err_msg = "You intend to plot multiple precision-recall curves"
     with pytest.raises(ValueError, match=err_msg):
         display.plot(pr_curve_kwargs=pr_curve_kwargs)
@@ -330,10 +328,8 @@ def test_precision_recall_curve_display_data_source_binary_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.precision_recall(data_source="train")
+    display = report.metrics.precision_recall(data_source="train")
     assert display.lines_[0].get_label() == "Train set (AP = 1.00)"
 
-    display = report.metrics.plot.precision_recall(
-        data_source="X_y", X=X_train, y=y_train
-    )
+    display = report.metrics.precision_recall(data_source="X_y", X=X_train, y=y_train)
     assert display.lines_[0].get_label() == "AP = 1.00"

--- a/skore/tests/unit/sklearn/plot/test_prediction_error.py
+++ b/skore/tests/unit/sklearn/plot/test_prediction_error.py
@@ -38,7 +38,7 @@ def test_prediction_error_display_raise_error(pyplot, params, err_msg, regressio
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.plot.prediction_error(**params)
+        report.metrics.prediction_error(**params)
 
 
 @pytest.mark.parametrize("subsample", [None, 1_000])
@@ -49,7 +49,7 @@ def test_prediction_error_display_regression(pyplot, regression_data, subsample)
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.prediction_error(subsample=subsample)
+    display = report.metrics.prediction_error(subsample=subsample)
     assert isinstance(display, PredictionErrorDisplay)
 
     # check the structure of the attributes
@@ -81,7 +81,7 @@ def test_prediction_error_cross_validation_display_regression(
     with cross-validation data."""
     (estimator, X, y), cv = regression_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.prediction_error()
+    display = report.metrics.prediction_error()
     assert isinstance(display, PredictionErrorDisplay)
 
     # check the structure of the attributes
@@ -111,7 +111,7 @@ def test_prediction_error_display_regression_kind(pyplot, regression_data):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.prediction_error(kind="actual_vs_predicted")
+    display = report.metrics.prediction_error(kind="actual_vs_predicted")
     assert isinstance(display, PredictionErrorDisplay)
 
     assert isinstance(display.line_, mpl.lines.Line2D)
@@ -138,7 +138,7 @@ def test_prediction_error_cross_validation_display_regression_kind(
     """Check the attributes when switching to the "actual_vs_predicted" kind."""
     (estimator, X, y), cv = regression_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.prediction_error(kind="actual_vs_predicted")
+    display = report.metrics.prediction_error(kind="actual_vs_predicted")
     assert isinstance(display, PredictionErrorDisplay)
 
     # check the structure of the attributes
@@ -169,13 +169,11 @@ def test_prediction_error_display_data_source(pyplot, regression_data):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.prediction_error(data_source="train")
+    display = report.metrics.prediction_error(data_source="train")
     assert display.line_.get_label() == "Perfect predictions"
     assert display.scatter_.get_label() == "Train set"
 
-    display = report.metrics.plot.prediction_error(
-        data_source="X_y", X=X_train, y=y_train
-    )
+    display = report.metrics.prediction_error(data_source="X_y", X=X_train, y=y_train)
     assert display.line_.get_label() == "Perfect predictions"
     assert display.scatter_.get_label() == "Data set"
 
@@ -186,7 +184,7 @@ def test_prediction_error_display_kwargs(pyplot, regression_data):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.prediction_error()
+    display = report.metrics.prediction_error()
     display.plot(scatter_kwargs={"color": "red"}, line_kwargs={"color": "blue"})
     np.testing.assert_allclose(display.scatter_.get_facecolor(), [[1, 0, 0, 0.3]])
     assert display.line_.get_color() == "blue"
@@ -196,9 +194,9 @@ def test_prediction_error_display_kwargs(pyplot, regression_data):
     assert display.ax_.spines["right"].get_visible()
 
     expected_subsample = 10
-    display = report.metrics.plot.prediction_error(subsample=expected_subsample)
+    display = report.metrics.prediction_error(subsample=expected_subsample)
     assert len(display.scatter_.get_offsets()) == expected_subsample
 
     expected_subsample = int(X_test.shape[0] * 0.5)
-    display = report.metrics.plot.prediction_error(subsample=0.5)
+    display = report.metrics.prediction_error(subsample=0.5)
     assert len(display.scatter_.get_offsets()) == expected_subsample

--- a/skore/tests/unit/sklearn/plot/test_roc_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_roc_curve.py
@@ -42,7 +42,7 @@ def test_roc_curve_display_binary_classification(pyplot, binary_classification_d
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     assert isinstance(display, RocCurveDisplay)
 
     # check the structure of the attributes
@@ -91,7 +91,7 @@ def test_roc_curve_display_multiclass_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     assert isinstance(display, RocCurveDisplay)
 
     # check the structure of the attributes
@@ -140,10 +140,10 @@ def test_roc_curve_display_data_source_binary_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc(data_source="train")
+    display = report.metrics.roc(data_source="train")
     assert display.lines_[0].get_label() == "Train set (AUC = 1.00)"
 
-    display = report.metrics.plot.roc(data_source="X_y", X=X_train, y=y_train)
+    display = report.metrics.roc(data_source="X_y", X=X_train, y=y_train)
     assert display.lines_[0].get_label() == "AUC = 1.00"
 
 
@@ -155,14 +155,14 @@ def test_roc_curve_display_data_source_multiclass_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc(data_source="train")
+    display = report.metrics.roc(data_source="train")
     for class_label in estimator.classes_:
         assert display.lines_[class_label].get_label() == (
             f"{str(class_label).title()} - train set "
             f"(AUC = {display.roc_auc[class_label][0]:0.2f})"
         )
 
-    display = report.metrics.plot.roc(data_source="X_y", X=X_train, y=y_train)
+    display = report.metrics.roc(data_source="X_y", X=X_train, y=y_train)
     for class_label in estimator.classes_:
         assert display.lines_[class_label].get_label() == (
             f"{str(class_label).title()} - AUC = 1.00"
@@ -178,7 +178,7 @@ def test_roc_curve_display_plot_error_wrong_roc_curve_kwargs(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     err_msg = (
         "You intend to plot a single ROC curve and provide multiple ROC curve "
         "keyword arguments"
@@ -190,7 +190,7 @@ def test_roc_curve_display_plot_error_wrong_roc_curve_kwargs(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     err_msg = "You intend to plot multiple ROC curves."
     with pytest.raises(ValueError, match=err_msg):
         display.plot(roc_curve_kwargs=[{}, {}])
@@ -208,7 +208,7 @@ def test_roc_curve_display_roc_curve_kwargs_binary_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     display.plot(
         roc_curve_kwargs=roc_curve_kwargs, chance_level_kwargs={"color": "blue"}
     )
@@ -226,7 +226,7 @@ def test_roc_curve_display_roc_curve_kwargs_multiclass_classification(
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     display.plot(
         roc_curve_kwargs=[dict(color="red"), dict(color="blue"), dict(color="green")],
         chance_level_kwargs={"color": "blue"},
@@ -252,7 +252,7 @@ def test_roc_curve_display_cross_validation_binary_classification(
     (estimator, X, y), cv = binary_classification_data_no_split, 3
 
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     assert isinstance(display, RocCurveDisplay)
 
     # check the structure of the attributes
@@ -301,7 +301,7 @@ def test_roc_curve_display_cross_validation_multiclass_classification(
     multiclass data."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     assert isinstance(display, RocCurveDisplay)
 
     # check the structure of the attributes
@@ -361,7 +361,7 @@ def test_roc_curve_display_cross_validation_binary_classification_kwargs(
     (estimator, X, y), cv = binary_classification_data_no_split, 3
 
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     display.plot(roc_curve_kwargs=roc_curve_kwargs)
     if isinstance(roc_curve_kwargs, list):
         assert display.lines_[0].get_color() == "red"
@@ -385,7 +385,7 @@ def test_roc_curve_display_cross_validation_multiple_roc_curve_kwargs_error(
     (estimator, X, y), cv = request.getfixturevalue(fixture_name), 3
 
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.roc()
+    display = report.metrics.roc()
     err_msg = "You intend to plot multiple ROC curves"
     with pytest.raises(ValueError, match=err_msg):
         display.plot(roc_curve_kwargs=roc_curve_kwargs)

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -220,31 +220,11 @@ def test_cross_validation_report_pickle(tmp_path, binary_classification_data):
 ########################################################################################
 
 
-def test_cross_validation_report_plot_help(capsys, binary_classification_data):
-    """Check that the help method writes to the console."""
-    estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-
-    report.metrics.plot.help()
-    captured = capsys.readouterr()
-    assert "Available plot methods" in captured.out
-
-
-def test_cross_validation_report_plot_repr(binary_classification_data):
-    """Check that __repr__ returns a string starting with the expected prefix."""
-    estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-
-    repr_str = repr(report.metrics.plot)
-    assert "skore.CrossValidationReport.metrics.plot" in repr_str
-    assert "report.metrics.plot.help()" in repr_str
-
-
 def test_cross_validation_report_plot_roc(binary_classification_data):
     """Check that the ROC plot method works."""
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-    assert isinstance(report.metrics.plot.roc(), RocCurveDisplay)
+    assert isinstance(report.metrics.roc(), RocCurveDisplay)
 
 
 @pytest.mark.parametrize("display", ["roc", "precision_recall"])
@@ -254,10 +234,10 @@ def test_cross_validation_report_display_binary_classification(
     """General behaviour of the function creating display on binary classification."""
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)()
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)()
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)()
+    display_second_call = getattr(report.metrics, display)()
     assert display_first_call is display_second_call
 
 
@@ -266,10 +246,10 @@ def test_cross_validation_report_display_regression(pyplot, regression_data, dis
     """General behaviour of the function creating display on regression."""
     estimator, X, y = regression_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)()
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)()
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)()
+    display_second_call = getattr(report.metrics, display)()
     assert display_first_call is display_second_call
 
 

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -268,10 +268,10 @@ def test_estimator_report_check_support_plot(
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
     for supported_plot_method in supported_plot_methods:
-        assert hasattr(report.metrics.plot, supported_plot_method)
+        assert hasattr(report.metrics, supported_plot_method)
 
     for not_supported_plot_method in not_supported_plot_methods:
-        assert not hasattr(report.metrics.plot, not_supported_plot_method)
+        assert not hasattr(report.metrics, not_supported_plot_method)
 
 
 def test_estimator_report_help(capsys, binary_classification_data):
@@ -347,31 +347,11 @@ def test_estimator_report_pickle(tmp_path, binary_classification_data):
 ########################################################################################
 
 
-def test_estimator_report_plot_help(capsys, binary_classification_data):
-    """Check that the help method writes to the console."""
-    estimator, X_test, y_test = binary_classification_data
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-
-    report.metrics.plot.help()
-    captured = capsys.readouterr()
-    assert "Available plot methods" in captured.out
-
-
-def test_estimator_report_plot_repr(binary_classification_data):
-    """Check that __repr__ returns a string starting with the expected prefix."""
-    estimator, X_test, y_test = binary_classification_data
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-
-    repr_str = repr(report.metrics.plot)
-    assert "skore.EstimatorReport.metrics.plot" in repr_str
-    assert "report.metrics.plot.help()" in repr_str
-
-
 def test_estimator_report_plot_roc(binary_classification_data):
     """Check that the ROC plot method works."""
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert isinstance(report.metrics.plot.roc(), RocCurveDisplay)
+    assert isinstance(report.metrics.roc(), RocCurveDisplay)
 
 
 @pytest.mark.parametrize("display", ["roc", "precision_recall"])
@@ -381,10 +361,10 @@ def test_estimator_report_display_binary_classification(
     """General behaviour of the function creating display on binary classification."""
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)()
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)()
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)()
+    display_second_call = getattr(report.metrics, display)()
     assert display_first_call is display_second_call
 
 
@@ -393,10 +373,10 @@ def test_estimator_report_display_regression(pyplot, regression_data, display):
     """General behaviour of the function creating display on regression."""
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)()
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)()
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)()
+    display_second_call = getattr(report.metrics, display)()
     assert display_first_call is display_second_call
 
 
@@ -409,12 +389,12 @@ def test_estimator_report_display_binary_classification_external_data(
     """
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator)
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)(
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)(
         data_source="X_y", X=X_test, y=y_test
     )
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)(
+    display_second_call = getattr(report.metrics, display)(
         data_source="X_y", X=X_test, y=y_test
     )
     assert display_first_call is display_second_call
@@ -429,12 +409,12 @@ def test_estimator_report_display_regression_external_data(
     """
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator)
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)(
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)(
         data_source="X_y", X=X_test, y=y_test
     )
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)(
+    display_second_call = getattr(report.metrics, display)(
         data_source="X_y", X=X_test, y=y_test
     )
     assert display_first_call is display_second_call
@@ -449,12 +429,12 @@ def test_estimator_report_display_binary_classification_switching_data_source(
     report = EstimatorReport(
         estimator, X_train=X_test, y_train=y_test, X_test=X_test, y_test=y_test
     )
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)(data_source="test")
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)(data_source="test")
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)(data_source="train")
+    display_second_call = getattr(report.metrics, display)(data_source="train")
     assert display_first_call is not display_second_call
-    display_third_call = getattr(report.metrics.plot, display)(
+    display_third_call = getattr(report.metrics, display)(
         data_source="X_y", X=X_test, y=y_test
     )
     assert display_first_call is not display_third_call
@@ -470,12 +450,12 @@ def test_estimator_report_display_regression_switching_data_source(
     report = EstimatorReport(
         estimator, X_train=X_test, y_train=y_test, X_test=X_test, y_test=y_test
     )
-    assert hasattr(report.metrics.plot, display)
-    display_first_call = getattr(report.metrics.plot, display)(data_source="test")
+    assert hasattr(report.metrics, display)
+    display_first_call = getattr(report.metrics, display)(data_source="test")
     assert report._cache != {}
-    display_second_call = getattr(report.metrics.plot, display)(data_source="train")
+    display_second_call = getattr(report.metrics, display)(data_source="train")
     assert display_first_call is not display_second_call
-    display_third_call = getattr(report.metrics.plot, display)(
+    display_third_call = getattr(report.metrics, display)(
         data_source="X_y", X=X_test, y=y_test
     )
     assert display_first_call is not display_third_call

--- a/sphinx/api.rst
+++ b/sphinx/api.rst
@@ -66,8 +66,7 @@ Metrics
 """""""
 
 The `metrics` accessor helps you to evaluate the statistical performance of your
-estimator. In addition, we provide a sub-accessor `plot`, to get the common
-performance metric representations.
+estimator.
 
 .. autosummary::
     :toctree: generated/
@@ -81,14 +80,14 @@ performance metric representations.
     EstimatorReport.metrics.brier_score
     EstimatorReport.metrics.log_loss
     EstimatorReport.metrics.precision
+    EstimatorReport.metrics.precision_recall
+    EstimatorReport.metrics.prediction_error
     EstimatorReport.metrics.r2
     EstimatorReport.metrics.recall
     EstimatorReport.metrics.rmse
+    EstimatorReport.metrics.roc
     EstimatorReport.metrics.roc_auc
-    EstimatorReport.metrics.plot.help
-    EstimatorReport.metrics.plot.precision_recall
-    EstimatorReport.metrics.plot.prediction_error
-    EstimatorReport.metrics.plot.roc
+
 
 Cross-validation report for an estimator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -121,8 +120,7 @@ Metrics
 """""""
 
 The `metrics` accessor helps you to evaluate the statistical performance of your
-estimator during a cross-validation. In addition, we provide a sub-accessor `plot`, to
-get the common performance metric representations.
+estimator during a cross-validation.
 
 .. autosummary::
     :toctree: generated/
@@ -136,14 +134,13 @@ get the common performance metric representations.
     CrossValidationReport.metrics.brier_score
     CrossValidationReport.metrics.log_loss
     CrossValidationReport.metrics.precision
+    CrossValidationReport.metrics.precision_recall
+    CrossValidationReport.metrics.prediction_error
     CrossValidationReport.metrics.r2
     CrossValidationReport.metrics.recall
     CrossValidationReport.metrics.rmse
+    CrossValidationReport.metrics.roc
     CrossValidationReport.metrics.roc_auc
-    CrossValidationReport.metrics.plot.help
-    CrossValidationReport.metrics.plot.precision_recall
-    CrossValidationReport.metrics.plot.prediction_error
-    CrossValidationReport.metrics.plot.roc
 
 .. Deprecated
 .. ----------


### PR DESCRIPTION
This PR removes the `.metrics.plot` sub-accessor to make it available at the `.metrics` level.
It allows to have a consistent access with dataframe, e.g.:

```python
report.metrics.report_metrics().plot()
report.metrics.roc().plot()
```