### PR TITLE
Progress info cleanup

### DIFF
--- a/skore/src/skore/utils/_progress_bar.py
+++ b/skore/src/skore/utils/_progress_bar.py
@@ -63,6 +63,14 @@ def progress_decorator(
                 )
                 progress.start()
 
+            # assigning progress to child reports
+            reports_to_cleanup: list[Any] = []
+            if hasattr(self_obj, "reports_"):
+                for report in self_obj.reports_:
+                    if hasattr(report, "_parent_progress"):
+                        report._parent_progress = progress
+                        reports_to_cleanup.append(report)
+
             task = progress.add_task(desc, total=None)
             self_obj._progress_info = {
                 "current_progress": progress,
@@ -85,6 +93,13 @@ def progress_decorator(
                             task, completed=progress.tasks[task].total, refresh=True
                         )
                     progress.stop()
+
+                # clean up child reports
+                for rpt in reports_to_cleanup:
+                    rpt._parent_progress = None
+                    if hasattr(rpt, "_progress_info"):
+                        rpt._progress_info = None
+
                 # clean up to make object pickable
                 self_obj._parent_progress = None
                 self_obj._progress_info = None

--- a/skore/tests/unit/utils/test_progress_bar.py
+++ b/skore/tests/unit/utils/test_progress_bar.py
@@ -134,3 +134,45 @@ def test_exception_handling():
     # Verify progress bar was cleaned up
     assert task._progress_info is None
     assert task._parent_progress is None
+
+
+def test_child_report_cleanup():
+    """Ensure that child reports in reports_ get progress assigned and then cleaned
+    up."""
+
+    class Child:
+        def __init__(self):
+            self._parent_progress = None
+            self._progress_info = None
+            self.called = False
+
+        @progress_decorator("Child Process")
+        def process(self):
+            self.called = True
+            return "child_done"
+
+    class Parent:
+        def __init__(self):
+            self._parent_progress = None
+            self._progress_info = None
+            self.reports_ = [Child(), Child()]
+
+        @progress_decorator("Parent Process")
+        def run(self):
+            results = []
+            for rpt in self.reports_:
+                results.append(rpt.process())
+            return results
+
+    parent = Parent()
+    results = parent.run()
+
+    assert results == ["child_done", "child_done"]
+    assert all(rp.called for rp in parent.reports_)
+    # Verify that progress attributes are cleaned for each child report
+    for rp in parent.reports_:
+        assert rp._parent_progress is None
+        assert rp._progress_info is None
+    # Also verify if parent reports are cleaned up as well
+    assert parent._parent_progress is None
+    assert parent._progress_info is None


### PR DESCRIPTION
Experimenting #1622

- Moved the assignment and cleaned up progress bars to child reports into the `progress_decorator` function.
- Capturing all reports that get assigned a progress bar in a `reports_to_cleanup` list, then cleaning them up in the finally block. This ensures that all reports (including EstimatorReports) will have their progress information cleaned up properly.
- Instead of checking for specific report types, using `hasattr(report, "_parent_progress")` to determine if a report should get a progress bar or not.
- Added `test_child_report_cleanup` to verify that child reports get the progress bar info and their progress bar attributes get cleaned up from the reports later. Likewise, parent reports also get cleaned up.