### PR TITLE
docs: Change config_context docs

### DIFF
--- a/skore/src/skore/_config.py
+++ b/skore/src/skore/_config.py
@@ -30,7 +30,7 @@ def get_config():
 
     See Also
     --------
-    config_context : Context manager for global skore configuration.
+    config_context : Context manager for local skore configuration.
     set_config : Set global skore configuration.
 
     Examples
@@ -57,7 +57,7 @@ def set_config(
 
     See Also
     --------
-    config_context : Context manager for global skore configuration.
+    config_context : Context manager for local skore configuration.
     get_config : Retrieve current values of the global configuration.
 
     Examples
@@ -76,7 +76,7 @@ def config_context(
     *,
     show_progress: bool = None,
 ):
-    """Context manager for global skore configuration.
+    """Context manager for local skore configuration.
 
     Parameters
     ----------


### PR DESCRIPTION
From the example given in config_context, I understand that it is not global, as apposed to set_config, but rather a local behavior. Is it correct?  
In any case, the current docs is blurry to me, because it doesn't appear at first sight what is the difference between `set_config` and `config_context`.