### PR TITLE
fix: Fix duplicate target name warning during Sphinx build (make html)

### DIFF
--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -288,7 +288,7 @@ plt.tight_layout()
 #   More generally, :meth:`skore.EstimatorReport.feature_importance.coefficients` can
 #   help you inspect the coefficients of all linear models.
 #   We consider a linear model as defined in
-#   `scikit-learn's user guide
+#   `scikit-learn's model documentation
 #   <https://scikit-learn.org/stable/modules/linear_model.html>`_.
 #   In short, we consider a "linear model" as a scikit-learn compatible estimator that
 #   holds a ``coef_`` attribute (after being fitted).

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -288,7 +288,7 @@ plt.tight_layout()
 #   More generally, :meth:`skore.EstimatorReport.feature_importance.coefficients` can
 #   help you inspect the coefficients of all linear models.
 #   We consider a linear model as defined in
-#   `scikit-learn's model documentation
+#   `scikit-learn's documentation
 #   <https://scikit-learn.org/stable/modules/linear_model.html>`_.
 #   In short, we consider a "linear model" as a scikit-learn compatible estimator that
 #   holds a ``coef_`` attribute (after being fitted).


### PR DESCRIPTION
### Description
This pull request fixes a duplicate target name warning that came up during the make html process (see issue #1202).
The warning was caused by two hyperlinks having the same display text. 

"...We consider a linear model as defined in scikit-learn's user guide <https://scikit-learn.org/stable/modules/linear_model.html>."

"...For more information, see scikit-learn's user guide <https://scikit-learn.org/stable/modules/permutation_importance.html#misleading-values-on-strongly-correlated-features>."

<br>


```python
skore/sphinx/auto_examples/use_cases/plot_feature_importance.rst:25: WARNING: Duplicate explicit target name: "scikit-learn's user guide". [docutils]
```
---

### **Environment**

- Model: Dell Latitude E7440
- RAM: 12GB 
- OS: Windows 10 pro
- Python Version: Python 3.12
- Terminal: Ubuntu 22.04 LTS

---

### Steps to reproduce:
1. Clone the skore repository
2. Create and activate a virtual environment using the Ubuntu terminal
3. Run the _make install-skore_ command.
4. Navigate to the sphinx directory
5. Run `make html`.

---

### Solution:
To fix this, one of the link labels was modified to eliminate the naming conflict.

   - Identified the Python file that generated the affected .rst files (examples/use_cases/plot_feature_importance.py).
   - Changed the display text that references the linear model (<https://scikit-learn.org/stable/modules/linear_model.html>) from "scikit-learn's user guide" to "scikit-learn's model documentation".

---

cc @sylvaincom @thomass-dev 