### PR TITLE
ci: Fix temporarily the version of `sphinx` to `<8.2.0`

### DIFF
--- a/skore/sphinx-requirements.in
+++ b/skore/sphinx-requirements.in
@@ -5,7 +5,7 @@ polars
 kaleido
 pydata-sphinx-theme
 sentence-transformers
-sphinx
+sphinx<8.2.0
 sphinx_autosummary_accessors
 sphinx-design
 sphinx-gallery


### PR DESCRIPTION
Originally addressed by @glemaitre.

> We should temporary pin sphinx to 8.1.3 when building the documentation. They released 3 hours ago and it broke our CI
> Basically, the autosummary extension is broken because the signature of this function was changed: [https://github.com/xarray-contrib/sphinx-autosummary-accessors/blob/b230c4ea37bf3c[…]8f3179093439001ca7d/sphinx_autosummary_accessors/autosummary.py](https://github.com/xarray-contrib/sphinx-autosummary-accessors/blob/b230c4ea37bf3cf9fd1128f3179093439001ca7d/sphinx_autosummary_accessors/autosummary.py#L22C5-L22C36)

Example of broken pipeline: https://github.com/probabl-ai/skore/actions/runs/13408165303/job/37452025719