### PR TITLE
fix: Set size limit of `DiskCacheStorage` from 1go to unlimited

### DIFF
--- a/skore/src/skore/persistence/storage/disk_cache_storage.py
+++ b/skore/src/skore/persistence/storage/disk_cache_storage.py
@@ -1,12 +1,15 @@
 """In-memory storage."""
 
 from collections.abc import Iterator
+from functools import partial
 from pathlib import Path
 from typing import Any
 
 from diskcache import Cache
 
 from .abstract_storage import AbstractStorage
+
+Cache = partial(Cache, size_limit=float("inf"), cull_limit=0, eviction=None)
 
 
 class DirectoryDoesNotExist(Exception):


### PR DESCRIPTION
Fixes failing pipelines from https://github.com/probabl-ai/skore/pull/1617.

---

https://grantjenks.com/docs/diskcache/tutorial.html#settings
https://grantjenks.com/docs/diskcache/tutorial.html#eviction-policies

```
size_limit, default one gigabyte. The maximum on-disk size of the cache.

cull_limit, default ten. The maximum number of keys to cull when adding a new item. 

    Set to zero to disable automatic culling.

eviction_policy, default “least-recently-stored”. The setting to determine [eviction policy](https://grantjenks.com/docs/diskcache/tutorial.html#tutorial-eviction-policies).

    "none" disables cache evictions. Caches will grow without bound.
```