### PR TITLE
fix: Do not use aspect ratio of 1 for residual plot

### DIFF
--- a/skore/src/skore/sklearn/_plot/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/prediction_error.py
@@ -259,7 +259,6 @@ class PredictionErrorDisplay(HelpDisplayMixin):
         else:
             self.line_ = ax.plot(x_range_perfect_pred, [0, 0], **perfect_line_kwargs)[0]
             ax.set(
-                aspect="equal",
                 xlim=x_range_perfect_pred,
                 ylim=y_range_perfect_pred,
                 xticks=np.linspace(

--- a/skore/tests/unit/sklearn/plot/test_prediction_error.py
+++ b/skore/tests/unit/sklearn/plot/test_prediction_error.py
@@ -73,6 +73,8 @@ def test_prediction_error_display_regression(pyplot, regression_data, subsample)
     assert display.ax_.get_xlabel() == "Predicted values"
     assert display.ax_.get_ylabel() == "Residuals (actual - predicted)"
 
+    assert display.ax_.get_aspect() not in ("equal", 1.0)
+
 
 def test_prediction_error_cross_validation_display_regression(
     pyplot, regression_data_no_split
@@ -104,6 +106,8 @@ def test_prediction_error_cross_validation_display_regression(
 
     assert display.ax_.get_xlabel() == "Predicted values"
     assert display.ax_.get_ylabel() == "Residuals (actual - predicted)"
+
+    assert display.ax_.get_aspect() not in ("equal", 1.0)
 
 
 def test_prediction_error_display_regression_kind(pyplot, regression_data):
@@ -163,6 +167,8 @@ def test_prediction_error_cross_validation_display_regression_kind(
 
     assert display.ax_.get_xlabel() == "Predicted values"
     assert display.ax_.get_ylabel() == "Actual values"
+
+    assert display.ax_.get_aspect() in ("equal", 1.0)
 
 
 def test_prediction_error_display_data_source(pyplot, regression_data):


### PR DESCRIPTION
closes #1292 

We forced the aspect ratio of 1.0 for the residual plot. However the residual is computing `actual vs predicted` and the scale of the residual can be really different from the prediction if the error is low, explaining the problem of the plot.

This PR only set the aspect ratio for the actual vs predicted plot only.