### PR TITLE
refactor: Remove `_parent_progress` attribute

### DIFF
--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -244,7 +244,6 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         )
 
         self._progress_info: Optional[dict[str, Any]] = None
-        self._parent_progress = None
 
         self.n_jobs = n_jobs
         self._rng = np.random.default_rng(time.time_ns())
@@ -353,8 +352,8 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         progress.update(main_task, total=total_estimators)
 
         for report in self.reports_:
-            # Pass the progress manager to child tasks
-            report._parent_progress = progress
+            # Share the parent's progress bar with child report
+            report._progress_info = {"current_progress": progress}
             report.cache_predictions(response_methods=response_methods, n_jobs=n_jobs)
             progress.update(main_task, advance=1, refresh=True)
 

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -126,7 +126,6 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     ) -> None:
         # used to know if a parent launch a progress bar manager
         self._progress_info: Optional[dict[str, Any]] = None
-        self._parent_progress = None
 
         self._estimator = clone(estimator)
 
@@ -288,8 +287,8 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         progress.update(main_task, total=total_estimators)
 
         for estimator_report in self.estimator_reports_:
-            # Pass the progress manager to child tasks
-            estimator_report._parent_progress = progress
+            # Share the parent's progress bar with child report
+            estimator_report._progress_info = {"current_progress": progress}
             estimator_report.cache_predictions(
                 response_methods=response_methods, n_jobs=n_jobs
             )

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -131,7 +131,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     ) -> None:
         # used to know if a parent launch a progress bar manager
         self._progress_info: Optional[dict[str, Any]] = None
-        self._parent_progress = None
 
         fit_time: Optional[float] = None
         if fit == "auto":

--- a/skore/src/skore/utils/_progress_bar.py
+++ b/skore/src/skore/utils/_progress_bar.py
@@ -45,8 +45,10 @@ def progress_decorator(
 
             desc = description(self_obj) if callable(description) else description
 
-            if getattr(self_obj, "_parent_progress", None) is not None:
-                progress = self_obj._parent_progress
+            created_progress = False
+
+            if getattr(self_obj, "_progress_info", None) is not None:
+                progress = self_obj._progress_info["current_progress"]
             else:
                 progress = Progress(
                     SpinnerColumn(),
@@ -62,13 +64,14 @@ def progress_decorator(
                     disable=not get_config()["show_progress"],
                 )
                 progress.start()
+                created_progress = True
 
             # assigning progress to child reports
             reports_to_cleanup: list[Any] = []
             if hasattr(self_obj, "reports_"):
                 for report in self_obj.reports_:
-                    if hasattr(report, "_parent_progress"):
-                        report._parent_progress = progress
+                    if hasattr(report, "_progress_info"):
+                        report._progress_info = {"current_progress": progress}
                         reports_to_cleanup.append(report)
 
             task = progress.add_task(desc, total=None)
@@ -87,7 +90,7 @@ def progress_decorator(
                 has_errored = True
                 raise
             finally:
-                if self_obj._parent_progress is None:
+                if created_progress:
                     if not has_errored:
                         progress.update(
                             task, completed=progress.tasks[task].total, refresh=True
@@ -96,12 +99,9 @@ def progress_decorator(
 
                 # clean up child reports
                 for report in reports_to_cleanup:
-                    report._parent_progress = None
-                    if hasattr(report, "_progress_info"):
-                        report._progress_info = None
+                    report._progress_info = None
 
                 # clean up to make object pickable
-                self_obj._parent_progress = None
                 self_obj._progress_info = None
 
         return wrapper


### PR DESCRIPTION
Closes #1620

Refactored to use a single attribute `_progress_info` for all progress bar handling, eliminating the redundant `_parent_progress` attribute.

- Removed initialization of `_parent_progress` from all report classes: EstimatorReport, CrossValidationReport, ComparisonReport.
- Modified the `progress_decorator` to check only for `_progress_info` attribute instead of checking for both attributes (`_parent_progress` and `_progress_info`).
- When sharing a progress bar from parent to child reports, we have this now:
```python
child._progress_info = {"current_progress": progress}
```
instead of this before:
```python
child._parent_progress = progress
```