### PR TITLE
chore: Complete blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.yml
+++ b/.github/ISSUE_TEMPLATE/blank_issue.yml
@@ -1,2 +1,3 @@
 name: Blank issue
+description: Any kind of issue that doesn't fit the other templates.
 labels: ['needs-triage', 'user-reported']

--- a/.github/ISSUE_TEMPLATE/blank_issue.yml
+++ b/.github/ISSUE_TEMPLATE/blank_issue.yml
@@ -1,3 +1,8 @@
 name: Blank issue
 description: Any kind of issue that doesn't fit the other templates.
 labels: ['needs-triage', 'user-reported']
+
+body:
+- type: textarea
+  attributes:
+    label: "What would you like to say?"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e31541ad-8815-481a-9b9d-d792c02a474b)

Today blank issue template is not displayed, because description and body are mandatory keys (cf [doc I hadn't find before](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax)).