### PR TITLE
ci: Fix CDN pruning when deploying root files in sphinx pipeline

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -224,9 +224,10 @@ jobs:
         run: |
           curl --fail-with-body \
           -X POST \
-          --url "https://api.bunny.net/purge?url=https%3A%2F%2F${DOMAIN}%2F%2A.%2A&async=false" \
+          --url "https://api.bunny.net/pullzone/${PULLZONE}/purgeCache" \
           --header "AccessKey: ${ACCESS_KEY}"
         env:
+          PULLZONE: ${{ vars.BUNNY_PULLZONE }}
           ACCESS_KEY: ${{ secrets.BUNNY_API_KEY }}
           DOMAIN: ${{ vars.DOCUMENTATION_DOMAIN }}
 


### PR DESCRIPTION
The root `/` URL wasn't purged. So the redirection from `/` to the newest release done by the `index.html` file wasn't effective until the CDN cache was revoked by its policy.

After a new release, we purge now the entire CDN cache.

![image](https://github.com/user-attachments/assets/6a348079-4d13-4def-b652-b6113c4095a1)
