### PR TITLE
docs: Resolve `Block quote [...], unexpected unindent` warnings

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -1226,7 +1226,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             - "train" : use the train set provided when creating the report.
             - "X_y" : use the provided `X` and `y` to compute the metric.
 
-                X : array-like of shape (n_samples, n_features), default=None
+        X : array-like of shape (n_samples, n_features), default=None
             New data on which to compute the metric. By default, we use the validation
             set provided when creating the report.
 


### PR DESCRIPTION
### **Description**
This PR addresses the `Block quote ends without a blank line; unexpected unindent. [docutils]` warnings encountered during the Sphinx `make html` build process (Issue #1671).

This warning occurred because a block quote in the docstring is not properly formatted.

```python   
# block quote unindent warnings
~/src/skore/sklearn/_comparison/report.py:docstring of skore.sklearn._comparison.report.ComparisonReport:31: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
```
---

### **Environment**

- Model: Dell Latitude E7440
- RAM: 12GB 
- OS: Windows 10 pro
- Python Version: Python 3.12
- Terminal: Ubuntu 22.04 LTS

---

### **Steps to reproduce:**
1. Clone the skore repository
2. Create and activate a virtual environment using the Ubuntu terminal
3. Run the _make install-skore_ command.
4. Change directory into the sphinx directory
5. Run `make html`.

---

### **Solution**
Not resolved yet

---
**Attempts to resolve this warning**
- 1: Confirmed that the .. caution:: directive, and the content was properly indented with tabs and added blank lines above and below. ❌
   ```python
    .. caution::

        Reports passed to `ComparisonReport` are not copied.
        If you pass a report to `ComparisonReport`, and then modify the report outside
        later, it will affect the report stored inside the `ComparisonReport` as well,
        which can lead to inconsistent results. For this reason, modifying reports after
        creation is strongly discouraged.
   ```
- 2: Added explicit line breaks at the fullstops within the paragraph. ❌
   ```python
    .. caution::

        Reports passed to `ComparisonReport` are not copied.

        If you pass a report to `ComparisonReport`, and then modify the report outside
        later, it will affect the report stored inside the `ComparisonReport` as well,
        which can lead to inconsistent results.

        For this reason, modifying reports after creation is strongly discouraged.
   ```
- 3: Rewrote the entire block from scratch to ensure that there were no hidden characters or line endings, which may be causing the issue. ❌
- 4: Modified conf.py. I read that it may be caused by Google style docstrings, and the suggestion was to add "sphinx.ext.napoleon" to the extensions list in conf.py. I edited the conf.py to include this but it did not fix the issue. ❌
   ```python
   extensions = [
      "sphinx.ext.napoleon",
      "numpydoc",
      "sphinx.ext.autosummary",
   ###
   ]
   ```
- 5: Switched the directive from `.. caution::` to `.. warning::`, which has similar formatting, but it did not resolve the error. ❌
   ```python
      .. warning:: Reports passed to `ComparisonReport` are not copied.

      If you pass a report to `ComparisonReport`, and then modify the report outside
      later, it will affect the report stored inside the `ComparisonReport` as well,
      which can lead to inconsistent results. For this reason, modifying reports after
      creation is strongly discouraged.
   ```

cc @thomass-dev