### PR TITLE
fix: Fix underline warnings during Sphinx build (make html) 

### DIFF
--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -91,7 +91,7 @@ y
 
 # %%
 # Tree-based model
-# ===============
+# ================
 
 # %%
 # Let's start by creating a tree-based model using some out-of-the-box tools.
@@ -145,7 +145,7 @@ report.metrics.report_metrics()
 
 # %%
 # Linear model
-# =========
+# ============
 #
 # Now that we have established a first model that serves as a baseline,
 # we shall proceed to define a quite complex linear model


### PR DESCRIPTION
### **Description**
This pull request fixes the title underline too short warnings encountered during the Sphinx make html build process (Issue #1202). 

These warnings occurred because the underlines did not match the length of their corresponding titles in several files.

Example warnings:
```python 
skore/sphinx/auto_examples/use_cases/plot_employee_salaries.rst:14417: Tree-based model =============== [docutils]
skore/sphinx/auto_examples/use_cases/plot_employee_salaries.rst:14417: Title underline too short. Tree-based model =============== [docutils]
skore/sphinx/auto_examples/use_cases/plot_employee_salaries.rst:15060: Title underline too short. Linear model ========= [docutils]
skore/sphinx/auto_examples/use_cases/plot_employee_salaries.rst:15060: Title underline too short. Linear model ========= [docutils]
skore/sphinx/auto_examples/use_cases/plot_feature_importance.rst:12457: Title underline too short. Splitting the data ----------------- [docutils]
skore/sphinx/auto_examples/use_cases/plot_feature_importance.rst:12457: Title underline too short. Splitting the data ----------------- [docutils]
```

---

### **Environment**

- Model: Dell Latitude E7440
- RAM: 12GB 
- OS: Windows 10 pro
- Python Version: Python 3.12
- Terminal: Ubuntu 22.04 LTS

---

### **Steps to reproduce**:
1. Clone the skore repository
2. Create and activate a virtual environment using the Ubuntu terminal
3. Run the _make install-skore_ command.
4. Cd into the sphinx directory
5. Run `make html`.
---

### **Solution**:
- Identified the Python files generating the .rst files (in examples/use_cases).
- Modified the code to ensure underlines match the length of their titles.
--- 
cc @sylvaincom @glemaitre 