### PR TITLE
docs: Use left-out dataset for the external case in example

### DIFF
--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -64,6 +64,10 @@ model
 from skore import train_test_split
 
 X_train, X_test, y_train, y_test = train_test_split(df, y, random_state=42)
+# Let's keep a completely left-out dataset
+X_train, X_external, y_train, y_external = train_test_split(
+    X_train, y_train, random_state=42
+)
 
 # %%
 # Caching the predictions for fast metric computation
@@ -172,7 +176,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 # The report can also work with external data. We use `data_source="X_y"` to indicate
 # that we want to pass those external data.
 start = time.time()
-result = report.metrics.log_loss(data_source="X_y", X=X_test, y=y_test)
+result = report.metrics.log_loss(data_source="X_y", X=X_external, y=y_external)
 end = time.time()
 result
 
@@ -185,7 +189,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 # or test sets because it needs to compute a hash of the new data for later retrieval.
 # Let's calculate it again:
 start = time.time()
-result = report.metrics.log_loss(data_source="X_y", X=X_test, y=y_test)
+result = report.metrics.log_loss(data_source="X_y", X=X_external, y=y_external)
 end = time.time()
 result
 
@@ -198,7 +202,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 # The remaining time corresponds to the hash computation.
 # Let's compute the ROC AUC on the same data:
 start = time.time()
-result = report.metrics.roc_auc(data_source="X_y", X=X_test, y=y_test)
+result = report.metrics.roc_auc(data_source="X_y", X=X_external, y=y_external)
 end = time.time()
 result
 

--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -64,7 +64,7 @@ model
 from skore import train_test_split
 
 X_train, X_test, y_train, y_test = train_test_split(df, y, random_state=42)
-# Let's keep a completely left-out dataset
+# Let's keep a completely separate dataset
 X_train, X_external, y_train, y_external = train_test_split(
     X_train, y_train, random_state=42
 )


### PR DESCRIPTION
closes #1216 

This PR will make two splits instead of a single one to have a completely left-out set to not have any confusion when we present the `data_source="X_y"` principle.