### PR TITLE
docs: Fix `plot_tracking_items.py` for figure display

### DIFF
--- a/examples/skore_project/plot_tracking_items.py
+++ b/examples/skore_project/plot_tracking_items.py
@@ -107,10 +107,10 @@ fig = px.line(
     markers=True,
 )
 fig.update_layout(xaxis_type="category")
-fig
 # sphinx_gallery_start_ignore
 temp_dir.cleanup()
 # sphinx_gallery_end_ignore
+fig
 
 # %%
 # .. note::


### PR DESCRIPTION
### Problem

The plotly figure is not displayed:

![Capture d’écran 2025-03-09 à 10 35 40](https://github.com/user-attachments/assets/772951ec-17bd-42ce-b58a-ef875cbf8916)