### PR TITLE
Revert "docs: Add Plausible tracker (#1605)"

### DIFF
--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -65,10 +65,6 @@ Skore is just at the beginning of its journey, but we’re shipping fast! Freque
 
 .. raw:: html
 
-   <!-- Start of Plausible Javascript -->
-   <script defer data-domain="docs.skore.probabl.ai" src="https://plausible.io/js/script.js"></script>
-   <!-- End of Plausible Javascript -->
-
    <!-- Start of Reo Javascript -->
    <script type="text/javascript">
       !function(){var e,t,n;e="460c80a5e0b7c04",t=function(){Reo.init({clientID:"460c80a5e0b7c04"})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();


### PR DESCRIPTION
Pausible was already activated

```python
# Plausible Analytics                                              
html_theme_options["analytics"] = {                                
    # The domain you'd like to use for this analytics instance     
    "plausible_analytics_domain": domain,                          
    # The analytics script that is served by Plausible             
    "plausible_analytics_url": "https://plausible.io/js/script.js",
}                                                                  
```
This reverts commit 867f007f0454fdda16a7db8f0dad3ce74015ed93.