### PR TITLE
chore: Replace `cross_validation` with `CrossValidationReport` in warnings

### DIFF
--- a/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
@@ -25,7 +25,8 @@ class HighClassImbalanceTooFewExamplesWarning(TrainTestSplitWarning):
         "fewer than 100 examples in the test set. In this case, using train_test_split "
         "may not be a good idea because of high variability in the scores obtained on "
         "the test set. We suggest three options to tackle this challenge: you can "
-        "increase test_size, collect more data, or use skore's cross_validate function."
+        "increase test_size, collect more data, or use skore's CrossValidationReport "
+        "with the `cv_splitter` parameter of your choice. "
     )
 
     @staticmethod

--- a/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_warning.py
+++ b/skore/src/skore/sklearn/train_test_split/warning/high_class_imbalance_warning.py
@@ -26,7 +26,8 @@ class HighClassImbalanceWarning(TrainTestSplitWarning):
         "case, using train_test_split may not be a good idea because of high "
         "variability in the scores obtained on the test set. "
         "To tackle this challenge we suggest to use skore's "
-        "cross_validate function."
+        "CrossValidationReport with the `cv_splitter` parameter "
+        "of your choice. "
     )
 
     @staticmethod


### PR DESCRIPTION
the `cross_validation` function doesn't exist anymore. It was replace in PR https://github.com/probabl-ai/skore/pull/847 with the `CrossValidationReport` class. Please let me know if this change LGTY-- or should I've replaced "skore's `cross_validation` function." with something in sklearn (e.g. - this page: https://scikit-learn.org/stable/modules/cross_validation.html#cross-validation)?

Thank you :)