### PR TITLE
fix: Use process instead of thread when caching predictions

### DIFF
--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -112,7 +112,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.pipeline import make_pipeline
 
 model = make_pipeline(
-    TableVectorizer(high_cardinality=TextEncoder(store_weights_in_pickle=True)),
+    TableVectorizer(high_cardinality=TextEncoder()),
     HistGradientBoostingRegressor(),
 )
 model

--- a/skore/src/skore/sklearn/_base.py
+++ b/skore/src/skore/sklearn/_base.py
@@ -330,8 +330,13 @@ def _get_cached_response_values(
     pos_label: Optional[PositiveLabel] = None,
     data_source: Literal["test", "train", "X_y"] = "test",
     data_source_hash: Optional[int] = None,
-) -> NDArray:
+) -> list[tuple[tuple[Any, ...], Any, bool]]:
     """Compute or load from local cache the response values.
+
+    Be aware that the predictions are not loaded from the cache, they will not be added
+    to it. The reason is that we want to be able to run this function in parallel
+    settings in a thread-safe manner. The update should be done outside of this
+    function.
 
     Parameters
     ----------
@@ -366,8 +371,18 @@ def _get_cached_response_values(
 
     Returns
     -------
-    array-like of shape (n_samples,) or (n_samples, n_outputs)
-        The response values.
+    list of tuples
+        A list of tuples, each containing:
+
+        - cache_key : tuple
+            The cache key.
+
+        - cache_value : Any
+            The cache value. It corresponds to the predictions but also to the predict
+            time when it has not been cached yet.
+
+        - is_cached : bool
+            Whether the cache value was loaded from the cache.
     """
     prediction_method = _check_response_method(estimator, response_method).__name__
 
@@ -392,7 +407,7 @@ def _get_cached_response_values(
 
     if cache_key in cache:
         cached_predictions = cast(NDArray, cache[cache_key])
-        return cached_predictions
+        return [(cache_key, cached_predictions, True)]
 
     with MeasureTime() as predict_time:
         predictions, _ = _get_response_values(
@@ -403,14 +418,14 @@ def _get_cached_response_values(
             return_response_method_used=False,
         )
 
-    cache[cache_key] = predictions
-
     predict_time_cache_key: tuple[Any, ...] = (
         estimator_hash,
         data_source,
         data_source_hash,
         "predict_time",
     )
-    cache[predict_time_cache_key] = predict_time()
 
-    return predictions
+    return [
+        (cache_key, predictions, False),
+        (predict_time_cache_key, predict_time(), False),
+    ]

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -232,9 +232,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         else:
             parallel = joblib.Parallel(
                 **_validate_joblib_parallel_params(
-                    n_jobs=self._parent.n_jobs,
-                    return_as="generator",
-                    require="sharedmem",
+                    n_jobs=self._parent.n_jobs, return_as="generator"
                 )
             )
 
@@ -1430,18 +1428,21 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 )
 
                 y_true.append(report_y)
-                y_pred.append(
-                    _get_cached_response_values(
-                        cache=report._cache,
-                        estimator_hash=report._hash,
-                        estimator=report._estimator,
-                        X=report_X,
-                        response_method=response_method,
-                        data_source=data_source,
-                        data_source_hash=None,
-                        pos_label=display_kwargs.get("pos_label"),
-                    )
+                results = _get_cached_response_values(
+                    cache=report._cache,
+                    estimator_hash=report._hash,
+                    estimator=report._estimator,
+                    X=report_X,
+                    response_method=response_method,
+                    data_source=data_source,
+                    data_source_hash=None,
+                    pos_label=display_kwargs.get("pos_label"),
                 )
+                for key, value, is_cached in results:
+                    if not is_cached:
+                        report._cache[key] = value
+                    if key[-1] != "predict_time":
+                        y_pred.append(value)
                 progress.update(main_task, advance=1, refresh=True)
 
             display = display_class._compute_data_for_display(

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -211,9 +211,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         else:
             parallel = Parallel(
                 **_validate_joblib_parallel_params(
-                    n_jobs=self._parent.n_jobs,
-                    return_as="generator",
-                    require="sharedmem",
+                    n_jobs=self._parent.n_jobs, return_as="generator"
                 )
             )
             generator = parallel(
@@ -1172,18 +1170,21 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
                         data_source=data_source
                     )
                 y_true.append(y)
-                y_pred.append(
-                    _get_cached_response_values(
-                        cache=report._cache,
-                        estimator_hash=report._hash,
-                        estimator=report._estimator,
-                        X=X,
-                        response_method=response_method,
-                        data_source=data_source,
-                        data_source_hash=data_source_hash,
-                        pos_label=display_kwargs.get("pos_label"),
-                    )
+                results = _get_cached_response_values(
+                    cache=report._cache,
+                    estimator_hash=report._hash,
+                    estimator=report._estimator,
+                    X=X,
+                    response_method=response_method,
+                    data_source=data_source,
+                    data_source_hash=data_source_hash,
+                    pos_label=display_kwargs.get("pos_label"),
                 )
+                for key, value, is_cached in results:
+                    if not is_cached:
+                        report._cache[key] = value
+                    if key[-1] != "predict_time":
+                        y_pred.append(value)
                 progress.update(main_task, advance=1, refresh=True)
 
             display = display_class._compute_data_for_display(


### PR DESCRIPTION
This PR forces to use process-based parallelism instead of thread-based parallelism.

Thread-based parallelism was required such that each thread could update the same cache dictionary. However, with model such as `TextEncoder`, those models could potentially load weights from the disk at start and it is not thread safe.

