### PR TITLE
feat: Draft the new package `skore-remote-project`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,8 @@ examples/plot_*.png
 # Include excluded directories from github-actions
 !/.github/**/build/
 !/skore/ci/**/.python-version
+!/skore-remote-project/ci/**/.python-version
 
 # Exclude hatch artifacts
 skore/LICENSE
+skore-remote-project/LICENSE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,13 +25,13 @@ repos:
     rev: v0.9.10
     hooks:
       - id: ruff
-        files: ^(skore/(src|tests))|(examples)/
+        files: ^((skore|skore-remote-project)/(hatch|src|tests))|(examples)/
         args: [--fix]
       - id: ruff-format
-        files: ^(skore/(src|tests))|(examples)/
+        files: ^((skore|skore-remote-project)/(hatch|src|tests))|(examples)/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
     hooks:
       - id: mypy
-        files: ^(skore/src)/
+        files: ^(skore|skore-remote-project)/src/

--- a/skore/ci/requirements/python-3.10/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.10/scikit-learn-1.6/test-requirements.txt
@@ -147,8 +147,6 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.9.3
-    # via skore (skore/pyproject.toml)
 scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt

--- a/skore/ci/requirements/python-3.11/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.11/scikit-learn-1.6/test-requirements.txt
@@ -145,8 +145,6 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.9.3
-    # via skore (skore/pyproject.toml)
 scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt

--- a/skore/ci/requirements/python-3.12/scikit-learn-1.4/test-requirements.txt
+++ b/skore/ci/requirements/python-3.12/scikit-learn-1.4/test-requirements.txt
@@ -145,8 +145,6 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.9.3
-    # via skore (skore/pyproject.toml)
 scikit-learn==1.4.2
     # via
     #   --override skore/overrides.txt

--- a/skore/ci/requirements/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/skore/ci/requirements/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -145,8 +145,6 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.9.3
-    # via skore (skore/pyproject.toml)
 scikit-learn==1.5.2
     # via
     #   --override skore/overrides.txt

--- a/skore/ci/requirements/python-3.12/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.12/scikit-learn-1.6/test-requirements.txt
@@ -145,8 +145,6 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.9.3
-    # via skore (skore/pyproject.toml)
 scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt

--- a/skore/ci/requirements/python-3.9/scikit-learn-1.6/test-requirements.txt
+++ b/skore/ci/requirements/python-3.9/scikit-learn-1.6/test-requirements.txt
@@ -151,8 +151,6 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.9.3
-    # via skore (skore/pyproject.toml)
 scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt

--- a/skore/hatch/metadata.py
+++ b/skore/hatch/metadata.py
@@ -1,16 +1,26 @@
+"""Hatchling hooks used to dynamically update the metadata of the package."""
+
 from pathlib import Path
 
 from hatchling.metadata.plugin.interface import MetadataHookInterface
 
 
 def readlines(filepath):
+    """Yied the content of ``filepath`` line by line."""
     with open(filepath) as file:
         yield from file
 
 
 class MetadataHook(MetadataHookInterface):
+    """Hatchling hooks used to dynamically update the metadata of the package."""
+
     def update(self, metadata):
         """
+        Update the metadata of the package, after it has been loaded.
+
+        Update ``LICENSE`` and ``README`` from root files, shared in the GH repository.
+        Update ``VERSION`` from environment variables filled by the GH release pipeline.
+
         Notes
         -----
         Example of configuration:
@@ -22,7 +32,6 @@ class MetadataHook(MetadataHookInterface):
                 'readme': {'file': '../README.md'},
             }
         """
-
         # Retrieve LICENCE from root files
         license_filepath = self.config["license"]["file"]
         license = Path(self.root, license_filepath).read_text(encoding="utf-8")

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -46,7 +46,6 @@ test = [
   "pytest-order",
   "pytest-randomly",
   "pytest-xdist",
-  "ruff",
   "scikit-learn<1.7",
   "skrub",
   "xdoctest",
@@ -106,12 +105,6 @@ addopts = [
   "--import-mode=importlib",
   "--no-header",
   "--verbosity=2",
-  # We ignore unwanted directories rather than including wanted ones, because
-  # otherwise it becomes impossible to test only one file (the argument gets
-  # appended to the defaults)
-  "--ignore=doc",
-  "--ignore=examples",
-  "--ignore=notebooks",
   "--dist=loadscope",
 ]
 
@@ -127,7 +120,6 @@ show_missing = true
 
 [tool.ruff]
 src = ["skore"]
-exclude = ["doc"]
 
 [tool.ruff.lint]
 select = [

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -83,8 +83,6 @@ class Project:
     1.0
     """
 
-    _server_info = None
-
     def __init__(
         self,
         path: Union[str, PathLike[str]] = "project.skore",

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -374,6 +374,10 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         )
 
     @property
+    def ml_task(self) -> str:
+        return self._ml_task
+
+    @property
     def estimator_(self) -> BaseEstimator:
         return self._estimator
 


### PR DESCRIPTION
Some minor changes to prepare for the arrival of the new package `skore-remote-project`:

- Add reference to the new package `skore-remote-project` in `.gitignore` and `pre-commit` configuration,
- Remove deprecated code from `skore`,
- Add a new `ml_task` property in the `skore.EstimatorReport` class.