### PR TITLE
docs(api): Change structure to enable dropdowns in sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,7 +185,7 @@ tramp
 # Sphinx documentation
 sphinx/build/
 sphinx/auto_examples/
-sphinx/generated/
+sphinx/reference/api/
 sphinx/sg_execution_times.rst
 examples/plot_*.png
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -177,7 +177,7 @@ Skipping examples when building the docs
 
 The examples can take a long time to build, so if you are not working on them you can instead run `make html-noplot` to avoid building them altogether.
 
-If you are working on an example and wish to only build that one, you can do so by temporarily editing `sphinx/conf.py`. Follow `the sphinx-gallery documentation https://sphinx-gallery.github.io/stable/configuration.html#parsing-and-executing-examples-via-matching-patterns` for more information.
+If you are working on an example and wish to only build that one, you can do so by temporarily editing `sphinx/conf.py`. Follow `the sphinx-gallery documentation <https://sphinx-gallery.github.io/stable/configuration.html#parsing-and-executing-examples-via-matching-patterns>`_ for more information.
 By default, the examples that are built are Python files that start with `plot_`.
 
 Note that by default, if an example has not changed since the last time you built it, it will not be re-built.
@@ -210,4 +210,4 @@ Contributing to the ReadMe
 --------------------------
 
 The README.md file can be modified and is part of the documentation.
-This file is used to be presented on [PyPI](https://pypi.org/project/skore/#description).
+This file is used to be presented on `PyPI <https://pypi.org/project/skore/#description>`_.

--- a/sphinx/_static/css/custom.css
+++ b/sphinx/_static/css/custom.css
@@ -110,17 +110,16 @@ div.docutils.container.index-box {
 
 
 /* Change the colors to the orange and blue of skore */
-
 html[data-theme="dark"]{
-    --pst-color-primary: #F89A36;
-    --pst-color-secondary: #3499CD;
+    --pst-color-primary: #f89a36;
+    --pst-color-secondary: #3499cd;
+    --pst-color-inline-code-links: var(--pst-color-primary);
 }
 
 /* 
-choose darker colors for light to ensure at least AA contrast https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast 
+Choose darker colors for light to ensure at least AA contrast https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast 
 Tool to test: https://docusaurus.io/docs/styling-layout
 */
-
 html[data-theme="light"]{
     --pst-color-primary: #ad5d06;
     --pst-color-secondary: #297ba6;

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -95,7 +95,7 @@ sphinx_gallery_conf = {
         # The module you locally document uses None
         "skore": None,
     },
-    "backreferences_dir": "generated",
+    "backreferences_dir": "reference/api",
     "doc_module": "skore",
     "reset_modules": (reset_mpl, "seaborn"),
     "abort_on_example_error": True,

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -58,5 +58,5 @@ Skore is just at the beginning of its journey, but we’re shipping fast! Freque
 
    install
    auto_examples/index
-   api
+   reference/index
    contributing

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -12,5 +12,5 @@ This page lists all the public functions and classes of the skore package.
 .. toctree::
    :maxdepth: 2
 
-   project
-   report/index
+   Managing a project <project>
+   ML Assistance <report/index>

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -1,153 +1,15 @@
 API
 ===
 
-.. currentmodule:: skore
-
 This page lists all the public functions and classes of the skore package.
 
 .. warning ::
 
     This code is still in development. **The API is subject to change.**
 
-Project
--------
+.. currentmodule:: skore
 
-These functions and classes are meant for managing a Project.
+.. toctree::
+   :maxdepth: 2
 
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-    :caption: Managing a project
-
-    Project
-    Project.put
-    Project.get
-
-Get assistance when developing ML/DS projects
----------------------------------------------
-
-These functions and classes enhance scikit-learn's ones.
-
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-    :caption: ML Assistance
-
-    train_test_split
-
-Report for a single estimator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The class :class:`EstimatorReport` provides a report allowing to inspect and
-evaluate a scikit-learn estimator in an interactive way. The functionalities of the
-report are accessible through accessors.
-
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-
-    EstimatorReport
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    EstimatorReport.help
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor.rst
-
-    EstimatorReport.metrics
-
-Metrics
-"""""""
-
-The `metrics` accessor helps you to evaluate the statistical performance of your
-estimator.
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    EstimatorReport.metrics.help
-    EstimatorReport.metrics.report_metrics
-    EstimatorReport.metrics.custom_metric
-    EstimatorReport.metrics.accuracy
-    EstimatorReport.metrics.brier_score
-    EstimatorReport.metrics.log_loss
-    EstimatorReport.metrics.precision
-    EstimatorReport.metrics.precision_recall
-    EstimatorReport.metrics.prediction_error
-    EstimatorReport.metrics.r2
-    EstimatorReport.metrics.recall
-    EstimatorReport.metrics.rmse
-    EstimatorReport.metrics.roc
-    EstimatorReport.metrics.roc_auc
-
-
-Cross-validation report for an estimator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The class :class:`CrossValidationReport` provides a report allowing to inspect and
-evaluate a scikit-learn estimator through cross-validation in an interactive way. The
-functionalities of the report are accessible through accessors.
-
-.. autosummary::
-    :toctree: api/
-    :template: base.rst
-
-    CrossValidationReport
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    CrossValidationReport.help
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor.rst
-
-    CrossValidationReport.metrics
-
-Metrics
-"""""""
-
-The `metrics` accessor helps you to evaluate the statistical performance of your
-estimator during a cross-validation.
-
-.. autosummary::
-    :toctree: api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
-
-    CrossValidationReport.metrics.help
-    CrossValidationReport.metrics.report_metrics
-    CrossValidationReport.metrics.custom_metric
-    CrossValidationReport.metrics.accuracy
-    CrossValidationReport.metrics.brier_score
-    CrossValidationReport.metrics.log_loss
-    CrossValidationReport.metrics.precision
-    CrossValidationReport.metrics.precision_recall
-    CrossValidationReport.metrics.prediction_error
-    CrossValidationReport.metrics.r2
-    CrossValidationReport.metrics.recall
-    CrossValidationReport.metrics.rmse
-    CrossValidationReport.metrics.roc
-    CrossValidationReport.metrics.roc_auc
-
-.. Deprecated
-.. ----------
-
-.. These functions and classes are deprecated.
-
-.. .. autosummary::
-..     :toctree: api/
-..     :template: base.rst
-..     :caption: Deprecated
+   report

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -12,4 +12,5 @@ This page lists all the public functions and classes of the skore package.
 .. toctree::
    :maxdepth: 2
 
+   project
    report/index

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -15,7 +15,7 @@ Project
 These functions and classes are meant for managing a Project.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
     :caption: Managing a project
 
@@ -29,7 +29,7 @@ Get assistance when developing ML/DS projects
 These functions and classes enhance scikit-learn's ones.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
     :caption: ML Assistance
 
@@ -43,20 +43,20 @@ evaluate a scikit-learn estimator in an interactive way. The functionalities of 
 report are accessible through accessors.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
 
     EstimatorReport
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
     EstimatorReport.help
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor.rst
 
@@ -69,7 +69,7 @@ The `metrics` accessor helps you to evaluate the statistical performance of your
 estimator.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
@@ -97,20 +97,20 @@ evaluate a scikit-learn estimator through cross-validation in an interactive way
 functionalities of the report are accessible through accessors.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :template: base.rst
 
     CrossValidationReport
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
     CrossValidationReport.help
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor.rst
 
@@ -123,7 +123,7 @@ The `metrics` accessor helps you to evaluate the statistical performance of your
 estimator during a cross-validation.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 
@@ -148,6 +148,6 @@ estimator during a cross-validation.
 .. These functions and classes are deprecated.
 
 .. .. autosummary::
-..     :toctree: generated/
+..     :toctree: api/
 ..     :template: base.rst
 ..     :caption: Deprecated

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -12,4 +12,4 @@ This page lists all the public functions and classes of the skore package.
 .. toctree::
    :maxdepth: 2
 
-   report
+   report/index

--- a/sphinx/reference/project.rst
+++ b/sphinx/reference/project.rst
@@ -1,0 +1,14 @@
+Managing a project
+------------------
+
+.. currentmodule:: skore
+
+These functions and classes are meant for managing a Project.
+
+.. autosummary::
+    :toctree: api/
+    :template: base.rst
+
+    Project
+    Project.put
+    Project.get

--- a/sphinx/reference/report.rst
+++ b/sphinx/reference/report.rst
@@ -1,0 +1,18 @@
+Report
+======
+
+.. currentmodule:: skore
+
+This section contains documentation for different types of reports available in skore.
+
+Single Estimator Report
+-----------------------
+
+The :doc:`report/estimator_report` provides comprehensive reporting capabilities for individual
+scikit-learn estimators, including metrics, visualizations, and evaluation tools.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   report/estimator_report

--- a/sphinx/reference/report/cross_validation_report.rst
+++ b/sphinx/reference/report/cross_validation_report.rst
@@ -1,0 +1,54 @@
+Report for a cross-validation of an estimator
+=============================================
+
+.. currentmodule:: skore
+
+The class :class:`CrossValidationReport` performs cross-validation and provides a report to inspect and evaluate a scikit-learn estimator in an interactive way. The functionalities of the report are exposed through accessors.
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   CrossValidationReport
+
+.. rubric:: Methods
+
+.. autosummary::
+   :toctree: ../api/
+   :template: autosummary/accessor_method.rst
+
+   CrossValidationReport.help
+
+.. rubric:: Metrics
+
+.. autosummary::
+   :toctree: ../api/
+   :template: autosummary/accessor.rst
+
+   CrossValidationReport.metrics
+
+Metrics
+-------
+
+The `metrics` accessor helps you to evaluate the statistical performance of your
+estimator across cross-validation folds.
+
+.. autosummary::
+    :toctree: ../api/
+    :nosignatures:
+    :template: autosummary/accessor_method.rst
+
+    CrossValidationReport.metrics.help
+    CrossValidationReport.metrics.report_metrics
+    CrossValidationReport.metrics.custom_metric
+    CrossValidationReport.metrics.accuracy
+    CrossValidationReport.metrics.brier_score
+    CrossValidationReport.metrics.log_loss
+    CrossValidationReport.metrics.precision
+    CrossValidationReport.metrics.precision_recall
+    CrossValidationReport.metrics.prediction_error
+    CrossValidationReport.metrics.r2
+    CrossValidationReport.metrics.recall
+    CrossValidationReport.metrics.rmse
+    CrossValidationReport.metrics.roc
+    CrossValidationReport.metrics.roc_auc

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -36,7 +36,7 @@ The `metrics` accessor helps you to evaluate the statistical performance of your
 estimator.
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../api/
     :nosignatures:
     :template: autosummary/accessor_method.rst
 

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -17,7 +17,7 @@ report are accessible through accessors.
 
 .. autosummary::
    :toctree: ../api/
-   :template: base.rst
+   :template: autosummary/accessor_method.rst
 
    EstimatorReport.help
 
@@ -25,20 +25,32 @@ report are accessible through accessors.
 
 .. autosummary::
    :toctree: ../api/
-   :template: base.rst
+   :template: autosummary/accessor.rst
 
    EstimatorReport.metrics
-   EstimatorReport.metrics.help
-   EstimatorReport.metrics.report_metrics
-   EstimatorReport.metrics.custom_metric
-   EstimatorReport.metrics.accuracy
-   EstimatorReport.metrics.brier_score
-   EstimatorReport.metrics.log_loss
-   EstimatorReport.metrics.precision
-   EstimatorReport.metrics.precision_recall
-   EstimatorReport.metrics.prediction_error
-   EstimatorReport.metrics.r2
-   EstimatorReport.metrics.recall
-   EstimatorReport.metrics.rmse
-   EstimatorReport.metrics.roc
-   EstimatorReport.metrics.roc_auc
+
+Metrics
+-------
+
+The `metrics` accessor helps you to evaluate the statistical performance of your
+estimator.
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+    :template: autosummary/accessor_method.rst
+
+    EstimatorReport.metrics.help
+    EstimatorReport.metrics.report_metrics
+    EstimatorReport.metrics.custom_metric
+    EstimatorReport.metrics.accuracy
+    EstimatorReport.metrics.brier_score
+    EstimatorReport.metrics.log_loss
+    EstimatorReport.metrics.precision
+    EstimatorReport.metrics.precision_recall
+    EstimatorReport.metrics.prediction_error
+    EstimatorReport.metrics.r2
+    EstimatorReport.metrics.recall
+    EstimatorReport.metrics.rmse
+    EstimatorReport.metrics.roc
+    EstimatorReport.metrics.roc_auc

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -1,0 +1,44 @@
+Report for a single estimator
+============================
+
+.. currentmodule:: skore
+
+The class :class:`EstimatorReport` provides a report allowing to inspect and
+evaluate a scikit-learn estimator in an interactive way. The functionalities of the
+report are accessible through accessors.
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   EstimatorReport
+
+.. rubric:: Methods
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   EstimatorReport.help
+
+.. rubric:: Metrics
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   EstimatorReport.metrics
+   EstimatorReport.metrics.help
+   EstimatorReport.metrics.report_metrics
+   EstimatorReport.metrics.custom_metric
+   EstimatorReport.metrics.accuracy
+   EstimatorReport.metrics.brier_score
+   EstimatorReport.metrics.log_loss
+   EstimatorReport.metrics.precision
+   EstimatorReport.metrics.precision_recall
+   EstimatorReport.metrics.prediction_error
+   EstimatorReport.metrics.r2
+   EstimatorReport.metrics.recall
+   EstimatorReport.metrics.rmse
+   EstimatorReport.metrics.roc
+   EstimatorReport.metrics.roc_auc

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -1,5 +1,5 @@
 Report for a single estimator
-============================
+=============================
 
 .. currentmodule:: skore
 

--- a/sphinx/reference/report/index.rst
+++ b/sphinx/reference/report/index.rst
@@ -16,3 +16,14 @@ scikit-learn estimators, including metrics, visualizations, and evaluation tools
    :hidden:
 
    estimator_report
+
+Cross-validation Report
+-----------------------
+
+:class:`skore.CrossValidationReport` provides comprehensive capabilities for evaluating scikit-learn estimators by cross-validation, and reporting the results.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   cross_validation_report

--- a/sphinx/reference/report/index.rst
+++ b/sphinx/reference/report/index.rst
@@ -1,5 +1,5 @@
-Report
-======
+ML Assistance
+=============
 
 .. currentmodule:: skore
 
@@ -8,11 +8,11 @@ This section contains documentation for different types of reports available in 
 Single Estimator Report
 -----------------------
 
-The :doc:`report/estimator_report` provides comprehensive reporting capabilities for individual
+:class:`skore.EstimatorReport` provides comprehensive reporting capabilities for individual
 scikit-learn estimators, including metrics, visualizations, and evaluation tools.
 
 .. toctree::
    :maxdepth: 2
    :hidden:
 
-   report/estimator_report
+   estimator_report

--- a/sphinx/reference/report/index.rst
+++ b/sphinx/reference/report/index.rst
@@ -3,7 +3,18 @@ ML Assistance
 
 .. currentmodule:: skore
 
-This section contains documentation for different types of reports available in skore.
+This section contains documentation for skore features that enhance the ML development process.
+
+Get assistance when developing ML/DS projects
+---------------------------------------------
+
+These functions and classes build upon scikit-learn's functionality.
+
+.. autosummary::
+    :toctree: ../api/
+    :template: base.rst
+
+    train_test_split
 
 Single Estimator Report
 -----------------------


### PR DESCRIPTION
Our sphinx theme automatically adds dropdowns in the sidebar when the docs are nested in directories and subdirectories. This PR changes the structure of the docs to enable dropdowns.

One trade-off is that `toctree` and `autosummary` cannot both be used, so in the API index page, we no longer have a table-formatted list of all the public API functions and classes.

Before:
<image src="https://github.com/user-attachments/assets/0e547f3a-7b07-4f7a-be8e-79eb9e752a95" width="50%"></image>

After:
<image src="https://github.com/user-attachments/assets/385e8797-9791-49a4-b19c-c18bf6232c84" width="50%"></image>

Supersedes #1302

Closes #1095

Co-authored-by: Guillaume Lemaitre <guillaume@probabl.ai>
