### PR TITLE
feat: Change repr method of `EstimatorReport` and `CrossValidationReport`

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -323,7 +323,5 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         )
 
     def __repr__(self):
-        """Return a string representation using rich."""
-        return self._rich_repr(
-            class_name="skore.CrossValidationReport", help_method_name="help()"
-        )
+        """Return a string representation."""
+        return f"{self.__class__.__name__}(estimator={self.estimator_}, ...)"

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -326,7 +326,5 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         )
 
     def __repr__(self):
-        """Return a string representation using rich."""
-        return self._rich_repr(
-            class_name="skore.EstimatorReport", help_method_name="help()"
-        )
+        """Return a string representation."""
+        return f"{self.__class__.__name__}(estimator={self.estimator_}, ...)"

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -169,8 +169,7 @@ def test_cross_validation_report_repr(binary_classification_data):
     report = CrossValidationReport(estimator, X, y)
 
     repr_str = repr(report)
-    assert "skore.CrossValidationReport" in repr_str
-    assert "help()" in repr_str
+    assert "CrossValidationReport" in repr_str
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/sklearn/test_estimator.py
+++ b/skore/tests/unit/sklearn/test_estimator.py
@@ -291,8 +291,7 @@ def test_estimator_report_repr(binary_classification_data):
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
     repr_str = repr(report)
-    assert "skore.EstimatorReport" in repr_str
-    assert "help()" in repr_str
+    assert "EstimatorReport" in repr_str
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This makes it more practical to print objects containing such reports,
e.g. `[report]`.

Closes #1293
