### PR TITLE
chore: Rename random_state to seed to highlight int-only support

### DIFF
--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -98,7 +98,7 @@ plt.tight_layout()
 # In particular, we can inspect the model using the permutation feature importance:
 
 # %%
-rf_report.feature_importance.permutation().T.boxplot(vert=False)
+rf_report.feature_importance.permutation(seed=0).T.boxplot(vert=False)
 plt.tight_layout()
 
 # %%

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -863,7 +863,7 @@ ridge_report.help()
 # accessor:
 
 # %%
-ridge_report.feature_importance.permutation(random_state=0)
+ridge_report.feature_importance.permutation(seed=0)
 
 # %%
 # The permutation importance is often calculated several times, each time
@@ -877,16 +877,16 @@ def plot_permutation_train_test(est_report):
     fig, axes = plt.subplots(nrows=1, ncols=2, sharey=True)
 
     # Boxplot for the train set
-    est_report.feature_importance.permutation(
-        data_source="train", random_state=0
-    ).T.boxplot(ax=axes[0], vert=False)
+    est_report.feature_importance.permutation(data_source="train", seed=0).T.boxplot(
+        ax=axes[0], vert=False
+    )
     axes[0].set_title("Train set")
     axes[0].set_xlabel("r2")
 
     # Boxplot for the test set
-    est_report.feature_importance.permutation(
-        data_source="test", random_state=0
-    ).T.boxplot(ax=axes[1], vert=False)
+    est_report.feature_importance.permutation(data_source="test", seed=0).T.boxplot(
+        ax=axes[1], vert=False
+    )
     axes[1].set_title("Test set")
     axes[1].set_xlabel("r2")
 

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -1201,7 +1201,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         display : display_class
             The display.
         """
-        if "random_state" in display_kwargs and display_kwargs["random_state"] is None:
+        if "seed" in display_kwargs and display_kwargs["seed"] is None:
             cache_key = None
         else:
             # build the cache key components to finally create a tuple that will be used
@@ -1257,9 +1257,9 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 **display_kwargs,
             )
 
-            # Unless random_state is an int (i.e. the call is deterministic),
-            # we do not cache
             if cache_key is not None:
+                # Unless seed is an int (i.e. the call is deterministic),
+                # we do not cache
                 self._parent._cache[cache_key] = display
 
         return display
@@ -1442,7 +1442,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         X: Optional[ArrayLike] = None,
         y: Optional[ArrayLike] = None,
         subsample: int = 1_000,
-        random_state: Optional[int] = None,
+        seed: Optional[int] = None,
     ) -> PredictionErrorDisplay:
         """Plot the prediction error of a regression model.
 
@@ -1472,8 +1472,9 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             display on the scatter plot. If `None`, no subsampling will be
             applied. by default, 1,000 samples or less will be displayed.
 
-        random_state : int, default=None
-            The random state to use for the subsampling.
+        seed : int, default=None
+            The seed used to initialize the random number generator used for the
+            subsampling.
 
         Returns
         -------
@@ -1510,7 +1511,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         >>> display = comparison_report.metrics.prediction_error()
         >>> display.plot(kind="actual_vs_predicted")
         """
-        display_kwargs = {"subsample": subsample, "random_state": random_state}
+        display_kwargs = {"subsample": subsample, "seed": seed}
         display = self._get_display(
             X=X,
             y=y,

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -960,7 +960,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         display : display_class
             The display.
         """
-        if "random_state" in display_kwargs and display_kwargs["random_state"] is None:
+        if "seed" in display_kwargs and display_kwargs["seed"] is None:
             cache_key = None
         else:
             # Create a list of cache key components and then convert to tuple
@@ -1011,9 +1011,9 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
                 **display_kwargs,
             )
 
-            # Unless random_state is an int (i.e. the call is deterministic),
-            # we do not cache
             if cache_key is not None:
+                # Unless seed is an int (i.e. the call is deterministic),
+                # we do not cache
                 self._parent._cache[cache_key] = display
 
         return display
@@ -1130,7 +1130,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         *,
         data_source: DataSource = "test",
         subsample: Union[float, int, None] = 1_000,
-        random_state: Optional[int] = None,
+        seed: Optional[int] = None,
     ) -> PredictionErrorDisplay:
         """Plot the prediction error of a regression model.
 
@@ -1151,8 +1151,9 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             display on the scatter plot. If `None`, no subsampling will be
             applied. by default, 1,000 samples or less will be displayed.
 
-        random_state : int, default=None
-            The random state to use for the subsampling.
+        seed : int, default=None
+            The seed used to initialize the random number generator used for the
+            subsampling.
 
         Returns
         -------
@@ -1170,7 +1171,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         >>> display = report.metrics.prediction_error()
         >>> display.plot(kind="actual_vs_predicted", line_kwargs={"color": "tab:red"})
         """
-        display_kwargs = {"subsample": subsample, "random_state": random_state}
+        display_kwargs = {"subsample": subsample, "seed": seed}
         display = self._get_display(
             data_source=data_source,
             response_method="predict",

--- a/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
@@ -297,7 +297,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         n_repeats: int = 5,
         max_samples: float = 1.0,
         n_jobs: Optional[int] = None,
-        random_state: Optional[int] = None,
+        seed: Optional[int] = None,
         flat_index: bool = False,
     ) -> pd.DataFrame:
         """Report the permutation feature importance.
@@ -308,10 +308,10 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         the value of `scoring` between with and without the permutation, which gives an
         indication on the impact of the feature.
 
-        By default, `random_state` is set to `None`, which means the function will
+        By default, `seed` is set to `None`, which means the function will
         return a different result at every call. In that case, the results are not
         cached. If you wish to take advantage of skore's caching capabilities, make
-        sure you set the `random_state` parameter.
+        sure you set the `seed` parameter.
 
         Parameters
         ----------
@@ -368,9 +368,9 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         n_jobs : int or None, default=None
             Number of jobs to run in parallel. -1 means using all processors.
 
-        random_state : int or None, default=None
-            Pseudo-random number generator to control the permutations of each feature.
-            Pass an int to get reproducible results across function calls.
+        seed : int or None, default=None
+            The seed used to initialize the random number generator used for the
+            permutations.
 
         flat_index : bool, default=False
             Whether to flatten the multi-index columns. Flat index will always be lower
@@ -401,7 +401,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
 
         >>> report.feature_importance.permutation(
         ...    n_repeats=2,
-        ...    random_state=0,
+        ...    seed=0,
         ... )
         Repeat              Repeat #0  Repeat #1
         Metric  Feature
@@ -412,7 +412,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.feature_importance.permutation(
         ...    scoring=["r2", "rmse"],
         ...    n_repeats=2,
-        ...    random_state=0,
+        ...    seed=0,
         ... )
         Repeat             Repeat #0  Repeat #1
         Metric Feature
@@ -426,7 +426,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.feature_importance.permutation(
         ...    n_repeats=2,
         ...    aggregate=["mean", "std"],
-        ...    random_state=0,
+        ...    seed=0,
         ... )
                                 mean       std
         Metric  Feature
@@ -438,7 +438,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         ...    n_repeats=2,
         ...    aggregate=["mean", "std"],
         ...    flat_index=True,
-        ...    random_state=0,
+        ...    seed=0,
         ... )
                           mean       std
         r2_feature_0  0.792...  0.131...
@@ -455,7 +455,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             n_repeats=n_repeats,
             max_samples=max_samples,
             n_jobs=n_jobs,
-            random_state=random_state,
+            seed=seed,
             flat_index=flat_index,
         )
 
@@ -471,7 +471,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         n_repeats: int = 5,
         max_samples: float = 1.0,
         n_jobs: Optional[int] = None,
-        random_state: Optional[int] = None,
+        seed: Optional[int] = None,
         flat_index: bool = False,
     ) -> pd.DataFrame:
         """Private interface of `feature_permutation` to pass `data_source_hash`.
@@ -487,11 +487,11 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
                 data_source=data_source, X=X, y=y
             )
 
-        # If random_state is None, then we do not do any caching
-        if random_state is None:
+        # If seed is None, then we do not do any caching
+        if seed is None:
             cache_key = None
 
-        elif isinstance(random_state, int):
+        elif isinstance(seed, int):
             # build the cache key components to finally create a tuple that will be used
             # to check if the metric has already been computed
             cache_key_parts: list[Any] = [
@@ -516,7 +516,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             kwargs = {
                 "n_repeats": n_repeats,
                 "max_samples": max_samples,
-                "random_state": random_state,
+                "seed": seed,
             }
             for _, v in sorted(kwargs.items()):
                 cache_key_parts.append(v)
@@ -524,9 +524,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             cache_key = tuple(cache_key_parts)
 
         else:
-            raise ValueError(
-                f"random_state must be an integer or None; got {type(random_state)}"
-            )
+            raise ValueError(f"seed must be an integer or None; got {type(seed)}")
 
         if cache_key in self._parent._cache:
             score = self._parent._cache[cache_key]
@@ -538,7 +536,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
                 scoring=checked_scoring,
                 n_repeats=n_repeats,
                 n_jobs=n_jobs,
-                random_state=random_state,
+                random_state=seed,
                 max_samples=max_samples,
             )
             score = sklearn_score.get("importances")
@@ -591,9 +589,9 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
                 )
                 score = pd.DataFrame(data=data, index=index, columns=columns)
 
-            # Unless random_state is an int (i.e. the call is deterministic),
-            # we do not cache
             if cache_key is not None:
+                # Unless seed is an int (i.e. the call is deterministic),
+                # we do not cache
                 self._parent._cache[cache_key] = score
 
         if aggregate:

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1677,7 +1677,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         # build the cache key components to finally create a tuple that will be used
         # to check if the metric has already been computed
 
-        if "random_state" in display_kwargs and display_kwargs["random_state"] is None:
+        if "seed" in display_kwargs and display_kwargs["seed"] is None:
             cache_key = None
         else:
             cache_key_parts: list[Any] = [self._parent._hash, display_class.__name__]
@@ -1713,9 +1713,9 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                 **display_kwargs,
             )
 
-            # Unless random_state is an int (i.e. the call is deterministic),
-            # we do not cache
             if cache_key is not None:
+                # Unless seed is an int (i.e. the call is deterministic),
+                # we do not cache
                 self._parent._cache[cache_key] = display
 
         return display
@@ -1878,7 +1878,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         X: Optional[ArrayLike] = None,
         y: Optional[ArrayLike] = None,
         subsample: Union[float, int, None] = 1_000,
-        random_state: Optional[int] = None,
+        seed: Optional[int] = None,
     ) -> PredictionErrorDisplay:
         """Plot the prediction error of a regression model.
 
@@ -1908,8 +1908,9 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             display on the scatter plot. If `None`, no subsampling will be
             applied. by default, 1,000 samples or less will be displayed.
 
-        random_state : int, default=None
-            The random state to use for the subsampling.
+        seed : int, default=None
+            The seed used to initialize the random number generator used for the
+            subsampling.
 
         Returns
         -------
@@ -1936,7 +1937,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         >>> display = report.metrics.prediction_error()
         >>> display.plot(line_kwargs={"color": "tab:red"})
         """
-        display_kwargs = {"subsample": subsample, "random_state": random_state}
+        display_kwargs = {"subsample": subsample, "seed": seed}
         display = self._get_display(
             X=X,
             y=y,

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -8,7 +8,7 @@ from matplotlib import colormaps
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes
 from numpy.typing import ArrayLike, NDArray
-from sklearn.utils.validation import _num_samples, check_array, check_random_state
+from sklearn.utils.validation import _num_samples, check_array
 
 from skore.externals._sklearn_compat import _safe_indexing
 from skore.sklearn._plot.style import StyleDisplayMixin
@@ -636,7 +636,7 @@ class PredictionErrorDisplay(HelpDisplayMixin, StyleDisplayMixin):
         ml_task: MLTask,
         data_source: Literal["train", "test", "X_y"],
         subsample: Union[float, int, None] = 1_000,
-        random_state: Optional[Union[int, np.random.RandomState]] = None,
+        seed: Optional[int] = None,
         **kwargs,
     ) -> "PredictionErrorDisplay":
         """Plot the prediction error given the true and predicted targets.
@@ -665,9 +665,9 @@ class PredictionErrorDisplay(HelpDisplayMixin, StyleDisplayMixin):
             display on the scatter plot. If `None`, no subsampling will be
             applied. by default, 1000 samples or less will be displayed.
 
-        random_state : int or RandomState, default=None
-            Controls the randomness when `subsample` is not `None`.
-            See :term:`Glossary <random_state>` for details.
+        seed : int, default=None
+            The seed used to initialize the random number generator used for the
+            subsampling.
 
         **kwargs : dict
             Additional keyword arguments that are ignored for compatibility with
@@ -677,7 +677,7 @@ class PredictionErrorDisplay(HelpDisplayMixin, StyleDisplayMixin):
         -------
         display : PredictionErrorDisplay
         """
-        rng: np.random.RandomState = check_random_state(random_state)
+        rng = np.random.default_rng(seed)
         if isinstance(subsample, numbers.Integral):
             if subsample <= 0:
                 raise ValueError(

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -376,9 +376,9 @@ def test_estimator_report_display_regression(pyplot, regression_data, display):
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     assert hasattr(report.metrics, display)
-    display_first_call = getattr(report.metrics, display)(random_state=0)
+    display_first_call = getattr(report.metrics, display)(seed=0)
     assert report._cache != {}
-    display_second_call = getattr(report.metrics, display)(random_state=0)
+    display_second_call = getattr(report.metrics, display)(seed=0)
     assert display_first_call is display_second_call
 
 
@@ -410,11 +410,11 @@ def test_estimator_report_display_regression_external_data(
     report = EstimatorReport(estimator)
     assert hasattr(report.metrics, display)
     display_first_call = getattr(report.metrics, display)(
-        data_source="X_y", X=X_test, y=y_test, random_state=0
+        data_source="X_y", X=X_test, y=y_test, seed=0
     )
     assert report._cache != {}
     display_second_call = getattr(report.metrics, display)(
-        data_source="X_y", X=X_test, y=y_test, random_state=0
+        data_source="X_y", X=X_test, y=y_test, seed=0
     )
     assert display_first_call is display_second_call
 

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -278,18 +278,18 @@ def test_cross_validation_report_display_regression(pyplot, regression_data, dis
     estimator, X, y = regression_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
     assert hasattr(report.metrics, display)
-    display_first_call = getattr(report.metrics, display)(random_state=0)
+    display_first_call = getattr(report.metrics, display)(seed=0)
     assert report._cache != {}
-    display_second_call = getattr(report.metrics, display)(random_state=0)
+    display_second_call = getattr(report.metrics, display)(seed=0)
     assert display_first_call is display_second_call
 
 
-def test_random_state(regression_data):
-    """If random_state is None (the default) the call should not be cached."""
+def test_seed_none(regression_data):
+    """If `seed` is None (the default) the call should not be cached."""
     estimator, X, y = regression_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
 
-    report.metrics.prediction_error()
+    report.metrics.prediction_error(seed=None)
     # skore should store the y_pred of the internal estimators, but not the plot
     assert report._cache == {}
 


### PR DESCRIPTION
closes #1397 

This PR proposes to rename `random_state` handled by `skore` to `seed` since we can only support integral when it comes to caching.
