### PR TITLE
docs: Collapse feature importance graphs to one graph

### DIFF
--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -874,24 +874,55 @@ ridge_report.feature_importance.permutation(random_state=0)
 
 # %%
 def plot_permutation_train_test(est_report):
-    fig, axes = plt.subplots(nrows=1, ncols=2, sharey=True)
-
-    # Boxplot for the train set
-    est_report.feature_importance.permutation(
+    # Extract feature importance for train and test
+    train_importance = est_report.feature_importance.permutation(
         data_source="train", random_state=0
-    ).T.boxplot(ax=axes[0], vert=False)
-    axes[0].set_title("Train set")
-    axes[0].set_xlabel("r2")
-
-    # Boxplot for the test set
-    est_report.feature_importance.permutation(
+    ).T
+    test_importance = est_report.feature_importance.permutation(
         data_source="test", random_state=0
-    ).T.boxplot(ax=axes[1], vert=False)
-    axes[1].set_title("Test set")
-    axes[1].set_xlabel("r2")
+    ).T
 
-    fig.suptitle(f"Permutation feature importance of {est_report.estimator_name_}")
-    plt.tight_layout()
+    train_importance.columns = [
+        f"({col[0]}, {col[1]})" if isinstance(col, tuple) else col
+        for col in train_importance.columns
+    ]
+    test_importance.columns = [
+        f"({col[0]}, {col[1]})" if isinstance(col, tuple) else col
+        for col in test_importance.columns
+    ]
+
+    # Convert to long format
+    train_df = train_importance.reset_index(drop=True).melt(
+        var_name="Feature", value_name="Importance"
+    )
+    train_df["Dataset"] = "Train"
+
+    test_df = test_importance.reset_index(drop=True).melt(
+        var_name="Feature", value_name="Importance"
+    )
+    test_df["Dataset"] = "Test"
+
+    combined_df = pd.concat([train_df, test_df])
+
+    plt.figure(figsize=(10, 6))
+    sns.boxplot(
+        data=combined_df,
+        x="Importance",
+        y="Feature",
+        hue="Dataset",
+        palette={
+            "Train": "blue",
+            "Test": "#F99905",  # orange
+        },
+    )
+
+    plt.title(
+        f"Permutation feature importance of {est_report.estimator_name_} (Train vs Test)"
+    )
+    plt.xlabel("r2")
+    plt.ylabel("Feature")
+    plt.legend(title="Dataset")
+    plt.grid()
     plt.show()
 
 

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -906,7 +906,7 @@ def plot_permutation_train_test(est_report):
 
     ax.legend(
         handles=[
-            plt.Line2D([], [0], color=train_color, lw=5, label="Train"),
+            plt.Line2D([0], [0], color=train_color, lw=5, label="Train"),
             plt.Line2D([0], [0], color=test_color, lw=5, label="Test"),
         ],
         loc="lower right",

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -909,7 +909,7 @@ def plot_permutation_train_test(est_report):
             plt.Line2D([0], [0], color=train_color, lw=5, label="Train"),
             plt.Line2D([0], [0], color=test_color, lw=5, label="Test"),
         ],
-        loc="lower right",
+        loc="best",
         title="Dataset",
     )
 

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -873,56 +873,54 @@ ridge_report.feature_importance.permutation(random_state=0)
 
 
 # %%
+
+
 def plot_permutation_train_test(est_report):
-    # Extract feature importance for train and test
-    train_importance = est_report.feature_importance.permutation(
+    _, ax = plt.subplots(figsize=(8, 6))
+
+    train_color = "blue"
+    test_color = "orange"
+
+    est_report.feature_importance.permutation(
         data_source="train", random_state=0
-    ).T
-    test_importance = est_report.feature_importance.permutation(
+    ).T.boxplot(
+        ax=ax,
+        vert=False,
+        widths=0.35,
+        patch_artist=True,
+        boxprops=dict(facecolor=train_color, alpha=0.7),
+        medianprops=dict(color="black"),
+        positions=[x + 0.4 for x in range(len(est_report.X_train.columns))],
+    )
+    est_report.feature_importance.permutation(
         data_source="test", random_state=0
-    ).T
-
-    train_importance.columns = [
-        f"({col[0]}, {col[1]})" if isinstance(col, tuple) else col
-        for col in train_importance.columns
-    ]
-    test_importance.columns = [
-        f"({col[0]}, {col[1]})" if isinstance(col, tuple) else col
-        for col in test_importance.columns
-    ]
-
-    # Convert to long format
-    train_df = train_importance.reset_index(drop=True).melt(
-        var_name="Feature", value_name="Importance"
-    )
-    train_df["Dataset"] = "Train"
-
-    test_df = test_importance.reset_index(drop=True).melt(
-        var_name="Feature", value_name="Importance"
-    )
-    test_df["Dataset"] = "Test"
-
-    combined_df = pd.concat([train_df, test_df])
-
-    plt.figure(figsize=(10, 6))
-    sns.boxplot(
-        data=combined_df,
-        x="Importance",
-        y="Feature",
-        hue="Dataset",
-        palette={
-            "Train": "blue",
-            "Test": "#F99905",  # orange
-        },
+    ).T.boxplot(
+        ax=ax,
+        vert=False,
+        widths=0.35,
+        patch_artist=True,
+        boxprops=dict(facecolor=test_color, alpha=0.7),
+        medianprops=dict(color="black"),
+        positions=range(len(est_report.X_test.columns)),
     )
 
-    plt.title(
+    ax.legend(
+        handles=[
+            plt.Line2D([], [0], color=train_color, lw=5, label="Train"),
+            plt.Line2D([0], [0], color=test_color, lw=5, label="Test"),
+        ],
+        loc="lower right",
+        title="Dataset",
+    )
+
+    ax.set_title(
         f"Permutation feature importance of {est_report.estimator_name_} (Train vs Test)"
     )
-    plt.xlabel("r2")
-    plt.ylabel("Feature")
-    plt.legend(title="Dataset")
-    plt.grid()
+    ax.set_xlabel("r2")
+    ax.set_yticks([x + 0.2 for x in range(len(est_report.X_train.columns))])
+    ax.set_yticklabels(est_report.X_train.columns)
+
+    plt.tight_layout()
     plt.show()
 
 
@@ -984,3 +982,5 @@ plot_permutation_train_test(tree_report)
 # compared to linear models.
 # The model-agnostic permutation feature importance further enabled us to compare
 # feature significance across diverse model types.
+
+# %%


### PR DESCRIPTION
Issue referenced: https://github.com/probabl-ai/skore/issues/1420

Example:

**Before**:

<img width="773" alt="image" src="https://github.com/user-attachments/assets/3486e93c-32e3-49c4-b456-3734caab639c" />

**After**: 

<img width="654" alt="image" src="https://github.com/user-attachments/assets/5f645fbb-6aa2-4828-8213-f9da70120b13" />


Regarding @auguste-probabl comment `Is there no way to do combined_df.boxplot() like we had previously?`
Let me know what you think of the latest version. I followed the existing example by calling `.boxplot` by chaining it on the `est_report`. 

(p.s. apologies for the close/re-open, I did not have proper signature settings set and my signature attempts got messed up and ended up hard reseting my fork)