### PR TITLE
feat: Increase the font size, use `tight_layout`, and better legend location

### DIFF
--- a/examples/getting_started/plot_quick_start.py
+++ b/examples/getting_started/plot_quick_start.py
@@ -41,11 +41,8 @@ df_cv_report_metrics
 # Display the ROC curve that was generated for you:
 
 # %%
-import matplotlib.pyplot as plt
-
 roc_plot = cv_report.metrics.roc()
 roc_plot.plot()
-plt.tight_layout()
 
 # %%
 # Skore project: storing some items

--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -86,11 +86,8 @@ rf_report.metrics.report_metrics(pos_label=1)
 # We can also plot the ROC curve that is generated for us:
 
 # %%
-import matplotlib.pyplot as plt
-
 roc_plot = rf_report.metrics.roc()
 roc_plot.plot()
-plt.tight_layout()
 
 # %%
 # Furthermore, we can inspect our model using the
@@ -98,6 +95,8 @@ plt.tight_layout()
 # In particular, we can inspect the model using the permutation feature importance:
 
 # %%
+import matplotlib.pyplot as plt
+
 rf_report.feature_importance.permutation().T.boxplot(vert=False)
 plt.tight_layout()
 
@@ -146,7 +145,6 @@ cv_report.metrics.report_metrics(aggregate=["mean", "std"], pos_label=1)
 # %%
 roc_plot_cv = cv_report.metrics.roc()
 roc_plot_cv.plot()
-plt.tight_layout()
 
 # %%
 # We can retrieve the estimator report of a specific fold to investigate further,
@@ -210,7 +208,6 @@ comparator.metrics.report_metrics(pos_label=1)
 
 # %%
 comparator.metrics.roc().plot()
-plt.tight_layout()
 
 # %%
 # Train-test split with skore

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -335,7 +335,6 @@ report.metrics.help()
 # Let's start by plotting the ROC curve for our binary classification task.
 display = report.metrics.roc(pos_label=pos_label)
 display.plot()
-plt.tight_layout()
 
 # %%
 #
@@ -350,9 +349,7 @@ display.help()
 
 # %%
 display.plot()
-display.ax_.set_title("Example of a ROC curve")
-display.figure_
-plt.tight_layout()
+_ = display.ax_.set_title("Example of a ROC curve")
 
 # %%
 #
@@ -364,7 +361,6 @@ start = time.time()
 # we already trigger the computation of the predictions in a previous call
 display = report.metrics.roc(pos_label=pos_label)
 display.plot()
-plt.tight_layout()
 end = time.time()
 
 # %%
@@ -379,7 +375,6 @@ report.clear_cache()
 start = time.time()
 display = report.metrics.roc(pos_label=pos_label)
 display.plot()
-plt.tight_layout()
 end = time.time()
 
 # %%

--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -215,13 +215,11 @@ print(f"Time taken: {end - start:.2f} seconds")
 # ^^^^^^^^^^^^^^^^^^^^
 #
 # The cache also speeds up plots. Let's create a ROC curve:
-import matplotlib.pyplot as plt
 
 start = time.time()
 display = report.metrics.roc(pos_label="allowed")
 display.plot()
 end = time.time()
-plt.tight_layout()
 
 # %%
 print(f"Time taken: {end - start:.2f} seconds")
@@ -233,7 +231,6 @@ start = time.time()
 display = report.metrics.roc(pos_label="allowed")
 display.plot()
 end = time.time()
-plt.tight_layout()
 
 # %%
 print(f"Time taken: {end - start:.2f} seconds")
@@ -243,7 +240,6 @@ print(f"Time taken: {end - start:.2f} seconds")
 # We only use the cache to retrieve the `display` object and not directly the matplotlib
 # figure. It means that we can still customize the cached plot before displaying it:
 display.plot(roc_curve_kwargs={"color": "tab:orange"})
-plt.tight_layout()
 
 # %%
 #

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -326,9 +326,6 @@ for split_idx, (ax, estimator_report) in enumerate(
     estimator_report.metrics.prediction_error().plot(kind="actual_vs_predicted", ax=ax)
     ax.set_title(f"Split #{split_idx + 1}")
     ax.legend(loc="lower right")
-plt.tight_layout()
 # sphinx_gallery_start_ignore
 temp_dir.cleanup()
 # sphinx_gallery_end_ignore
-
-# %%

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -253,7 +253,6 @@ ridge_report.metrics.report_metrics()
 
 # %%
 ridge_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
-plt.tight_layout()
 
 # %%
 # We can observe that the model has issues predicting large house prices, due to the
@@ -430,7 +429,6 @@ comparator.metrics.report_metrics()
 
 # %%
 engineered_ridge_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
-plt.tight_layout()
 
 # %%
 # About the clipping issue, compared to the prediction error of our previous model

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -267,7 +267,7 @@ class PrecisionRecallCurveDisplay(
 
             info_pos_label = None  # irrelevant for multiclass
 
-        ax.legend(title=estimator_name)
+        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -401,7 +401,7 @@ class PrecisionRecallCurveDisplay(
                     )
                     lines.append(line)
 
-        ax.legend(title=estimator_name)
+        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -526,7 +526,10 @@ class PrecisionRecallCurveDisplay(
                     )
                     lines.append(line)
 
-        ax.legend(title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set")
+        ax.legend(
+            bbox_to_anchor=(1.02, 1),
+            title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set",
+        )
 
         return ax, lines, info_pos_label
 

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -25,7 +25,7 @@ from skore.sklearn.types import MLTask
 
 
 class PrecisionRecallCurveDisplay(
-    HelpDisplayMixin, _ClassifierCurveDisplayMixin, StyleDisplayMixin
+    StyleDisplayMixin, HelpDisplayMixin, _ClassifierCurveDisplayMixin
 ):
     """Precision Recall visualization.
 
@@ -533,6 +533,7 @@ class PrecisionRecallCurveDisplay(
 
         return ax, lines, info_pos_label
 
+    @StyleDisplayMixin.style_plot
     def plot(
         self,
         ax: Optional[Axes] = None,

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -267,7 +267,12 @@ class PrecisionRecallCurveDisplay(
 
             info_pos_label = None  # irrelevant for multiclass
 
-        ax.legend(loc="lower left", title=estimator_name)
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            title=estimator_name,
+            borderaxespad=0,
+        )
 
         return ax, lines, info_pos_label
 
@@ -401,7 +406,12 @@ class PrecisionRecallCurveDisplay(
                     )
                     lines.append(line)
 
-        ax.legend(loc="lower left", title=estimator_name)
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            title=estimator_name,
+            borderaxespad=0,
+        )
 
         return ax, lines, info_pos_label
 
@@ -527,8 +537,10 @@ class PrecisionRecallCurveDisplay(
                     lines.append(line)
 
         ax.legend(
-            loc="lower left",
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
             title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set",
+            borderaxespad=0,
         )
 
         return ax, lines, info_pos_label

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -267,12 +267,7 @@ class PrecisionRecallCurveDisplay(
 
             info_pos_label = None  # irrelevant for multiclass
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=estimator_name,
-            borderaxespad=0,
-        )
+        ax.legend(title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -406,12 +401,7 @@ class PrecisionRecallCurveDisplay(
                     )
                     lines.append(line)
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=estimator_name,
-            borderaxespad=0,
-        )
+        ax.legend(title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -536,12 +526,7 @@ class PrecisionRecallCurveDisplay(
                     )
                     lines.append(line)
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set",
-            borderaxespad=0,
-        )
+        ax.legend(title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set")
 
         return ax, lines, info_pos_label
 

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -256,12 +256,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                 )
             )
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=estimator_name,
-            borderaxespad=0,
-        )
+        ax.legend(title=estimator_name)
 
         return scatter
 
@@ -349,12 +344,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                     )
                 )
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=estimator_name,
-            borderaxespad=0,
-        )
+        ax.legend(title=estimator_name)
 
         return scatter
 
@@ -441,12 +431,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                     )
                 )
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=f"Prediction errors on $\\bf{{{data_source}}}$ set",
-            borderaxespad=0,
-        )
+        ax.legend(title=f"Prediction errors on $\\bf{{{data_source}}}$ set")
 
         return scatter
 

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -256,7 +256,12 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                 )
             )
 
-        ax.legend(title=estimator_name)
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            title=estimator_name,
+            borderaxespad=0,
+        )
 
         return scatter
 
@@ -344,7 +349,12 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                     )
                 )
 
-        ax.legend(title=estimator_name)
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            title=estimator_name,
+            borderaxespad=0,
+        )
 
         return scatter
 
@@ -431,7 +441,12 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                     )
                 )
 
-        ax.legend(title=f"Prediction errors on $\\bf{{{data_source}}}$ set")
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            title=f"Prediction errors on $\\bf{{{data_source}}}$ set",
+            borderaxespad=0,
+        )
 
         return scatter
 

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -260,7 +260,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                 )
             )
 
-        ax.legend(title=estimator_name)
+        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
 
         return scatter
 
@@ -348,7 +348,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                     )
                 )
 
-        ax.legend(title=estimator_name)
+        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
 
         return scatter
 
@@ -435,7 +435,10 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                     )
                 )
 
-        ax.legend(title=f"Prediction errors on $\\bf{{{data_source}}}$ set")
+        ax.legend(
+            bbox_to_anchor=(1.02, 1),
+            title=f"Prediction errors on $\\bf{{{data_source}}}$ set",
+        )
 
         return scatter
 

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -23,7 +23,7 @@ from skore.sklearn.types import MLTask
 RangeData = namedtuple("RangeData", ["min", "max"])
 
 
-class PredictionErrorDisplay(HelpDisplayMixin, StyleDisplayMixin):
+class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
     """Visualization of the prediction error of a regression model.
 
     This tool can display "residuals vs predicted" or "actual vs predicted"
@@ -435,6 +435,7 @@ class PredictionErrorDisplay(HelpDisplayMixin, StyleDisplayMixin):
 
         return scatter
 
+    @StyleDisplayMixin.style_plot
     def plot(
         self,
         ax: Optional[Axes] = None,

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -266,7 +266,7 @@ class RocCurveDisplay(
 
             info_pos_label = None  # irrelevant for multiclass
 
-        ax.legend(title=estimator_name)
+        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -396,7 +396,7 @@ class RocCurveDisplay(
                     (line,) = ax.plot(fpr_split, tpr_split, **line_kwargs_validated)
                     lines.append(line)
 
-        ax.legend(title=estimator_name)
+        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -520,6 +520,7 @@ class RocCurveDisplay(
                     lines.append(line)
 
         ax.legend(
+            bbox_to_anchor=(1.02, 1),
             title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set",
         )
 

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -266,12 +266,7 @@ class RocCurveDisplay(
 
             info_pos_label = None  # irrelevant for multiclass
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=estimator_name,
-            borderaxespad=0,
-        )
+        ax.legend(title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -401,12 +396,7 @@ class RocCurveDisplay(
                     (line,) = ax.plot(fpr_split, tpr_split, **line_kwargs_validated)
                     lines.append(line)
 
-        ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
-            title=estimator_name,
-            borderaxespad=0,
-        )
+        ax.legend(title=estimator_name)
 
         return ax, lines, info_pos_label
 
@@ -530,10 +520,7 @@ class RocCurveDisplay(
                     lines.append(line)
 
         ax.legend(
-            loc="upper left",
-            bbox_to_anchor=(1.02, 1),
             title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set",
-            borderaxespad=0,
         )
 
         return ax, lines, info_pos_label

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -266,7 +266,12 @@ class RocCurveDisplay(
 
             info_pos_label = None  # irrelevant for multiclass
 
-        ax.legend(loc="lower right", title=estimator_name)
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            title=estimator_name,
+            borderaxespad=0,
+        )
 
         return ax, lines, info_pos_label
 
@@ -396,7 +401,12 @@ class RocCurveDisplay(
                     (line,) = ax.plot(fpr_split, tpr_split, **line_kwargs_validated)
                     lines.append(line)
 
-        ax.legend(loc="lower right", title=estimator_name)
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            title=estimator_name,
+            borderaxespad=0,
+        )
 
         return ax, lines, info_pos_label
 
@@ -520,8 +530,10 @@ class RocCurveDisplay(
                     lines.append(line)
 
         ax.legend(
-            loc="lower right",
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
             title=f"{ml_task.title()} on $\\bf{{{data_source}}}$ set",
+            borderaxespad=0,
         )
 
         return ax, lines, info_pos_label

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -25,7 +25,7 @@ from skore.sklearn.types import MLTask
 
 
 class RocCurveDisplay(
-    HelpDisplayMixin, _ClassifierCurveDisplayMixin, StyleDisplayMixin
+    StyleDisplayMixin, HelpDisplayMixin, _ClassifierCurveDisplayMixin
 ):
     """ROC Curve visualization.
 
@@ -526,6 +526,7 @@ class RocCurveDisplay(
 
         return ax, lines, info_pos_label
 
+    @StyleDisplayMixin.style_plot
     def plot(
         self,
         ax: Optional[Axes] = None,

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -3,6 +3,29 @@ from typing import Any, Callable
 
 import matplotlib.pyplot as plt
 
+DEFAULT_STYLE = {
+    "font.size": 14,
+    "axes.labelsize": 14,
+    "axes.titlesize": 14,
+    "xtick.labelsize": 13,
+    "ytick.labelsize": 13,
+    "legend.fontsize": 13,
+    "legend.title_fontsize": 14,
+    "axes.linewidth": 1.25,
+    "grid.linewidth": 1.25,
+    "lines.linewidth": 1.75,
+    "lines.markersize": 6,
+    "patch.linewidth": 1.25,
+    "xtick.major.width": 1.5,
+    "ytick.major.width": 1.5,
+    "xtick.minor.width": 1.25,
+    "ytick.minor.width": 1.25,
+    "xtick.major.size": 7,
+    "ytick.major.size": 7,
+    "xtick.minor.size": 5,
+    "ytick.minor.size": 5,
+}
+
 
 class StyleDisplayMixin:
     """Mixin to control the style plot of a display."""
@@ -75,7 +98,7 @@ class StyleDisplayMixin:
 
         @wraps(plot_func)
         def wrapper(self, *args: Any, **kwargs: Any) -> Any:
-            with plt.style.context("seaborn-v0_8-notebook"):
+            with plt.style.context(DEFAULT_STYLE):
                 result = plot_func(self, *args, **kwargs)
                 if hasattr(self, "figure_"):
                     self.figure_.tight_layout()

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -1,4 +1,7 @@
-from typing import Any
+from functools import wraps
+from typing import Any, Callable
+
+import seaborn as sns
 
 
 class StyleDisplayMixin:
@@ -49,3 +52,33 @@ class StyleDisplayMixin:
                 )
             setattr(self, default_attr, param_value)
         return self
+
+    @staticmethod
+    def style_plot(plot_func: Callable) -> Callable:
+        """Apply consistent style to skore displays.
+
+        This decorator:
+        1. Sets seaborn's plotting context to "talk"
+        2. Executes the plotting code
+        3. Applies tight_layout to the figure if it exists
+
+        Parameters
+        ----------
+        plot_func : callable
+            The plot function to be decorated.
+
+        Returns
+        -------
+        callable
+            The decorated plot function.
+        """
+
+        @wraps(plot_func)
+        def wrapper(self, *args: Any, **kwargs: Any) -> Any:
+            with sns.plotting_context("notebook"):
+                result = plot_func(self, *args, **kwargs)
+                if hasattr(self, "figure_"):
+                    self.figure_.tight_layout()
+                return result
+
+        return wrapper

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -99,7 +99,7 @@ class StyleDisplayMixin:
         @wraps(plot_func)
         def wrapper(self, *args: Any, **kwargs: Any) -> Any:
             # We need to manually handle setting the style of the parameters because
-            # `plt.style.context` as a side effect with the interactive mode.
+            # `plt.style.context` has a side effect with the interactive mode.
             # See https://github.com/matplotlib/matplotlib/issues/25041
             original_params = {key: plt.rcParams[key] for key in DEFAULT_STYLE}
             for key, value in DEFAULT_STYLE.items():

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -24,6 +24,9 @@ DEFAULT_STYLE = {
     "ytick.major.size": 7,
     "xtick.minor.size": 5,
     "ytick.minor.size": 5,
+    "legend.loc": "upper left",
+    "legend.bbox_to_anchor": (1.02, 1),
+    "legend.borderaxespad": 0,
 }
 
 
@@ -83,7 +86,7 @@ class StyleDisplayMixin:
         This decorator:
         1. Applies default style settings
         2. Executes `plot_func`
-        3. Applies `tight_layout` to the figure if it exists
+        3. Applies `tight_layout`
 
         Parameters
         ----------

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -25,8 +25,8 @@ DEFAULT_STYLE = {
     "xtick.minor.size": 5,
     "ytick.minor.size": 5,
     "legend.loc": "upper left",
-    "legend.bbox_to_anchor": (1.02, 1),
     "legend.borderaxespad": 0,
+    "axes.bbox": (1.02, 1),
 }
 
 

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -82,7 +82,7 @@ class StyleDisplayMixin:
 
         This decorator:
         1. Applies default style settings
-        2. Executes the plotting code
+        2. Executes `plot_func`
         3. Applies `tight_layout` to the figure if it exists
 
         Parameters

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -26,7 +26,6 @@ DEFAULT_STYLE = {
     "ytick.minor.size": 5,
     "legend.loc": "upper left",
     "legend.borderaxespad": 0,
-    "axes.bbox": (1.02, 1),
 }
 
 

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from typing import Any, Callable
 
-import seaborn as sns
+import matplotlib.pyplot as plt
 
 
 class StyleDisplayMixin:
@@ -75,7 +75,7 @@ class StyleDisplayMixin:
 
         @wraps(plot_func)
         def wrapper(self, *args: Any, **kwargs: Any) -> Any:
-            with sns.plotting_context("notebook"):
+            with plt.style.context("seaborn-v0_8-notebook"):
                 result = plot_func(self, *args, **kwargs)
                 if hasattr(self, "figure_"):
                     self.figure_.tight_layout()

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -60,7 +60,7 @@ class StyleDisplayMixin:
         This decorator:
         1. Sets seaborn's plotting context to "talk"
         2. Executes the plotting code
-        3. Applies tight_layout to the figure if it exists
+        3. Applies `tight_layout` to the figure if it exists
 
         Parameters
         ----------

--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -102,12 +102,12 @@ class StyleDisplayMixin:
             # `plt.style.context` has a side effect with the interactive mode.
             # See https://github.com/matplotlib/matplotlib/issues/25041
             original_params = {key: plt.rcParams[key] for key in DEFAULT_STYLE}
-            for key, value in DEFAULT_STYLE.items():
-                plt.rcParams[key] = value
-            result = plot_func(self, *args, **kwargs)
-            self.figure_.tight_layout()
-            for key, value in original_params.items():
-                plt.rcParams[key] = value
+            plt.rcParams.update(DEFAULT_STYLE)
+            try:
+                result = plot_func(self, *args, **kwargs)
+                self.figure_.tight_layout()
+            finally:
+                plt.rcParams.update(original_params)
             return result
 
         return wrapper

--- a/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
@@ -63,6 +63,8 @@ def test_precision_recall_curve_display_binary_classification(
         assert len(attr[estimator.classes_[1]]) == 1
 
     display.plot()
+    assert hasattr(display, "ax_")
+    assert hasattr(display, "figure_")
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == 1
     precision_recall_curve_mpl = display.lines_[0]
@@ -109,6 +111,8 @@ def test_precision_recall_curve_cross_validation_display_binary_classification(
         assert len(attr[pos_label]) == cv
 
     display.plot()
+    assert hasattr(display, "ax_")
+    assert hasattr(display, "figure_")
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == cv
     expected_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)

--- a/skore/tests/unit/sklearn/plot/test_prediction_error.py
+++ b/skore/tests/unit/sklearn/plot/test_prediction_error.py
@@ -71,6 +71,8 @@ def test_prediction_error_display_regression(pyplot, regression_data, subsample)
     assert display.range_residuals.max == np.max(display.residuals[0])
 
     display.plot()
+    assert hasattr(display, "ax_")
+    assert hasattr(display, "figure_")
     assert isinstance(display.line_, mpl.lines.Line2D)
     assert display.line_.get_label() == "Perfect predictions"
     assert display.line_.get_color() == "black"

--- a/skore/tests/unit/sklearn/plot/test_roc_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_roc_curve.py
@@ -60,6 +60,8 @@ def test_roc_curve_display_binary_classification(pyplot, binary_classification_d
         assert len(attr[estimator.classes_[1]]) == 1
 
     display.plot()
+    assert hasattr(display, "ax_")
+    assert hasattr(display, "figure_")
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == 1
     roc_curve_mpl = display.lines_[0]
@@ -109,6 +111,8 @@ def test_roc_curve_display_multiclass_classification(
             assert len(attr[class_label]) == 1
 
     display.plot()
+    assert hasattr(display, "ax_")
+    assert hasattr(display, "figure_")
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == len(estimator.classes_)
     default_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)


### PR DESCRIPTION
closes #1457
closes #1201
closes #1456

This PR creates a context manager where we temporary increases the font size to have better styled figure and make sure to use `tight_layout` on the figure before to return. Additionally, we move the legend outside of the figure such that it is more readable

