### PR TITLE
fix: Add classification type for _find_ml_task when y is unknown

### DIFF
--- a/skore/src/skore/sklearn/find_ml_task.py
+++ b/skore/src/skore/sklearn/find_ml_task.py
@@ -138,7 +138,8 @@ def _find_ml_task(y, estimator=None) -> MLTask:
             else:
                 # fallback on the target
                 if y is None:
-                    return "unknown"
+                    # we cannot do better than classification
+                    return "classification"
 
     # fallback on the target
     if y is None:

--- a/skore/src/skore/sklearn/types.py
+++ b/skore/src/skore/sklearn/types.py
@@ -7,6 +7,7 @@ from numpy.typing import ArrayLike
 
 MLTask = Literal[
     "binary-classification",
+    "classification",
     "clustering",
     "multiclass-classification",
     "multioutput-binary-classification",

--- a/skore/tests/unit/sklearn/test_utils.py
+++ b/skore/tests/unit/sklearn/test_utils.py
@@ -100,7 +100,7 @@ def test_find_ml_task_without_estimator(target, expected_task):
 @pytest.mark.parametrize(
     "estimator, expected",
     [
-        (DummyClassifier(), "unknown"),
+        (DummyClassifier(), "classification"),
         (DummyRegressor(), "regression"),
     ],
 )


### PR DESCRIPTION
It is a bit weird to get an `unknown` type for `_find_ml_task` by providing an unfitted classifier and no target. We could instead return `classification`. We cannot infer better but it is more inline with whatever task we have at hand.