### PR TITLE
chore: Replace `_register_accessor` with assignment

### DIFF
--- a/skore/src/skore/externals/_pandas_accessors.py
+++ b/skore/src/skore/externals/_pandas_accessors.py
@@ -36,18 +36,3 @@ class Accessor:
             # we're accessing the attribute of the class, i.e., Dataset.geo
             return self._accessor
         return self._accessor(obj)
-
-
-def _register_accessor(name, cls):
-    def decorator(accessor):
-        if hasattr(cls, name):
-            raise ValueError(
-                f"registration of accessor {accessor!r} under name "
-                f"{name!r} for type {cls!r} is overriding a preexisting "
-                f"attribute with the same name."
-            )
-        setattr(cls, name, Accessor(name, accessor))
-        cls._accessors.add(name)
-        return accessor
-
-    return decorator

--- a/skore/src/skore/sklearn/_comparison/__init__.py
+++ b/skore/src/skore/sklearn/_comparison/__init__.py
@@ -1,7 +1,9 @@
-from skore.externals._pandas_accessors import _register_accessor
+from typing import cast
+
+from skore.externals._pandas_accessors import Accessor
 from skore.sklearn._comparison.metrics_accessor import _MetricsAccessor
 from skore.sklearn._comparison.report import ComparisonReport
 
-_register_accessor("metrics", ComparisonReport)(_MetricsAccessor)
+ComparisonReport.metrics = cast(_MetricsAccessor, Accessor("metrics", _MetricsAccessor))
 
 __all__ = ["ComparisonReport"]

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -13,7 +13,7 @@ from skore.sklearn._estimator.report import EstimatorReport
 from skore.utils._progress_bar import progress_decorator
 
 if TYPE_CHECKING:
-    from skore.sklearn._estimator.metrics_accessor import _MetricsAccessor
+    from skore.sklearn._comparison.metrics_accessor import _MetricsAccessor
 
 
 class ComparisonReport(_BaseReport, DirNamesMixin):

--- a/skore/src/skore/sklearn/_cross_validation/__init__.py
+++ b/skore/src/skore/sklearn/_cross_validation/__init__.py
@@ -1,9 +1,13 @@
-from skore.externals._pandas_accessors import _register_accessor
+from typing import cast
+
+from skore.externals._pandas_accessors import Accessor
 from skore.sklearn._cross_validation.metrics_accessor import _MetricsAccessor
 from skore.sklearn._cross_validation.report import (
     CrossValidationReport,
 )
 
-_register_accessor("metrics", CrossValidationReport)(_MetricsAccessor)
+CrossValidationReport.metrics = cast(
+    _MetricsAccessor, Accessor("metrics", _MetricsAccessor)
+)
 
 __all__ = ["CrossValidationReport"]

--- a/skore/src/skore/sklearn/_estimator/__init__.py
+++ b/skore/src/skore/sklearn/_estimator/__init__.py
@@ -1,12 +1,17 @@
-from skore.externals._pandas_accessors import _register_accessor
+from typing import cast
+
+from skore.externals._pandas_accessors import Accessor
 from skore.sklearn._estimator.feature_importance_accessor import (
     _FeatureImportanceAccessor,
 )
 from skore.sklearn._estimator.metrics_accessor import _MetricsAccessor
 from skore.sklearn._estimator.report import EstimatorReport
 
-_register_accessor("metrics", EstimatorReport)(_MetricsAccessor)
+EstimatorReport.metrics = cast(_MetricsAccessor, Accessor("metrics", _MetricsAccessor))
 
-_register_accessor("feature_importance", EstimatorReport)(_FeatureImportanceAccessor)
+EstimatorReport.feature_importance = cast(
+    _FeatureImportanceAccessor,
+    Accessor("feature_importance", _FeatureImportanceAccessor),
+)
 
 __all__ = ["EstimatorReport"]

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import time
 import warnings
@@ -80,7 +82,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         "metrics": {"name": "metrics"},
         "feature_importance": {"name": "feature_importance"},
     }
-    metrics: "_MetricsAccessor"
+    metrics: _MetricsAccessor
 
     @staticmethod
     def _fit_estimator(

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -21,6 +21,9 @@ from skore.utils._parallel import Parallel, delayed
 from skore.utils._progress_bar import progress_decorator
 
 if TYPE_CHECKING:
+    from skore.sklearn._estimator.feature_importance_accessor import (
+        _FeatureImportanceAccessor,
+    )
     from skore.sklearn._estimator.metrics_accessor import _MetricsAccessor
 
 
@@ -83,6 +86,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         "feature_importance": {"name": "feature_importance"},
     }
     metrics: _MetricsAccessor
+    feature_importance: _FeatureImportanceAccessor
 
     @staticmethod
     def _fit_estimator(

--- a/skore/tests/unit/utils/test_accessors.py
+++ b/skore/tests/unit/utils/test_accessors.py
@@ -23,8 +23,8 @@ def test_register_accessor():
         def func(self):
             return True
 
+    ParentClass.accessor = Accessor("accessor", _Accessor)
     obj = ParentClass()
-    obj.accessor = Accessor("accessor", _Accessor)
     assert hasattr(obj, "accessor")
     assert isinstance(obj.accessor, _Accessor)
     assert obj.accessor.func()

--- a/skore/tests/unit/utils/test_accessors.py
+++ b/skore/tests/unit/utils/test_accessors.py
@@ -1,6 +1,6 @@
 import pytest
 from sklearn.pipeline import make_pipeline
-from skore.externals._pandas_accessors import DirNamesMixin, _register_accessor
+from skore.externals._pandas_accessors import Accessor, DirNamesMixin
 from skore.utils._accessor import (
     _check_has_coef,
     _check_has_feature_importances,
@@ -16,11 +16,6 @@ def test_register_accessor():
     class ParentClass(DirNamesMixin):
         pass
 
-    def register_parent_class_accessor(name: str):
-        """Register an accessor for the ParentClass class."""
-        return _register_accessor(name, ParentClass)
-
-    @register_parent_class_accessor("accessor")
     class _Accessor:
         def __init__(self, parent):
             self._parent = parent
@@ -29,6 +24,7 @@ def test_register_accessor():
             return True
 
     obj = ParentClass()
+    obj.accessor = Accessor("accessor", _Accessor)
     assert hasattr(obj, "accessor")
     assert isinstance(obj.accessor, _Accessor)
     assert obj.accessor.func()


### PR DESCRIPTION
`_register_accessor` is mysterious, but its implementation is simply an assignment with an extra check.

It turns out that this check makes it impossible to run single doctests; e.g.
```
# with _register_accessor

pytest src/skore/sklearn/_estimator/report.py::EstimatorReport.clear_cache:0
...
<frozen importlib._bootstrap_external>:999: in exec_module
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
src/skore/sklearn/_estimator/__init__.py:8: in <module>
    _register_accessor("metrics", EstimatorReport)(_MetricsAccessor)
src/skore/externals/_pandas_accessors.py:44: in decorator
    raise ValueError(
E   ValueError: registration of accessor <class 'skore.sklearn._estimator.metrics_accessor._MetricsAccessor'> under name 'metrics' for type <class 'skore.sklearn._estimator.report.EstimatorReport'> is overriding a preexisting attribute with the same name.
...
```

```
# without _register_accessor

pytest src/skore/sklearn/_estimator/report.py::EstimatorReport.clear_cache:0
1 passed in 1.49s
```

I had to add `cast`s to satisfy mypy.