### PR TITLE
docs: Fix rendering using custom matplotlib scraper

### DIFF
--- a/skore/src/skore/sklearn/_plot/style.py
+++ b/skore/src/skore/sklearn/_plot/style.py
@@ -107,7 +107,6 @@ class StyleDisplayMixin:
             plt.rcParams.update(DEFAULT_STYLE)
             try:
                 result = plot_func(self, *args, **kwargs)
-                self.figure_.tight_layout()
             finally:
                 plt.rcParams.update(original_params)
             return result

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -15,6 +15,7 @@ from sphinx_gallery.sorting import ExplicitOrder
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("sphinxext"))
 from github_link import make_linkcode_resolve  # noqa
+from matplotlib_skore_scraper import matplotlib_skore_scraper  # noqa
 
 project = "skore"
 copyright = "2024, Probabl"
@@ -72,15 +73,6 @@ subsections_order = [
     "../examples/technical_details",
 ]
 
-
-# Augment the dpi of matplotlib figures in Sphinx examples
-# https://sphinx-gallery.github.io/stable/advanced.html#resetting-before-each-example
-def reset_mpl(gallery_conf, fname):
-    import matplotlib
-
-    matplotlib.rcParams["figure.dpi"] = 200
-
-
 # sphinx_gallery options
 sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to example scripts
@@ -97,7 +89,8 @@ sphinx_gallery_conf = {
     },
     "backreferences_dir": "reference/api",
     "doc_module": "skore",
-    "reset_modules": (reset_mpl, "seaborn"),
+    # "reset_modules": (reset_mpl, "seaborn"),
+    "image_scrapers": [matplotlib_skore_scraper],
     "abort_on_example_error": True,
 }
 

--- a/sphinx/sphinxext/matplotlib_skore_scraper.py
+++ b/sphinx/sphinxext/matplotlib_skore_scraper.py
@@ -1,0 +1,5 @@
+from sphinx_gallery.scrapers import matplotlib_scraper
+
+
+def matplotlib_skore_scraper(*args, **kwargs):
+    return matplotlib_scraper(*args, bbox_inches="tight", **kwargs)


### PR DESCRIPTION
It looks that the `display.figure_.tight_layout()` does not work for the purpose of the documentation. I was looking within notebooks and VS code but forgot to check the website.

For the website, we can actually solve it by modifying the matplotlib scrappers from sphinx-gallery and fix pass the right parameter to `savefig`. I removed the "200 dpi" because it makes the figure too big and I don't think that the default quality is bad.