### PR TITLE
chore: Delegate availability methods to underlying EstimatorReport

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -16,7 +16,7 @@ from skore.sklearn._plot import (
     PredictionErrorDisplay,
     RocCurveDisplay,
 )
-from skore.utils._accessor import _check_estimator_has_method, _check_supported_ml_task
+from skore.utils._accessor import _check_estimator_report_has_method
 from skore.utils._index import flatten_multi_index
 from skore.utils._parallel import Parallel, delayed
 from skore.utils._progress_bar import progress_decorator
@@ -231,11 +231,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             self._parent._cache[cache_key] = results
         return results
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "accuracy"))
     def accuracy(
         self,
         *,
@@ -282,11 +278,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             aggregate=aggregate,
         )
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "precision"))
     def precision(
         self,
         *,
@@ -368,11 +360,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             scoring_kwargs={"average": average},
         )
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "recall"))
     def recall(
         self,
         *,
@@ -455,10 +443,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             scoring_kwargs={"average": average},
         )
 
-    @available_if(
-        _check_supported_ml_task(supported_ml_tasks=["binary-classification"])
-    )
-    @available_if(_check_estimator_has_method(method_name="predict_proba"))
+    @available_if(_check_estimator_report_has_method("metrics", "brier_score"))
     def brier_score(
         self,
         *,
@@ -505,11 +490,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             aggregate=aggregate,
         )
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "roc_auc"))
     def roc_auc(
         self,
         *,
@@ -592,11 +573,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             scoring_kwargs={"average": average, "multi_class": multi_class},
         )
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "log_loss"))
     def log_loss(
         self,
         *,
@@ -643,11 +620,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             aggregate=aggregate,
         )
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["regression", "multioutput-regression"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "r2"))
     def r2(
         self,
         *,
@@ -706,11 +679,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             scoring_kwargs={"multioutput": multioutput},
         )
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["regression", "multioutput-regression"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "rmse"))
     def rmse(
         self,
         *,
@@ -1018,11 +987,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         return display
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "roc"))
     def roc(
         self,
         *,
@@ -1069,11 +1034,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         assert isinstance(display, RocCurveDisplay)
         return display
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "precision_recall"))
     def precision_recall(
         self,
         *,
@@ -1120,11 +1081,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         assert isinstance(display, PrecisionRecallCurveDisplay)
         return display
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["regression", "multioutput-regression"]
-        )
-    )
+    @available_if(_check_estimator_report_has_method("metrics", "prediction_error"))
     def prediction_error(
         self,
         *,

--- a/skore/src/skore/utils/_accessor.py
+++ b/skore/src/skore/utils/_accessor.py
@@ -2,6 +2,10 @@ from typing import Any, Callable
 
 from sklearn.pipeline import Pipeline
 
+########################################################################################
+# Accessor related to `EstimatorReport`
+########################################################################################
+
 
 def _check_supported_ml_task(supported_ml_tasks: list[str]) -> Callable:
     def check(accessor: Any) -> bool:
@@ -31,31 +35,6 @@ def _check_estimator_has_method(method_name: str) -> Callable:
             f"Estimator {parent_estimator} is not a supported estimator by "
             f"the function called. The estimator should have a `{method_name}` "
             "method."
-        )
-
-    return check
-
-
-def _check_estimator_report_has_method(
-    accessor_name: str,
-    method_name: str,
-) -> Callable:
-    def check(accessor: Any) -> bool:
-        estimator_report = accessor._parent.estimator_reports_[0]
-
-        if not hasattr(estimator_report, accessor_name):
-            raise AttributeError(
-                f"Estimator report {estimator_report} does not have the "
-                f"'{accessor_name}' accessor."
-            )
-        estimator_report = getattr(estimator_report, accessor_name)
-
-        if hasattr(estimator_report, method_name):
-            return True
-        raise AttributeError(
-            f"Estimator report {estimator_report} is not a supported estimator report "
-            "by the function called. The estimator report should have a "
-            f"`{method_name}` method."
         )
 
     return check
@@ -94,6 +73,36 @@ def _check_has_feature_importances() -> Callable:
         raise AttributeError(
             f"Estimator {parent_estimator} is not a supported estimator by "
             "the function called."
+        )
+
+    return check
+
+
+########################################################################################
+# Accessor related to `CrossValidationReport`
+########################################################################################
+
+
+def _check_estimator_report_has_method(
+    accessor_name: str,
+    method_name: str,
+) -> Callable:
+    def check(accessor: Any) -> bool:
+        estimator_report = accessor._parent.estimator_reports_[0]
+
+        if not hasattr(estimator_report, accessor_name):
+            raise AttributeError(
+                f"Estimator report {estimator_report} does not have the "
+                f"'{accessor_name}' accessor."
+            )
+        accessor = getattr(estimator_report, accessor_name)
+
+        if hasattr(accessor, method_name):
+            return True
+        raise AttributeError(
+            f"Estimator report {estimator_report} is not a supported estimator report "
+            "by the function called. The estimator report should have a "
+            f"`{method_name}` method."
         )
 
     return check

--- a/skore/src/skore/utils/_accessor.py
+++ b/skore/src/skore/utils/_accessor.py
@@ -36,6 +36,31 @@ def _check_estimator_has_method(method_name: str) -> Callable:
     return check
 
 
+def _check_estimator_report_has_method(
+    accessor_name: str,
+    method_name: str,
+) -> Callable:
+    def check(accessor: Any) -> bool:
+        estimator_report = accessor._parent.estimator_reports_[0]
+
+        if not hasattr(estimator_report, accessor_name):
+            raise AttributeError(
+                f"Estimator report {estimator_report} does not have the "
+                f"'{accessor_name}' accessor."
+            )
+        estimator_report = getattr(estimator_report, accessor_name)
+
+        if hasattr(estimator_report, method_name):
+            return True
+        raise AttributeError(
+            f"Estimator report {estimator_report} is not a supported estimator report "
+            "by the function called. The estimator report should have a "
+            f"`{method_name}` method."
+        )
+
+    return check
+
+
 def _check_has_coef() -> Callable:
     def check(accessor: Any) -> bool:
         """Check if the estimator has a `coef_` attribute."""


### PR DESCRIPTION
closes #1472

Delegate the availability of all different methods from `CrossValidationReport` depending if they are available into the `EstimatorReport` from the first CV split.