### PR TITLE
fix: Support joblib < 1.4 by using list container as output

### DIFF
--- a/skore/src/skore/__init__.py
+++ b/skore/src/skore/__init__.py
@@ -1,11 +1,14 @@
 """Configure logging and global settings."""
 
 import logging
+import warnings
 
+import joblib
 from rich.console import Console
 from rich.theme import Theme
 
 from skore._config import config_context, get_config, set_config
+from skore.externals._sklearn_compat import parse_version
 from skore.project import Project
 from skore.sklearn import (
     ComparisonReport,
@@ -50,3 +53,13 @@ skore_console_theme = Theme(
 )
 
 console = Console(theme=skore_console_theme, width=88)
+
+joblib_version = parse_version(joblib.__version__)
+if joblib_version < parse_version("1.4"):
+    warnings.warn(
+        "Because your version of joblib is older than 1.4, some of the features of "
+        "skore will not be enabled (e.g. progress bars). You can update joblib to "
+        "benefit from these features.",
+        stacklevel=2,
+    )
+    set_config(show_progress=False)

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -18,6 +18,7 @@ from skore.sklearn._plot.metrics import (
     RocCurveDisplay,
 )
 from skore.utils._accessor import _check_supported_ml_task
+from skore.utils._fixes import _validate_joblib_parallel_params
 from skore.utils._index import flatten_multi_index
 from skore.utils._progress_bar import progress_decorator
 
@@ -207,9 +208,11 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             results = self._parent._cache[cache_key]
         else:
             parallel = joblib.Parallel(
-                n_jobs=self._parent.n_jobs,
-                return_as="generator",
-                require="sharedmem",
+                **_validate_joblib_parallel_params(
+                    n_jobs=self._parent.n_jobs,
+                    return_as="generator",
+                    require="sharedmem",
+                )
             )
             generator = parallel(
                 joblib.delayed(getattr(report.metrics, report_metric_name))(

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -17,6 +17,7 @@ from skore.sklearn._plot import (
     RocCurveDisplay,
 )
 from skore.utils._accessor import _check_estimator_has_method, _check_supported_ml_task
+from skore.utils._fixes import _validate_joblib_parallel_params
 from skore.utils._index import flatten_multi_index
 from skore.utils._parallel import Parallel, delayed
 from skore.utils._progress_bar import progress_decorator
@@ -186,9 +187,11 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             results = self._parent._cache[cache_key]
         else:
             parallel = Parallel(
-                n_jobs=self._parent.n_jobs,
-                return_as="generator",
-                require="sharedmem",
+                **_validate_joblib_parallel_params(
+                    n_jobs=self._parent.n_jobs,
+                    return_as="generator",
+                    require="sharedmem",
+                )
             )
             generator = parallel(
                 delayed(getattr(report.metrics, report_metric_name))(

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -15,6 +15,7 @@ from skore.sklearn._base import _BaseReport
 from skore.sklearn._estimator.report import EstimatorReport
 from skore.sklearn.find_ml_task import _find_ml_task
 from skore.sklearn.types import SKLearnCrossValidator
+from skore.utils._fixes import _validate_joblib_parallel_params
 from skore.utils._parallel import Parallel, delayed
 from skore.utils._progress_bar import progress_decorator
 
@@ -174,7 +175,11 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         n_splits = self._cv_splitter.get_n_splits(self._X, self._y)
         progress.update(task, total=n_splits)
 
-        parallel = Parallel(n_jobs=self.n_jobs, return_as="generator")
+        parallel = Parallel(
+            **_validate_joblib_parallel_params(
+                n_jobs=self.n_jobs, return_as="generator"
+            )
+        )
         # do not split the data to take advantage of the memory mapping
         generator = parallel(
             delayed(_generate_estimator_report)(

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -15,6 +15,7 @@ from skore.externals._pandas_accessors import DirNamesMixin
 from skore.externals._sklearn_compat import is_clusterer
 from skore.sklearn._base import _BaseReport, _get_cached_response_values
 from skore.sklearn.find_ml_task import _find_ml_task
+from skore.utils._fixes import _validate_joblib_parallel_params
 from skore.utils._measure_time import MeasureTime
 from skore.utils._parallel import Parallel, delayed
 from skore.utils._progress_bar import progress_decorator
@@ -257,7 +258,11 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         if self._X_train is not None:
             data_sources += [("train", self._X_train)]
 
-        parallel = Parallel(n_jobs=n_jobs, return_as="generator", require="sharedmem")
+        parallel = Parallel(
+            **_validate_joblib_parallel_params(
+                n_jobs=n_jobs, return_as="generator", require="sharedmem"
+            )
+        )
         generator = parallel(
             delayed(_get_cached_response_values)(
                 cache=self._cache,

--- a/skore/src/skore/utils/_fixes.py
+++ b/skore/src/skore/utils/_fixes.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+import joblib
+
+from skore.externals._sklearn_compat import parse_version
+
+
+# FIXME: Remove this function once we support joblib >= 1.4
+def _validate_joblib_parallel_params(**kwargs: Any) -> dict[str, Any]:
+    """Validate the parameters for `joblib.Parallel`.
+
+    Currently this function is in charge of removing the parameter `return_as`
+    because it is not supported by joblib < 1.4.
+    """
+    joblib_version = parse_version(joblib.__version__)
+    if joblib_version < parse_version("1.4") and "return_as" in kwargs:
+        del kwargs["return_as"]
+    return kwargs

--- a/skore/src/skore/utils/_fixes.py
+++ b/skore/src/skore/utils/_fixes.py
@@ -5,7 +5,7 @@ import joblib
 from skore.externals._sklearn_compat import parse_version
 
 
-# FIXME: Remove this function once we support joblib >= 1.4
+# FIXME: Remove this function once we support only joblib >= 1.4
 def _validate_joblib_parallel_params(**kwargs: Any) -> dict[str, Any]:
     """Validate the parameters for `joblib.Parallel`.
 

--- a/skore/src/skore/utils/_fixes.py
+++ b/skore/src/skore/utils/_fixes.py
@@ -13,6 +13,6 @@ def _validate_joblib_parallel_params(**kwargs: Any) -> dict[str, Any]:
     because it is not supported by joblib < 1.4.
     """
     joblib_version = parse_version(joblib.__version__)
-    if joblib_version < parse_version("1.4") and "return_as" in kwargs:
-        del kwargs["return_as"]
+    if joblib_version < parse_version("1.4"):
+        kwargs.pop("return_as", None)
     return kwargs

--- a/skore/tests/unit/test_at_import.py
+++ b/skore/tests/unit/test_at_import.py
@@ -1,0 +1,19 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def test_warning_old_joblib():
+    """Test that importing skore with old joblib version raises a warning."""
+    # Remove skore from sys.modules to force a fresh import
+    if "skore" in sys.modules:
+        del sys.modules["skore"]
+
+    with (
+        patch("joblib.__version__", "1.3.0"),
+        pytest.warns(
+            UserWarning, match="Because your version of joblib is older than 1.4"
+        ),
+    ):
+        import skore  # noqa: F401

--- a/skore/tests/unit/utils/test_fixes.py
+++ b/skore/tests/unit/utils/test_fixes.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from skore.utils._fixes import _validate_joblib_parallel_params
+
+
+def test_validate_joblib_parallel_params_old_version():
+    """Test that return_as is removed from kwargs when joblib < 1.4."""
+    with patch("skore.utils._fixes.joblib.__version__", "1.3.0"):
+        kwargs = {"n_jobs": -1, "return_as": "list"}
+        result = _validate_joblib_parallel_params(**kwargs)
+
+        assert "return_as" not in result
+        assert result == {"n_jobs": -1}
+
+
+def test_validate_joblib_parallel_params_new_version():
+    """Test that return_as is kept in kwargs when joblib >= 1.4."""
+    with patch("skore.utils._fixes.joblib.__version__", "1.4.0"):
+        kwargs = {"n_jobs": -1, "return_as": "list"}
+        result = _validate_joblib_parallel_params(**kwargs)
+
+        assert "return_as" in result
+        assert result == kwargs


### PR DESCRIPTION
closes #1452 

This PR introduces a way to be compatible with `joblib < 1.4` where `return_as` is not implemented. In this case, we can only use `list`.

The issue with using `list` is that we will be in degraded mode for the progress bars.

The proposal here is to:

- warn at import about the old `joblib` version and ask potentially to update it.
- disable the progress bar.