### PR TITLE
fix: Use a more general formulation for the rich repr

### DIFF
--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -97,13 +97,13 @@ class _HelpMixin(ABC):
 
         console.print(self._create_help_panel())
 
-    def _rich_repr(self, class_name: str, help_method_name: str) -> str:
+    def _rich_repr(self, class_name: str) -> str:
         """Return a string representation using rich."""
         string_buffer = StringIO()
         console = Console(file=string_buffer, force_terminal=False)
         console.print(
             Panel(
-                f"Get guidance using the {help_method_name} method",
+                "Get guidance using the help() method",
                 title=f"[cyan]{class_name}[/cyan]",
                 border_style="orange1",
                 expand=False,

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -1148,10 +1148,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
 
     def __repr__(self) -> str:
         """Return a string representation using rich."""
-        return self._rich_repr(
-            class_name="skore.ComparisonReport.metrics",
-            help_method_name="help()",
-        )
+        return self._rich_repr(class_name="skore.ComparisonReport.metrics")
 
     ####################################################################################
     # Methods related to displays

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -1150,7 +1150,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         """Return a string representation using rich."""
         return self._rich_repr(
             class_name="skore.ComparisonReport.metrics",
-            help_method_name="report.metrics.help()",
+            help_method_name="help()",
         )
 
     ####################################################################################

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -918,10 +918,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
     def __repr__(self) -> str:
         """Return a string representation using rich."""
-        return self._rich_repr(
-            class_name="skore.CrossValidationReport.metrics",
-            help_method_name="help()",
-        )
+        return self._rich_repr(class_name="skore.CrossValidationReport.metrics")
 
     ####################################################################################
     # Methods related to displays

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -920,7 +920,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         """Return a string representation using rich."""
         return self._rich_repr(
             class_name="skore.CrossValidationReport.metrics",
-            help_method_name="report.metrics.help()",
+            help_method_name="help()",
         )
 
     ####################################################################################

--- a/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
@@ -623,5 +623,5 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         """Return a string representation using rich."""
         return self._rich_repr(
             class_name="skore.EstimatorReport.feature_importance",
-            help_method_name="report.feature_importance.help()",
+            help_method_name="help()",
         )

--- a/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
@@ -621,7 +621,4 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
 
     def __repr__(self) -> str:
         """Return a string representation using rich."""
-        return self._rich_repr(
-            class_name="skore.EstimatorReport.feature_importance",
-            help_method_name="help()",
-        )
+        return self._rich_repr(class_name="skore.EstimatorReport.feature_importance")

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1619,7 +1619,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         """Return a string representation using rich."""
         return self._rich_repr(
             class_name="skore.EstimatorReport.metrics",
-            help_method_name="report.metrics.help()",
+            help_method_name="help()",
         )
 
     ####################################################################################

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1617,10 +1617,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
 
     def __repr__(self) -> str:
         """Return a string representation using rich."""
-        return self._rich_repr(
-            class_name="skore.EstimatorReport.metrics",
-            help_method_name="help()",
-        )
+        return self._rich_repr(class_name="skore.EstimatorReport.metrics")
 
     ####################################################################################
     # Methods related to displays

--- a/skore/src/skore/sklearn/_plot/utils.py
+++ b/skore/src/skore/sklearn/_plot/utils.py
@@ -112,7 +112,7 @@ class HelpDisplayMixin:
         console = Console(file=string_buffer, force_terminal=False)
         console.print(
             Panel(
-                "Get guidance using the display.help() method",
+                "Get guidance using the help() method",
                 title=f"[cyan]{self.__class__.__name__}[/cyan]",
                 border_style="orange1",
                 expand=False,

--- a/skore/tests/unit/sklearn/comparison/test_comparison.py
+++ b/skore/tests/unit/sklearn/comparison/test_comparison.py
@@ -269,7 +269,7 @@ def test_comparison_report_metrics_repr(binary_classification_model):
 
     repr_str = repr(report.metrics)
     assert "skore.ComparisonReport.metrics" in repr_str
-    assert "report.metrics.help()" in repr_str
+    assert "help()" in repr_str
 
 
 @pytest.mark.parametrize("data_source", ["test", "X_y"])

--- a/skore/tests/unit/sklearn/estimator/feature_importance/test_feature_importance.py
+++ b/skore/tests/unit/sklearn/estimator/feature_importance/test_feature_importance.py
@@ -20,4 +20,4 @@ def test_estimator_report_feature_importance_repr(regression_data):
 
     repr_str = repr(report.feature_importance)
     assert "skore.EstimatorReport.feature_importance" in repr_str
-    assert "report.feature_importance.help()" in repr_str
+    assert "help()" in repr_str

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -483,7 +483,7 @@ def test_estimator_report_metrics_repr(binary_classification_data):
 
     repr_str = repr(report.metrics)
     assert "skore.EstimatorReport.metrics" in repr_str
-    assert "report.metrics.help()" in repr_str
+    assert "help()" in repr_str
 
 
 @pytest.mark.parametrize("metric", ["accuracy", "brier_score", "roc_auc", "log_loss"])

--- a/skore/tests/unit/sklearn/plot/test_common.py
+++ b/skore/tests/unit/sklearn/plot/test_common.py
@@ -54,7 +54,7 @@ def test_display_str(pyplot, plot_func, estimator, dataset):
 
     str_str = str(display)
     assert f"{display.__class__.__name__}" in str_str
-    assert "display.help()" in str_str
+    assert "help()" in str_str
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -316,7 +316,7 @@ def test_cross_validation_report_metrics_repr(binary_classification_data):
 
     repr_str = repr(report.metrics)
     assert "skore.CrossValidationReport.metrics" in repr_str
-    assert "report.metrics.help()" in repr_str
+    assert "help()" in repr_str
 
 
 def _normalize_metric_name(index):


### PR DESCRIPTION
closes #1236 

Formulate the sentence of the guidance using only "help() method" instead of fully qualified name with ambiguous variable name, e.g. "report.metrics.help()"