### PR TITLE
fix: Check if private metrics are available for an estimator

### DIFF
--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1,6 +1,7 @@
 import inspect
 from collections.abc import Iterable
 from functools import partial
+from operator import attrgetter
 from typing import Any, Callable, Literal, Optional, Union
 
 import joblib
@@ -515,11 +516,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
 
         return fit_time | predict_times
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(attrgetter("_accuracy"))
     def accuracy(
         self,
         *,
@@ -606,11 +603,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         return score
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(attrgetter("_precision"))
     def precision(
         self,
         *,
@@ -753,11 +746,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         return result
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(attrgetter("_recall"))
     def recall(
         self,
         *,
@@ -901,10 +890,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         return result
 
-    @available_if(
-        _check_supported_ml_task(supported_ml_tasks=["binary-classification"])
-    )
-    @available_if(_check_estimator_has_method(method_name="predict_proba"))
+    @available_if(attrgetter("_brier_score"))
     def brier_score(
         self,
         *,
@@ -1000,11 +986,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         return result
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(attrgetter("_roc_auc"))
     def roc_auc(
         self,
         *,
@@ -1143,11 +1125,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         return result
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
-        )
-    )
+    @available_if(attrgetter("_log_loss"))
     def log_loss(
         self,
         *,
@@ -1231,11 +1209,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         return result
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["regression", "multioutput-regression"]
-        )
-    )
+    @available_if(attrgetter("_r2"))
     def r2(
         self,
         *,
@@ -1353,11 +1327,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         return result
 
-    @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["regression", "multioutput-regression"]
-        )
-    )
+    @available_if(attrgetter("_rmse"))
     def rmse(
         self,
         *,

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -573,6 +573,11 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         """
         return self._accuracy(data_source=data_source, data_source_hash=None, X=X, y=y)
 
+    @available_if(
+        _check_supported_ml_task(
+            supported_ml_tasks=["binary-classification", "multiclass-classification"]
+        )
+    )
     def _accuracy(
         self,
         *,
@@ -698,6 +703,11 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             pos_label=pos_label,
         )
 
+    @available_if(
+        _check_supported_ml_task(
+            supported_ml_tasks=["binary-classification", "multiclass-classification"]
+        )
+    )
     def _precision(
         self,
         *,
@@ -841,6 +851,11 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             pos_label=pos_label,
         )
 
+    @available_if(
+        _check_supported_ml_task(
+            supported_ml_tasks=["binary-classification", "multiclass-classification"]
+        )
+    )
     def _recall(
         self,
         *,
@@ -948,6 +963,10 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             y=y,
         )
 
+    @available_if(
+        _check_supported_ml_task(supported_ml_tasks=["binary-classification"])
+    )
+    @available_if(_check_estimator_has_method(method_name="predict_proba"))
     def _brier_score(
         self,
         *,
@@ -1081,6 +1100,11 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             multi_class=multi_class,
         )
 
+    @available_if(
+        _check_supported_ml_task(
+            supported_ml_tasks=["binary-classification", "multiclass-classification"]
+        )
+    )
     def _roc_auc(
         self,
         *,
@@ -1175,6 +1199,11 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             y=y,
         )
 
+    @available_if(
+        _check_supported_ml_task(
+            supported_ml_tasks=["binary-classification", "multiclass-classification"]
+        )
+    )
     def _log_loss(
         self,
         *,
@@ -1279,6 +1308,11 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             multioutput=multioutput,
         )
 
+    @available_if(
+        _check_supported_ml_task(
+            supported_ml_tasks=["regression", "multioutput-regression"]
+        )
+    )
     def _r2(
         self,
         *,
@@ -1396,6 +1430,11 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             multioutput=multioutput,
         )
 
+    @available_if(
+        _check_supported_ml_task(
+            supported_ml_tasks=["regression", "multioutput-regression"]
+        )
+    )
     def _rmse(
         self,
         *,

--- a/skore/tests/unit/sklearn/comparison/test_comparison.py
+++ b/skore/tests/unit/sklearn/comparison/test_comparison.py
@@ -62,8 +62,8 @@ def test_comparison_report_without_testing_data(binary_classification_model):
     """If there is no test data (`None`) for some estimator report,
     initialization works, but computing metrics can fail.
     """
-    estimator, _, _, _, _ = binary_classification_model
-    estimator_report = EstimatorReport(estimator, fit=False)
+    estimator, X_train, _, y_train, _ = binary_classification_model
+    estimator_report = EstimatorReport(estimator, X_train=X_train, y_train=y_train)
 
     report = ComparisonReport([estimator_report, estimator_report])
 


### PR DESCRIPTION
closes #1396 

The private metric functions should be decorate as the public one such that we don't provide an unsupported metric for a class of estimators via the `report.metrics.report_metrics` method.

Note that one test was actually wrong. We needed to at least train the classifier to infer the proper ML task.