### PR TITLE
ci(coverage-report): Produce XML coverage report rather than plain text

### DIFF
--- a/.github/workflows/pr-display-code-coverage.yml
+++ b/.github/workflows/pr-display-code-coverage.yml
@@ -41,6 +41,7 @@ jobs:
         uses: MishaKav/pytest-coverage-comment@81882822c5b22af01f91bd3eacb1cefb6ad73dc2 # v1.1.53
         with:
           issue-number: ${{ steps.acquire-pr-context.outputs.pr-number }}
-          pytest-coverage-path: coverage/coverage.txt
-          junitxml-path: coverage/coverage.xml
-          title: Coverage Report for `${{ github.event.workflow_run.name }}`
+          pytest-xml-coverage-path: coverage/pytest-coverage.xml
+          junitxml-path: coverage/pytest.xml
+          title: Coverage Report for `${{ github.event.workflow_run.name }}/`
+          unique-id-for-comment: ${{ github.event.workflow_run.name }}

--- a/.github/workflows/skore-remote-project.yml
+++ b/.github/workflows/skore-remote-project.yml
@@ -181,7 +181,7 @@ jobs:
         working-directory: skore-remote-project/
         run: |
           mkdir coverage
-          python -m pytest -n auto src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
+          python -m pytest -n auto src/ tests/ --junitxml=coverage/pytest.xml --cov-config=pyproject.toml --cov-report=xml:coverage/pytest-coverage.xml --cov
 
       - name: Upload coverage reports
         if: ${{ matrix.coverage && (github.event_name == 'pull_request') }}

--- a/.github/workflows/skore.yml
+++ b/.github/workflows/skore.yml
@@ -185,7 +185,7 @@ jobs:
         working-directory: skore/
         run: |
           mkdir coverage
-          python -m pytest -n auto src/ tests/ --junitxml=coverage/coverage.xml --cov-config=pyproject.toml --cov | tee coverage/coverage.txt
+          python -m pytest -n auto src/ tests/ --junitxml=coverage/pytest.xml --cov-config=pyproject.toml --cov-report=xml:coverage/pytest-coverage.xml --cov
 
       - name: Upload coverage reports
         if: ${{ matrix.coverage && (github.event_name == 'pull_request') }}


### PR DESCRIPTION
This robustly solves an issue with the coverage report message action. See https://github.com/MishaKav/pytest-coverage-comment/issues/202 for more context.

Additionally, make sure that each project in the repo (i.e. skore and skore-remote-project) has its own coverage message.

Co-authored-by: Thomas S <thomas@probabl.ai>