### PR TITLE
ci: Fix sphinx pipeline

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -106,19 +106,12 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - shell: bash
-        run: wget -qO- "${SKRUB_DATA_URL}" | tar -zxvf - -C "${HOME}"
-        env:
-          SKRUB_DATA_URL: https://skore.probabl.ai/f355443be646d49eab1aa76e29dfd0a8/skrub-data.tar.gz
-          HOME: ${{ github.workspace }}
       - uses: ./.github/actions/sphinx/build
         timeout-minutes: 60
         with:
           SPHINX_VERSION: ${{ needs.sphinx-version.outputs.SPHINX_VERSION }}
           SPHINX_RELEASE: ${{ needs.sphinx-version.outputs.SPHINX_RELEASE }}
           SPHINX_DOMAIN: ${{ vars.DOCUMENTATION_DOMAIN }}
-        env:
-          HOME: ${{ github.workspace }}
       - uses: actions/upload-artifact@v4
         with:
           name: sphinx-html-artifact


### PR DESCRIPTION
Removes the temporary fix introduced to download `skrub` resources when OpenML was inaccessible.

![image](https://github.com/user-attachments/assets/bc328c20-a5aa-45f4-b426-1ffce25376cf)

Removes `HOME` envar overload which modified the `pip-cache` directory used in the sphinx build action, which differed from the `pip-cache` directory used in the calling workflow causing [errors](https://github.com/probabl-ai/skore/actions/runs/13583937631/job/37974812004).

![image](https://github.com/user-attachments/assets/ad5648d2-fa27-4b40-8da7-9b444239e2ca)
