### PR TITLE
docs: Avoid failure when pytorch load weights from TextEncoder with parallelism

### DIFF
--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -112,7 +112,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.pipeline import make_pipeline
 
 model = make_pipeline(
-    TableVectorizer(high_cardinality=TextEncoder()),
+    TableVectorizer(high_cardinality=TextEncoder(store_weights_in_pickle=True)),
     HistGradientBoostingRegressor(),
 )
 model
@@ -121,7 +121,8 @@ model
 # Evaluation
 # ^^^^^^^^^^
 #
-# Let us compute the cross-validation report for this model using :class:`skore.CrossValidationReport`:
+# Let us compute the cross-validation report for this model using
+# :class:`skore.CrossValidationReport`:
 from skore import CrossValidationReport
 
 report = CrossValidationReport(estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4)


### PR DESCRIPTION
It is a workaround on the failure that is sometimes happening when request `transform` from `TextEncoder` in parallel.

In short, there is a failure in the weights loading from PyTorch where some tensors are loaded on a meta device (only metadata) and does not load the weight. I did not yet found the root cause of the failure why the weights are not loaded properly.

In the meanwhile, we can avoid this issue by storing the weights. We should monitor that loading several time the language model does not make blow up the RAM on the GitHub actions. Othwerwise, we need to deactivate the parallelism most probably.