### PR TITLE
fix(ComparisonReport): Only check `y_test`

### DIFF
--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -178,8 +178,6 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
             reports_list = cast(list[EstimatorReport], reports_list)
             reports_type = "EstimatorReport"
 
-            # FIXME: We should only check y_test since it is all we need to tell us
-            # whether we have a distinct ML task at hand.
             test_dataset_hashes = {
                 joblib.hash(report.y_test)
                 for report in reports_list

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -181,13 +181,13 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
             # FIXME: We should only check y_test since it is all we need to tell us
             # whether we have a distinct ML task at hand.
             test_dataset_hashes = {
-                joblib.hash((report.X_test, report.y_test))
+                joblib.hash(report.y_test)
                 for report in reports_list
-                if not ((report.X_test is None) and (report.y_test is None))
+                if report.y_test is not None
             }
             if len(test_dataset_hashes) > 1:
                 raise ValueError(
-                    "Expected all estimators to have the same testing data."
+                    "Expected all estimators to share the same test targets."
                 )
 
         elif all(isinstance(report, CrossValidationReport) for report in reports_list):

--- a/skore/tests/unit/sklearn/comparison/estimator/test_comparison.py
+++ b/skore/tests/unit/sklearn/comparison/estimator/test_comparison.py
@@ -69,23 +69,22 @@ def test_comparison_report_without_testing_data(binary_classification_model):
 
 
 def test_comparison_report_different_test_data(binary_classification_model):
-    """Raise an error if the passed estimators do not have the same testing data."""
+    """Raise an error if the passed estimators do not have the same testing targets."""
     estimator, X_train, X_test, y_train, y_test = binary_classification_model
     estimator.fit(X_train, y_train)
 
-    # The estimators that have testing data, need to have the same testing data
-    # The estimators that do not have testing data do not count
+    # The estimators that have testing data need to have the same testing targets
     with pytest.raises(
-        ValueError, match="Expected all estimators to have the same testing data"
+        ValueError, match="Expected all estimators to share the same test targets."
     ):
         ComparisonReport(
             [
-                EstimatorReport(estimator, X_test=X_test, y_test=y_test),
-                EstimatorReport(estimator, X_test=X_test[1:], y_test=y_test[1:]),
+                EstimatorReport(estimator, y_test=y_test),
+                EstimatorReport(estimator, y_test=y_test[1:]),
             ]
         )
 
-    # The estimators without testing data (i.e. no X_test and no y_test) do not count
+    # The estimators without testing data (i.e., no y_test) do not count
     ComparisonReport(
         [
             EstimatorReport(estimator, X_test=X_test, y_test=y_test),
@@ -94,16 +93,13 @@ def test_comparison_report_different_test_data(binary_classification_model):
         ]
     )
 
-    # If there is an X_test but no y_test, it counts
-    with pytest.raises(
-        ValueError, match="Expected all estimators to have the same testing data"
-    ):
-        ComparisonReport(
-            [
-                EstimatorReport(estimator, fit=False, X_test=X_test, y_test=y_test),
-                EstimatorReport(estimator, fit=False, X_test=X_test),
-            ]
-        )
+    # If there is an X_test but no y_test, it should not raise an error
+    ComparisonReport(
+        [
+            EstimatorReport(estimator, fit=False, X_test=X_test, y_test=None),
+            EstimatorReport(estimator, fit=False, X_test=X_test, y_test=None),
+        ]
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes [#1621](https://github.com/probabl-ai/skore/issues/1621)

Hi @auguste-probabl  , @thomass-dev  !

`ComparisonReport` now only checks `y_test` consistency, enabling comparison of models with different feature sets.

Thank You!