### PR TITLE
feat(train_test_split): Add optional argument to return dict

### DIFF
--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -47,7 +47,12 @@ pos_label, neg_label = "allowed", "disallowed"
 # and a validation set.
 from skore import train_test_split
 
-X_train, X_test, y_train, y_test = train_test_split(df, y, random_state=42)
+# If you have many dataframes to split on, you can always ask train_test_split to return a dictionary.
+# Remember, it needs to be passed as a keyword argument!
+my_dict = train_test_split(X=df, y=y, random_state=42, return_dict=True)
+
+# Since we only have 2 dataframes to split, we can simply unpack as follows.
+X_train, X_test, y_train, y_test = my_dict.values()
 
 # %%
 # By the way, notice how skore's :func:`~skore.train_test_split` automatically warns us

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -49,10 +49,7 @@ from skore import train_test_split
 
 # If you have many dataframes to split on, you can always ask train_test_split to return a dictionary.
 # Remember, it needs to be passed as a keyword argument!
-my_dict = train_test_split(X=df, y=y, random_state=42, return_dict=True)
-
-# Since we only have 2 dataframes to split, we can simply unpack as follows.
-X_train, X_test, y_train, y_test = my_dict.values()
+split_data = train_test_split(X=df, y=y, random_state=42, as_dict=True)
 
 # %%
 # By the way, notice how skore's :func:`~skore.train_test_split` automatically warns us
@@ -67,7 +64,9 @@ X_train, X_test, y_train, y_test = my_dict.values()
 # So let's create a classifier for our task and fit it on the training set.
 from skrub import tabular_learner
 
-estimator = tabular_learner("classifier").fit(X_train, y_train)
+estimator = tabular_learner("classifier").fit(
+    split_data["X_train"], split_data["y_train"]
+)
 estimator
 
 # %%
@@ -82,9 +81,7 @@ estimator
 # detect that our estimator is already fitted and will not fit it again.
 from skore import EstimatorReport
 
-report = EstimatorReport(
-    estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
-)
+report = EstimatorReport(estimator, **split_data)
 
 # %%
 #
@@ -188,7 +185,10 @@ report.metrics.log_loss(data_source="train")
 
 start = time.time()
 metric_report = report.metrics.report_metrics(
-    data_source="X_y", X=X_test, y=y_test, pos_label=pos_label
+    data_source="X_y",
+    X=split_data["X_test"],
+    y=split_data["y_test"],
+    pos_label=pos_label,
 )
 end = time.time()
 metric_report
@@ -205,7 +205,10 @@ print(f"Time taken to compute the metrics: {end - start:.2f} seconds")
 # %%
 start = time.time()
 metric_report = report.metrics.report_metrics(
-    data_source="X_y", X=X_test, y=y_test, pos_label=pos_label
+    data_source="X_y",
+    X=split_data["X_test"],
+    y=split_data["y_test"],
+    pos_label=pos_label,
 )
 end = time.time()
 metric_report
@@ -247,7 +250,7 @@ def operational_decision_cost(y_true, y_pred, amount):
 import numpy as np
 
 rng = np.random.default_rng(42)
-amount = rng.integers(low=100, high=1000, size=len(y_test))
+amount = rng.integers(low=100, high=1000, size=len(split_data["y_test"]))
 
 # %%
 #

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -70,7 +70,8 @@ def train_test_split(
         If not None, data is split in a stratified fashion, using this as the
         class labels.
     return_dict : bool, default is False
-        If True, returns a dictionary with keys instead of a list. Dictionary keys are in format ``X_train``, ``X_test``, ``y_train``, and ``y_test``.
+        If True, returns a Dictionary with keys values ``X_train``, ``X_test``,
+        ``y_train``, and ``y_test`` instead of a List.
 
     Returns
     -------
@@ -82,7 +83,9 @@ def train_test_split(
         arrays passed positionally, in the order they were passed, then ``X`` if it
         was passed, then ``y`` if it was passed.
 
-        If return_dict=True: Dictionary with keys ``X_train``, ``X_test``, ``y_train``, and ``y_test``, each containing respective split data.
+        If return_dict=True: Dictionary with keys
+        ``X_train``, ``X_test``, ``y_train``, and ``y_test``,
+        each containing respective split data.
 
     Examples
     --------
@@ -183,14 +186,11 @@ def train_test_split(
             )
 
     if return_dict:
-        result = {
-            'X_train': output[0],
-            'X_test': output[1]
-            }
+        result = {"X_train": output[0], "X_test": output[1]}
 
-        if len(output)>2:
-            result['y_train'] = output[2]
-            result['y_test'] = output[3]
+        if len(output) > 2:
+            result["y_train"] = output[2]
+            result["y_test"] = output[3]
         output = result
-        
+
     return output

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -75,7 +75,7 @@ def train_test_split(
     Returns
     -------
     splitting : list or dict
-        If return_dict=False (default): List containing train-test split of inputs.
+        If return_dict=False (the default): List containing train-test split of inputs.
         The length of the list is twice the number of arrays passed, including
         the ``X`` and ``y`` keyword arguments. If arrays are passed positionally as well
         as through ``X`` and ``y``, the output arrays are ordered as follows: first the

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -70,9 +70,13 @@ def train_test_split(
     stratify : array-like, optional
         If not None, data is split in a stratified fashion, using this as the
         class labels.
-    return_dict : bool, default is False
+    as_dict : bool, default is False
         If True, returns a Dictionary with keys values ``X_train``, ``X_test``,
-        ``y_train``, and ``y_test`` instead of a List.
+        ``y_train``, and ``y_test`` instead of a List. Requires data to be
+        passed as keyword arguments.
+    **keyword_arrays : array-like, optional
+        Additional array-like arguments passed by keyword. Each keyword should
+        correspond to an array-like object.
 
     Returns
     -------

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -25,7 +25,7 @@ def train_test_split(
     random_state: Optional[Union[int, RandomState]] = None,
     shuffle: bool = True,
     stratify: Optional[ArrayLike] = None,
-    return_dict: bool = False,
+    as_dict: bool = False,
     **keyword_arrays: ArrayLike,
 ):
     """Perform train-test-split of data.
@@ -131,7 +131,7 @@ def train_test_split(
         new_arrays.append(y)
         keys += ["y"]
 
-    if return_dict and arrays:
+    if as_dict and arrays:
         raise ValueError(
             "When return_dict=True, arrays must be passed as keyword arguments.\n"
             "Example: train_test_split(X=X, y=y, sw=sample_weight, return_dict=True)"
@@ -204,7 +204,7 @@ def train_test_split(
                 )
             )
 
-    if return_dict:
+    if as_dict:
         result = {}
         for i, k in enumerate(keys):
             train, test = i * 2, i * 2 + 1

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -26,6 +26,7 @@ def train_test_split(
     shuffle: bool = True,
     stratify: Optional[ArrayLike] = None,
     return_dict: bool = False,
+    **arr,
 ):
     """Perform train-test-split of data.
 
@@ -122,10 +123,24 @@ def train_test_split(
     import sklearn.model_selection
 
     new_arrays = list(arrays)
+    keys = []
     if X is not None:
         new_arrays.append(X)
+        keys += ["X"]
     if y is not None:
         new_arrays.append(y)
+        keys += ["y"]
+
+    if return_dict and arrays:
+        raise ValueError(
+            "When return_dict=True, arrays must be passed as keyword arguments.\n"
+            "Example: train_test_split(X=X, y=y, sw=sample_weight, return_dict=True)"
+        )
+    elif arr:
+        if X is None and y is None:
+            arrays = tuple(arr.values())  # if X and y is not passed but other variables
+        keys += list(arr.keys())
+        new_arrays += list(arr.values())
 
     output = sklearn.model_selection.train_test_split(
         *new_arrays,

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -140,7 +140,8 @@ def train_test_split(
             "When return_dict=True, arrays must be passed as keyword arguments.\n"
             "Example: train_test_split(X=X, y=y, sw=sample_weight, return_dict=True)"
         )
-    elif keyword_arrays:
+
+    if keyword_arrays:
         if X is None and y is None:
             arrays = tuple(
                 keyword_arrays.values()

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -201,11 +201,10 @@ def train_test_split(
             )
 
     if return_dict:
-        result = {"X_train": output[0], "X_test": output[1]}
-
-        if len(output) > 2:
-            result["y_train"] = output[2]
-            result["y_test"] = output[3]
+        result = {}
+        for i, k in enumerate(keys):
+            train, test = i * 2, i * 2 + 1
+            result[f"{k}_train"], result[f"{k}_test"] = output[train], output[test]
         output = result
 
     return output

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -183,11 +183,14 @@ def train_test_split(
             )
 
     if return_dict:
-        output = {
+        result = {
             'X_train': output[0],
-            'X_test': output[1],
-            'y_train': output[2],
-            'y_test': output[3]
+            'X_test': output[1]
             }
+
+        if len(output)>2:
+            result['y_train'] = output[2]
+            result['y_test'] = output[3]
+        output = result
         
     return output

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -25,6 +25,7 @@ def train_test_split(
     random_state: Optional[Union[int, RandomState]] = None,
     shuffle: bool = True,
     stratify: Optional[ArrayLike] = None,
+    return_dict: bool = False,
 ):
     """Perform train-test-split of data.
 
@@ -68,16 +69,20 @@ def train_test_split(
     stratify : array-like, optional
         If not None, data is split in a stratified fashion, using this as the
         class labels.
+    return_dict : bool, default is False
+        If True, returns a dictionary with keys instead of a list. Dictionary keys are in format ``X_train``, ``X_test``, ``y_train``, and ``y_test``.
 
     Returns
     -------
-    splitting : list
-        List containing train-test split of inputs.
+    splitting : list or dict
+        If return_dict=False (default): List containing train-test split of inputs.
         The length of the list is twice the number of arrays passed, including
         the ``X`` and ``y`` keyword arguments. If arrays are passed positionally as well
         as through ``X`` and ``y``, the output arrays are ordered as follows: first the
         arrays passed positionally, in the order they were passed, then ``X`` if it
         was passed, then ``y`` if it was passed.
+
+        If return_dict=True: Dictionary with keys ``X_train``, ``X_test``, ``y_train``, and ``y_test``, each containing respective split data.
 
     Examples
     --------
@@ -177,4 +182,12 @@ def train_test_split(
                 )
             )
 
+    if return_dict:
+        output = {
+            'X_train': output[0],
+            'X_test': output[1],
+            'y_train': output[2],
+            'y_test': output[3]
+            }
+        
     return output

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -137,8 +137,8 @@ def train_test_split(
 
     if as_dict and arrays:
         raise ValueError(
-            "When return_dict=True, arrays must be passed as keyword arguments.\n"
-            "Example: train_test_split(X=X, y=y, sw=sample_weight, return_dict=True)"
+            "When as_dict=True, arrays must be passed as keyword arguments.\n"
+            "Example: train_test_split(X=X, y=y, sw=sample_weight, as_dict=True)"
         )
 
     if keyword_arrays:

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -26,7 +26,7 @@ def train_test_split(
     shuffle: bool = True,
     stratify: Optional[ArrayLike] = None,
     return_dict: bool = False,
-    **arr,
+    **keyword_arrays: ArrayLike,
 ):
     """Perform train-test-split of data.
 
@@ -136,11 +136,13 @@ def train_test_split(
             "When return_dict=True, arrays must be passed as keyword arguments.\n"
             "Example: train_test_split(X=X, y=y, sw=sample_weight, return_dict=True)"
         )
-    elif arr:
+    elif keyword_arrays:
         if X is None and y is None:
-            arrays = tuple(arr.values())  # if X and y is not passed but other variables
-        keys += list(arr.keys())
-        new_arrays += list(arr.values())
+            arrays = tuple(
+                keyword_arrays.values()
+            )  # if X and y is not passed but other variables
+        keys += list(keyword_arrays.keys())
+        new_arrays += list(keyword_arrays.values())
 
     output = sklearn.model_selection.train_test_split(
         *new_arrays,
@@ -159,7 +161,9 @@ def train_test_split(
 
     if y is not None:
         y_labels = np.unique(y)
-        y_test = output[3] if arr else output[-1]  # when more kwargs are given
+        y_test = (
+            output[3] if keyword_arrays else output[-1]
+        )  # when more kwargs are given
     else:
         y_labels = None
         y_test = None

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -159,7 +159,7 @@ def train_test_split(
 
     if y is not None:
         y_labels = np.unique(y)
-        y_test = output[-1]
+        y_test = output[3] if arr else output[-1]  # when more kwargs are given
     else:
         y_labels = None
         y_test = None

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -75,20 +75,20 @@ def train_test_split(
         ``y_train``, and ``y_test`` instead of a List. Requires data to be
         passed as keyword arguments.
     **keyword_arrays : array-like, optional
-        Additional array-like arguments passed by keyword. Each keyword should
-        correspond to an array-like object.
+        Additional array-like arguments passed by keyword. Used to determine the keys
+        of the output dict when ``as_dict=True``.
 
     Returns
     -------
     splitting : list or dict
-        If return_dict=False (the default): List containing train-test split of inputs.
+        If ``as_dict=False`` (the default): List containing train-test split of inputs.
         The length of the list is twice the number of arrays passed, including
         the ``X`` and ``y`` keyword arguments. If arrays are passed positionally as well
         as through ``X`` and ``y``, the output arrays are ordered as follows: first the
         arrays passed positionally, in the order they were passed, then ``X`` if it
         was passed, then ``y`` if it was passed.
 
-        If return_dict=True: Dictionary with keys
+        If ``as_dict=True``: Dictionary with keys
         ``X_train``, ``X_test``, ``y_train``, and ``y_test``,
         each containing respective split data.
 
@@ -123,6 +123,15 @@ def train_test_split(
     array([[4, 5],
            [0, 1],
            [6, 7]])
+
+    >>> # Returns dictionary when as_dict is True, inputs must be keyword arguments.
+    >>> sample_weights = np.arange(10).reshape((5, 2))
+    >>> split_dict = train_test_split(
+    ...     X=X, y=y, sample_weights=sample_weights, as_dict=True, random_state=0)
+    >>> split_dict
+    {'X_train': ..., 'X_test': ...,
+     'y_train': ..., 'y_test': ...,
+     'sample_weights_train': ..., 'sample_weights_test': ...}
     """
     import sklearn.model_selection
 

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -182,11 +182,22 @@ def test_train_test_split_kwargs():
     assert output1 == output2
 
 
+def test_train_test_split_dict_kwargs():
+    """Passing data without keyword arguments with return_dict=True
+    should raise ValueError."""
+
+    X = [[1]] * 20
+    y = [0] * 10 + [1] * 10
+
+    with pytest.raises(ValueError):
+        train_test_split(X, y, random_state=0, return_dict=True)
+
+
 def test_train_test_split_check_dict():
     """Check dict is returned if `return_dict` argument is True"""
     X = [[1]] * 20
     y = [0] * 10 + [1] * 10
-    output = train_test_split(X, y, random_state=0, return_dict=True)
+    output = train_test_split(X=X, y=y, random_state=0, return_dict=True)
     assert type(output) is dict
 
 
@@ -195,5 +206,15 @@ def test_train_test_split_check_dict_unsupervised_case():
     unsupervised case."""
 
     X = [[1]] * 20
-    output = train_test_split(X, random_state=0, return_dict=True)
+    output = train_test_split(X=X, random_state=0, return_dict=True)
     assert len(output.keys()) == 2
+
+
+def test_train_test_split_check_dict_no_X_no_y():
+    """Check if a dict is returned when X, y are None and a third kwarg is passed."""
+
+    z = [[1]] * 20
+    output = train_test_split(z=z, test_size=0.33, random_state=0, return_dict=True)
+    keys = output.keys()
+    assert len(keys) == 2
+    assert list(keys) == ["z_train", "z_test"]

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -189,12 +189,15 @@ def test_train_test_split_dict_kwargs():
     X = [[1]] * 20
     y = [0] * 10 + [1] * 10
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="When return_dict=True, arrays must be passed as keyword arguments",
+    ):
         train_test_split(X, y, random_state=0, return_dict=True)
 
 
 def test_train_test_split_check_dict():
-    """Check dict is returned if `return_dict` argument is True"""
+    """If `return_dict` is True then the result is a dict."""
     X = [[1]] * 20
     y = [0] * 10 + [1] * 10
     output = train_test_split(X=X, y=y, random_state=0, return_dict=True)
@@ -202,8 +205,8 @@ def test_train_test_split_check_dict():
 
 
 def test_train_test_split_check_dict_unsupervised_case():
-    """Check 2 keys are is returned if `return_dict` argument is True for
-    unsupervised case."""
+    """If `return_dict` is True and only `X` is passed,
+    the result is a dict with 2 keys."""
 
     X = [[1]] * 20
     output = train_test_split(X=X, random_state=0, return_dict=True)
@@ -211,10 +214,10 @@ def test_train_test_split_check_dict_unsupervised_case():
 
 
 def test_train_test_split_check_dict_no_X_no_y():
-    """Check if a dict is returned when X, y are None and a third kwarg is passed."""
+    """If the input is a keyword argument and `X` and `y` are None,
+    then the result is a dict with 2 keys."""
 
     z = [[1]] * 20
-    output = train_test_split(z=z, test_size=0.33, random_state=0, return_dict=True)
+    output = train_test_split(z=z, random_state=0, return_dict=True)
     keys = output.keys()
-    assert len(keys) == 2
     assert list(keys) == ["z_train", "z_test"]

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -180,3 +180,20 @@ def test_train_test_split_kwargs():
     output2 = train_test_split(X=X, y=y, random_state=0)
 
     assert output1 == output2
+
+
+def test_train_test_split_check_dict():
+    """Check dict is returned if `return_dict` argument is True"""
+    X = [[1]] * 20
+    y = [0] * 10 + [1] * 10
+    output = train_test_split(X, y, random_state=0, return_dict=True)
+    assert type(output) is dict
+
+
+def test_train_test_split_check_dict_unsupervised_case():
+    """Check 2 keys are is returned if `return_dict` argument is True for
+    unsupervised case."""
+
+    X = [[1]] * 20
+    output = train_test_split(X, random_state=0, return_dict=True)
+    assert len(output.keys()) == 2

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -193,14 +193,14 @@ def test_train_test_split_dict_kwargs():
         ValueError,
         match="When return_dict=True, arrays must be passed as keyword arguments",
     ):
-        train_test_split(X, y, random_state=0, return_dict=True)
+        train_test_split(X, y, random_state=0, as_dict=True)
 
 
 def test_train_test_split_check_dict():
     """If `return_dict` is True then the result is a dict."""
     X = [[1]] * 20
     y = [0] * 10 + [1] * 10
-    output = train_test_split(X=X, y=y, random_state=0, return_dict=True)
+    output = train_test_split(X=X, y=y, random_state=0, as_dict=True)
     assert type(output) is dict
 
 
@@ -209,7 +209,7 @@ def test_train_test_split_check_dict_unsupervised_case():
     the result is a dict with 2 keys."""
 
     X = [[1]] * 20
-    output = train_test_split(X=X, random_state=0, return_dict=True)
+    output = train_test_split(X=X, random_state=0, as_dict=True)
     assert len(output.keys()) == 2
 
 
@@ -218,6 +218,6 @@ def test_train_test_split_check_dict_no_X_no_y():
     then the result is a dict with 2 keys."""
 
     z = [[1]] * 20
-    output = train_test_split(z=z, random_state=0, return_dict=True)
+    output = train_test_split(z=z, random_state=0, as_dict=True)
     keys = output.keys()
     assert list(keys) == ["z_train", "z_test"]

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -191,7 +191,7 @@ def test_train_test_split_dict_kwargs():
 
     with pytest.raises(
         ValueError,
-        match="When return_dict=True, arrays must be passed as keyword arguments",
+        match="When as_dict=True, arrays must be passed as keyword arguments",
     ):
         train_test_split(X, y, random_state=0, as_dict=True)
 


### PR DESCRIPTION
# What does it solve?
Adds enhancement based on #1453.

# Design choice
I deviate from what is asked in #1453 and add a boolean argument `return_dict` that returns a dictionary if `True`. If required, I can change it into a wrapper instead but this should not break any code base per se.

# Todo
What was done?
- [x] Implemented return dictionary.
- [x] Updated doc string.
- [x] Tests - Would you require them?
- [x] If all is okay, let me know so I can add in an example in the doc-string.
- [x] Tested with EstimatorReport as per #1453.

# Example
```python
from skore import train_test_split
from skore import EstimatorReport
import numpy as np

def main():
    X, y = np.arange(10).reshape((5, 2)), range(5)
    
    # default
    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)

    # with my_dict true
    my_dict = train_test_split(X,y, test_size=0.33,random_state=42, return_dict=True)

    print(f"X_train: {X_train}\n X_test:{X_test}\n y_train:{y_train}\n y_test:{y_test}")
    print(my_dict)

    from sklearn.neural_network import MLPClassifier
    mlp = MLPClassifier()
    report = EstimatorReport(mlp, **my_dict)
    print(report.metrics)

if __name__ == "__main__":
    main()
```

# Output
```cmd
╭────────────────────── HighClassImbalanceTooFewExamplesWarning ───────────────────────╮
│ It seems that you have a classification problem with at least one class with fewer   │
│ than 100 examples in the test set. In this case, using train_test_split may not be a │
│ good idea because of high variability in the scores obtained on the test set. We     │
│ suggest three options to tackle this challenge: you can increase test_size, collect  │
│ more data, or use skore's cross_validate function.                                   │
╰──────────────────────────────────────────────────────────────────────────────────────╯
╭───────────────────────────────── ShuffleTrueWarning ─────────────────────────────────╮
│ We detected that the `shuffle` parameter is set to `True` either explicitly or from  │
│ its default value. In case of time-ordered events (even if they are independent),    │
│ this will result in inflated model performance evaluation because natural drift will │
│ not be taken into account. We recommend setting the shuffle parameter to `False` in  │
│ order to ensure the evaluation process is really representative of your production   │
│ release process.                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────╯
╭────────────────────── HighClassImbalanceTooFewExamplesWarning ───────────────────────╮
│ It seems that you have a classification problem with at least one class with fewer   │
│ than 100 examples in the test set. In this case, using train_test_split may not be a │
│ good idea because of high variability in the scores obtained on the test set. We     │
│ suggest three options to tackle this challenge: you can increase test_size, collect  │
│ more data, or use skore's cross_validate function.                                   │
╰──────────────────────────────────────────────────────────────────────────────────────╯
╭───────────────────────────────── ShuffleTrueWarning ─────────────────────────────────╮
│ We detected that the `shuffle` parameter is set to `True` either explicitly or from  │
│ its default value. In case of time-ordered events (even if they are independent),    │
│ this will result in inflated model performance evaluation because natural drift will │
│ not be taken into account. We recommend setting the shuffle parameter to `False` in  │
│ order to ensure the evaluation process is really representative of your production   │
│ release process.                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────╯
X_train: [[4 5]
 [0 1]
 [6 7]]
 X_test:[[2 3]
 [8 9]]
 y_train:[2, 0, 3]
 y_test:[1, 4]
{'X_train': array([[4, 5],
       [0, 1],
       [6, 7]]), 'X_test': array([[2, 3],
       [8, 9]]), 'y_train': [2, 0, 3], 'y_test': [1, 4]}
/Users/nkapila6/Code/rands/.venv/lib/python3.10/site-packages/sklearn/neural_network/_multilayer_perceptron.py:691: ConvergenceWarning: Stochastic Optimizer: Maximum iterations (200) reached and the optimization hasn't converged yet.
  warnings.warn(
EstimatorReport(estimator=MLPClassifier(), ...)
╭─────────── skore.EstimatorReport.metrics ───────────╮
│ Get guidance using the report.metrics.help() method │
╰─────────────────────────────────────────────────────╯
```

## With `skore.EstimatorReport` in Debug Console (breakpoint in __init__ method).
![image](https://github.com/user-attachments/assets/a9a0b00c-0e7a-44c6-a2ff-369eb1212b81)


