### PR TITLE
fix: Do not expose Brier score if estimator does not implement predict_proba

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -16,7 +16,7 @@ from skore.sklearn._plot import (
     PredictionErrorDisplay,
     RocCurveDisplay,
 )
-from skore.utils._accessor import _check_supported_ml_task
+from skore.utils._accessor import _check_estimator_has_method, _check_supported_ml_task
 from skore.utils._index import flatten_multi_index
 from skore.utils._parallel import Parallel, delayed
 from skore.utils._progress_bar import progress_decorator
@@ -458,6 +458,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
     @available_if(
         _check_supported_ml_task(supported_ml_tasks=["binary-classification"])
     )
+    @available_if(_check_estimator_has_method(method_name="predict_proba"))
     def brier_score(
         self,
         *,

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -20,7 +20,7 @@ from skore.sklearn._plot import (
     RocCurveDisplay,
 )
 from skore.sklearn.types import SKLearnScorer
-from skore.utils._accessor import _check_supported_ml_task
+from skore.utils._accessor import _check_estimator_has_method, _check_supported_ml_task
 from skore.utils._index import flatten_multi_index
 
 DataSource = Literal["test", "train", "X_y"]
@@ -818,6 +818,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
     @available_if(
         _check_supported_ml_task(supported_ml_tasks=["binary-classification"])
     )
+    @available_if(_check_estimator_has_method(method_name="predict_proba"))
     def brier_score(
         self,
         *,

--- a/skore/src/skore/utils/_accessor.py
+++ b/skore/src/skore/utils/_accessor.py
@@ -20,6 +20,22 @@ def _check_supported_ml_task(supported_ml_tasks: list[str]) -> Callable:
     return check
 
 
+def _check_estimator_has_method(method_name: str) -> Callable:
+    def check(accessor: Any) -> bool:
+        parent_estimator = accessor._parent.estimator_
+
+        if hasattr(parent_estimator, method_name):
+            return True
+
+        raise AttributeError(
+            f"Estimator {parent_estimator} is not a supported estimator by "
+            f"the function called. The estimator should have a `{method_name}` "
+            "method."
+        )
+
+    return check
+
+
 def _check_has_coef() -> Callable:
     def check(accessor: Any) -> bool:
         """Check if the estimator has a `coef_` attribute."""

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -1195,7 +1195,11 @@ def test_estimator_has_no_deep_copy():
 
 def test_estimator_report_brier_score_requires_probabilities():
     """Check that the Brier score is not defined for estimator that do not
-    implement `predict_proba`."""
+    implement `predict_proba`.
+
+    Non-regression test for:
+    https://github.com/probabl-ai/skore/pull/1471
+    """
     estimator = SVC()  # SVC does not implement `predict_proba` with default parameters
     X, y = make_classification(n_classes=2, random_state=42)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -1191,3 +1191,16 @@ def test_estimator_has_no_deep_copy():
             y_train=y_train,
             y_test=y_test,
         )
+
+
+def test_estimator_report_brier_score_requires_probabilities():
+    """Check that the Brier score is not defined for estimator that do not
+    implement `predict_proba`."""
+    estimator = SVC()  # SVC does not implement `predict_proba` with default parameters
+    X, y = make_classification(n_classes=2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+    assert not hasattr(report.metrics, "brier_score")

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -825,3 +825,17 @@ def test_cross_validation_report_interrupted(
     )
     assert result.shape == (1, 1)
     assert result.index == ["accuracy_score"]
+
+
+def test_cross_validation_report_brier_score_requires_probabilities():
+    """Check that the Brier score is not defined for estimator that do not
+    implement `predict_proba`.
+
+    Non-regression test for:
+    https://github.com/probabl-ai/skore/pull/1471
+    """
+    estimator = SVC()  # SVC does not implement `predict_proba` with default parameters
+    X, y = make_classification(n_classes=2, random_state=42)
+
+    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
+    assert not hasattr(report.metrics, "brier_score")


### PR DESCRIPTION
closes #1470 

This PR makes sure that a report exposes Brier score only if the estimator under the hood are exposing a `predict_proba` method.