### PR TITLE
ci(licenses): Check Python requirements licenses

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -1,0 +1,35 @@
+name: check-licenses
+
+on:
+  pull_request:
+    paths:
+      - 'skore/requirements.in'
+      - 'skore/pyproject.toml'
+      - '.github/workflows/check-licenses.yaml'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: "bash"
+
+jobs:
+  check-python-licenses:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - run: pip install -U pip setuptools liccheck==0.9.2
+
+      - run: pip install ./skore
+
+      - name: Check Skore dependencies with liccheck
+        working-directory: ./skore
+        run: liccheck

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -136,3 +136,33 @@ exclude = ["src/skore/externals/.*", "ci/*", "hatch/*", "tests/*"]
 [[tool.mypy.overrides]]
 module = ["diskcache.*", "sklearn.*"]
 ignore_missing_imports = true
+
+[tool.liccheck]
+authorized_licenses = [
+    "bsd",
+    "new bsd",
+    "bsd license",
+    "new bsd license",
+    "simplified bsd",
+    "apache",
+    "apache 2.0",
+    "apache software license",
+    "gnu lgpl",
+    "lgpl with exceptions or zpl",
+    "isc license",
+    "isc license (iscl)",
+    "mit",
+    "mit license",
+    "Mozilla Public License.*",
+    "python software foundation.*",
+    "The Unlicense.*",
+    "wtfpl",
+    "zpl 2.1",
+]
+unauthorized_licenses = [
+    "\bagpl",
+    "\bgpl",
+]
+as_regex = true
+level = "PARANOID"
+requirement_txt_file = "./requirements.in"


### PR DESCRIPTION
Using [liccheck](https://pypi.org/project/liccheck/) to check Python dependencies licenses.

Note: I'm using the `paranoid` mode of liccheck so if you use a dependency with a new license you need to add it in `authorized_licenses` section.

https://github.com/probabl-ai/skore/issues/60