### PR TITLE
feat: Add `Makefile/make-install-skore-lts-cpu` target

### DIFF
--- a/.github/actions/sphinx/build/action.yml
+++ b/.github/actions/sphinx/build/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install '.[polars,sphinx]'
+        python -m pip install '.[sphinx]'
     - working-directory: sphinx
       shell: bash
       run: >

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,6 +77,11 @@ You'll need ``python >=3.9, <3.13``.
 
         make install-skore
 
+    On `old CPU architecture <https://github.com/pola-rs/polars?tab=readme-ov-file#legacy>`_ to get the support of ``polars``:
+
+    .. code-block:: bash
+
+        make install-skore-lts-cpu
 
 Choosing an issue
 -----------------

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 install-skore:
-	python -m pip install -e './skore[polars,test,sphinx,dev]'
+	python -m pip install -e './skore[test,sphinx,dev]'
+	pre-commit install
+
+install-skore-lts-cpu:
+	python -m pip install -e './skore[test-lts-cpu,sphinx-lts-cpu,dev]'
 	pre-commit install
 
 lint:

--- a/ci/pip-compile.sh
+++ b/ci/pip-compile.sh
@@ -69,7 +69,6 @@ set -eu
            --quiet \
            --no-strip-extras \
            --no-header \
-           --extra=polars \
            --extra=test \
            --override "${PACKAGE}/overrides.txt" \
            --python-version "${python}" \

--- a/skore-remote-project/pyproject.toml
+++ b/skore-remote-project/pyproject.toml
@@ -13,9 +13,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-polars = ["polars"]
-polars-lts-cpu = ["polars-lts-cpu"]
-test = [
+test-base = [
   "altair",
   "numpy",
   "pillow",
@@ -33,6 +31,8 @@ test = [
   "skrub",
   "xdoctest",
 ]
+test = ["skore-remote-project[test-base]", "polars"]
+test-lts-cpu = ["skore-remote-project[test-base]", "polars-lts-cpu"]
 
 [project.scripts]
 skore-hub-login = "skore_remote_project.authentication.login:login"

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -34,9 +34,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-polars = ["polars"]
-polars-lts-cpu = ["polars-lts-cpu"]
-test = [
+test-base = [
   "altair>=5,<6",
   "pillow",
   "plotly>=5,<6",
@@ -50,7 +48,9 @@ test = [
   "skrub",
   "xdoctest",
 ]
-sphinx = [
+test = ["skore[test-base]", "polars"]
+test-lts-cpu = ["skore[test-base]", "polars-lts-cpu"]
+sphinx-base = [
   "IPython",
   "altair",
   "kaleido",
@@ -69,6 +69,8 @@ sphinx = [
   "sphinx_autosummary_accessors",
   "transformers<4.51",  # core dumped on `>=4.51,<4.51.2`
 ]
+sphinx = ["skore[sphinx-base]", "polars"]
+sphinx-lts-cpu = ["skore[sphinx-base]", "polars-lts-cpu"]
 dev = [
   "nbformat",
   "ipykernel",


### PR DESCRIPTION
Following https://github.com/probabl-ai/skore/pull/1618:

- Add a new target to install `skore` on LTS CPU,
- Make `test`/`sphinx` optional dependencies self-sufficient.