### PR TITLE
docs: Document the different displays as part of public API

### DIFF
--- a/skore/src/skore/__init__.py
+++ b/skore/src/skore/__init__.py
@@ -9,6 +9,9 @@ from skore.project import Project, open
 from skore.sklearn import (
     CrossValidationReport,
     EstimatorReport,
+    PrecisionRecallCurveDisplay,
+    PredictionErrorDisplay,
+    RocCurveDisplay,
     train_test_split,
 )
 from skore.utils._patch import setup_jupyter_display
@@ -17,7 +20,10 @@ from skore.utils._show_versions import show_versions
 __all__ = [
     "CrossValidationReport",
     "EstimatorReport",
+    "PrecisionRecallCurveDisplay",
+    "PredictionErrorDisplay",
     "Project",
+    "RocCurveDisplay",
     "open",
     "show_versions",
     "train_test_split",

--- a/skore/src/skore/sklearn/__init__.py
+++ b/skore/src/skore/sklearn/__init__.py
@@ -2,10 +2,18 @@
 
 from skore.sklearn._cross_validation import CrossValidationReport
 from skore.sklearn._estimator import EstimatorReport
+from skore.sklearn._plot import (
+    PrecisionRecallCurveDisplay,
+    PredictionErrorDisplay,
+    RocCurveDisplay,
+)
 from skore.sklearn.train_test_split.train_test_split import train_test_split
 
 __all__ = [
     "train_test_split",
     "CrossValidationReport",
     "EstimatorReport",
+    "RocCurveDisplay",
+    "PrecisionRecallCurveDisplay",
+    "PredictionErrorDisplay",
 ]

--- a/sphinx/reference/report/cross_validation_report.rst
+++ b/sphinx/reference/report/cross_validation_report.rst
@@ -3,7 +3,9 @@ Report for a cross-validation of an estimator
 
 .. currentmodule:: skore
 
-The class :class:`CrossValidationReport` performs cross-validation and provides a report to inspect and evaluate a scikit-learn estimator in an interactive way. The functionalities of the report are exposed through accessors.
+The class :class:`CrossValidationReport` performs cross-validation and provides a report
+to inspect and evaluate a scikit-learn estimator in an interactive way. The
+functionalities of the report are exposed through accessors.
 
 .. autosummary::
    :toctree: ../api/

--- a/sphinx/reference/report/displays.rst
+++ b/sphinx/reference/report/displays.rst
@@ -1,0 +1,15 @@
+Visualization Displays
+======================
+
+.. currentmodule:: skore
+
+A set of displays are available through the different reports. Find in this section
+the API of each display.
+
+.. autosummary::
+   :toctree: ../api/
+   :template: base.rst
+
+   RocCurveDisplay
+   PrecisionRecallCurveDisplay
+   PredictionErrorDisplay

--- a/sphinx/reference/report/index.rst
+++ b/sphinx/reference/report/index.rst
@@ -3,7 +3,8 @@ ML Assistance
 
 .. currentmodule:: skore
 
-This section contains documentation for skore features that enhance the ML development process.
+This section contains documentation for skore features that enhance the ML development
+process.
 
 Get assistance when developing ML/DS projects
 ---------------------------------------------
@@ -19,8 +20,9 @@ These functions and classes build upon scikit-learn's functionality.
 Single Estimator Report
 -----------------------
 
-:class:`skore.EstimatorReport` provides comprehensive reporting capabilities for individual
-scikit-learn estimators, including metrics, visualizations, and evaluation tools.
+:class:`skore.EstimatorReport` provides comprehensive reporting capabilities for
+individual scikit-learn estimators, including metrics, visualizations, and evaluation
+tools.
 
 .. toctree::
    :maxdepth: 2
@@ -31,10 +33,23 @@ scikit-learn estimators, including metrics, visualizations, and evaluation tools
 Cross-validation Report
 -----------------------
 
-:class:`skore.CrossValidationReport` provides comprehensive capabilities for evaluating scikit-learn estimators by cross-validation, and reporting the results.
+:class:`skore.CrossValidationReport` provides comprehensive capabilities for evaluating
+scikit-learn estimators by cross-validation, and reporting the results.
 
 .. toctree::
    :maxdepth: 2
    :hidden:
 
    cross_validation_report
+
+Visualization Displays
+----------------------
+
+A set of displays are available through the different reports. Find in this section
+the API of each display.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   displays


### PR DESCRIPTION
closes #1328 

Document the different displays since they are part of the public API.