### PR TITLE
feat: Add `get_predictions` method to all reporters

### DIFF
--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import joblib
 import numpy as np
+from numpy.typing import ArrayLike
 
 from skore.externals._pandas_accessors import DirNamesMixin
 from skore.sklearn._base import _BaseReport
@@ -266,6 +267,56 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
                 response_methods=response_methods, n_jobs=n_jobs
             )
             progress.update(main_task, advance=1, refresh=True)
+
+    def get_predictions(
+        self,
+        *,
+        data_source: Literal["train", "test", "X_y"],
+        response_method: str,
+        pos_label: Optional[Any] = None,
+    ) -> ArrayLike:
+        """Get estimator's predictions.
+
+        This method has the advantage to reload from the cache if the predictions
+        were already computed in a previous call.
+
+        Parameters
+        ----------
+        data_source : {"test", "train", "X_y"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the report.
+            - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        response_method : str
+            The response method to use.
+
+        pos_label : int, float, bool or str, default=None
+            The positive class when it comes to binary classification. When
+            `response_method="predict_proba"`, it will select the column corresponding
+            to the positive class. When `response_method="decision_function"`, it will
+            negate the decision function if `pos_label` is different from
+            `estimator.classes_[1]`.
+
+        Returns
+        -------
+        list of np.ndarray of shape (n_samples,) or (n_samples, n_classes)
+            The predictions for each cross-validation split.
+
+        Raises
+        ------
+        ValueError
+            If the data source is invalid.
+        """
+        return [
+            report.get_predictions(
+                data_source=data_source,
+                response_method=response_method,
+                pos_label=pos_label,
+            )
+            for report in self.estimator_reports_
+        ]
 
     ####################################################################################
     # Methods related to the help and repr

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -272,7 +272,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         self,
         *,
         data_source: Literal["train", "test", "X_y"],
-        response_method: str,
+        response_method: Literal["predict", "predict_proba", "decision_function"],
         pos_label: Optional[Any] = None,
     ) -> ArrayLike:
         """Get estimator's predictions.

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -289,7 +289,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
             - "train" : use the train set provided when creating the report.
             - "X_y" : use the provided `X` and `y` to compute the metric.
 
-        response_method : str
+        response_method : {"predict", "predict_proba", "decision_function"}
             The response method to use.
 
         pos_label : int, float, bool or str, default=None

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -308,6 +308,38 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         ------
         ValueError
             If the data source is invalid.
+
+        Examples
+        --------
+        >>> from sklearn.datasets import make_classification
+        >>> from sklearn.model_selection import train_test_split
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> from skore import ComparisonReport, EstimatorReport
+        >>> X, y = make_classification(random_state=42)
+        >>> X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+        >>> estimator_1 = LogisticRegression()
+        >>> estimator_report_1 = EstimatorReport(
+        ...     estimator_1,
+        ...     X_train=X_train,
+        ...     y_train=y_train,
+        ...     X_test=X_test,
+        ...     y_test=y_test
+        ... )
+        >>> estimator_2 = LogisticRegression(C=2)  # Different regularization
+        >>> estimator_report_2 = EstimatorReport(
+        ...     estimator_2,
+        ...     X_train=X_train,
+        ...     y_train=y_train,
+        ...     X_test=X_test,
+        ...     y_test=y_test
+        ... )
+        >>> report = ComparisonReport([estimator_report_1, estimator_report_2])
+        >>> report.cache_predictions()
+        >>> predictions = report.get_predictions(
+        ...     data_source="test", response_method="predict"
+        ... )
+        >>> print([split_predictions.shape for split_predictions in predictions])
+        [(25,), (25,)]
         """
         return [
             report.get_predictions(

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -294,7 +294,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         self,
         *,
         data_source: Literal["train", "test"],
-        response_method: str,
+        response_method: Literal["predict", "predict_proba", "decision_function"],
         pos_label: Optional[Any] = None,
     ) -> ArrayLike:
         """Get estimator's predictions.

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -329,6 +329,20 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         ------
         ValueError
             If the data source is invalid.
+
+        Examples
+        --------
+        >>> from sklearn.datasets import make_classification
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> X, y = make_classification(random_state=42)
+        >>> estimator = LogisticRegression()
+        >>> from skore import CrossValidationReport
+        >>> report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
+        >>> predictions = report.get_predictions(
+        ...     data_source="test", response_method="predict"
+        ... )
+        >>> print([split_predictions.shape for split_predictions in predictions])
+        [(50,), (50,)]
         """
         if data_source not in ("train", "test"):
             raise ValueError(

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -310,7 +310,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
 
-        response_method : str
+        response_method : {"predict", "predict_proba", "decision_function"}
             The response method to use.
 
         pos_label : int, float, bool or str, default=None

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -305,7 +305,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
             - "train" : use the train set provided when creating the report.
             - "X_y" : use the provided `X` and `y` to compute the metric.
 
-        response_method : str
+        response_method : {"predict", "predict_proba", "decision_function"}
             The response method to use.
 
         X : array-like of shape (n_samples, n_features), optional

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -285,6 +285,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
 
     def get_predictions(
         self,
+        *,
         data_source: Literal["train", "test", "X_y"],
         response_method: str,
         X: Optional[ArrayLike] = None,

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -328,6 +328,22 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         ------
         ValueError
             If the data source is invalid.
+
+        Examples
+        --------
+        >>> from sklearn.datasets import make_classification
+        >>> from sklearn.model_selection import train_test_split
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> X, y = make_classification(random_state=42)
+        >>> X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+        >>> estimator = LogisticRegression().fit(X_train, y_train)
+        >>> from skore import EstimatorReport
+        >>> report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+        >>> predictions = report.get_predictions(
+        ...     data_source="test", response_method="predict"
+        ... )
+        >>> predictions.shape
+        (25,)
         """
         if data_source == "test":
             X_ = self._X_test

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -283,6 +283,70 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         for _ in generator:
             progress.update(task, advance=1, refresh=True)
 
+    def get_predictions(
+        self,
+        data_source: Literal["train", "test", "X_y"],
+        response_method: str,
+        X: Optional[ArrayLike] = None,
+        pos_label: Optional[Any] = None,
+    ) -> ArrayLike:
+        """Get estimator's predictions.
+
+        This method has the advantage to reload from the cache if the predictions
+        were already computed in a previous call.
+
+        Parameters
+        ----------
+        data_source : {"test", "train", "X_y"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the report.
+            - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        response_method : str
+            The response method to use.
+
+        X : array-like of shape (n_samples, n_features), optional
+            When `data_source` is "X_y", the input features on which to compute the
+            response method.
+
+        pos_label : int, float, bool or str, default=None
+            The positive class when it comes to binary classification. When
+            `response_method="predict_proba"`, it will select the column corresponding
+            to the positive class. When `response_method="decision_function"`, it will
+            negate the decision function if `pos_label` is different from
+            `estimator.classes_[1]`.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples,) or (n_samples, n_classes)
+            The predictions.
+
+        Raises
+        ------
+        ValueError
+            If the data source is invalid.
+        """
+        if data_source == "test":
+            X_ = self._X_test
+        elif data_source == "train":
+            X_ = self._X_train
+        elif data_source == "X_y":
+            X_ = X
+        else:
+            raise ValueError(f"Invalid data source: {data_source}")
+
+        return _get_cached_response_values(
+            cache=self._cache,
+            estimator_hash=self._hash,
+            estimator=self._estimator,
+            X=X_,
+            response_method=response_method,
+            pos_label=pos_label,
+            data_source=data_source,
+        )
+
     @property
     def estimator_(self) -> BaseEstimator:
         return self._estimator

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -287,7 +287,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         self,
         *,
         data_source: Literal["train", "test", "X_y"],
-        response_method: str,
+        response_method: Literal["predict", "predict_proba", "decision_function"],
         X: Optional[ArrayLike] = None,
         pos_label: Optional[Any] = None,
     ) -> ArrayLike:

--- a/skore/tests/unit/sklearn/comparison/test_comparison.py
+++ b/skore/tests/unit/sklearn/comparison/test_comparison.py
@@ -726,3 +726,52 @@ def test_random_state(regression_model):
     report.metrics.prediction_error()
     # skore should store the y_pred of the internal estimators, but not the plot
     assert report._cache == {}
+
+
+@pytest.mark.parametrize("data_source", ["train", "test"])
+@pytest.mark.parametrize(
+    "response_method", ["predict", "predict_proba", "decision_function"]
+)
+@pytest.mark.parametrize("pos_label", [None, 0, 1])
+def test_comparison_report_get_predictions(
+    binary_classification_model, data_source, response_method, pos_label
+):
+    """Check the behaviour of the `get_predictions` method."""
+    estimator, X_train, X_test, y_train, y_test = binary_classification_model
+    estimator_report = EstimatorReport(
+        estimator,
+        X_train=X_train,
+        y_train=y_train,
+        X_test=X_test,
+        y_test=y_test,
+    )
+
+    report = ComparisonReport([estimator_report, estimator_report])
+
+    predictions = report.get_predictions(
+        data_source=data_source, response_method=response_method, pos_label=pos_label
+    )
+    assert len(predictions) == 2
+    for split_idx, split_predictions in enumerate(predictions):
+        if data_source == "train":
+            expected_shape = report.estimator_reports_[split_idx].y_train.shape
+        else:
+            expected_shape = report.estimator_reports_[split_idx].y_test.shape
+        assert split_predictions.shape == expected_shape
+
+
+def test_comparison_report_get_predictions_error(binary_classification_model):
+    """Check that we raise an error when the data source is invalid."""
+    estimator, X_train, X_test, y_train, y_test = binary_classification_model
+    estimator_report = EstimatorReport(
+        estimator,
+        X_train=X_train,
+        y_train=y_train,
+        X_test=X_test,
+        y_test=y_test,
+    )
+
+    report = ComparisonReport([estimator_report, estimator_report])
+
+    with pytest.raises(ValueError, match="Invalid data source"):
+        report.get_predictions(data_source="invalid", response_method="predict")

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -343,8 +343,12 @@ def test_estimator_report_flat_index(binary_classification_data):
     assert result.columns.tolist() == ["RandomForestClassifier"]
 
 
-def test_estimator_report_get_predictions_binary_classification():
-    """Check that the predictions are correctly retrieved for binary classification."""
+def test_estimator_report_get_predictions():
+    """Check the behaviour of the `get_predictions` method.
+
+    We use the binary classification because it uses all the parameters of the
+    `get_predictions` method.
+    """
     X, y = make_classification(n_classes=2, random_state=42)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
     estimator = LogisticRegression()
@@ -397,6 +401,19 @@ def test_estimator_report_get_predictions_binary_classification():
         data_source="X_y", response_method="decision_function", X=X_test
     )
     np.testing.assert_allclose(predictions, report.estimator_.decision_function(X_test))
+
+
+def test_estimator_report_get_predictions_error():
+    """Check that we raise an error when the data source is invalid."""
+    X, y = make_classification(n_classes=2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    estimator = LogisticRegression()
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+
+    with pytest.raises(ValueError, match="Invalid data source"):
+        report.get_predictions(data_source="invalid", response_method="predict")
 
 
 ########################################################################################

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -343,6 +343,62 @@ def test_estimator_report_flat_index(binary_classification_data):
     assert result.columns.tolist() == ["RandomForestClassifier"]
 
 
+def test_estimator_report_get_predictions_binary_classification():
+    """Check that the predictions are correctly retrieved for binary classification."""
+    X, y = make_classification(n_classes=2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    estimator = LogisticRegression()
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+
+    # check the `predict` method
+    predictions = report.get_predictions(data_source="test", response_method="predict")
+    np.testing.assert_allclose(predictions, report.estimator_.predict(X_test))
+    predictions = report.get_predictions(data_source="train", response_method="predict")
+    np.testing.assert_allclose(predictions, report.estimator_.predict(X_train))
+    predictions = report.get_predictions(
+        data_source="X_y", response_method="predict", X=X_test
+    )
+    np.testing.assert_allclose(predictions, report.estimator_.predict(X_test))
+
+    # check the validity of the `predict_proba` method
+    predictions = report.get_predictions(
+        data_source="test", response_method="predict_proba"
+    )
+    np.testing.assert_allclose(
+        predictions, report.estimator_.predict_proba(X_test)[:, 1]
+    )
+    predictions = report.get_predictions(
+        data_source="train", response_method="predict_proba", pos_label=0
+    )
+    np.testing.assert_allclose(
+        predictions, report.estimator_.predict_proba(X_train)[:, 0]
+    )
+    predictions = report.get_predictions(
+        data_source="X_y", response_method="predict_proba", X=X_test
+    )
+    np.testing.assert_allclose(
+        predictions, report.estimator_.predict_proba(X_test)[:, 1]
+    )
+
+    # check the validity of the `decision_function` method
+    predictions = report.get_predictions(
+        data_source="test", response_method="decision_function"
+    )
+    np.testing.assert_allclose(predictions, report.estimator_.decision_function(X_test))
+    predictions = report.get_predictions(
+        data_source="train", response_method="decision_function", pos_label=0
+    )
+    np.testing.assert_allclose(
+        predictions, -report.estimator_.decision_function(X_train)
+    )
+    predictions = report.get_predictions(
+        data_source="X_y", response_method="decision_function", X=X_test
+    )
+    np.testing.assert_allclose(predictions, report.estimator_.decision_function(X_test))
+
+
 ########################################################################################
 # Check the plot methods
 ########################################################################################

--- a/sphinx/reference/report/comparison_report.rst
+++ b/sphinx/reference/report/comparison_report.rst
@@ -17,6 +17,7 @@ The class :class:`ComparisonReport` provides a report allowing to compare :class
     :template: autosummary/accessor_method.rst
 
     ComparisonReport.help
+    ComparisonReport.get_predictions
 
 .. autosummary::
     :toctree: ../api/

--- a/sphinx/reference/report/cross_validation_report.rst
+++ b/sphinx/reference/report/cross_validation_report.rst
@@ -20,6 +20,7 @@ functionalities of the report are exposed through accessors.
    :template: autosummary/accessor_method.rst
 
    CrossValidationReport.help
+   CrossValidationReport.get_predictions
 
 .. rubric:: Metrics
 

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -20,6 +20,7 @@ report are accessible through accessors.
    :template: autosummary/accessor_method.rst
 
    EstimatorReport.help
+   EstimatorReport.get_predictions
 
 .. rubric:: Metrics
 


### PR DESCRIPTION
Partially address #1417 by implementing `EstimatorReport.get_predictions` such that one can get the predictions from a model and eventually from the cache if it was already computed before. 