### PR TITLE
ci: Fix backend workflow to cache venv using exact python version

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -86,8 +86,10 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ matrix.python }}
+          check-latest: True
           cache: pip
 
       - name: Restore python-venv
@@ -98,7 +100,7 @@ jobs:
           key: >-
             python-venv
             -${{ matrix.os }}
-            -${{ matrix.python }}
+            -${{ steps.setup-python.outputs.python-version }}
             -${{ hashFiles(format('skore/ci/requirements/python-{0}/scikit-learn-{1}/test-requirements.txt', matrix.python, matrix.scikit-learn)) }}
 
       - name: Setup python-venv


### PR DESCRIPTION
Cache venv using exact python version to fix failing pipelines https://github.com/probabl-ai/skore/actions/runs/13260129137/job/37014601717?pr=1305.

References:

https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#check-latest-version
https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python-version

---

![image](https://github.com/user-attachments/assets/e60dacb5-ded7-49d8-92d0-1e3896b1d9ab)
![image](https://github.com/user-attachments/assets/4d777563-55e4-4bfb-9a66-83e0f4b5b17a)