### PR TITLE
chore: Add dependencies for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install-skore:
-	python -m pip install -e './skore[test,sphinx]'
+	python -m pip install -e './skore[test,sphinx,dev]'
 	pre-commit install
 
 lint:

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -67,6 +67,8 @@ sphinx = [
   "sphinx-tabs",
   "sphinx<8.2.0",
   "sphinx_autosummary_accessors",
+]
+dev = [
   "nbformat",
   "ipykernel",
 ]

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -67,6 +67,8 @@ sphinx = [
   "sphinx-tabs",
   "sphinx<8.2.0",
   "sphinx_autosummary_accessors",
+  "nbformat",
+  "ipykernel",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #1426   

Add 2 dependencies to be able to run .py examples locally in the IDE.  