### PR TITLE
fix: Allow single scoring metric in estimator reports

### DIFF
--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -71,7 +71,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                 list[Union[str, Callable[..., object], SKLearnScorer]],
             ]
         ] = None,
-        scoring_names: Optional[Union[str, None, list[Optional[str]]]] = None,
+        scoring_names: Optional[Union[str, list[Union[str, None]]]] = None,
         scoring_kwargs: Optional[dict[str, Any]] = None,
         pos_label: Optional[PositiveLabel] = None,
         indicator_favorability: bool = False,

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -146,6 +146,9 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         ROC AUC                0.99...         (↗︎)
         Brier score            0.03...         (↘︎)
         """
+        if scoring is not None and not isinstance(scoring, list):
+            scoring = [scoring]
+
         if data_source == "X_y":
             # optimization of the hash computation to avoid recomputing it
             # FIXME: we are still recomputing the hash for all the metrics that we

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -155,6 +155,8 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         """
         if scoring is not None and not isinstance(scoring, list):
             scoring = [scoring]
+        if scoring_names is not None and not isinstance(scoring_names, list):
+            scoring_names = [scoring_names]
 
         if data_source == "X_y":
             # optimization of the hash computation to avoid recomputing it

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -155,6 +155,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         """
         if scoring is not None and not isinstance(scoring, list):
             scoring = [scoring]
+
         if scoring_names is not None and not isinstance(scoring_names, list):
             scoring_names = [scoring_names]
 

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -63,8 +63,15 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         data_source: DataSource = "test",
         X: Optional[ArrayLike] = None,
         y: Optional[ArrayLike] = None,
-        scoring: Optional[list[Union[str, Callable, SKLearnScorer]]] = None,
-        scoring_names: Optional[list[Union[str, None]]] = None,
+        scoring: Optional[
+            Union[
+                str,
+                Callable[..., object],
+                SKLearnScorer,
+                list[Union[str, Callable[..., object], SKLearnScorer]],
+            ]
+        ] = None,
+        scoring_names: Optional[Union[str, None, list[Optional[str]]]] = None,
         scoring_kwargs: Optional[dict[str, Any]] = None,
         pos_label: Optional[PositiveLabel] = None,
         indicator_favorability: bool = False,


### PR DESCRIPTION
### Summary  
This PR allows `metrics.report_metrics` to accept a single scoring metric and a single scoring name, whereas it previously only supported lists of scoring metrics and names.

### Changes  
- Updated the types of `scoring` and `scoring_names` to accept both single elements and lists  
- Automatically wrap single `scoring` and `scoring_names` inputs into one-element lists

### Motivation  
It is more natural and user-friendly to allow single values instead of requiring one-element lists.  
See the original issue: [#1518](#1518).