### PR TITLE
fix: Fix unpickable configuration value during Sphinx `make html` process

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -90,7 +90,8 @@ sphinx_gallery_conf = {
     "backreferences_dir": "reference/api",
     "doc_module": "skore",
     # "reset_modules": (reset_mpl, "seaborn"),
-    "image_scrapers": [matplotlib_skore_scraper],
+    # "image_scrapers": ['matplotlib'], # use in-built scraper
+    "image_scrapers": [matplotlib_skore_scraper()], # alternative option using custom class
     "abort_on_example_error": True,
 }
 

--- a/sphinx/sphinxext/matplotlib_skore_scraper.py
+++ b/sphinx/sphinxext/matplotlib_skore_scraper.py
@@ -1,5 +1,11 @@
 from sphinx_gallery.scrapers import matplotlib_scraper
 
 
-def matplotlib_skore_scraper(*args, **kwargs):
-    return matplotlib_scraper(*args, bbox_inches="tight", **kwargs)
+class matplotlib_skore_scraper: # defining matplotlib scraper as a class not a function
+    def __call__(self, *args, **kwargs):
+        kwargs.setdefault("bbox_inches", "tight")
+        return matplotlib_scraper(*args, **kwargs)
+
+
+# def matplotlib_skore_scraper(*args, **kwargs):
+#     return matplotlib_scraper(*args, bbox_inches="tight", **kwargs)


### PR DESCRIPTION
### **Description**
This PR addresses the `unpickleable configuration value` warning encountered during the Sphinx `make html` build process (Issue #1202).

The warning arises because the matplotlib_skore_scraper function in sphinx_gallery_conf (defined in conf.py) cannot be serialized by Python’s pickle module.

```python
# configuration cache warning
- pickling environment... WARNING: cannot cache unpickable configuration value: 'sphinx_gallery_conf' (because it contains a function, class, or module object) [config.cache]
```

---

### **Environment**

- Model: Dell Latitude E7440
- RAM: 12GB 
- OS: Windows 10 pro
- Python Version: Python 3.12
- Terminal: Ubuntu 22.04 LTS

---


### **Steps to reproduce:**
1. Clone the skore repository
2. Create and activate a virtual environment using the Ubuntu terminal
3. Run the _make install-skore_ command.
4. Cd into the sphinx directory
5. Run `make html`.
---

### **Proposed Solutions**
There are several ways this warning can be resolved.
1: Using the built-in Matplotlib scraper
- Pros: It is simple to maintain and has no pickling issues.
- Cons: Requires extra configuration to make it match the custom function defined in sphinxext/matplotlib_skore_scraper.py.

```python
# in conf.py
import matplotlib
matplotlib.rcParams['savefig.bbox'] = 'tight' # extra configuration to match the custom scraper function

sphinx_gallery_conf = {
    "image_scrapers": ['matplotlib'], # use the built-in matplotlib scraper
}
```

2. Converting the custom matplotlib_skore_scraper function to a class. 
- Pros: This option is flexible,  serializable and can be customized further, if required.
- Cons: More complex than using the built-in scraper.

```python
# in matplotlib_skore_scraper.py
class matplotlib_skore_scraper:
    def __call__(self, *args, **kwargs):
        kwargs.setdefault("bbox_inches", "tight")
        return matplotlib_scraper(*args, **kwargs)

# in conf.py
sphinx_gallery_conf = {
    "image_scrapers": [matplotlib_skore_scraper()],
}
```

3. Defining the Scraper Directly in conf.py: This requires adding the custom matplotlib_skore_scraper function directly in the conf.py file. 
- Pros: No pickling issue or import errors when importing the function from a different file.
- Cons: It would clutter the conf.py file.

```python
# in conf.py
def __call__(self, *args, **kwargs):
   kwargs.setdefault("bbox_inches", "tight")
   return matplotlib_scraper(*args, **kwargs)

sphinx_gallery_conf = {
    "image_scrapers": [matplotlib_skore_scraper],
}
```

4. Supressing the warning. 
Pros: No major code change required. 
Cons: It does not address the root cause of this warning, and it would mask other caching issues because it is declared globally.
```python
# in conf.py
suppress_warnings = [
   'config.cache'  # silence config warnings
]
```

---

I chose the class option, because it resolves the pickling issue, it is flexible and keeps the code organized. However, I'm happy to modify this if another solution would work better.

cc @sylvaincom @glemaitre @thomass-dev 