### PR TITLE
chore: Use cast instead of assert when there is no need for defensive assert

### DIFF
--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -2,10 +2,9 @@ import inspect
 import re
 from abc import ABC, abstractmethod
 from io import StringIO
-from typing import Any, Generic, Literal, Optional, TypeVar, Union
+from typing import Any, Generic, Literal, Optional, TypeVar, Union, cast
 
 import joblib
-import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from rich.console import Console, Group
 from rich.panel import Panel
@@ -391,8 +390,7 @@ def _get_cached_response_values(
     )
 
     if cache_key in cache:
-        cached_predictions = cache[cache_key]
-        assert isinstance(cached_predictions, np.ndarray)
+        cached_predictions = cast(NDArray, cache[cache_key])
         return cached_predictions
 
     with MeasureTime() as predict_time:

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union, cast
 
 import joblib
 import numpy as np
@@ -1336,15 +1336,17 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display = self._get_display(
-            X=X,
-            y=y,
-            data_source=data_source,
-            response_method=response_method,
-            display_class=RocCurveDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            RocCurveDisplay,
+            self._get_display(
+                X=X,
+                y=y,
+                data_source=data_source,
+                response_method=response_method,
+                display_class=RocCurveDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, RocCurveDisplay)
         return display
 
     @available_if(
@@ -1419,15 +1421,17 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display = self._get_display(
-            X=X,
-            y=y,
-            data_source=data_source,
-            response_method=response_method,
-            display_class=PrecisionRecallCurveDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            PrecisionRecallCurveDisplay,
+            self._get_display(
+                X=X,
+                y=y,
+                data_source=data_source,
+                response_method=response_method,
+                display_class=PrecisionRecallCurveDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, PrecisionRecallCurveDisplay)
         return display
 
     @available_if(
@@ -1511,13 +1515,15 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         >>> display.plot(kind="actual_vs_predicted")
         """
         display_kwargs = {"subsample": subsample, "random_state": random_state}
-        display = self._get_display(
-            X=X,
-            y=y,
-            data_source=data_source,
-            response_method="predict",
-            display_class=PredictionErrorDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            PredictionErrorDisplay,
+            self._get_display(
+                X=X,
+                y=y,
+                data_source=data_source,
+                response_method="predict",
+                display_class=PredictionErrorDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, PredictionErrorDisplay)
         return display

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union, cast
 
 import joblib
 import numpy as np
@@ -1060,13 +1060,15 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display = self._get_display(
-            data_source=data_source,
-            response_method=response_method,
-            display_class=RocCurveDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            RocCurveDisplay,
+            self._get_display(
+                data_source=data_source,
+                response_method=response_method,
+                display_class=RocCurveDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, RocCurveDisplay)
         return display
 
     @available_if(
@@ -1111,13 +1113,15 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display = self._get_display(
-            data_source=data_source,
-            response_method=response_method,
-            display_class=PrecisionRecallCurveDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            PrecisionRecallCurveDisplay,
+            self._get_display(
+                data_source=data_source,
+                response_method=response_method,
+                display_class=PrecisionRecallCurveDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, PrecisionRecallCurveDisplay)
         return display
 
     @available_if(
@@ -1171,11 +1175,13 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         >>> display.plot(kind="actual_vs_predicted", line_kwargs={"color": "tab:red"})
         """
         display_kwargs = {"subsample": subsample, "random_state": random_state}
-        display = self._get_display(
-            data_source=data_source,
-            response_method="predict",
-            display_class=PredictionErrorDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            PredictionErrorDisplay,
+            self._get_display(
+                data_source=data_source,
+                response_method="predict",
+                display_class=PredictionErrorDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, PredictionErrorDisplay)
         return display

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Iterable
 from functools import partial
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union, cast
 
 import joblib
 import numpy as np
@@ -595,11 +595,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             data_source_hash=data_source_hash,
             response_method="predict",
         )
-        assert isinstance(score, float), (
-            "The accuracy score should be a float, got "
-            f"{type(score)} with value {score}."
-        )
-        return score
+        return cast(float, score)
 
     @available_if(
         _check_supported_ml_task(
@@ -732,16 +728,8 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             average=average,
         )
         if self._parent._ml_task == "binary-classification" and pos_label is not None:
-            assert isinstance(result, float), (
-                "The precision score should be a float, got "
-                f"{type(result)} with value {result}."
-            )
-            return result
-        assert isinstance(result, dict), (
-            "The precision score should be a dict, got "
-            f"{type(result)} with value {result}."
-        )
-        return result
+            return cast(float, result)
+        return cast(dict[Union[int, float, bool, str], float], result)
 
     @available_if(
         _check_supported_ml_task(
@@ -875,16 +863,8 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             average=average,
         )
         if self._parent._ml_task == "binary-classification" and pos_label is not None:
-            assert isinstance(result, float), (
-                "The precision score should be a float, got "
-                f"{type(result)} with value {result}."
-            )
-            return result
-        assert isinstance(result, dict), (
-            "The precision score should be a dict, got "
-            f"{type(result)} with value {result}."
-        )
-        return result
+            return cast(float, result)
+        return cast(dict[Union[int, float, bool, str], float], result)
 
     @available_if(
         _check_supported_ml_task(supported_ml_tasks=["binary-classification"])
@@ -975,11 +955,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             response_method="predict_proba",
             pos_label=self._parent._estimator.classes_[-1],
         )
-        assert isinstance(result, float), (
-            "The Brier score should be a float, got "
-            f"{type(result)} with value {result}."
-        )
-        return result
+        return cast(float, result)
 
     @available_if(
         _check_supported_ml_task(
@@ -1108,16 +1084,8 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             multi_class=multi_class,
         )
         if self._parent._ml_task == "multiclass-classification" and average is None:
-            assert isinstance(result, dict), (
-                "The ROC AUC score should be a dict, got "
-                f"{type(result)} with value {result}."
-            )
-            return result
-        assert isinstance(result, float), (
-            "The ROC AUC score should be a float, got "
-            f"{type(result)} with value {result}."
-        )
-        return result
+            return cast(dict[Union[int, float, bool, str], float], result)
+        return cast(float, result)
 
     @available_if(
         _check_supported_ml_task(
@@ -1197,10 +1165,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             data_source_hash=data_source_hash,
             response_method="predict_proba",
         )
-        assert isinstance(result, float), (
-            f"The log loss should be a float, got {type(result)} with value {result}."
-        )
-        return result
+        return cast(float, result)
 
     @available_if(
         _check_supported_ml_task(
@@ -1309,15 +1274,8 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             self._parent._ml_task == "multioutput-regression"
             and multioutput == "raw_values"
         ):
-            assert isinstance(result, list), (
-                "The R² score should be a list, got "
-                f"{type(result)} with value {result}."
-            )
-            return result
-        assert isinstance(result, float), (
-            f"The R² score should be a float, got {type(result)} with value {result}."
-        )
-        return result
+            return cast(list, result)
+        return cast(float, result)
 
     @available_if(
         _check_supported_ml_task(
@@ -1426,15 +1384,8 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             self._parent._ml_task == "multioutput-regression"
             and multioutput == "raw_values"
         ):
-            assert isinstance(result, list), (
-                "The RMSE score should be a list, got "
-                f"{type(result)} with value {result}."
-            )
-            return result
-        assert isinstance(result, float), (
-            f"The RMSE score should be a float, got {type(result)} with value {result}."
-        )
-        return result
+            return cast(list, result)
+        return cast(float, result)
 
     def custom_metric(
         self,
@@ -1782,15 +1733,17 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display = self._get_display(
-            X=X,
-            y=y,
-            data_source=data_source,
-            response_method=response_method,
-            display_class=RocCurveDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            RocCurveDisplay,
+            self._get_display(
+                X=X,
+                y=y,
+                data_source=data_source,
+                response_method=response_method,
+                display_class=RocCurveDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, RocCurveDisplay)
         return display
 
     @available_if(
@@ -1855,15 +1808,17 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         """
         response_method = ("predict_proba", "decision_function")
         display_kwargs = {"pos_label": pos_label}
-        display = self._get_display(
-            X=X,
-            y=y,
-            data_source=data_source,
-            response_method=response_method,
-            display_class=PrecisionRecallCurveDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            PrecisionRecallCurveDisplay,
+            self._get_display(
+                X=X,
+                y=y,
+                data_source=data_source,
+                response_method=response_method,
+                display_class=PrecisionRecallCurveDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, PrecisionRecallCurveDisplay)
         return display
 
     @available_if(
@@ -1937,13 +1892,15 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         >>> display.plot(line_kwargs={"color": "tab:red"})
         """
         display_kwargs = {"subsample": subsample, "random_state": random_state}
-        display = self._get_display(
-            X=X,
-            y=y,
-            data_source=data_source,
-            response_method="predict",
-            display_class=PredictionErrorDisplay,
-            display_kwargs=display_kwargs,
+        display = cast(
+            PredictionErrorDisplay,
+            self._get_display(
+                X=X,
+                y=y,
+                data_source=data_source,
+                response_method="predict",
+                display_class=PredictionErrorDisplay,
+                display_kwargs=display_kwargs,
+            ),
         )
-        assert isinstance(display, PredictionErrorDisplay)
         return display

--- a/skore/src/skore/sklearn/_plot/utils.py
+++ b/skore/src/skore/sklearn/_plot/utils.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Sequence
 from io import StringIO
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union, cast
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -175,10 +175,8 @@ class _ClassifierCurveDisplayMixin:
             If the format of curve_kwargs is invalid.
         """
         if self.ml_task == "binary-classification":
-            assert self.pos_label is not None, (
-                "pos_label should not be None with binary classification."
-            )
-            n_curves = len(metric[self.pos_label])
+            pos_label = cast(Union[int, float, bool, str], self.pos_label)
+            n_curves = len(metric[pos_label])
             if report_type in ("estimator", "cross-validation"):
                 allow_single_dict = True
             elif report_type == "comparison-estimator":

--- a/skore/tests/unit/sklearn/estimator/test_timings.py
+++ b/skore/tests/unit/sklearn/estimator/test_timings.py
@@ -1,3 +1,4 @@
+import joblib
 import pandas as pd
 import pytest
 from sklearn.datasets import make_classification
@@ -50,7 +51,8 @@ def test_predict_prefitted(data_source, binary_classification_data):
 
     if data_source == "X_y":
         X_, y_ = (data["X_test"], data["y_test"])
-        data_source_check = "X_y_ed3deae4cb54a7cf5f0e6fa6f7b4badd"
+        data_source_hash = joblib.hash((data["X_test"], data["y_test"]))
+        data_source_check = f"X_y_{data_source_hash}"
     else:
         X_, y_ = (None, None)
         data_source_check = data_source
@@ -72,6 +74,8 @@ def test_everything(binary_classification_data):
     report.metrics.accuracy(data_source="train", X=None, y=None)
     report.metrics.accuracy(data_source="test", X=None, y=None)
     report.metrics.accuracy(data_source="X_y", X=data["X_test"], y=data["y_test"])
+    data_source_hash = joblib.hash((data["X_test"], data["y_test"]))
+    data_source_check = f"X_y_{data_source_hash}"
 
     result = report.metrics.timings()
     assert isinstance(result, dict)
@@ -79,10 +83,7 @@ def test_everything(binary_classification_data):
     assert isinstance(result.get("fit_time"), float)
     assert isinstance(result.get("predict_time_train"), float)
     assert isinstance(result.get("predict_time_test"), float)
-    assert isinstance(
-        result.get("predict_time_X_y_ed3deae4cb54a7cf5f0e6fa6f7b4badd"),
-        float,
-    )
+    assert isinstance(result.get(f"predict_time_{data_source_check}"), float)
 
 
 def test_fit_time(binary_classification_data):


### PR DESCRIPTION
closes #1466 

Use `typing.cast` when there is not real need for `assert` inside the source code.