### PR TITLE
ci: Fix `backend-lockfiles` job after the removal of `requirements.ini` files

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -79,13 +79,21 @@ jobs:
         run: |
           set -eu
 
-          changes=$(git diff --name-only HEAD^1 HEAD)
+          # Check if `pyproject.toml` has changed in this pull-request
+          # ├── False
+          # │   └── Exit 0
+          # └── True
+          #     └── Check if lockfiles have changed in this pull-request
+          #         ├── True
+          #         │   └── Exit 0
+          #         └── False
+          #             └── Recompile lockfiles and check if they have to change
+          #                 ├── False
+          #                 │   └── Exit 0
+          #                 └── True
+          #                     └── Exit 1
 
-          # check if `pyproject.toml` has changed
-          # if so, check if requirements are unchanged
-          # if so, recompile requirements and check for modifications
-          # if so, exit on error
-          # otherwise, exit on success
+          changes=$(git diff --name-only HEAD^1 HEAD)
 
           if
             (echo "${changes}" | grep -qE "skore/pyproject.toml") &&

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,7 +91,7 @@ jobs:
             (echo "${changes}" | grep -qE "skore/pyproject.toml") &&
             (echo "${changes}" | (! grep -qE "skore/ci/requirements/.*/test-requirements.txt"))
           then
-              curl -LsSf https://astral.sh/uv/install.sh | sh
+              curl -LsSf https://astral.sh/uv/0.6.16/install.sh | sh
               bash skore/ci/pip-compile.sh
 
               if (git diff --name-only | grep -qE "skore/ci/requirements/.*/test-requirements.txt"); then

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -77,14 +77,27 @@ jobs:
 
       - name: Check lockfiles are not obsolete
         run: |
+          set -eu
+
           changes=$(git diff --name-only HEAD^1 HEAD)
 
+          # check if `pyproject.toml` has changed
+          # if so, check if requirements are unchanged
+          # if so, recompile requirements and check for modifications
+          # if so, exit on error
+          # otherwise, exit on success
+
           if
-            (echo "${changes}" | grep -qE 'skore/(test-)?requirements.in') &&
+            (echo "${changes}" | grep -qE "skore/pyproject.toml") &&
             (echo "${changes}" | (! grep -qE "skore/ci/requirements/.*/test-requirements.txt"))
           then
-            echo '::error title=backend-lockfiles:: Lockfiles obsolete, please execute `$ cd skore/ci; bash pip-compile.sh`'
-            exit 1
+              curl -LsSf https://astral.sh/uv/install.sh | sh
+              bash skore/ci/pip-compile.sh
+
+              if (git diff --name-only | grep -qE "skore/ci/requirements/.*/test-requirements.txt"); then
+                  echo '::error title=backend-lockfiles::Lockfiles obsolete, please execute `$ bash skore/ci/pip-compile.sh`'
+                  exit 1
+             fi
           fi
 
   backend-test:


### PR DESCRIPTION
Fix `backend-lockfiles` job which no longer works since we deleted the `requirements.ini` https://github.com/probabl-ai/skore/pull/1418.

Examples showing that this PR works:
- [Commit](https://github.com/probabl-ai/skore/pull/1595/commits/bde257d5aa67ad6a0c3e20d8ec19f53ad7acd708) showing a red pipeline, with a change on `pyproject.toml` without requirements update,
- [Commit](https://github.com/probabl-ai/skore/pull/1595/commits/25cb3c8588f536034dd9c88fec91d270ab334bbf) showing a green pipeline, with a change on `pyproject.toml` and requirements update.
