### PR TITLE
docs: Fixed the flakiness in the plot_employee_salaries.py example

### DIFF
--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -44,6 +44,7 @@ my_project = skore.Project("my_project")
 # We use a skrub dataset that is non-trivial.
 from skrub.datasets import fetch_employee_salaries
 
+
 datasets = fetch_employee_salaries()
 df, y = datasets.X, datasets.y
 
@@ -107,12 +108,12 @@ y
 # Modelling
 # ^^^^^^^^^
 
-from skrub import TableVectorizer, TextEncoder
+from skrub import TableVectorizer, GapEncoder
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.pipeline import make_pipeline
 
 model = make_pipeline(
-    TableVectorizer(high_cardinality=TextEncoder()),
+    TableVectorizer(high_cardinality=GapEncoder(n_components=100)),
     HistGradientBoostingRegressor(),
 )
 model


### PR DESCRIPTION
This pull request resolves the flakiness issue in the `plot_employee_salaries.py` example by replacing the `TextEncoder` with the `GapEncoder`. The problem was identified due to the use of `TextEncoder` to handle high-cardinality columns such as `division` and `employee_position_title`, which was leading to unstable results in the example.

Changes Made:
Replaced `TextEncoder` with `GapEncoder` for handling high-cardinality categorical columns (`division` and `employee_position_title`).

`GapEncoder` is more suitable for high-cardinality features as it efficiently handles them without generating excessive unique feature tokens, improving model stability.

This adjustment significantly mitigates the flakiness observed in the example, leading to more consistent results.

Impact:
By applying the `GapEncoder`, the script's stability is enhanced when working with high-cardinality categorical columns, ensuring that the example runs reliably for users.

This update provides a more robust implementation, addressing the root cause of the issue and improving the example’s performance.