### PR TITLE
fix: Set `matplotlib.backend` to `agg` during artifacts generation

### DIFF
--- a/skore-remote-project/src/skore_remote_project/item/item.py
+++ b/skore-remote-project/src/skore_remote_project/item/item.py
@@ -4,8 +4,33 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from base64 import b64decode, b64encode
+from contextlib import contextmanager
 from inspect import signature as inspect_signature
 from typing import Any
+
+
+@contextmanager
+def switch_mpl_backend():
+    """
+    Context-manager for switching ``matplotlib.backend`` to ``agg``.
+
+    Notes
+    -----
+    The ``agg`` backend is a non-interactive backend that can only write to files.
+    It is used in ``skore-remote-project`` to generate artifacts where we don't need an
+    X display.
+
+    https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend
+    """
+    import matplotlib
+
+    original_backend = matplotlib.get_backend()
+
+    try:
+        matplotlib.use("agg")
+        yield
+    finally:
+        matplotlib.use(original_backend)
 
 
 def lazy_is_instance(value: Any, cls_fullname: str) -> bool:

--- a/skore-remote-project/src/skore_remote_project/item/matplotlib_figure_item.py
+++ b/skore-remote-project/src/skore_remote_project/item/matplotlib_figure_item.py
@@ -7,36 +7,14 @@ This module defines the ``MatplotlibFigureItem`` class used to serialize instanc
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 from io import BytesIO
 from typing import TYPE_CHECKING
 
-from .item import ItemTypeError, bytes_to_b64_str, lazy_is_instance
+from .item import ItemTypeError, bytes_to_b64_str, lazy_is_instance, switch_mpl_backend
 from .pickle_item import PickleItem
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
-
-
-@contextmanager
-def mpl_backend(backend="agg"):
-    """
-    Context-manager for switching matplotlib backend.
-
-    Notes
-    -----
-    The ``agg`` backend is headless. No system-window pops in a background thread.
-    It is particularly useful on OSX.
-    """
-    import matplotlib
-
-    original_backend = matplotlib.get_backend()
-
-    try:
-        matplotlib.use(backend)
-        yield
-    finally:
-        matplotlib.use(original_backend)
 
 
 class MatplotlibFigureItem(PickleItem):
@@ -45,7 +23,7 @@ class MatplotlibFigureItem(PickleItem):
     @property
     def __representation__(self) -> dict:
         """Get the representation of the ``MatplotlibFigureItem`` instance."""
-        with mpl_backend(), BytesIO() as stream:
+        with switch_mpl_backend(), BytesIO() as stream:
             self.__raw__.savefig(stream, format="svg", bbox_inches="tight")
 
             figure_bytes = stream.getvalue()

--- a/skore-remote-project/src/skore_remote_project/item/skore_estimator_report_item.py
+++ b/skore-remote-project/src/skore_remote_project/item/skore_estimator_report_item.py
@@ -12,7 +12,7 @@ from inspect import getmembers, ismethod, signature
 from operator import attrgetter
 from typing import TYPE_CHECKING
 
-from .item import ItemTypeError, lazy_is_instance
+from .item import ItemTypeError, lazy_is_instance, switch_mpl_backend
 from .matplotlib_figure_item import MatplotlibFigureItem
 from .media_item import MediaItem
 from .pandas_dataframe_item import PandasDataFrameItem
@@ -217,8 +217,6 @@ class Representations:
 
     def mpl(self, name, category, **kwargs) -> Union[Representation, None]:
         """Return sub-representation made of ``matplotlib`` figures."""
-        from matplotlib.pyplot import close
-
         try:
             function = attrgetter(name)(self.report)
         except AttributeError:
@@ -228,9 +226,11 @@ class Representations:
             function_kwargs = {
                 k: v for k, v in kwargs.items() if k in function_parameters
             }
+
             display = function(**function_kwargs)
-            display.plot()
-            close(display.figure_)
+
+            with switch_mpl_backend():
+                display.plot()
 
             item = MatplotlibFigureItem.factory(display.figure_)
 

--- a/skore-remote-project/src/skore_remote_project/item/skrub_table_report_item.py
+++ b/skore-remote-project/src/skore_remote_project/item/skrub_table_report_item.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .item import ItemTypeError, lazy_is_instance
+from .item import ItemTypeError, lazy_is_instance, switch_mpl_backend
 from .pickle_item import PickleItem
 
 if TYPE_CHECKING:
@@ -22,12 +22,13 @@ class SkrubTableReportItem(PickleItem):
     @property
     def __representation__(self) -> dict:
         """Get the representation of the ``SkrubTableReportItem`` instance."""
-        return {
-            "representation": {
-                "media_type": "text/html",
-                "value": self.__raw__.html_snippet(),
+        with switch_mpl_backend():
+            return {
+                "representation": {
+                    "media_type": "text/html",
+                    "value": self.__raw__.html_snippet(),
+                }
             }
-        }
 
     @classmethod
     def factory(cls, value: TableReport, /) -> SkrubTableReportItem:

--- a/skore-remote-project/tests/conftest.py
+++ b/skore-remote-project/tests/conftest.py
@@ -13,50 +13,71 @@ def nowstr(now):
     return now.isoformat()
 
 
-@fixture(autouse=True)
-def setup(monkeypatch, tmp_path):
+def pytest_configure(config):
+    import matplotlib
+
+    # Use a non-interactive ``matplotlib.backend`` that can only write to files.
+    #
+    # https://github.com/matplotlib/matplotlib/issues/29119
+    # https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend
+    matplotlib.use("agg")
+
+
+@fixture
+def monkeypatch_tmpdir(monkeypatch, tmp_path):
+    """
+    Change ``TMPDIR`` used by ``tempfile.gettempdir()`` to point to ``tmp_path``, so
+    that it is automatically deleted after use, with no impact on user's environment.
+
+    Force the reload of the ``tempfile`` module to change the cached return of
+    ``tempfile.gettempdir()``.
+
+    https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir
+    """
     import importlib
     import tempfile
 
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    importlib.reload(tempfile)
+
+
+@fixture
+def monkeypatch_skrub(monkeypatch):
+    """
+    Make `skrub.TableReport.html_snippet()` reproducible
+
+    https://github.com/skrub-data/skrub/blob/35f573ce586fe61ef2c72f4c0c4b188ebf2e664b/skrub/_reporting/_html.py#L153
+    """
+    monkeypatch.setattr("secrets.token_hex", lambda: "<token>")
+
+
+@fixture
+def monkeypatch_matplotlib(monkeypatch):
+    """
+    Make `matplotlib.Figure.savefig(format="svg")` reproducible
+
+    https://matplotlib.org/stable/users/prev_whats_new/whats_new_2.1.0.html#reproducible-ps-pdf-and-svg-output
+    https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.10.0.html#svg-id-rcparam
+    """
     import matplotlib
 
-    with monkeypatch.context() as mp:
-        # Change ``TMPDIR`` used by ``tempfile.gettempdir()`` to point to ``tmp_path``,
-        # so that it is automatically deleted after use, with no impact on the user's
-        # environment.
-        mp.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "0")
 
-        # Force the reload of the ``tempfile`` module to change the cached return of
-        # ``tempfile.gettempdir()``.
-        #
-        # https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir
-        importlib.reload(tempfile)
+    matplotlib_rcparams = matplotlib.rcParams.copy()
+    matplotlib.rcParams["svg.hashsalt"] = "<hashsalt>"
 
-        # Make `skrub.TableReport.html_snippet()` reproducible
-        #
-        # https://github.com/skrub-data/skrub/blob/35f573ce586fe61ef2c72f4c0c4b188ebf2e664b/skrub/_reporting/_html.py#L153
-        mp.setattr("secrets.token_hex", lambda: "<token>")
+    if "svg.id" in matplotlib.rcParams:
+        matplotlib.rcParams["svg.id"] = "<id>"
 
-        # Make `matplotlib.Figure.savefig(format="svg")` reproducible
-        #
-        # https://matplotlib.org/stable/users/prev_whats_new/whats_new_2.1.0.html#reproducible-ps-pdf-and-svg-output
-        # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.10.0.html#svg-id-rcparam
-        mp.setenv("SOURCE_DATE_EPOCH", "0")
+    try:
+        yield
+    finally:
+        matplotlib.rcParams = matplotlib_rcparams
 
-        matplotlib_rcparams = matplotlib.rcParams.copy()
 
-        try:
-            matplotlib.rcParams["svg.hashsalt"] = "<hashsalt>"
-
-            if "svg.id" in matplotlib.rcParams:
-                matplotlib.rcParams["svg.id"] = "<id>"
-
-            # Use a non-interactive ``matplotlib.backend`` that can only write to files.
-            #
-            # https://github.com/matplotlib/matplotlib/issues/29119
-            # https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend
-            matplotlib.rcParams["backend"] = "agg"
-
-            yield
-        finally:
-            matplotlib.rcParams = matplotlib_rcparams
+@fixture(autouse=True)
+def setup(
+    monkeypatch_tmpdir,
+    monkeypatch_matplotlib,
+    monkeypatch_skrub,
+): ...

--- a/skore-remote-project/tests/conftest.py
+++ b/skore-remote-project/tests/conftest.py
@@ -1,4 +1,16 @@
+from datetime import datetime, timezone
+
 from pytest import fixture
+
+
+@fixture
+def now():
+    return datetime.now(tz=timezone.utc)
+
+
+@fixture
+def nowstr(now):
+    return now.isoformat()
 
 
 @fixture(autouse=True)
@@ -48,15 +60,3 @@ def setup(monkeypatch, tmp_path):
             yield
         finally:
             matplotlib.rcParams = matplotlib_rcparams
-
-
-@fixture
-def now():
-    import datetime
-
-    return datetime.datetime.now(tz=datetime.timezone.utc)
-
-
-@fixture
-def nowstr(now):
-    return now.isoformat()

--- a/skore-remote-project/tests/conftest.py
+++ b/skore-remote-project/tests/conftest.py
@@ -1,62 +1,62 @@
-from datetime import datetime, timezone
-
 from pytest import fixture
+
+
+@fixture(autouse=True)
+def setup(monkeypatch, tmp_path):
+    import importlib
+    import tempfile
+
+    import matplotlib
+
+    with monkeypatch.context() as mp:
+        # Change ``TMPDIR`` used by ``tempfile.gettempdir()`` to point to ``tmp_path``,
+        # so that it is automatically deleted after use, with no impact on the user's
+        # environment.
+        mp.setenv("TMPDIR", str(tmp_path))
+
+        # Force the reload of the ``tempfile`` module to change the cached return of
+        # ``tempfile.gettempdir()``.
+        #
+        # https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir
+        importlib.reload(tempfile)
+
+        # Make `skrub.TableReport.html_snippet()` reproducible
+        #
+        # https://github.com/skrub-data/skrub/blob/35f573ce586fe61ef2c72f4c0c4b188ebf2e664b/skrub/_reporting/_html.py#L153
+        mp.setattr("secrets.token_hex", lambda: "<token>")
+
+        # Make `matplotlib.Figure.savefig(format="svg")` reproducible
+        #
+        # https://matplotlib.org/stable/users/prev_whats_new/whats_new_2.1.0.html#reproducible-ps-pdf-and-svg-output
+        # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.10.0.html#svg-id-rcparam
+        mp.setenv("SOURCE_DATE_EPOCH", "0")
+
+        matplotlib_rcparams = matplotlib.rcParams.copy()
+
+        try:
+            matplotlib.rcParams["svg.hashsalt"] = "<hashsalt>"
+
+            if "svg.id" in matplotlib.rcParams:
+                matplotlib.rcParams["svg.id"] = "<id>"
+
+            # Use a non-interactive ``matplotlib.backend`` that can only write to files.
+            #
+            # https://github.com/matplotlib/matplotlib/issues/29119
+            # https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend
+            matplotlib.rcParams["backend"] = "agg"
+
+            yield
+        finally:
+            matplotlib.rcParams = matplotlib_rcparams
 
 
 @fixture
 def now():
-    return datetime.now(tz=timezone.utc)
+    import datetime
+
+    return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 @fixture
 def nowstr(now):
     return now.isoformat()
-
-
-@fixture(autouse=True)
-def monkeypatch_tmpdir(monkeypatch, tmp_path):
-    """
-    A pytest fixture that temporarily changes the system's temporary directory.
-
-    It modifies the ``TMPDIR`` environment variable to point to a temporary path managed
-    by pytest's ``tmp_path`` fixture. Thus, it will be automatically deleted after use
-    and will not impact the user's environment.
-
-    It also forces the reload of the ``tempfile`` module to change the cached return of
-    ``tempfile.gettempdir()``.
-    """
-    import tempfile
-    from importlib import reload
-
-    with monkeypatch.context() as mp:
-        mp.setenv("TMPDIR", str(tmp_path))
-
-        # The first call of `tempfile.gettempdir` being cached, reload the module.
-        # https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir
-        reload(tempfile)
-
-        yield
-
-
-@fixture
-def reproducible(monkeypatch):
-    import matplotlib
-
-    # Make `skrub.TableReport.html_snippet()` reproducible
-    # https://github.com/skrub-data/skrub/blob/35f573ce586fe61ef2c72f4c0c4b188ebf2e664b/skrub/_reporting/_html.py#L153
-    monkeypatch.setattr("secrets.token_hex", lambda: "<token>")
-
-    # Make `matplotlib.Figure.savefig(format="svg")` reproducible
-    # https://matplotlib.org/stable/users/prev_whats_new/whats_new_2.1.0.html#reproducible-ps-pdf-and-svg-output
-    # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.10.0.html#svg-id-rcparam
-    monkeypatch.setenv("SOURCE_DATE_EPOCH", "0")
-
-    try:
-        matplotlib.rcParams["svg.hashsalt"] = "<hashsalt>"
-
-        if "svg.id" in matplotlib.rcParams:
-            matplotlib.rcParams["svg.id"] = "<id>"
-
-        yield
-    finally:
-        matplotlib.rcdefaults()

--- a/skore-remote-project/tests/unit/item/test_matplotlib_figure_item.py
+++ b/skore-remote-project/tests/unit/item/test_matplotlib_figure_item.py
@@ -22,7 +22,6 @@ class TestMatplotlibFigureItem:
         with pytest.raises(ItemTypeError):
             MatplotlibFigureItem.factory(None)
 
-    @pytest.mark.usefixtures("reproducible")
     def test_representation(self, tmp_path):
         figure, ax = subplots()
         ax.plot([1, 2, 3, 4], [1, 4, 2, 3])

--- a/skore-remote-project/tests/unit/item/test_skrub_table_report_item.py
+++ b/skore-remote-project/tests/unit/item/test_skrub_table_report_item.py
@@ -30,7 +30,6 @@ class TestSkrubTableReportItem:
         with pytest.raises(ItemTypeError):
             SkrubTableReportItem.factory(None)
 
-    @pytest.mark.usefixtures("reproducible")
     def test_representation(self, monkeypatch, now):
         report = TableReport(
             DataFrame(


### PR DESCRIPTION
> [!IMPORTANT]
> skore-remote-project

Fix [flaky pipeline](https://github.com/probabl-ai/skore/actions/runs/14732548381/job/41350256575#step:10:392) by setting `matplotlib.backend` to `agg` during artifacts generation, and force it in tests.

Reference:
https://github.com/matplotlib/matplotlib/issues/29119
https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend