### PR TITLE
docs: Pass format to `pd.to_datetime`

### DIFF
--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -232,7 +232,9 @@ from skrub.datasets import fetch_employee_salaries
 
 dataset_employee = fetch_employee_salaries()
 X_employee, y_employee = dataset_employee.X, dataset_employee.y
-X_employee["date_first_hired"] = pd.to_datetime(X_employee["date_first_hired"])
+X_employee["date_first_hired"] = pd.to_datetime(
+    X_employee["date_first_hired"], format="%m/%d/%Y"
+)
 X_employee.head(2)
 
 # %%

--- a/examples/model_evaluation/plot_train_test_split.py
+++ b/examples/model_evaluation/plot_train_test_split.py
@@ -217,7 +217,7 @@ from skrub.datasets import fetch_employee_salaries
 
 dataset = fetch_employee_salaries()
 X, y = dataset.X, dataset.y
-X["date_first_hired"] = pd.to_datetime(X["date_first_hired"])
+X["date_first_hired"] = pd.to_datetime(X["date_first_hired"], format="%m/%d/%Y")
 X.head(2)
 
 # %%


### PR DESCRIPTION
Closes #1504.

I simply inspected the `X_employee["date_first_hired"]` series by printing it, and saw that it uses the `mm/dd/yyyy` format. I have updated both examples to use the corresponding format argument.

The linked issue also mentions `skrub.ToDatetime` but I am not clear on what exactly is to be done with that. It looks like that API is only used in one example: `examples/use_cases/plot_employee_salaries.py`. If anyone can clarify what needs to be done I would love to take it up in this PR or a future PR.