### PR TITLE
docs: Allow to have dropdown menu to show the API of reporters

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -94,7 +94,7 @@ sphinx_gallery_conf = {
         # The module you locally document uses None
         "skore": None,
     },
-    "backreferences_dir": "generated",
+    "backreferences_dir": "reference/api",
     "doc_module": "skore",
     "reset_modules": (reset_mpl, "seaborn"),
     "abort_on_example_error": True,

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -58,5 +58,5 @@ Skore is just at the beginning of its journey, but we’re shipping fast! Freque
 
    install
    auto_examples/index
-   api
+   reference/index
    contributing_link

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -1,153 +1,15 @@
 API
 ===
 
-.. currentmodule:: skore
-
 This page lists all the public functions and classes of the skore package.
 
 .. warning ::
 
     This code is still in development. **The API is subject to change.**
 
-Project
--------
+.. currentmodule:: skore
 
-These functions and classes are meant for managing a Project.
+.. toctree::
+   :maxdepth: 2
 
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-    :caption: Managing a project
-
-    Project
-    Project.put
-    Project.get
-
-Get assistance when developing ML/DS projects
----------------------------------------------
-
-These functions and classes enhance scikit-learn's ones.
-
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-    :caption: ML Assistance
-
-    train_test_split
-
-Report for a single estimator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The class :class:`EstimatorReport` provides a report allowing to inspect and
-evaluate a scikit-learn estimator in an interactive way. The functionalities of the
-report are accessible through accessors.
-
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-
-    EstimatorReport
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    EstimatorReport.help
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor.rst
-
-    EstimatorReport.metrics
-
-Metrics
-"""""""
-
-The `metrics` accessor helps you to evaluate the statistical performance of your
-estimator.
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    EstimatorReport.metrics.help
-    EstimatorReport.metrics.report_metrics
-    EstimatorReport.metrics.custom_metric
-    EstimatorReport.metrics.accuracy
-    EstimatorReport.metrics.brier_score
-    EstimatorReport.metrics.log_loss
-    EstimatorReport.metrics.precision
-    EstimatorReport.metrics.precision_recall
-    EstimatorReport.metrics.prediction_error
-    EstimatorReport.metrics.r2
-    EstimatorReport.metrics.recall
-    EstimatorReport.metrics.rmse
-    EstimatorReport.metrics.roc
-    EstimatorReport.metrics.roc_auc
-
-
-Cross-validation report for an estimator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The class :class:`CrossValidationReport` provides a report allowing to inspect and
-evaluate a scikit-learn estimator through cross-validation in an interactive way. The
-functionalities of the report are accessible through accessors.
-
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-
-    CrossValidationReport
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    CrossValidationReport.help
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor.rst
-
-    CrossValidationReport.metrics
-
-Metrics
-"""""""
-
-The `metrics` accessor helps you to evaluate the statistical performance of your
-estimator during a cross-validation.
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    CrossValidationReport.metrics.help
-    CrossValidationReport.metrics.report_metrics
-    CrossValidationReport.metrics.custom_metric
-    CrossValidationReport.metrics.accuracy
-    CrossValidationReport.metrics.brier_score
-    CrossValidationReport.metrics.log_loss
-    CrossValidationReport.metrics.precision
-    CrossValidationReport.metrics.precision_recall
-    CrossValidationReport.metrics.prediction_error
-    CrossValidationReport.metrics.r2
-    CrossValidationReport.metrics.recall
-    CrossValidationReport.metrics.rmse
-    CrossValidationReport.metrics.roc
-    CrossValidationReport.metrics.roc_auc
-
-.. Deprecated
-.. ----------
-
-.. These functions and classes are deprecated.
-
-.. .. autosummary::
-..     :toctree: api/
-..     :template: base.rst
-..     :caption: Deprecated
+   report

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -15,7 +15,7 @@ Project
 These functions and classes are meant for managing a Project.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
     :caption: Managing a project
 
@@ -29,7 +29,7 @@ Get assistance when developing ML/DS projects
 These functions and classes enhance scikit-learn's ones.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
     :caption: ML Assistance
 
@@ -43,20 +43,20 @@ evaluate a scikit-learn estimator in an interactive way. The functionalities of 
 report are accessible through accessors.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
 
     EstimatorReport
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
     EstimatorReport.help
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor.rst
 
@@ -69,7 +69,7 @@ The `metrics` accessor helps you to evaluate the statistical performance of your
 estimator.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
@@ -97,20 +97,20 @@ evaluate a scikit-learn estimator through cross-validation in an interactive way
 functionalities of the report are accessible through accessors.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
 
     CrossValidationReport
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
     CrossValidationReport.help
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor.rst
 
@@ -123,7 +123,7 @@ The `metrics` accessor helps you to evaluate the statistical performance of your
 estimator during a cross-validation.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
@@ -148,6 +148,6 @@ estimator during a cross-validation.
 .. These functions and classes are deprecated.
 
 .. .. autosummary::
-..     :toctree: generated/
+..     :toctree: api/
 ..     :template: base.rst
 ..     :caption: Deprecated

--- a/sphinx/reference/report.rst
+++ b/sphinx/reference/report.rst
@@ -1,0 +1,18 @@
+Report
+======
+
+.. currentmodule:: skore
+
+This section contains documentation for different types of reports available in skore.
+
+Single Estimator Report
+-----------------------
+
+The :doc:`report/estimator_report` provides comprehensive reporting capabilities for individual
+scikit-learn estimators, including metrics, visualizations, and evaluation tools.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   report/estimator_report

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -36,7 +36,7 @@ The `metrics` accessor helps you to evaluate the statistical performance of your
 estimator.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -17,7 +17,7 @@ report are accessible through accessors.
 
 .. autosummary::
    :toctree: ../api/
-   :template: base.rst
+   :template: autosummary/accessor_method.rst
 
    EstimatorReport.help
 
@@ -25,20 +25,32 @@ report are accessible through accessors.
 
 .. autosummary::
    :toctree: ../api/
-   :template: base.rst
+   :template: autosummary/accessor.rst
 
    EstimatorReport.metrics
-   EstimatorReport.metrics.help
-   EstimatorReport.metrics.report_metrics
-   EstimatorReport.metrics.custom_metric
-   EstimatorReport.metrics.accuracy
-   EstimatorReport.metrics.brier_score
-   EstimatorReport.metrics.log_loss
-   EstimatorReport.metrics.precision
-   EstimatorReport.metrics.precision_recall
-   EstimatorReport.metrics.prediction_error
-   EstimatorReport.metrics.r2
-   EstimatorReport.metrics.recall
-   EstimatorReport.metrics.rmse
-   EstimatorReport.metrics.roc
-   EstimatorReport.metrics.roc_auc
+
+Metrics
+-------
+
+The `metrics` accessor helps you to evaluate the statistical performance of your
+estimator.
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+    :template: autosummary/accessor_method.rst
+
+    EstimatorReport.metrics.help
+    EstimatorReport.metrics.report_metrics
+    EstimatorReport.metrics.custom_metric
+    EstimatorReport.metrics.accuracy
+    EstimatorReport.metrics.brier_score
+    EstimatorReport.metrics.log_loss
+    EstimatorReport.metrics.precision
+    EstimatorReport.metrics.precision_recall
+    EstimatorReport.metrics.prediction_error
+    EstimatorReport.metrics.r2
+    EstimatorReport.metrics.recall
+    EstimatorReport.metrics.rmse
+    EstimatorReport.metrics.roc
+    EstimatorReport.metrics.roc_auc

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -1,0 +1,44 @@
+Report for a single estimator
+============================
+
+.. currentmodule:: skore
+
+The class :class:`EstimatorReport` provides a report allowing to inspect and
+evaluate a scikit-learn estimator in an interactive way. The functionalities of the
+report are accessible through accessors.
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   EstimatorReport
+
+.. rubric:: Methods
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   EstimatorReport.help
+
+.. rubric:: Metrics
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   EstimatorReport.metrics
+   EstimatorReport.metrics.help
+   EstimatorReport.metrics.report_metrics
+   EstimatorReport.metrics.custom_metric
+   EstimatorReport.metrics.accuracy
+   EstimatorReport.metrics.brier_score
+   EstimatorReport.metrics.log_loss
+   EstimatorReport.metrics.precision
+   EstimatorReport.metrics.precision_recall
+   EstimatorReport.metrics.prediction_error
+   EstimatorReport.metrics.r2
+   EstimatorReport.metrics.recall
+   EstimatorReport.metrics.rmse
+   EstimatorReport.metrics.roc
+   EstimatorReport.metrics.roc_auc


### PR DESCRIPTION
closes #1095 

It is a wip PR to show that we can get a sort of dropdown menu with several level to show the API documentation of reporters, without the feeling that there is so much information at the top level.

The trick is to have a directory structure:

```
reference/
├── index.rst
├── report.rst
└── report/
    └── estimator_report.rst
```

that creates the tree on the navigation sidebar. The not ideal thing is the content of  `report.rst`. We need to think what content we want in this intermediate page. However, I think it is a good start to explore.

A couple of screen:

![image](https://github.com/user-attachments/assets/80cbcb8c-878b-4a63-96e1-61a72711a3c1)

![image](https://github.com/user-attachments/assets/97ea0ee3-0574-4fb0-b295-eea96819619d)

(I obviously broke the API auto-generated documentation but it should be possible to fix it).