### PR TITLE
docs: Add `cache_predictions` and `clear_cache` in API documentation

### DIFF
--- a/sphinx/reference/report/comparison_report.rst
+++ b/sphinx/reference/report/comparison_report.rst
@@ -10,7 +10,8 @@ The class :class:`ComparisonReport` provides a report allowing to compare :class
     :template: base.rst
 
     ComparisonReport
-
+    ComparisonReport.cache_predictions
+    ComparisonReport.clear_cache
 .. autosummary::
     :toctree: ../api/
     :nosignatures:

--- a/sphinx/reference/report/cross_validation_report.rst
+++ b/sphinx/reference/report/cross_validation_report.rst
@@ -20,6 +20,8 @@ functionalities of the report are exposed through accessors.
    :template: autosummary/accessor_method.rst
 
    CrossValidationReport.help
+   CrossValidationReport.cache_predictions
+   CrossValidationReport.clear_cache
 
 .. rubric:: Metrics
 

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -20,6 +20,8 @@ report are accessible through accessors.
    :template: autosummary/accessor_method.rst
 
    EstimatorReport.help
+   EstimatorReport.cache_predictions
+   EstimatorReport.clear_cache
 
 .. rubric:: Metrics
 


### PR DESCRIPTION
Adding two missing methods in the API documentation: `cache_predictions` and `clear_cache`.