### PR TITLE
docs(fix): Explicitely call .plot() in example to show the output

### DIFF
--- a/examples/getting_started/plot_quick_start.py
+++ b/examples/getting_started/plot_quick_start.py
@@ -44,7 +44,7 @@ df_cv_report_metrics
 import matplotlib.pyplot as plt
 
 roc_plot = cv_report.metrics.roc()
-roc_plot
+roc_plot.plot()
 plt.tight_layout()
 
 # %%

--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -219,6 +219,7 @@ import matplotlib.pyplot as plt
 
 start = time.time()
 display = report.metrics.roc(pos_label="allowed")
+display.plot()
 end = time.time()
 plt.tight_layout()
 
@@ -230,6 +231,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 # The second plot is instant because it uses cached data:
 start = time.time()
 display = report.metrics.roc(pos_label="allowed")
+display.plot()
 end = time.time()
 plt.tight_layout()
 


### PR DESCRIPTION
Maybe due to the resolution of a merge conflict in #1299, it is missing some call to `.plot()`.

Here, we call explicitly and thus show the plot.

ping @thomass-dev 