### PR TITLE
docs: Replace `scatter_mapbox` with `scatter_map` and handle zero-variance case in `SelectKBest`

### DIFF
--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -153,7 +153,7 @@ fig
 
 # %%
 def plot_map(df, color_feature):
-    fig = px.scatter_mapbox(
+    fig = px.scatter_map(
         df, lat="Latitude", lon="Longitude", color=color_feature, zoom=5, height=600
     )
     fig.update_layout(
@@ -515,6 +515,7 @@ plot_map(X_train_plot, "clustering_labels")
 # %%
 from sklearn.feature_selection import SelectKBest, VarianceThreshold
 from sklearn.linear_model import RidgeCV
+from sklearn.feature_selection import SelectKBest, VarianceThreshold, f_regression
 
 preprocessor = make_column_transformer(
     (KMeans(n_clusters=10, random_state=0), geo_columns),
@@ -524,8 +525,8 @@ selectkbest_ridge = make_pipeline(
     preprocessor,
     SplineTransformer(sparse_output=True),
     PolynomialFeatures(degree=2, interaction_only=True, include_bias=False),
-    VarianceThreshold(),
-    SelectKBest(k=150),
+    VarianceThreshold(1e-8), 
+    SelectKBest(score_func=lambda X, y: f_regression(X, y, center=False), k=150), 
     RidgeCV(np.logspace(-5, 5, num=100)),
 )
 

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -513,9 +513,8 @@ plot_map(X_train_plot, "clustering_labels")
 # number of features.
 
 # %%
-from sklearn.feature_selection import SelectKBest, VarianceThreshold
-from sklearn.linear_model import RidgeCV
 from sklearn.feature_selection import SelectKBest, VarianceThreshold, f_regression
+from sklearn.linear_model import RidgeCV
 
 preprocessor = make_column_transformer(
     (KMeans(n_clusters=10, random_state=0), geo_columns),
@@ -525,8 +524,8 @@ selectkbest_ridge = make_pipeline(
     preprocessor,
     SplineTransformer(sparse_output=True),
     PolynomialFeatures(degree=2, interaction_only=True, include_bias=False),
-    VarianceThreshold(1e-8), 
-    SelectKBest(score_func=lambda X, y: f_regression(X, y, center=False), k=150), 
+    VarianceThreshold(1e-8),
+    SelectKBest(score_func=lambda X, y: f_regression(X, y, center=False), k=150),
     RidgeCV(np.logspace(-5, 5, num=100)),
 )
 


### PR DESCRIPTION
Closes [#1587](https://github.com/probabl-ai/skore/issues/1587)

Hi @sylvaincom  , @thomass-dev  !

I updated the deprecated `scatter_mapbox` function and have now replaced it with the  more updated `scatter_map`.
On another note, in the feature selection pipeline scikit-learn's `SelectKBest` was seeing features with zero variance which raised division-by-zero errors during computation of feature importance. 
I have added a `VarianceThreshold` filter to eliminate near zero variance features prior to the feature selection process.