### PR TITLE
fix: Do not force installation of `polars-lts-cpu` on `x86_64` platform

### DIFF
--- a/.github/actions/sphinx/build/action.yml
+++ b/.github/actions/sphinx/build/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install '.[sphinx]'
+        python -m pip install '.[polars,sphinx]'
     - working-directory: sphinx
       shell: bash
       run: >

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install-skore:
-	python -m pip install -e './skore[test,sphinx,dev]'
+	python -m pip install -e './skore[polars,test,sphinx,dev]'
 	pre-commit install
 
 lint:

--- a/ci/pip-compile.sh
+++ b/ci/pip-compile.sh
@@ -69,6 +69,7 @@ set -eu
            --quiet \
            --no-strip-extras \
            --no-header \
+           --extra=polars \
            --extra=test \
            --override "${PACKAGE}/overrides.txt" \
            --python-version "${python}" \

--- a/skore-remote-project/pyproject.toml
+++ b/skore-remote-project/pyproject.toml
@@ -13,12 +13,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+polars = ["polars"]
+polars-lts-cpu = ["polars-lts-cpu"]
 test = [
   "altair",
   "numpy",
   "pillow",
   "plotly",
-  "polars",
   "pre-commit",
   "pyarrow",  # needed for polars.to_pandas()
   "pytest",

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -34,12 +34,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+polars = ["polars"]
+polars-lts-cpu = ["polars-lts-cpu"]
 test = [
   "altair>=5,<6",
   "pillow",
   "plotly>=5,<6",
-  "polars; platform_machine != 'x86_64'",
-  "polars-lts-cpu; platform_machine == 'x86_64'",
   "pre-commit",
   "pytest",
   "pytest-cov",
@@ -56,8 +56,6 @@ sphinx = [
   "kaleido",
   "numpydoc",
   "plotly>=5,<6",
-  "polars; platform_machine != 'x86_64'",
-  "polars-lts-cpu; platform_machine == 'x86_64'",
   "pydata-sphinx-theme",
   "scikit-learn<1.7",
   "seaborn",


### PR DESCRIPTION
Install `polars-lts-cpu` on demand: not all `x86_64` platform need this version of `polars`, only the **old** ones.
Fixing https://github.com/probabl-ai/skore/issues/1567 and https://github.com/probabl-ai/skore/pull/1568.