### PR TITLE
ci: Factorize lint jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,3 +46,5 @@ jobs:
           pre-commit run --all-files trailing-whitespace
           pre-commit run --all-files typos
           pre-commit run --all-files nbstripout
+          pre-commit run --all-files ruff
+          pre-commit run --all-files mypy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/skore-remote-project.yml
+++ b/.github/workflows/skore-remote-project.yml
@@ -39,31 +39,6 @@ jobs:
               - 'ci/requirements/skore-remote-project/**'
               - 'skore-remote-project/**'
 
-  skore-remote-project-lint:
-    runs-on: "ubuntu-latest"
-    needs: [skore-remote-project-changes]
-    if: ${{ (github.event_name == 'push') || (needs.skore-remote-project-changes.outputs.changes == 'true') }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip pre-commit
-
-      - name: Lint
-        working-directory: skore-remote-project/
-        run: |
-          pre-commit run --all-files ruff
-          pre-commit run --all-files mypy
-
   skore-remote-project-lockfiles:
     runs-on: "ubuntu-latest"
     needs: [skore-remote-project-changes]
@@ -218,7 +193,6 @@ jobs:
   skore-remote-project:
     needs:
       - skore-remote-project-changes
-      - skore-remote-project-lint
       - skore-remote-project-lockfiles
       - skore-remote-project-test
     if: ${{ always() }}

--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -39,31 +39,6 @@ jobs:
               - 'ci/requirements/skore/**'
               - 'skore/**'
 
-  skore-lint:
-    runs-on: "ubuntu-latest"
-    needs: [skore-changes]
-    if: ${{ (github.event_name == 'push') || (needs.skore-changes.outputs.changes == 'true') }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip pre-commit
-
-      - name: Lint
-        working-directory: skore/
-        run: |
-          pre-commit run --all-files ruff
-          pre-commit run --all-files mypy
-
   skore-lockfiles:
     runs-on: "ubuntu-latest"
     needs: [skore-changes]
@@ -222,7 +197,6 @@ jobs:
   skore:
     needs:
       - skore-changes
-      - skore-lint
       - skore-lockfiles
       - skore-test
     if: ${{ always() }}


### PR DESCRIPTION
**Context:**

Linting must be run on `/skore/`, `/skore-remote-project/` and `/examples/`.

```yml
      - name: Lint
        working-directory: skore-remote-project/
        run: |
          pre-commit run --all-files ruff
          pre-commit run --all-files mypy
```
```yml
      - name: Lint
        working-directory: skore/
        run: |
          pre-commit run --all-files ruff
          pre-commit run --all-files mypy
```

These snippets will not only run on `/skore/` or `/skore-remote-project`, but both on `/`.
So the `ruff` and `mypy` linting will be executed twice in integrality.
Wherever `pre-commit run --all-files` is executed, it will be execute from the root of the repository.

---

**Solution:**

One solution is to fix the command to run linting only on the wanted repository.
```yml
      - name: Lint
        working-directory: skore-remote-project/
        run: |
          git ls-files | xargs pre-commit run ruff --files
          git ls-files | xargs pre-commit run mypy --files
```
```yml
      - name: Lint
        working-directory: skore/
        run: |
          git ls-files | xargs pre-commit run ruff --files
          git ls-files | xargs pre-commit run mypy --files
```
But it implies to add an extra workflow to run `ruff` and `mypy` on `examples/`.
IMO it's not a good idea, so decided to simplify the whole linting process.

