### PR TITLE
test: Make it possible to ignore a whole block of doctests

### DIFF
--- a/skore/ci/requirements/python-3.10/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.10/scikit-learn-1.6/test-requirements.txt
@@ -189,3 +189,5 @@ urllib3==2.3.0
     # via requests
 virtualenv==20.29.1
     # via pre-commit
+xdoctest==1.2.0
+    # via skore (skore/pyproject.toml)

--- a/skore/ci/requirements/python-3.11/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.11/scikit-learn-1.6/test-requirements.txt
@@ -184,3 +184,5 @@ urllib3==2.3.0
     # via requests
 virtualenv==20.29.1
     # via pre-commit
+xdoctest==1.2.0
+    # via skore (skore/pyproject.toml)

--- a/skore/ci/requirements/python-3.12/scikit-learn-1.4/test-requirements.txt
+++ b/skore/ci/requirements/python-3.12/scikit-learn-1.4/test-requirements.txt
@@ -182,3 +182,5 @@ urllib3==2.3.0
     # via requests
 virtualenv==20.29.1
     # via pre-commit
+xdoctest==1.2.0
+    # via skore (skore/pyproject.toml)

--- a/skore/ci/requirements/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/skore/ci/requirements/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -182,3 +182,5 @@ urllib3==2.3.0
     # via requests
 virtualenv==20.29.1
     # via pre-commit
+xdoctest==1.2.0
+    # via skore (skore/pyproject.toml)

--- a/skore/ci/requirements/python-3.12/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.12/scikit-learn-1.6/test-requirements.txt
@@ -182,3 +182,5 @@ urllib3==2.3.0
     # via requests
 virtualenv==20.29.1
     # via pre-commit
+xdoctest==1.2.0
+    # via skore (skore/pyproject.toml)

--- a/skore/ci/requirements/python-3.9/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.9/scikit-learn-1.6/test-requirements.txt
@@ -193,6 +193,8 @@ urllib3==2.3.0
     # via requests
 virtualenv==20.29.1
     # via pre-commit
+xdoctest==1.2.0
+    # via skore (skore/pyproject.toml)
 zipp==3.21.0
     # via
     #   importlib-metadata

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -48,6 +48,7 @@ test = [
   "ruff",
   "scikit-learn<1.7",
   "skrub",
+  "xdoctest",
 ]
 sphinx = [
   "IPython",
@@ -93,7 +94,7 @@ package = ["src/skore/"]
 
 [tool.pytest.ini_options]
 addopts = [
-  "--doctest-modules",
+  "--xdoctest",
   "--import-mode=importlib",
   "--no-header",
   "--verbosity=2",
@@ -105,7 +106,6 @@ addopts = [
   "--ignore=notebooks",
   "--dist=loadscope",
 ]
-doctest_optionflags = ["ELLIPSIS", "NORMALIZE_WHITESPACE"]
 
 [tool.coverage.run]
 branch = true

--- a/skore/src/skore/_config.py
+++ b/skore/src/skore/_config.py
@@ -68,8 +68,9 @@ def set_config(
 
     Examples
     --------
+    >>> # xdoctest: +SKIP
     >>> from skore import set_config
-    >>> set_config(show_progress=False)  # doctest: +SKIP
+    >>> set_config(show_progress=False)
     """
     local_config = _get_threadlocal_config()
 

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -75,10 +75,11 @@ class Project:
 
     Examples
     --------
+    >>> # xdoctest: +SKIP
     >>> import skore
-    >>> project = skore.Project("my-xp")  # doctest: +SKIP
-    >>> project.put("score", 1.0)  # doctest: +SKIP
-    >>> project.get("score")  # doctest: +SKIP
+    >>> project = skore.Project("my-xp")
+    >>> project.put("score", 1.0)
+    >>> project.get("score")
     1.0
     """
 
@@ -321,10 +322,11 @@ class Project:
 
         Examples
         --------
+        >>> # xdoctest: +SKIP
         >>> # Annotate latest version of key "key"
-        >>> project.set_note("key", "note")  # doctest: +SKIP
+        >>> project.set_note("key", "note")
         >>> # Annotate first version of key "key"
-        >>> project.set_note("key", "note", version=0)  # doctest: +SKIP
+        >>> project.set_note("key", "note", version=0)
         """
         return self._item_repository.set_item_note(key=key, note=note, version=version)
 
@@ -351,10 +353,11 @@ class Project:
 
         Examples
         --------
+        >>> # xdoctest: +SKIP
         >>> # Retrieve note attached to latest version of key "key"
-        >>> project.get_note("key")  # doctest: +SKIP
+        >>> project.get_note("key")
         >>> # Retrieve note attached to first version of key "key"
-        >>> project.get_note("key", version=0)  # doctest: +SKIP
+        >>> project.get_note("key", version=0)
         """
         return self._item_repository.get_item_note(key=key, version=version)
 
@@ -379,9 +382,10 @@ class Project:
 
         Examples
         --------
+        >>> # xdoctest: +SKIP
         >>> # Delete note attached to latest version of key "key"
-        >>> project.delete_note("key")  # doctest: +SKIP
+        >>> project.delete_note("key")
         >>> # Delete note attached to first version of key "key"
-        >>> project.delete_note("key", version=0)  # doctest: +SKIP
+        >>> project.delete_note("key", version=0)
         """
         return self._item_repository.delete_item_note(key=key, version=version)

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -85,31 +85,32 @@ def train_test_split(
 
     Examples
     --------
+    >>> # xdoctest: +SKIP
     >>> import numpy as np
     >>> X, y = np.arange(10).reshape((5, 2)), range(5)
 
     >>> # Drop-in replacement for sklearn train_test_split
-    >>> X_train, X_test, y_train, y_test = train_test_split(X, y,  # doctest: +SKIP
+    >>> X_train, X_test, y_train, y_test = train_test_split(X, y,
     ...     test_size=0.33, random_state=42)
-    >>> X_train  # doctest: +SKIP
+    >>> X_train
     array([[4, 5],
            [0, 1],
            [6, 7]])
 
     >>> # Explicit X and y, makes detection of problems easier
-    >>> X_train, X_test, y_train, y_test = train_test_split(X=X, y=y,  # doctest: +SKIP
+    >>> X_train, X_test, y_train, y_test = train_test_split(X=X, y=y,
     ...     test_size=0.33, random_state=42)
-    >>> X_train  # doctest: +SKIP
+    >>> X_train
     array([[4, 5],
            [0, 1],
            [6, 7]])
 
     >>> # When passing X and y explicitly, X is returned before y
     >>> arr = np.arange(10).reshape((5, 2))
-    >>> splits = train_test_split(  # doctest: +SKIP
+    >>> splits = train_test_split(
     ...     arr, y=y, X=X, test_size=0.33, random_state=42)
-    >>> arr_train, arr_test, X_train, X_test, y_train, y_test = splits  # doctest: +SKIP
-    >>> X_train  # doctest: +SKIP
+    >>> arr_train, arr_test, X_train, X_test, y_train, y_test = splits
+    >>> X_train
     array([[4, 5],
            [0, 1],
            [6, 7]])

--- a/skore/src/skore/utils/_show_versions.py
+++ b/skore/src/skore/utils/_show_versions.py
@@ -72,8 +72,9 @@ def show_versions() -> None:
 
     Examples
     --------
+    >>> # xdoctest: +SKIP
     >>> from skore import show_versions
-    >>> show_versions()  # doctest: +SKIP
+    >>> show_versions()
     """
     sys_info = _get_sys_info()
     deps_info = _get_deps_info()


### PR DESCRIPTION
The PR introduces a new test dependency, [xdoctest](https://github.com/Erotemic/xdoctest), a modern rewrite of `doctest`. xdoctest makes it possible to apply a (x)doctest directive to all following lines. Example from [xdoctest's own docs](https://xdoctest.readthedocs.io/en/latest/auto/xdoctest.directive.html):

```python
>>> # An inline directive appears on the same line as a command and
>>> # only applies to the current line.
>>> raise AssertionError('this will not be run (a)')  # xdoctest: +SKIP
>>> print('This line will print: (A)')
>>> print('This line will print: (B)')
>>> # However, if a directive appears on its own line, then it applies
>>> # too all subsequent lines.
>>> # xdoctest: +SKIP()
>>> raise AssertionError('this will not be run (b)')
>>> print('This line will not print: (A)')
>>> # Note, that SKIP is simply a state and can be disabled to allow
>>> # the program to continue executing.
>>> # xdoctest: -SKIP
>>> print('This line will print: (C)')
>>> print('This line will print: (D)')
>>> # This applies to inline directives as well
>>> # xdoctest: +SKIP("an assertion would occur")
>>> raise AssertionError('this will not be run (c)')
>>> print('This line will print: (E)')  # xdoctest: -SKIP
>>> raise AssertionError('this will not be run (d)')
>>> # xdoctest: -SKIP("a reason can be given as an argument")
>>> print('This line will print: (F)')
```

Closes #1347 