### PR TITLE
docs: Discord link fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discord server
-    url: https://discord.gg/scBZerAGwW
+    url: https://discord.probabl.ai
     about: Developers and users can be found on the Discord server

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -150,7 +150,7 @@ html_theme_options = {
         },
         {
             "name": "Discord",
-            "url": "https://discord.gg/scBZerAGwW",
+            "url": "https://discord.probabl.ai",
             "icon": "fa-brands fa-discord",
         },
         {


### PR DESCRIPTION
Fix a couple of links in the documentation that did not use the canonical URL to our discord server.