### PR TITLE
feat: Enable data_source=X_y in CrossValidationReport

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Literal, Optional, Union, cast
 import joblib
 import numpy as np
 import pandas as pd
+from numpy.typing import ArrayLike
 from sklearn.metrics import make_scorer
 from sklearn.metrics._scorer import _BaseScorer as SKLearnScorer
 from sklearn.utils.metaestimators import available_if
@@ -22,7 +23,7 @@ from skore.utils._index import flatten_multi_index
 from skore.utils._parallel import Parallel, delayed
 from skore.utils._progress_bar import progress_decorator
 
-DataSource = Literal["test", "train"]
+DataSource = Literal["test", "train", "X_y"]
 
 
 class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
@@ -51,6 +52,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         scoring: Optional[Union[list[str], Callable, SKLearnScorer]] = None,
         scoring_names: Optional[list[str]] = None,
         scoring_kwargs: Optional[dict[str, Any]] = None,
@@ -63,11 +66,21 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the train set provided when creating the report and the target
+              variable.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         scoring : list of str, callable, or scorer, default=None
             The metrics to report. You can get the possible list of string by calling
@@ -127,6 +140,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         results = self._compute_metric_scores(
             report_metric_name="report_metrics",
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
             scoring=scoring,
             pos_label=pos_label,
@@ -147,16 +162,27 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         report_metric_name: str,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         aggregate: Optional[Aggregate] = None,
         **metric_kwargs: Any,
     ) -> pd.DataFrame:
-        # build the cache key components to finally create a tuple that will be used
-        # to check if the metric has already been computed
+        if data_source == "X_y":
+            X, y, data_source_hash = self._get_X_y_and_data_source_hash(
+                data_source=data_source, X=X, y=y
+            )
+        else:
+            data_source_hash = None
+
         cache_key_parts: list[Any] = [
             self._parent._hash,
             report_metric_name,
             data_source,
         ]
+
+        if data_source_hash is not None:
+            cache_key_parts.append(data_source_hash)
+
         if aggregate is None:
             cache_key_parts.append(aggregate)
         else:
@@ -188,7 +214,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             )
             generator = parallel(
                 delayed(getattr(report.metrics, report_metric_name))(
-                    data_source=data_source, **metric_kwargs
+                    data_source=data_source, X=X, y=y, **metric_kwargs
                 )
                 for report in self._parent.estimator_reports_
             )
@@ -285,17 +311,28 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         aggregate: Optional[Aggregate] = ("mean", "std"),
     ) -> pd.DataFrame:
         """Compute the accuracy score.
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
@@ -324,6 +361,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             scoring=["accuracy"],
             data_source=data_source,
             aggregate=aggregate,
+            X=X,
+            y=y,
         )
 
     @available_if(_check_estimator_report_has_method("metrics", "precision"))
@@ -331,6 +370,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         average: Optional[
             Literal["binary", "macro", "micro", "weighted", "samples"]
         ] = None,
@@ -341,11 +382,20 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         average : {"binary","macro", "micro", "weighted", "samples"} or None, \
                 default=None
@@ -403,6 +453,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             scoring=["precision"],
             data_source=data_source,
             aggregate=aggregate,
+            X=X,
+            y=y,
             pos_label=pos_label,
             scoring_kwargs={"average": average},
         )
@@ -412,6 +464,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         average: Optional[
             Literal["binary", "macro", "micro", "weighted", "samples"]
         ] = None,
@@ -422,11 +476,20 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         average : {"binary","macro", "micro", "weighted", "samples"} or None, \
                 default=None
@@ -484,6 +547,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         return self.report_metrics(
             scoring=["recall"],
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
             pos_label=pos_label,
             scoring_kwargs={"average": average},
@@ -494,17 +559,28 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         aggregate: Optional[Aggregate] = ("mean", "std"),
     ) -> pd.DataFrame:
         """Compute the Brier score.
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
@@ -532,6 +608,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         return self.report_metrics(
             scoring=["brier_score"],
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
         )
 
@@ -540,6 +618,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         average: Optional[Literal["macro", "micro", "weighted", "samples"]] = None,
         multi_class: Literal["raise", "ovr", "ovo"] = "ovr",
         aggregate: Optional[Aggregate] = ("mean", "std"),
@@ -548,11 +628,20 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         average : {"macro", "micro", "weighted", "samples"}, default=None
             Average to compute the ROC AUC score in a multiclass setting. By default,
@@ -613,6 +702,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         return self.report_metrics(
             scoring=["roc_auc"],
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
             scoring_kwargs={"average": average, "multi_class": multi_class},
         )
@@ -622,17 +713,28 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         aggregate: Optional[Aggregate] = ("mean", "std"),
     ) -> pd.DataFrame:
         """Compute the log loss.
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
@@ -660,6 +762,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         return self.report_metrics(
             scoring=["log_loss"],
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
         )
 
@@ -668,6 +772,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         multioutput: Literal["raw_values", "uniform_average"] = "raw_values",
         aggregate: Optional[Aggregate] = ("mean", "std"),
     ) -> pd.DataFrame:
@@ -675,11 +781,20 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         multioutput : {"raw_values", "uniform_average"} or array-like of shape \
                 (n_outputs,), default="raw_values"
@@ -717,6 +832,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         return self.report_metrics(
             scoring=["r2"],
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
             scoring_kwargs={"multioutput": multioutput},
         )
@@ -726,6 +843,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         multioutput: Literal["raw_values", "uniform_average"] = "raw_values",
         aggregate: Optional[Aggregate] = ("mean", "std"),
     ) -> pd.DataFrame:
@@ -733,11 +852,20 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         multioutput : {"raw_values", "uniform_average"} or array-like of shape \
                 (n_outputs,), default="raw_values"
@@ -775,6 +903,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         return self.report_metrics(
             scoring=["rmse"],
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
             scoring_kwargs={"multioutput": multioutput},
         )
@@ -786,6 +916,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         *,
         metric_name: Optional[str] = None,
         data_source: DataSource = "test",
+        X: Optional[ArrayLike] = None,
+        y: Optional[ArrayLike] = None,
         aggregate: Optional[Aggregate] = ("mean", "std"),
         **kwargs,
     ) -> pd.DataFrame:
@@ -815,11 +947,20 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             The name of the metric. If not provided, it will be inferred from the
             metric function.
 
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the provided `X` and `y` to compute the metric.
+
+        X : array-like of shape (n_samples, n_features), default=None
+            New data on which to compute the metric. By default, we use the validation
+            set provided when creating the report.
+
+        y : array-like of shape (n_samples,), default=None
+            New target on which to compute the metric. By default, we use the target
+            provided when creating the report.
 
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
@@ -863,6 +1004,8 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         return self.report_metrics(
             scoring=[scorer],
             data_source=data_source,
+            X=X,
+            y=y,
             aggregate=aggregate,
             scoring_names=[metric_name] if metric_name is not None else None,
         )

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -298,8 +298,9 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     def get_predictions(
         self,
         *,
-        data_source: Literal["train", "test"],
+        data_source: Literal["train", "test", "X_y"],
         response_method: Literal["predict", "predict_proba", "decision_function"],
+        X: Optional[ArrayLike] = None,
         pos_label: Optional[Any] = None,
     ) -> ArrayLike:
         """Get estimator's predictions.
@@ -309,14 +310,20 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "X_y"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "X_y" : use the train set provided when creating the report and the target
+              variable.
 
         response_method : {"predict", "predict_proba", "decision_function"}
             The response method to use.
+
+        X : array-like of shape (n_samples, n_features), optional
+            When `data_source` is "X_y", the input features on which to compute the
+            response method.
 
         pos_label : int, float, bool or str, default=None
             The positive class when it comes to binary classification. When
@@ -349,15 +356,16 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         >>> print([split_predictions.shape for split_predictions in predictions])
         [(50,), (50,)]
         """
-        if data_source not in ("train", "test"):
+        if data_source not in ("train", "test", "X_y"):
             raise ValueError(
                 f"Invalid data source: {data_source}. Valid data sources are "
-                "'train' and 'test'."
+                "'train', 'test' and 'X_y'."
             )
         return [
             report.get_predictions(
                 data_source=data_source,
                 response_method=response_method,
+                X=X,
                 pos_label=pos_label,
             )
             for report in self.estimator_reports_

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1685,9 +1685,6 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
         assert y is not None, "y must be provided"
 
-        # build the cache key components to finally create a tuple that will be used
-        # to check if the metric has already been computed
-
         if "seed" in display_kwargs and display_kwargs["seed"] is None:
             cache_key = None
         else:

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -355,6 +355,10 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         elif data_source == "train":
             X_ = self._X_train
         elif data_source == "X_y":
+            if X is None:
+                raise ValueError(
+                    "The `X` parameter is required when `data_source` is 'X_y'."
+                )
             X_ = X
         else:
             raise ValueError(f"Invalid data source: {data_source}")

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -389,9 +389,9 @@ class PrecisionRecallCurveDisplay(
                     )
                     if split_idx == 0:
                         line_kwargs_validated["label"] = (
-                            f"{str(class_).title()} - "
-                            f"AP = {average_precision_mean:0.2f} +/- "
-                            f"{average_precision_std:0.2f}"
+                            f"{str(class_).title()} "
+                            f"(AP = {average_precision_mean:0.2f} +/- "
+                            f"{average_precision_std:0.2f})"
                         )
                     else:
                         line_kwargs_validated["label"] = None
@@ -404,7 +404,7 @@ class PrecisionRecallCurveDisplay(
         if data_source in ("train", "test"):
             title = f"{estimator_name} on $\\bf{{{data_source}}}$ set"
         else:
-            title = f"{estimator_name} on $\\bf{{external}}$ data"
+            title = f"{estimator_name} on $\\bf{{external}}$ set"
         ax.legend(bbox_to_anchor=(1.02, 1), title=title)
 
         return ax, lines, info_pos_label

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -351,7 +351,7 @@ class PrecisionRecallCurveDisplay(
                     line_kwargs, pr_curve_kwargs[split_idx]
                 )
                 line_kwargs_validated["label"] = (
-                    f"{data_source.title()} set - fold #{split_idx + 1} "
+                    f"Estimator of fold #{split_idx + 1} "
                     f"(AP = {average_precision_split:0.2f})"
                 )
 
@@ -389,9 +389,9 @@ class PrecisionRecallCurveDisplay(
                     )
                     if split_idx == 0:
                         line_kwargs_validated["label"] = (
-                            f"{str(class_).title()} - {data_source} set"
-                            f" (AP = {average_precision_mean:0.2f} +/- "
-                            f"{average_precision_std:0.2f})"
+                            f"{str(class_).title()} - "
+                            f"AP = {average_precision_mean:0.2f} +/- "
+                            f"{average_precision_std:0.2f}"
                         )
                     else:
                         line_kwargs_validated["label"] = None
@@ -401,7 +401,11 @@ class PrecisionRecallCurveDisplay(
                     )
                     lines.append(line)
 
-        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
+        if data_source in ("train", "test"):
+            title = f"{estimator_name} on $\\bf{{{data_source}}}$ set"
+        else:
+            title = f"{estimator_name} on $\\bf{{external}}$ data"
+        ax.legend(bbox_to_anchor=(1.02, 1), title=title)
 
         return ax, lines, info_pos_label
 

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -350,7 +350,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
         if data_source in ("train", "test"):
             title = f"{estimator_name} on $\\bf{{{data_source}}}$ set"
         else:
-            title = f"{estimator_name} on $\\bf{{external}}$ data"
+            title = f"{estimator_name} on $\\bf{{external}}$ set"
         ax.legend(bbox_to_anchor=(1.02, 1), title=title)
 
         return scatter

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -316,7 +316,6 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
             len(y_true) if len(y_true) > 10 else 10,
         )
 
-        scatter_label = f"{data_source.title()} set"
         for split_idx in range(len(y_true)):
             data_points_kwargs_fold = {
                 "color": colors_markers[split_idx],
@@ -327,7 +326,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                 data_points_kwargs_fold, samples_kwargs[split_idx]
             )
 
-            label = scatter_label + f" - split #{split_idx + 1}"
+            label = f"Estimator of fold #{split_idx + 1}"
 
             if kind == "actual_vs_predicted":
                 scatter.append(
@@ -348,7 +347,11 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
                     )
                 )
 
-        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
+        if data_source in ("train", "test"):
+            title = f"{estimator_name} on $\\bf{{{data_source}}}$ set"
+        else:
+            title = f"{estimator_name} on $\\bf{{external}}$ data"
+        ax.legend(bbox_to_anchor=(1.02, 1), title=title)
 
         return scatter
 

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -349,8 +349,7 @@ class RocCurveDisplay(
                     line_kwargs, roc_curve_kwargs[split_idx]
                 )
                 line_kwargs_validated["label"] = (
-                    f"{data_source.title()} set - fold #{split_idx + 1} "
-                    f"(AUC = {roc_auc_split:0.2f})"
+                    f"Estimator of fold #{split_idx + 1} (AUC = {roc_auc_split:0.2f})"
                 )
 
                 (line,) = ax.plot(fpr_split, tpr_split, **line_kwargs_validated)
@@ -386,8 +385,9 @@ class RocCurveDisplay(
                     )
                     if split_idx == 0:
                         line_kwargs_validated["label"] = (
-                            f"{str(class_).title()} - {data_source} set"
-                            f" (AUC = {roc_auc_mean:0.2f} +/- "
+                            f"{str(class_).title()} - Estimator of "
+                            f"fold #{split_idx + 1} "
+                            f"(AUC = {roc_auc_mean:0.2f} +/- "
                             f"{roc_auc_std:0.2f})"
                         )
                     else:
@@ -396,7 +396,11 @@ class RocCurveDisplay(
                     (line,) = ax.plot(fpr_split, tpr_split, **line_kwargs_validated)
                     lines.append(line)
 
-        ax.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
+        if data_source in ("train", "test"):
+            title = f"{estimator_name} on $\\bf{{{data_source}}}$ set"
+        else:
+            title = f"{estimator_name} on $\\bf{{external}}$ data"
+        ax.legend(bbox_to_anchor=(1.02, 1), title=title)
 
         return ax, lines, info_pos_label
 

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -385,8 +385,7 @@ class RocCurveDisplay(
                     )
                     if split_idx == 0:
                         line_kwargs_validated["label"] = (
-                            f"{str(class_).title()} - Estimator of "
-                            f"fold #{split_idx + 1} "
+                            f"{str(class_).title()} "
                             f"(AUC = {roc_auc_mean:0.2f} +/- "
                             f"{roc_auc_std:0.2f})"
                         )
@@ -399,7 +398,7 @@ class RocCurveDisplay(
         if data_source in ("train", "test"):
             title = f"{estimator_name} on $\\bf{{{data_source}}}$ set"
         else:
-            title = f"{estimator_name} on $\\bf{{external}}$ data"
+            title = f"{estimator_name} on $\\bf{{external}}$ set"
         ax.legend(bbox_to_anchor=(1.02, 1), title=title)
 
         return ax, lines, info_pos_label

--- a/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
@@ -87,15 +87,21 @@ def test_precision_recall_curve_display_binary_classification(
     assert display.ax_.get_xlim() == display.ax_.get_ylim() == (-0.01, 1.01)
 
 
+@pytest.mark.parametrize("data_source", ["train", "test", "X_y"])
 def test_precision_recall_curve_cross_validation_display_binary_classification(
-    pyplot, binary_classification_data_no_split
+    pyplot, binary_classification_data_no_split, data_source
 ):
     """Check the attributes and default plotting behaviour of the
     precision-recall curve plot with binary data.
     """
     (estimator, X, y), cv = binary_classification_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.precision_recall()
+    if data_source == "X_y":
+        precision_recall_kwargs = {"data_source": data_source, "X": X, "y": y}
+    else:
+        precision_recall_kwargs = {"data_source": data_source}
+
+    display = report.metrics.precision_recall(**precision_recall_kwargs)
     assert isinstance(display, PrecisionRecallCurveDisplay)
 
     # check the structure of the attributes
@@ -126,7 +132,11 @@ def test_precision_recall_curve_cross_validation_display_binary_classification(
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
+    data_source_title = "external" if data_source == "X_y" else data_source
+    assert (
+        legend.get_title().get_text()
+        == f"LogisticRegression on $\\bf{{{data_source_title}}}$ set"
+    )
     assert len(legend.get_texts()) == 3
 
     assert display.ax_.get_xlabel() == "Recall\n(Positive label: 1)"
@@ -201,15 +211,21 @@ def test_precision_recall_curve_display_multiclass_classification(
     assert display.ax_.get_xlim() == display.ax_.get_ylim() == (-0.01, 1.01)
 
 
+@pytest.mark.parametrize("data_source", ["train", "test", "X_y"])
 def test_precision_recall_curve_cross_validation_display_multiclass_classification(
-    pyplot, multiclass_classification_data_no_split
+    pyplot, multiclass_classification_data_no_split, data_source
 ):
     """Check the attributes and default plotting behaviour of the precision-recall
     curve plot with multiclass data.
     """
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.precision_recall()
+    if data_source == "X_y":
+        precision_recall_kwargs = {"data_source": data_source, "X": X, "y": y}
+    else:
+        precision_recall_kwargs = {"data_source": data_source}
+
+    display = report.metrics.precision_recall(**precision_recall_kwargs)
     assert isinstance(display, PrecisionRecallCurveDisplay)
 
     # check the structure of the attributes
@@ -229,19 +245,23 @@ def test_precision_recall_curve_cross_validation_display_multiclass_classificati
     default_colors = sample_mpl_colormap(pyplot.cm.tab10, 10)
     for class_label, expected_color in zip(class_labels, default_colors):
         for split_idx in range(cv):
-            roc_curve_mpl = display.lines_[class_label * cv + split_idx]
-            assert isinstance(roc_curve_mpl, mpl.lines.Line2D)
+            precision_recall_curve_mpl = display.lines_[class_label * cv + split_idx]
+            assert isinstance(precision_recall_curve_mpl, mpl.lines.Line2D)
             if split_idx == 0:
-                assert roc_curve_mpl.get_label() == (
-                    f"{str(class_label).title()} - "
-                    f"AP = {np.mean(display.average_precision[class_label]):0.2f}"
-                    f" +/- {np.std(display.average_precision[class_label]):0.2f}"
+                assert precision_recall_curve_mpl.get_label() == (
+                    f"{str(class_label).title()} "
+                    f"(AP = {np.mean(display.average_precision[class_label]):0.2f}"
+                    f" +/- {np.std(display.average_precision[class_label]):0.2f})"
                 )
-            assert roc_curve_mpl.get_color() == expected_color
+            assert precision_recall_curve_mpl.get_color() == expected_color
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
+    data_source_title = "external" if data_source == "X_y" else data_source
+    assert (
+        legend.get_title().get_text()
+        == f"LogisticRegression on $\\bf{{{data_source_title}}}$ set"
+    )
     assert len(legend.get_texts()) == 3
 
     assert display.ax_.get_xlabel() == "Recall"

--- a/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_precision_recall_curve.py
@@ -119,14 +119,14 @@ def test_precision_recall_curve_cross_validation_display_binary_classification(
     for split_idx, line in enumerate(display.lines_):
         assert isinstance(line, mpl.lines.Line2D)
         assert line.get_label() == (
-            f"Test set - fold #{split_idx + 1} "
+            f"Estimator of fold #{split_idx + 1} "
             f"(AP = {display.average_precision[pos_label][split_idx]:0.2f})"
         )
         assert mpl.colors.to_rgba(line.get_color()) == expected_colors[split_idx]
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == estimator.__class__.__name__
+    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
     assert len(legend.get_texts()) == 3
 
     assert display.ax_.get_xlabel() == "Recall\n(Positive label: 1)"
@@ -233,15 +233,15 @@ def test_precision_recall_curve_cross_validation_display_multiclass_classificati
             assert isinstance(roc_curve_mpl, mpl.lines.Line2D)
             if split_idx == 0:
                 assert roc_curve_mpl.get_label() == (
-                    f"{str(class_label).title()} - test set "
-                    f"(AP = {np.mean(display.average_precision[class_label]):0.2f}"
-                    f" +/- {np.std(display.average_precision[class_label]):0.2f})"
+                    f"{str(class_label).title()} - "
+                    f"AP = {np.mean(display.average_precision[class_label]):0.2f}"
+                    f" +/- {np.std(display.average_precision[class_label]):0.2f}"
                 )
             assert roc_curve_mpl.get_color() == expected_color
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == estimator.__class__.__name__
+    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
     assert len(legend.get_texts()) == 3
 
     assert display.ax_.get_xlabel() == "Recall"

--- a/skore/tests/unit/sklearn/plot/test_prediction_error.py
+++ b/skore/tests/unit/sklearn/plot/test_prediction_error.py
@@ -83,7 +83,7 @@ def test_prediction_error_display_regression(pyplot, regression_data, subsample)
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == estimator.__class__.__name__
+    assert legend.get_title().get_text() == "LinearRegression"
     assert len(legend.get_texts()) == 2
 
     assert display.ax_.get_xlabel() == "Predicted values"
@@ -130,7 +130,7 @@ def test_prediction_error_cross_validation_display_regression(
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == estimator.__class__.__name__
+    assert legend.get_title().get_text() == "LinearRegression on $\\bf{test}$ set"
     assert len(legend.get_texts()) == 4
 
     assert display.ax_.get_xlabel() == "Predicted values"
@@ -258,7 +258,7 @@ def test_prediction_error_cross_validation_display_regression_kind(
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == estimator.__class__.__name__
+    assert legend.get_title().get_text() == "LinearRegression on $\\bf{test}$ set"
     assert len(legend.get_texts()) == 4
 
     assert display.ax_.get_xlabel() == "Predicted values"

--- a/skore/tests/unit/sklearn/plot/test_roc_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_roc_curve.py
@@ -280,15 +280,20 @@ def test_roc_curve_display_roc_curve_kwargs_multiclass_classification(
     assert display.ax_.spines["right"].get_visible()
 
 
+@pytest.mark.parametrize("data_source", ["train", "test", "X_y"])
 def test_roc_curve_display_cross_validation_binary_classification(
-    pyplot, binary_classification_data_no_split
+    pyplot, binary_classification_data_no_split, data_source
 ):
     """Check the attributes and default plotting behaviour of the ROC curve plot with
     binary data."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
+    if data_source == "X_y":
+        roc_kwargs = {"data_source": data_source, "X": X, "y": y}
+    else:
+        roc_kwargs = {"data_source": data_source}
 
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.roc()
+    display = report.metrics.roc(**roc_kwargs)
     assert isinstance(display, RocCurveDisplay)
 
     # check the structure of the attributes
@@ -321,7 +326,11 @@ def test_roc_curve_display_cross_validation_binary_classification(
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
+    data_source_title = "external" if data_source == "X_y" else data_source
+    assert (
+        legend.get_title().get_text()
+        == f"LogisticRegression on $\\bf{{{data_source_title}}}$ set"
+    )
     assert len(legend.get_texts()) == cv
 
     assert display.ax_.get_xlabel() == "False Positive Rate\n(Positive label: 1)"
@@ -331,14 +340,20 @@ def test_roc_curve_display_cross_validation_binary_classification(
     assert display.ax_.get_xlim() == display.ax_.get_ylim() == (-0.01, 1.01)
 
 
+@pytest.mark.parametrize("data_source", ["train", "test", "X_y"])
 def test_roc_curve_display_cross_validation_multiclass_classification(
-    pyplot, multiclass_classification_data_no_split
+    pyplot, multiclass_classification_data_no_split, data_source
 ):
     """Check the attributes and default plotting behaviour of the ROC curve plot with
     multiclass data."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
+    if data_source == "X_y":
+        roc_kwargs = {"data_source": data_source, "X": X, "y": y}
+    else:
+        roc_kwargs = {"data_source": data_source}
+
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    display = report.metrics.roc()
+    display = report.metrics.roc(**roc_kwargs)
     assert isinstance(display, RocCurveDisplay)
 
     # check the structure of the attributes
@@ -362,7 +377,7 @@ def test_roc_curve_display_cross_validation_multiclass_classification(
             assert isinstance(roc_curve_mpl, mpl.lines.Line2D)
             if split_idx == 0:
                 assert roc_curve_mpl.get_label() == (
-                    f"{str(class_label).title()} - Estimator of fold #{split_idx + 1} "
+                    f"{str(class_label).title()} "
                     f"(AUC = {np.mean(display.roc_auc[class_label]):0.2f}"
                     f" +/- {np.std(display.roc_auc[class_label]):0.2f})"
                 )
@@ -374,7 +389,11 @@ def test_roc_curve_display_cross_validation_multiclass_classification(
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
+    data_source_title = "external" if data_source == "X_y" else data_source
+    assert (
+        legend.get_title().get_text()
+        == f"LogisticRegression on $\\bf{{{data_source_title}}}$ set"
+    )
     assert len(legend.get_texts()) == cv
 
     assert display.ax_.get_xlabel() == "False Positive Rate"

--- a/skore/tests/unit/sklearn/plot/test_roc_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_roc_curve.py
@@ -310,7 +310,7 @@ def test_roc_curve_display_cross_validation_binary_classification(
     for split_idx, line in enumerate(display.lines_):
         assert isinstance(line, mpl.lines.Line2D)
         assert line.get_label() == (
-            f"Test set - fold #{split_idx + 1} "
+            f"Estimator of fold #{split_idx + 1} "
             f"(AUC = {display.roc_auc[pos_label][split_idx]:0.2f})"
         )
         assert mpl.colors.to_rgba(line.get_color()) == expected_colors[split_idx]
@@ -321,7 +321,7 @@ def test_roc_curve_display_cross_validation_binary_classification(
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == estimator.__class__.__name__
+    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
     assert len(legend.get_texts()) == cv
 
     assert display.ax_.get_xlabel() == "False Positive Rate\n(Positive label: 1)"
@@ -362,7 +362,7 @@ def test_roc_curve_display_cross_validation_multiclass_classification(
             assert isinstance(roc_curve_mpl, mpl.lines.Line2D)
             if split_idx == 0:
                 assert roc_curve_mpl.get_label() == (
-                    f"{str(class_label).title()} - test set "
+                    f"{str(class_label).title()} - Estimator of fold #{split_idx + 1} "
                     f"(AUC = {np.mean(display.roc_auc[class_label]):0.2f}"
                     f" +/- {np.std(display.roc_auc[class_label]):0.2f})"
                 )
@@ -374,7 +374,7 @@ def test_roc_curve_display_cross_validation_multiclass_classification(
 
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
-    assert legend.get_title().get_text() == estimator.__class__.__name__
+    assert legend.get_title().get_text() == "LogisticRegression on $\\bf{test}$ set"
     assert len(legend.get_texts()) == cv
 
     assert display.ax_.get_xlabel() == "False Positive Rate"

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -296,6 +296,24 @@ def test_cross_validation_report_flat_index(binary_classification_data):
     ]
 
 
+def test_cross_validation_report_metrics_data_source_external(
+    binary_classification_data,
+):
+    """Check that the `data_source` parameter works when using external data."""
+    estimator, X, y = binary_classification_data
+    cv_splitter = 2
+    report = CrossValidationReport(estimator, X, y, cv_splitter=cv_splitter)
+    result = report.metrics.report_metrics(data_source="X_y", X=X, y=y, aggregate=None)
+    for split_idx in range(cv_splitter):
+        # check that it is equivalent to call the individual estimator report
+        report_result = report.estimator_reports_[split_idx].metrics.report_metrics(
+            data_source="X_y", X=X, y=y
+        )
+        np.testing.assert_allclose(
+            report_result.iloc[:, 0].to_numpy(), result.iloc[:, split_idx].to_numpy()
+        )
+
+
 ########################################################################################
 # Check the plot methods
 ########################################################################################

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -220,9 +220,19 @@ def test_cross_validation_report_get_predictions(
     estimator = LogisticRegression()
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
 
-    predictions = report.get_predictions(
-        data_source=data_source, response_method=response_method, pos_label=pos_label
-    )
+    if data_source == "X_y":
+        predictions = report.get_predictions(
+            data_source=data_source,
+            response_method=response_method,
+            X=X,
+            pos_label=pos_label,
+        )
+    else:
+        predictions = report.get_predictions(
+            data_source=data_source,
+            response_method=response_method,
+            pos_label=pos_label,
+        )
     assert len(predictions) == 2
     for split_idx, split_predictions in enumerate(predictions):
         if data_source == "train":
@@ -242,6 +252,9 @@ def test_cross_validation_report_get_predictions_error():
 
     with pytest.raises(ValueError, match="Invalid data source"):
         report.get_predictions(data_source="invalid", response_method="predict")
+
+    with pytest.raises(ValueError, match="The `X` parameter is required"):
+        report.get_predictions(data_source="X_y", response_method="predict")
 
 
 def test_cross_validation_report_pickle(tmp_path, binary_classification_data):

--- a/skore/tests/unit/sklearn/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/test_cross_validation.py
@@ -207,7 +207,7 @@ def test_cross_validation_report_cache_predictions(
         assert estimator_report._cache == {}
 
 
-@pytest.mark.parametrize("data_source", ["train", "test"])
+@pytest.mark.parametrize("data_source", ["train", "test", "X_y"])
 @pytest.mark.parametrize(
     "response_method", ["predict", "predict_proba", "decision_function"]
 )
@@ -227,8 +227,10 @@ def test_cross_validation_report_get_predictions(
     for split_idx, split_predictions in enumerate(predictions):
         if data_source == "train":
             expected_shape = report.estimator_reports_[split_idx].y_train.shape
-        else:
+        elif data_source == "test":
             expected_shape = report.estimator_reports_[split_idx].y_test.shape
+        else:  # data_source == "X_y"
+            expected_shape = (X.shape[0],)
         assert split_predictions.shape == expected_shape
 
 


### PR DESCRIPTION
closes #1500 

Allow to pass `data_source="X_y"` to make underlying estimator predict on the same set with `CrossValidationReport`.