### PR TITLE
fix: Make sure that average != None return a float for metric

### DIFF
--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -731,7 +731,9 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             pos_label=pos_label,
             average=average,
         )
-        if self._parent._ml_task == "binary-classification" and pos_label is not None:
+        if self._parent._ml_task == "binary-classification" and (
+            pos_label is not None or average is not None
+        ):
             assert isinstance(result, float), (
                 "The precision score should be a float, got "
                 f"{type(result)} with value {result}."
@@ -874,7 +876,9 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             pos_label=pos_label,
             average=average,
         )
-        if self._parent._ml_task == "binary-classification" and pos_label is not None:
+        if self._parent._ml_task == "binary-classification" and (
+            pos_label is not None or average is not None
+        ):
             assert isinstance(result, float), (
                 "The precision score should be a float, got "
                 f"{type(result)} with value {result}."

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -1237,3 +1237,17 @@ def test_estimator_report_brier_score_requires_probabilities():
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     assert not hasattr(report.metrics, "brier_score")
+
+
+def test_estimator_report_average_return_float(binary_classification_data):
+    """Check that we expect a float value when computing a metric with averaging.
+
+    Non-regression test for:
+    https://github.com/probabl-ai/skore/issues/1501
+    """
+    estimator, X_test, y_test = binary_classification_data
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    for metric_name in ("precision", "recall", "roc_auc"):
+        result = getattr(report.metrics, metric_name)(average="macro")
+        assert isinstance(result, float)


### PR DESCRIPTION
closes #1501 

Fixing the regression described in #1501 where averaged score were falsely expected to be a `dict` instead of a `float`.