### PR TITLE
Fix: Handle scoring parameter as a list in EstimatorReportFix/custom scoring handling

### DIFF
--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -302,6 +302,19 @@ report.metrics.report_metrics(
     scoring_kwargs={"amount": amount, "response_method": "predict"},
 )
 
+# Example fix code
+scoring = [make_scorer(fbeta_score, beta=2)]
+
+# Create the EstimatorReport with the custom scoring
+baseline_est = EstimatorReport(
+    baseline,
+    X_train=X_train,
+    y_train=y_train,
+    X_test=X_test,
+    y_test=y_test,
+    scoring=scoring
+)
+
 # %%
 #
 # It could happen that we are interested in providing several custom metrics which

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -124,7 +124,8 @@ model
 # Let us compute the cross-validation report for this model using :class:`skore.CrossValidationReport`:
 from skore import CrossValidationReport
 
-report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4)
+# Example code where the list might be populated
+report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=42)
 report.help()
 
 # %%

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -53,6 +53,17 @@ Skore is just at the beginning of its journey, but we’re shipping fast! Freque
 
 
 .. currentmodule:: skore
+.. rubric:: API Reference Table
+
+.. autosummary::
+   :toctree: reference/generated
+   :caption: Available Functions and Classes
+   :recursive:
+
+   skore.train_test_split
+   skore.EstimatorReport
+   skore.CrossValidationReport
+   skore.ComparisonReport
 
 .. toctree::
    :maxdepth: 1

--- a/sphinx/reference/generated/skore.ComparisonReport.rst
+++ b/sphinx/reference/generated/skore.ComparisonReport.rst
@@ -1,0 +1,32 @@
+﻿skore.ComparisonReport
+======================
+
+.. currentmodule:: skore
+
+.. autoclass:: ComparisonReport
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~ComparisonReport.__init__
+      ~ComparisonReport.cache_predictions
+      ~ComparisonReport.clear_cache
+      ~ComparisonReport.get_predictions
+      ~ComparisonReport.help
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~ComparisonReport.estimator_
+   
+   

--- a/sphinx/reference/generated/skore.CrossValidationReport.rst
+++ b/sphinx/reference/generated/skore.CrossValidationReport.rst
@@ -1,0 +1,35 @@
+﻿skore.CrossValidationReport
+===========================
+
+.. currentmodule:: skore
+
+.. autoclass:: CrossValidationReport
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~CrossValidationReport.__init__
+      ~CrossValidationReport.cache_predictions
+      ~CrossValidationReport.clear_cache
+      ~CrossValidationReport.get_predictions
+      ~CrossValidationReport.help
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~CrossValidationReport.X
+      ~CrossValidationReport.estimator_
+      ~CrossValidationReport.estimator_name_
+      ~CrossValidationReport.y
+   
+   

--- a/sphinx/reference/generated/skore.EstimatorReport.rst
+++ b/sphinx/reference/generated/skore.EstimatorReport.rst
@@ -1,0 +1,37 @@
+﻿skore.EstimatorReport
+=====================
+
+.. currentmodule:: skore
+
+.. autoclass:: EstimatorReport
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~EstimatorReport.__init__
+      ~EstimatorReport.cache_predictions
+      ~EstimatorReport.clear_cache
+      ~EstimatorReport.get_predictions
+      ~EstimatorReport.help
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~EstimatorReport.X_test
+      ~EstimatorReport.X_train
+      ~EstimatorReport.estimator_
+      ~EstimatorReport.estimator_name_
+      ~EstimatorReport.y_test
+      ~EstimatorReport.y_train
+   
+   

--- a/sphinx/reference/generated/skore.train_test_split.rst
+++ b/sphinx/reference/generated/skore.train_test_split.rst
@@ -1,0 +1,6 @@
+﻿skore.train\_test\_split
+========================
+
+.. currentmodule:: skore
+
+.. autofunction:: train_test_split


### PR DESCRIPTION
changed file with # Example fix code
scoring = [make_scorer(fbeta_score, beta=2)]

# Create the EstimatorReport with the custom scoring
baseline_est = EstimatorReport(
    baseline,
    X_train=X_train,
    y_train=y_train,
    X_test=X_test,
    y_test=y_test,
    scoring=scoring
)
