### PR TITLE
docs: Avoid creating project in docstring

### DIFF
--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -47,8 +47,8 @@ class Project:
     --------
     >>> import skore
     >>> project = skore.Project("my-xp")
-    >>> project.put("score", 1.0)
-    >>> project.get("score")
+    >>> project.put("score", 1.0)  # doctest: +SKIP
+    >>> project.get("score")  # doctest: +SKIP
     1.0
     """
 

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -46,7 +46,7 @@ class Project:
     Examples
     --------
     >>> import skore
-    >>> project = skore.Project("my-xp")
+    >>> project = skore.Project("my-xp")  # doctest: +SKIP
     >>> project.put("score", 1.0)  # doctest: +SKIP
     >>> project.get("score")  # doctest: +SKIP
     1.0


### PR DESCRIPTION
Follow-up #1333 

Avoid to execute the `project.put` and `project.get` in the docstring of `Project`.