### PR TITLE
fix(api): Do not call .plot() in display factory

### DIFF
--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -77,7 +77,7 @@ df_est_report_metrics
 import matplotlib.pyplot as plt
 
 roc_plot = est_report.metrics.plot.roc()
-roc_plot
+roc_plot.plot()
 plt.tight_layout()
 
 # %%
@@ -117,7 +117,7 @@ df_cv_report_metrics
 
 # %%
 roc_plot_cv = cv_report.metrics.plot.roc()
-roc_plot_cv
+roc_plot_cv.plot()
 plt.tight_layout()
 
 # %%

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -338,6 +338,7 @@ report.metrics.plot.help()
 #
 # Let's start by plotting the ROC curve for our binary classification task.
 display = report.metrics.plot.roc(pos_label=pos_label)
+display.plot()
 plt.tight_layout()
 
 # %%
@@ -365,7 +366,8 @@ plt.tight_layout()
 # performance gain we can get.
 start = time.time()
 # we already trigger the computation of the predictions in a previous call
-report.metrics.plot.roc(pos_label=pos_label)
+display = report.metrics.plot.roc(pos_label=pos_label)
+display.plot()
 plt.tight_layout()
 end = time.time()
 
@@ -379,7 +381,8 @@ report.clear_cache()
 
 # %%
 start = time.time()
-report.metrics.plot.roc(pos_label=pos_label)
+display = report.metrics.plot.roc(pos_label=pos_label)
+display.plot()
 plt.tight_layout()
 end = time.time()
 

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -313,10 +313,14 @@ for split_idx, (ax, estimator_report) in enumerate(
     if estimator_report is None:
         ax.axis("off")
         continue
-    estimator_report.metrics.plot.prediction_error(kind="actual_vs_predicted", ax=ax)
+    estimator_report.metrics.plot.prediction_error().plot(
+        kind="actual_vs_predicted", ax=ax
+    )
     ax.set_title(f"Split #{split_idx + 1}")
     ax.legend(loc="lower right")
 plt.tight_layout()
 # sphinx_gallery_start_ignore
 temp_dir.cleanup()
 # sphinx_gallery_end_ignore
+
+# %%

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -844,7 +844,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         response_method,
         display_class,
         display_kwargs,
-        display_plot_kwargs,
     ):
         """Get the display from the cache or compute it.
 
@@ -865,9 +864,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         display_kwargs : dict
             The display kwargs used by `display_class._from_predictions`.
 
-        display_plot_kwargs : dict
-            The display kwargs used by `display.plot`.
-
         Returns
         -------
         display : display_class
@@ -884,7 +880,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
         if cache_key in self._parent._cache:
             display = self._parent._cache[cache_key]
-            display.plot(**display_plot_kwargs)
         else:
             y_true, y_pred = [], []
             for report in self._parent.estimator_reports_:
@@ -914,7 +909,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
                 ml_task=self._parent._ml_task,
                 data_source=data_source,
                 **display_kwargs,
-                **display_plot_kwargs,
             )
             self._parent._cache[cache_key] = display
 
@@ -925,7 +919,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
             supported_ml_tasks=["binary-classification", "multiclass-classification"]
         )
     )
-    def roc(self, *, data_source="test", pos_label=None, ax=None):
+    def roc(self, *, data_source="test", pos_label=None):
         """Plot the ROC curve.
 
         Parameters
@@ -938,9 +932,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
         pos_label : int, float, bool or str, default=None
             The positive class.
-
-        ax : matplotlib.axes.Axes, default=None
-            The axes to plot on.
 
         Returns
         -------
@@ -960,13 +951,11 @@ class _PlotMetricsAccessor(_BaseAccessor):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display_plot_kwargs = {"ax": ax, "plot_chance_level": True, "despine": True}
         return self._get_display(
             data_source=data_source,
             response_method=response_method,
             display_class=RocCurveDisplay,
             display_kwargs=display_kwargs,
-            display_plot_kwargs=display_plot_kwargs,
         )
 
     @available_if(
@@ -974,7 +963,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
             supported_ml_tasks=["binary-classification", "multiclass-classification"]
         )
     )
-    def precision_recall(self, *, data_source="test", pos_label=None, ax=None):
+    def precision_recall(self, *, data_source="test", pos_label=None):
         """Plot the precision-recall curve.
 
         Parameters
@@ -987,9 +976,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
         pos_label : int, float, bool or str, default=None
             The positive class.
-
-        ax : matplotlib.axes.Axes, default=None
-            The axes to plot on.
 
         Returns
         -------
@@ -1009,13 +995,11 @@ class _PlotMetricsAccessor(_BaseAccessor):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display_plot_kwargs = {"ax": ax, "despine": True}
         return self._get_display(
             data_source=data_source,
             response_method=response_method,
             display_class=PrecisionRecallCurveDisplay,
             display_kwargs=display_kwargs,
-            display_plot_kwargs=display_plot_kwargs,
         )
 
     @available_if(_check_supported_ml_task(supported_ml_tasks=["regression"]))
@@ -1023,8 +1007,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         self,
         *,
         data_source="test",
-        ax=None,
-        kind="residual_vs_predicted",
         subsample=1_000,
         random_state=None,
     ):
@@ -1039,20 +1021,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
-
-        ax : matplotlib axes, default=None
-            Axes object to plot on. If `None`, a new figure and axes is
-            created.
-
-        kind : {"actual_vs_predicted", "residual_vs_predicted"}, \
-                default="residual_vs_predicted"
-            The type of plot to draw:
-
-            - "actual_vs_predicted" draws the observed values (y-axis) vs.
-              the predicted values (x-axis).
-            - "residual_vs_predicted" draws the residuals, i.e. difference
-              between observed and predicted values, (y-axis) vs. the predicted
-              values (x-axis).
 
         subsample : float, int or None, default=1_000
             Sampling the samples to be shown on the scatter plot. If `float`,
@@ -1083,13 +1051,11 @@ class _PlotMetricsAccessor(_BaseAccessor):
         >>> display.plot(line_kwargs={"color": "tab:red"})
         """
         display_kwargs = {"subsample": subsample, "random_state": random_state}
-        display_plot_kwargs = {"ax": ax, "kind": kind}
         return self._get_display(
             data_source=data_source,
             response_method="predict",
             display_class=PredictionErrorDisplay,
             display_kwargs=display_kwargs,
-            display_plot_kwargs=display_plot_kwargs,
         )
 
     def _get_help_panel_title(self):

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -1045,10 +1045,8 @@ class _PlotMetricsAccessor(_BaseAccessor):
         >>> X, y = load_diabetes(return_X_y=True)
         >>> regressor = Ridge()
         >>> report = CrossValidationReport(regressor, X=X, y=y, cv_splitter=2)
-        >>> display = report.metrics.plot.prediction_error(
-        ...     kind="actual_vs_predicted"
-        ... )
-        >>> display.plot(line_kwargs={"color": "tab:red"})
+        >>> display = report.metrics.plot.prediction_error()
+        >>> display.plot(kind="actual_vs_predicted", line_kwargs={"color": "tab:red"})
         """
         display_kwargs = {"subsample": subsample, "random_state": random_state}
         return self._get_display(

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1423,7 +1423,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         response_method,
         display_class,
         display_kwargs,
-        display_plot_kwargs,
     ):
         """Get the display from the cache or compute it.
 
@@ -1451,9 +1450,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         display_kwargs : dict
             The display kwargs used by `display_class._from_predictions`.
 
-        display_plot_kwargs : dict
-            The display kwargs used by `display.plot`.
-
         Returns
         -------
         display : display_class
@@ -1469,7 +1465,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
         if cache_key in self._parent._cache:
             display = self._parent._cache[cache_key]
-            display.plot(**display_plot_kwargs)
         else:
             y_pred = _get_cached_response_values(
                 cache=self._parent._cache,
@@ -1490,7 +1485,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
                 ml_task=self._parent._ml_task,
                 data_source=data_source,
                 **display_kwargs,
-                **display_plot_kwargs,
             )
             self._parent._cache[cache_key] = display
 
@@ -1501,7 +1495,7 @@ class _PlotMetricsAccessor(_BaseAccessor):
             supported_ml_tasks=["binary-classification", "multiclass-classification"]
         )
     )
-    def roc(self, *, data_source="test", X=None, y=None, pos_label=None, ax=None):
+    def roc(self, *, data_source="test", X=None, y=None, pos_label=None):
         """Plot the ROC curve.
 
         Parameters
@@ -1523,9 +1517,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
         pos_label : int, float, bool or str, default=None
             The positive class.
-
-        ax : matplotlib.axes.Axes, default=None
-            The axes to plot on.
 
         Returns
         -------
@@ -1554,7 +1545,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display_plot_kwargs = {"ax": ax, "plot_chance_level": True, "despine": True}
         return self._get_display(
             X=X,
             y=y,
@@ -1562,7 +1552,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
             response_method=response_method,
             display_class=RocCurveDisplay,
             display_kwargs=display_kwargs,
-            display_plot_kwargs=display_plot_kwargs,
         )
 
     @available_if(
@@ -1577,7 +1566,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         X=None,
         y=None,
         pos_label=None,
-        ax=None,
     ):
         """Plot the precision-recall curve.
 
@@ -1600,9 +1588,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
 
         pos_label : int, float, bool or str, default=None
             The positive class.
-
-        ax : matplotlib.axes.Axes, default=None
-            The axes to plot on.
 
         Returns
         -------
@@ -1631,7 +1616,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display_plot_kwargs = {"ax": ax, "despine": True}
         return self._get_display(
             X=X,
             y=y,
@@ -1639,7 +1623,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
             response_method=response_method,
             display_class=PrecisionRecallCurveDisplay,
             display_kwargs=display_kwargs,
-            display_plot_kwargs=display_plot_kwargs,
         )
 
     @available_if(_check_supported_ml_task(supported_ml_tasks=["regression"]))
@@ -1649,8 +1632,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         data_source="test",
         X=None,
         y=None,
-        ax=None,
-        kind="residual_vs_predicted",
         subsample=1_000,
         random_state=None,
     ):
@@ -1674,20 +1655,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
         y : array-like of shape (n_samples,), default=None
             New target on which to compute the metric. By default, we use the target
             provided when creating the report.
-
-        ax : matplotlib axes, default=None
-            Axes object to plot on. If `None`, a new figure and axes is
-            created.
-
-        kind : {"actual_vs_predicted", "residual_vs_predicted"}, \
-                default="residual_vs_predicted"
-            The type of plot to draw:
-
-            - "actual_vs_predicted" draws the observed values (y-axis) vs.
-              the predicted values (x-axis).
-            - "residual_vs_predicted" draws the residuals, i.e. difference
-              between observed and predicted values, (y-axis) vs. the predicted
-              values (x-axis).
 
         subsample : float, int or None, default=1_000
             Sampling the samples to be shown on the scatter plot. If `float`,
@@ -1721,13 +1688,10 @@ class _PlotMetricsAccessor(_BaseAccessor):
         ...     X_test=X_test,
         ...     y_test=y_test,
         ... )
-        >>> display = report.metrics.plot.prediction_error(
-        ...     kind="actual_vs_predicted"
-        ... )
+        >>> display = report.metrics.plot.prediction_error()
         >>> display.plot(line_kwargs={"color": "tab:red"})
         """
         display_kwargs = {"subsample": subsample, "random_state": random_state}
-        display_plot_kwargs = {"ax": ax, "kind": kind}
         return self._get_display(
             X=X,
             y=y,
@@ -1735,7 +1699,6 @@ class _PlotMetricsAccessor(_BaseAccessor):
             response_method="predict",
             display_class=PredictionErrorDisplay,
             display_kwargs=display_kwargs,
-            display_plot_kwargs=display_plot_kwargs,
         )
 
     def _get_help_panel_title(self):

--- a/skore/src/skore/sklearn/_plot/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/precision_recall_curve.py
@@ -379,9 +379,6 @@ class PrecisionRecallCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin
         data_source=None,
         pos_label=None,
         drop_intermediate=False,
-        ax=None,
-        pr_curve_kwargs=None,
-        despine=True,
     ):
         """Plot precision-recall curve given binary class predictions.
 
@@ -415,19 +412,6 @@ class PrecisionRecallCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin
             Whether to drop some suboptimal thresholds which would not appear
             on a plotted precision-recall curve. This is useful in order to
             create lighter precision-recall curves.
-
-        ax : matplotlib axes, default=None
-            Axes object to plot on. If `None`, a new figure and axes is created.
-
-        pr_curve_kwargs : dict or list of dict, default=None
-            Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the precision-recall curve(s).
-
-        despine : bool, default=True
-            Whether to remove the top and right spines from the plot.
-
-        **kwargs : dict
-            Keyword arguments to be passed to matplotlib's `plot`.
 
         Returns
         -------
@@ -475,7 +459,7 @@ class PrecisionRecallCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin
                     recall[class_].append(recall_class_i)
                     average_precision[class_].append(average_precision_class_i)
 
-        viz = cls(
+        return cls(
             precision=precision,
             recall=recall,
             average_precision=average_precision,
@@ -483,12 +467,3 @@ class PrecisionRecallCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin
             pos_label=pos_label_validated,
             data_source=data_source,
         )
-
-        viz.plot(
-            ax=ax,
-            estimator_name=estimator_name,
-            pr_curve_kwargs=pr_curve_kwargs,
-            despine=despine,
-        )
-
-        return viz

--- a/skore/src/skore/sklearn/_plot/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/prediction_error.py
@@ -291,13 +291,8 @@ class PredictionErrorDisplay(HelpDisplayMixin):
         estimator_name,
         ml_task,  # FIXME: to be used when having single-output vs. multi-output
         data_source=None,
-        kind="residual_vs_predicted",
         subsample=1_000,
         random_state=None,
-        ax=None,
-        scatter_kwargs=None,
-        line_kwargs=None,
-        despine=True,
     ):
         """Plot the prediction error given the true and predicted targets.
 
@@ -321,16 +316,6 @@ class PredictionErrorDisplay(HelpDisplayMixin):
         data_source : {"train", "test", "X_y"}, default=None
             The data source used to compute the ROC curve.
 
-        kind : {"actual_vs_predicted", "residual_vs_predicted"}, \
-                default="residual_vs_predicted"
-            The type of plot to draw:
-
-            - "actual_vs_predicted" draws the observed values (y-axis) vs.
-              the predicted values (x-axis).
-            - "residual_vs_predicted" draws the residuals, i.e. difference
-              between observed and predicted values, (y-axis) vs. the predicted
-              values (x-axis).
-
         subsample : float, int or None, default=1_000
             Sampling the samples to be shown on the scatter plot. If `float`,
             it should be between 0 and 1 and represents the proportion of the
@@ -341,21 +326,6 @@ class PredictionErrorDisplay(HelpDisplayMixin):
         random_state : int or RandomState, default=None
             Controls the randomness when `subsample` is not `None`.
             See :term:`Glossary <random_state>` for details.
-
-        ax : matplotlib axes, default=None
-            Axes object to plot on. If `None`, a new figure and axes is
-            created.
-
-        scatter_kwargs : dict, default=None
-            Dictionary with keywords passed to the `matplotlib.pyplot.scatter`
-            call.
-
-        line_kwargs : dict, default=None
-            Dictionary with keyword passed to the `matplotlib.pyplot.plot`
-            call to draw the optimal line.
-
-        despine : bool, default=True
-            Whether to remove the top and right spines from the plot.
 
         Returns
         -------
@@ -394,20 +364,9 @@ class PredictionErrorDisplay(HelpDisplayMixin):
                 y_true_display.append(y_true_i)
                 y_pred_display.append(y_pred_i)
 
-        viz = cls(
+        return cls(
             y_true=y_true_display,
             y_pred=y_pred_display,
             estimator_name=estimator_name,
             data_source=data_source,
         )
-
-        viz.plot(
-            ax=ax,
-            estimator_name=estimator_name,
-            kind=kind,
-            scatter_kwargs=scatter_kwargs,
-            line_kwargs=line_kwargs,
-            despine=despine,
-        )
-
-        return viz

--- a/skore/src/skore/sklearn/_plot/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/roc_curve.py
@@ -389,11 +389,6 @@ class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
         data_source=None,
         pos_label=None,
         drop_intermediate=True,
-        ax=None,
-        roc_curve_kwargs=None,
-        plot_chance_level=True,
-        chance_level_kwargs=None,
-        despine=True,
     ):
         """Private method to create a RocCurveDisplay from predictions.
 
@@ -425,24 +420,6 @@ class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
 
         drop_intermediate : bool, default=True
             Whether to drop intermediate points with identical value.
-
-        ax : matplotlib axes, default=None
-            Axes object to plot on. If `None`, a new figure and axes is
-            created.
-
-        roc_curve_kwargs : dict or list of dict, default=None
-            Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the ROC curve(s).
-
-        plot_chance_level : bool, default=True
-            Whether to plot the chance level.
-
-        chance_level_kwargs : dict, default=None
-            Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
-
-        despine : bool, default=True
-            Whether to remove the top and right spines from the plot.
 
         Returns
         -------
@@ -485,7 +462,7 @@ class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
                     tpr[class_].append(tpr_class_i)
                     roc_auc[class_].append(roc_auc_class_i)
 
-        viz = cls(
+        return cls(
             fpr=fpr,
             tpr=tpr,
             roc_auc=roc_auc,
@@ -493,14 +470,3 @@ class RocCurveDisplay(HelpDisplayMixin, _ClassifierCurveDisplayMixin):
             pos_label=pos_label_validated,
             data_source=data_source,
         )
-
-        viz.plot(
-            ax=ax,
-            estimator_name=estimator_name,
-            roc_curve_kwargs=roc_curve_kwargs,
-            plot_chance_level=plot_chance_level,
-            chance_level_kwargs=chance_level_kwargs,
-            despine=despine,
-        )
-
-        return viz

--- a/skore/src/skore/sklearn/_plot/utils.py
+++ b/skore/src/skore/sklearn/_plot/utils.py
@@ -43,11 +43,12 @@ class HelpDisplayMixin:
         attr_branch = tree.add("[bold cyan] Attributes[/bold cyan]")
         # Ensure figure_ and ax_ are first
         sorted_attrs = sorted(attributes)
-        sorted_attrs.remove(".ax_")
-        sorted_attrs.remove(".figure_")
-        sorted_attrs = [".figure_", ".ax_"] + [
-            attr for attr in sorted_attrs if attr not in [".figure_", ".ax_"]
-        ]
+        if ("figure_" in sorted_attrs) and ("ax_" in sorted_attrs):
+            sorted_attrs.remove(".ax_")
+            sorted_attrs.remove(".figure_")
+            sorted_attrs = [".figure_", ".ax_"] + [
+                attr for attr in sorted_attrs if attr not in [".figure_", ".ax_"]
+            ]
         for attr in sorted_attrs:
             attr_branch.add(attr)
 

--- a/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
@@ -59,6 +59,7 @@ def test_precision_recall_curve_display_binary_classification(
         assert isinstance(attr[estimator.classes_[1]], list)
         assert len(attr[estimator.classes_[1]]) == 1
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == 1
     precision_recall_curve_mpl = display.lines_[0]
@@ -104,6 +105,7 @@ def test_precision_recall_curve_cross_validation_display_binary_classification(
         assert isinstance(attr[pos_label], list)
         assert len(attr[pos_label]) == cv
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == cv
     expected_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)
@@ -136,11 +138,13 @@ def test_precision_recall_curve_display_data_source(pyplot, binary_classificatio
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     display = report.metrics.plot.precision_recall(data_source="train")
+    display.plot()
     assert display.lines_[0].get_label() == "Train set (AP = 1.00)"
 
     display = report.metrics.plot.precision_recall(
         data_source="X_y", X=X_train, y=y_train
     )
+    display.plot()
     assert display.lines_[0].get_label() == "AP = 1.00"
 
 
@@ -167,6 +171,7 @@ def test_precision_recall_curve_display_multiclass_classification(
             assert isinstance(attr[class_label], list)
             assert len(attr[class_label]) == 1
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == len(estimator.classes_)
     default_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)
@@ -213,6 +218,7 @@ def test_precision_recall_curve_cross_validation_display_multiclass_classificati
             assert isinstance(attr[class_label], list)
             assert len(attr[class_label]) == cv
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == len(class_labels) * cv
     default_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)
@@ -331,9 +337,11 @@ def test_precision_recall_curve_display_data_source_binary_classification(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     display = report.metrics.plot.precision_recall(data_source="train")
+    display.plot()
     assert display.lines_[0].get_label() == "Train set (AP = 1.00)"
 
     display = report.metrics.plot.precision_recall(
         data_source="X_y", X=X_train, y=y_train
     )
+    display.plot()
     assert display.lines_[0].get_label() == "AP = 1.00"

--- a/skore/tests/unit/sklearn/plot/test_prediction_error.py
+++ b/skore/tests/unit/sklearn/plot/test_prediction_error.py
@@ -27,7 +27,6 @@ def regression_data_no_split():
         ({"subsample": -1}, "When an integer, subsample=-1 should be"),
         ({"subsample": 20.0}, "When a floating-point, subsample=20.0 should be"),
         ({"subsample": -20.0}, "When a floating-point, subsample=-20.0 should be"),
-        ({"kind": "xxx"}, "`kind` must be one of"),
     ],
 )
 def test_prediction_error_display_raise_error(pyplot, params, err_msg, regression_data):
@@ -59,6 +58,7 @@ def test_prediction_error_display_regression(pyplot, regression_data, subsample)
     np.testing.assert_allclose(display.y_pred[0], estimator.predict(X_test))
     assert display.data_source == "test"
 
+    display.plot()
     assert isinstance(display.line_, mpl.lines.Line2D)
     assert display.line_.get_label() == "Perfect predictions"
     assert display.line_.get_color() == "black"
@@ -90,6 +90,7 @@ def test_prediction_error_cross_validation_display_regression(
     assert len(display.y_true) == len(display.y_pred) == cv
     assert display.data_source == "test"
 
+    display.plot()
     assert isinstance(display.line_, mpl.lines.Line2D)
     assert display.line_.get_label() == "Perfect predictions"
     assert display.line_.get_color() == "black"
@@ -111,9 +112,10 @@ def test_prediction_error_display_regression_kind(pyplot, regression_data):
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    display = report.metrics.plot.prediction_error(kind="actual_vs_predicted")
+    display = report.metrics.plot.prediction_error()
     assert isinstance(display, PredictionErrorDisplay)
 
+    display.plot(kind="actual_vs_predicted")
     assert isinstance(display.line_, mpl.lines.Line2D)
     assert display.line_.get_label() == "Perfect predictions"
     assert display.line_.get_color() == "black"
@@ -138,7 +140,8 @@ def test_prediction_error_cross_validation_display_regression_kind(
     """Check the attributes when switching to the "actual_vs_predicted" kind."""
     (estimator, X, y), cv = regression_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.plot.prediction_error(kind="actual_vs_predicted")
+    display = report.metrics.plot.prediction_error()
+    display.plot(kind="actual_vs_predicted")
     assert isinstance(display, PredictionErrorDisplay)
 
     # check the structure of the attributes
@@ -170,12 +173,14 @@ def test_prediction_error_display_data_source(pyplot, regression_data):
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     display = report.metrics.plot.prediction_error(data_source="train")
+    display.plot()
     assert display.line_.get_label() == "Perfect predictions"
     assert display.scatter_.get_label() == "Train set"
 
     display = report.metrics.plot.prediction_error(
         data_source="X_y", X=X_train, y=y_train
     )
+    display.plot()
     assert display.line_.get_label() == "Perfect predictions"
     assert display.scatter_.get_label() == "Data set"
 
@@ -197,8 +202,10 @@ def test_prediction_error_display_kwargs(pyplot, regression_data):
 
     expected_subsample = 10
     display = report.metrics.plot.prediction_error(subsample=expected_subsample)
+    display.plot()
     assert len(display.scatter_.get_offsets()) == expected_subsample
 
     expected_subsample = int(X_test.shape[0] * 0.5)
     display = report.metrics.plot.prediction_error(subsample=0.5)
+    display.plot()
     assert len(display.scatter_.get_offsets()) == expected_subsample

--- a/skore/tests/unit/sklearn/plot/test_roc_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_roc_curve.py
@@ -56,6 +56,7 @@ def test_roc_curve_display_binary_classification(pyplot, binary_classification_d
         assert isinstance(attr[estimator.classes_[1]], list)
         assert len(attr[estimator.classes_[1]]) == 1
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == 1
     roc_curve_mpl = display.lines_[0]
@@ -104,6 +105,7 @@ def test_roc_curve_display_multiclass_classification(
             assert isinstance(attr[class_label], list)
             assert len(attr[class_label]) == 1
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == len(estimator.classes_)
     default_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)
@@ -141,9 +143,11 @@ def test_roc_curve_display_data_source_binary_classification(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     display = report.metrics.plot.roc(data_source="train")
+    display.plot()
     assert display.lines_[0].get_label() == "Train set (AUC = 1.00)"
 
     display = report.metrics.plot.roc(data_source="X_y", X=X_train, y=y_train)
+    display.plot()
     assert display.lines_[0].get_label() == "AUC = 1.00"
 
 
@@ -156,6 +160,7 @@ def test_roc_curve_display_data_source_multiclass_classification(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     display = report.metrics.plot.roc(data_source="train")
+    display.plot()
     for class_label in estimator.classes_:
         assert display.lines_[class_label].get_label() == (
             f"{str(class_label).title()} - train set "
@@ -163,6 +168,7 @@ def test_roc_curve_display_data_source_multiclass_classification(
         )
 
     display = report.metrics.plot.roc(data_source="X_y", X=X_train, y=y_train)
+    display.plot()
     for class_label in estimator.classes_:
         assert display.lines_[class_label].get_label() == (
             f"{str(class_label).title()} - AUC = 1.00"
@@ -267,6 +273,7 @@ def test_roc_curve_display_cross_validation_binary_classification(
         assert isinstance(attr[pos_label], list)
         assert len(attr[pos_label]) == cv
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == cv
     expected_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)
@@ -315,6 +322,7 @@ def test_roc_curve_display_cross_validation_multiclass_classification(
             assert isinstance(attr[class_label], list)
             assert len(attr[class_label]) == cv
 
+    display.plot()
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == len(class_labels) * cv
     default_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)


### PR DESCRIPTION
closes #1298 

This PR makes sure that the display factory does not call `.plot()` directly.
It allows:

- to pass plotting parameters to be passed only to `display.plot()`
- to have a consistent api as for pandas object like dataframe:

```python
report.metrics.report_metrics().plot(kind="barh")
report.metrics.roc().plot()
```