### PR TITLE
fix: Avoid pandas warning by using float('nan') instead of None

### DIFF
--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1,4 +1,5 @@
 import inspect
+import math
 from collections.abc import Iterable
 from functools import partial
 from typing import Any, Callable, Literal, Optional, Union
@@ -447,7 +448,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                 return score[0]
         return score
 
-    def _fit_time(self, **kwargs) -> Union[float, None]:
+    def _fit_time(self, **kwargs) -> float:
         """Get time to fit the estimator.
 
         kwargs are available for compatibility with other metrics.
@@ -496,7 +497,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
               given data source.
         """
         fit_time_ = self._fit_time()
-        fit_time = {"fit_time": fit_time_} if fit_time_ is not None else {}
+        fit_time = {"fit_time": fit_time_} if not math.isnan(fit_time_) else {}
 
         # predict_time cache keys are of the form
         # (self._parent._hash, data_source, data_source_hash, "predict_time")

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -60,9 +60,9 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     estimator_name_ : str
         The name of the estimator.
 
-    fit_time_ : float
+    fit_time_ : float or None
         The time taken to fit the estimator, in seconds. If the estimator is not
-        internally fitted, the value is `nan`.
+        internally fitted, the value is `None`.
 
     See Also
     --------
@@ -132,7 +132,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         self._progress_info: Optional[dict[str, Any]] = None
         self._parent_progress = None
 
-        fit_time: float = float("nan")
+        fit_time: Optional[float] = None
         if fit == "auto":
             try:
                 check_is_fitted(estimator)

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -60,9 +60,9 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     estimator_name_ : str
         The name of the estimator.
 
-    fit_time_ : float or None
-        The time taken to fit the estimator, in seconds. May be None if, for example,
-        the estimator was already fitted.
+    fit_time_ : float
+        The time taken to fit the estimator, in seconds. If the estimator is not
+        internally fitted, the value is `nan`.
 
     See Also
     --------
@@ -132,7 +132,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         self._progress_info: Optional[dict[str, Any]] = None
         self._parent_progress = None
 
-        fit_time: Optional[float] = None
+        fit_time: float = float("nan")
         if fit == "auto":
             try:
                 check_is_fitted(estimator)

--- a/skore/tests/unit/sklearn/estimator/test_timings.py
+++ b/skore/tests/unit/sklearn/estimator/test_timings.py
@@ -94,7 +94,7 @@ def test_fit_time(binary_classification_data):
     estimator, data = binary_classification_data
     report = EstimatorReport(estimator, **data)
 
-    assert isinstance(report.metrics._fit_time(), float)
+    assert isinstance(report.metrics._fit_time(cast=False), float)
 
 
 def test_fit_time_estimator_already_fitted(binary_classification_data):
@@ -104,7 +104,8 @@ def test_fit_time_estimator_already_fitted(binary_classification_data):
     estimator.fit(data["X_train"], data["y_train"])
     report = EstimatorReport(estimator, X_test=data["X_test"], y_test=data["y_test"])
 
-    assert math.isnan(report.metrics._fit_time())
+    assert report.metrics._fit_time(cast=False) is None
+    assert math.isnan(report.metrics._fit_time(cast=True))
 
 
 def test_fit_time_estimator_unfitted(binary_classification_data):
@@ -112,7 +113,8 @@ def test_fit_time_estimator_unfitted(binary_classification_data):
     estimator, data = binary_classification_data
     report = EstimatorReport(estimator, fit=False, **data)
 
-    assert math.isnan(report.metrics._fit_time())
+    assert report.metrics._fit_time(cast=False) is None
+    assert math.isnan(report.metrics._fit_time(cast=True))
 
 
 @pytest.mark.parametrize("data_source", ["test", "train", "X_y"])

--- a/skore/tests/unit/sklearn/estimator/test_timings.py
+++ b/skore/tests/unit/sklearn/estimator/test_timings.py
@@ -1,3 +1,6 @@
+import math
+
+import joblib
 import pandas as pd
 import pytest
 from sklearn.datasets import make_classification
@@ -50,7 +53,8 @@ def test_predict_prefitted(data_source, binary_classification_data):
 
     if data_source == "X_y":
         X_, y_ = (data["X_test"], data["y_test"])
-        data_source_check = "X_y_ed3deae4cb54a7cf5f0e6fa6f7b4badd"
+        data_source_hash = joblib.hash((X_, y_))
+        data_source_check = f"X_y_{data_source_hash}"
     else:
         X_, y_ = (None, None)
         data_source_check = data_source
@@ -72,6 +76,8 @@ def test_everything(binary_classification_data):
     report.metrics.accuracy(data_source="train", X=None, y=None)
     report.metrics.accuracy(data_source="test", X=None, y=None)
     report.metrics.accuracy(data_source="X_y", X=data["X_test"], y=data["y_test"])
+    data_source_hash = joblib.hash((data["X_test"], data["y_test"]))
+    data_source_check = f"predict_time_X_y_{data_source_hash}"
 
     result = report.metrics.timings()
     assert isinstance(result, dict)
@@ -79,10 +85,7 @@ def test_everything(binary_classification_data):
     assert isinstance(result.get("fit_time"), float)
     assert isinstance(result.get("predict_time_train"), float)
     assert isinstance(result.get("predict_time_test"), float)
-    assert isinstance(
-        result.get("predict_time_X_y_ed3deae4cb54a7cf5f0e6fa6f7b4badd"),
-        float,
-    )
+    assert isinstance(result.get(data_source_check), float)
 
 
 def test_fit_time(binary_classification_data):
@@ -101,7 +104,7 @@ def test_fit_time_estimator_already_fitted(binary_classification_data):
     estimator.fit(data["X_train"], data["y_train"])
     report = EstimatorReport(estimator, X_test=data["X_test"], y_test=data["y_test"])
 
-    assert report.metrics._fit_time() is None
+    assert math.isnan(report.metrics._fit_time())
 
 
 def test_fit_time_estimator_unfitted(binary_classification_data):
@@ -109,7 +112,7 @@ def test_fit_time_estimator_unfitted(binary_classification_data):
     estimator, data = binary_classification_data
     report = EstimatorReport(estimator, fit=False, **data)
 
-    assert report.metrics._fit_time() is None
+    assert math.isnan(report.metrics._fit_time())
 
 
 @pytest.mark.parametrize("data_source", ["test", "train", "X_y"])


### PR DESCRIPTION
While working on #1483, I realised that we are raising a pandas warning when a concatenation is done with fitted estimator in `report_metrics` because `fit_time=None` and `None` does not have the same `dtype` than other dataframe (`float`).

To avoid such issue, we can use `float("nan")` whenever we don't have the information and keep the `dtype` consistent. It will avoid the pandas warning as well.

In addition, I found a failure in #1483 in which, for some reason, the value of the hash of the data is changing. Therefore, I'm not hard-coding it anymore and instead computing on the go the value.