### PR TITLE
docs: Show simpler model first and complex second in example use case

### DIFF
--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -90,13 +90,70 @@ my_project.put("Input data summary", table_report)
 y
 
 # %%
+# Simple model
+# ===============
+
+# %%
+# Let's start by creating a simple baseline model using some out-of-the-box tools.
+#
+# For feature engineering we use skrub's :class:`~skrub.TableVectorizer`.
+# To deal with the high cardinality of the categorical features, we use a
+# :class:`~skrub.TextEncoder` that uses a language model and an embedding model to
+# encode the categorical features.
+#
+# Finally, we use a :class:`~sklearn.ensemble.HistGradientBoostingRegressor` as a
+# base estimator that is a rather robust model.
+#
 # Modelling
-# =========
+# ^^^^^^^^^
+
+from skrub import TableVectorizer, TextEncoder
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.pipeline import make_pipeline
+
+model = make_pipeline(
+    TableVectorizer(high_cardinality=TextEncoder()),
+    HistGradientBoostingRegressor(),
+)
+model
+
+# %%
+# Evaluation
+# ^^^^^^^^^^
+#
+# Let us compute the cross-validation report for this model using :class:`skore.CrossValidationReport`
+from skore import CrossValidationReport
+
+report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4)
+report.help()
 
 # %%
 #
-# In a first attempt, we define a rather complex predictive model that uses
+# We cache the predictions for later use.
+report.cache_predictions(n_jobs=4)
+
+# %%
+#
+# We store the report in our skore project.
+my_project.put("HGBDT model report", report)
+
+# %%
+#
+# We can now have a look at the performance of the model with some standard metrics.
+report.metrics.report_metrics()
+
+
+# %%
+# Complex model
+# =========
+#
+# Now that we have established a baseline, we shall proceed to define a rather more complex predictive model that uses
 # a linear model as a base estimator.
+
+# %%
+# Modelling
+# ^^^^^^^^^
+
 import numpy as np
 from sklearn.compose import make_column_transformer
 from sklearn.pipeline import make_pipeline
@@ -160,17 +217,12 @@ model
 # * Finally, we fit a :class:`~sklearn.linear_model.RidgeCV` model.
 
 # %%
-# Model evaluation using :class:`skore.CrossValidationReport`
-# ============================================================
-#
-# First model
-# ^^^^^^^^^^^
+# Evaluation
+# ^^^^^^^^^^
 #
 # Now, we want to evaluate this complex model via cross-validation (with 5 folds).
 # For that, we use skore's :class:`~skore.CrossValidationReport` to investigate the
 # performance of our model.
-from skore import CrossValidationReport
-
 report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4)
 report.help()
 
@@ -201,60 +253,17 @@ my_project.put("Linear model report", report)
 report.metrics.report_metrics(indicator_favorability=True)
 
 # %%
-# Second model
-# ^^^^^^^^^^^^
-#
-# Now that we have our first baseline model, we can try an out-of-the-box model:
-# skrub's :class:`~skrub.TableVectorizer` that makes the feature engineering for us.
-# To deal with the high cardinality of the categorical features, we use a
-# :class:`~skrub.TextEncoder` that uses a language model and an embedding model to
-# encode the categorical features.
-#
-# Finally, we use a :class:`~sklearn.ensemble.HistGradientBoostingRegressor` as a
-# base estimator that is a rather robust model.
-from skrub import TableVectorizer, TextEncoder
-from sklearn.ensemble import HistGradientBoostingRegressor
-from sklearn.pipeline import make_pipeline
-
-model = make_pipeline(
-    TableVectorizer(high_cardinality=TextEncoder()),
-    HistGradientBoostingRegressor(),
-)
-model
-
-# %%
-#
-# Let us compute the cross-validation report for this model.
-report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4)
-report.help()
-
-# %%
-#
-# We cache the predictions for later use.
-report.cache_predictions(n_jobs=4)
-
-# %%
-#
-# We store the report in our skore project.
-my_project.put("HGBDT model report", report)
-
-# %%
-#
-# We can now have a look at the performance of the model with some standard metrics.
-report.metrics.report_metrics()
-
-# %%
-# Investigating the models
-# ^^^^^^^^^^^^^^^^^^^^^^^^
+# Comparing the models
+# ====================
 #
 # At this point, we may not have been cautious and could have already overwritten the
-# report and model from our initial attempt.
+# report and model from our initial (simple model) attempt.
 # Fortunately, since we saved the reports in our skore project, we can easily recover
 # them.
 # So, let us retrieve those reports.
 
-linear_model_report = my_project.get("Linear model report")
 hgbdt_model_report = my_project.get("HGBDT model report")
+linear_model_report = my_project.get("Linear model report")
 
 # %%
 #
@@ -264,8 +273,8 @@ import pandas as pd
 
 results = pd.concat(
     [
-        linear_model_report.metrics.report_metrics(),
         hgbdt_model_report.metrics.report_metrics(),
+        linear_model_report.metrics.report_metrics(),
     ],
     axis=1,
 )
@@ -285,12 +294,12 @@ scoring_kwargs = {"response_method": "predict"}
 scoring_names = ["R2", "RMSE", "MAE"]
 results = pd.concat(
     [
-        linear_model_report.metrics.report_metrics(
+        hgbdt_model_report.metrics.report_metrics(
             scoring=scoring,
             scoring_kwargs=scoring_kwargs,
             scoring_names=scoring_names,
         ),
-        hgbdt_model_report.metrics.report_metrics(
+        linear_model_report.metrics.report_metrics(
             scoring=scoring,
             scoring_kwargs=scoring_kwargs,
             scoring_names=scoring_names,

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -94,7 +94,7 @@ y
 # ===============
 
 # %%
-# Let's start by creating a simple baseline model using some out-of-the-box tools.
+# Let's start by creating a tree-based model using some out-of-the-box tools.
 #
 # For feature engineering we use skrub's :class:`~skrub.TableVectorizer`.
 # To deal with the high cardinality of the categorical features, we use a

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -335,6 +335,8 @@ for split_idx, (ax, estimator_report) in enumerate(
     estimator_report.metrics.prediction_error().plot(kind="actual_vs_predicted", ax=ax)
     ax.set_title(f"Split #{split_idx + 1}")
     ax.legend(loc="lower right")
+
+plt.tight_layout()
 # sphinx_gallery_start_ignore
 temp_dir.cleanup()
 # sphinx_gallery_end_ignore

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -144,7 +144,7 @@ report.metrics.report_metrics()
 
 
 # %%
-# Complex model
+# Linear model
 # =========
 #
 # Now that we have established a baseline, we shall proceed to define a rather more complex predictive model that uses

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -90,7 +90,7 @@ my_project.put("Input data summary", table_report)
 y
 
 # %%
-# Simple model
+# Tree-based model
 # ===============
 
 # %%

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -147,8 +147,10 @@ report.metrics.report_metrics()
 # Linear model
 # =========
 #
-# Now that we have established a baseline, we shall proceed to define a rather more complex predictive model that uses
-# a linear model as a base estimator.
+# Now that we have established a first model that serves as a baseline,
+# we shall proceed to define a quite complex linear model
+# (a pipeline with a complex feature engineering that uses
+# a linear model as the base estimator).
 
 # %%
 # Modelling

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -259,7 +259,7 @@ report.metrics.report_metrics(indicator_favorability=True)
 # ====================
 #
 # At this point, we may not have been cautious and could have already overwritten the
-# report and model from our initial (simple model) attempt.
+# report and model from our initial (tree-based model) attempt.
 # Fortunately, since we saved the reports in our skore project, we can easily recover
 # them.
 # So, let us retrieve those reports.

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -222,7 +222,7 @@ model
 # Evaluation
 # ^^^^^^^^^^
 #
-# Now, we want to evaluate this complex model via cross-validation (with 5 folds).
+# Now, we want to evaluate this linear model via cross-validation (with 5 folds).
 # For that, we use skore's :class:`~skore.CrossValidationReport` to investigate the
 # performance of our model.
 report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4)

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -121,7 +121,7 @@ model
 # Evaluation
 # ^^^^^^^^^^
 #
-# Let us compute the cross-validation report for this model using :class:`skore.CrossValidationReport`
+# Let us compute the cross-validation report for this model using :class:`skore.CrossValidationReport`:
 from skore import CrossValidationReport
 
 report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4)
@@ -135,7 +135,7 @@ report.cache_predictions(n_jobs=4)
 # %%
 #
 # We store the report in our skore project.
-my_project.put("HGBDT model report", report)
+my_project.put("HGBT model report", report)
 
 # %%
 #
@@ -262,7 +262,7 @@ report.metrics.report_metrics(indicator_favorability=True)
 # them.
 # So, let us retrieve those reports.
 
-hgbdt_model_report = my_project.get("HGBDT model report")
+hgbt_model_report = my_project.get("HGBT model report")
 linear_model_report = my_project.get("Linear model report")
 
 # %%
@@ -273,7 +273,7 @@ import pandas as pd
 
 results = pd.concat(
     [
-        hgbdt_model_report.metrics.report_metrics(),
+        hgbt_model_report.metrics.report_metrics(),
         linear_model_report.metrics.report_metrics(),
     ],
     axis=1,
@@ -294,7 +294,7 @@ scoring_kwargs = {"response_method": "predict"}
 scoring_names = ["R2", "RMSE", "MAE"]
 results = pd.concat(
     [
-        hgbdt_model_report.metrics.report_metrics(
+        hgbt_model_report.metrics.report_metrics(
             scoring=scoring,
             scoring_kwargs=scoring_kwargs,
             scoring_names=scoring_names,


### PR DESCRIPTION
Closes https://github.com/probabl-ai/skore/issues/1505.

I have made the changes as discussed in the issue's comments. I created the docs locally and aesthetically they looked fine. Will double check with the CI/CD docs build and adjust upon comments/questions.

I had a small question regarding the variable names: hgbdt_model_report and linear_model_report. They’re definitely descriptive, but I was wondering if they might be a bit confusing for someone newer to machine learning. Since linear models are typically taught early on, they’re often seen as more "basic," whereas an abbreviation like hgbdt could feel a little intimidating if someone isn’t already familiar with it.

I know the models are explained well in the Modelling section, so it’s probably fine — I just wanted to check if you had any thoughts on whether the current naming feels clear enough. Alternatively, would it make sense to adjust the naming slightly when we save the report in Skore? For example:
my_project.put("Linear (complex) model report", report) and my_project.put("HGBDT (simple) model report", report) — just to make it a little clearer at a glance.

Totally happy either way, just thought I’d check.