### PR TITLE
ci: Ensure mypy checks are valid

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Lint
         working-directory: skore/
-        run: pre-commit run --all-files ruff
+        run: |
+          pre-commit run --all-files ruff
+          pre-commit run --all-files mypy
 
   backend-lockfiles:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Missing in https://github.com/probabl-ai/skore/pull/1337, call `mypy` from `pre-commit` in the GH pipelines.