### PR TITLE
docs: Resolve `Inline interpreted text [...] without end-string` warnings

### DIFF
--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -112,7 +112,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -274,7 +274,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -385,7 +385,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -487,7 +487,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -593,7 +593,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -664,7 +664,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -772,7 +772,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -843,7 +843,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -924,7 +924,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -1006,7 +1006,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------
@@ -1101,7 +1101,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
 
         Returns
         -------

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -112,7 +112,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -274,7 +274,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -385,7 +385,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -487,7 +487,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -593,7 +593,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -664,7 +664,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -772,7 +772,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -843,7 +843,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -924,7 +924,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -1006,7 +1006,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------
@@ -1101,7 +1101,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
 
         Returns
         -------

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -112,7 +112,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -274,7 +274,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -385,7 +385,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -487,7 +487,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -593,7 +593,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -664,7 +664,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -772,7 +772,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -843,7 +843,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -924,7 +924,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -1006,7 +1006,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------
@@ -1101,7 +1101,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
             Function to aggregate the scores across the cross-validation splits.
             None will return the scores for each split.
-            Ignored when comparison is between :class:`~skore.EstimatorReport`s.
+            Ignored when comparison is between :class:`~skore.EstimatorReport(s).
 
         Returns
         -------

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 class ComparisonReport(_BaseReport, DirNamesMixin):
     """Report for comparing reports.
 
-    This object can be used to compare several :class:`skore.EstimatorReport(s)`, or
-    several :class:`~skore.CrossValidationReport(s)`.
+    This object can be used to compare several :class:`skore.EstimatorReport` instances,
+    or several :class:`~skore.CrossValidationReport` instances.
 
     .. caution:: Reports passed to `ComparisonReport` are not copied. If you pass
        a report to `ComparisonReport`, and then modify the report outside later, it

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 class ComparisonReport(_BaseReport, DirNamesMixin):
     """Report for comparing reports.
 
-    This object can be used to compare several :class:`skore.EstimatorReport`s, or
-    several :class:`~skore.CrossValidationReport`s.
+    This object can be used to compare several :class:`skore.EstimatorReport(s)`, or
+    several :class:`~skore.CrossValidationReport(s)`.
 
     .. caution:: Reports passed to `ComparisonReport` are not copied. If you pass
        a report to `ComparisonReport`, and then modify the report outside later, it


### PR DESCRIPTION
### **Description**
This PR addresses the `Inline interpreted text or phrase reference start-string without end-string` warnings encountered during the Sphinx `make html` build process (Issue #1671).
These warnings occurred because of a reference that starts with a backtick but doesn't have a matching closing backtick in the docstring.

```python   
# report.py
~/_comparison/report.py:docstring of skore.sklearn._comparison.report.ComparisonReport:4: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
~/_comparison/report.py:docstring of skore.sklearn._comparison.report.ComparisonReport:4: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]

# metrics_accessor.py
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.accuracy:23: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]       
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.brier_score:23: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]    
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.custom_metric:47: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]  
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.log_loss:23: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]       
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.precision:50: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]      
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.r2:32: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.recall:51: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.report_metrics:50: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils] 
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.rmse:32: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.roc_auc:56: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]        
~/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor.timings:11: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
```
---

### **Environment**

- Model: Dell Latitude E7440
- RAM: 12GB 
- OS: Windows 10 pro
- Python Version: Python 3.12
- Terminal: Ubuntu 22.04 LTS

---

### **Steps to reproduce:**
1. Clone the skore repository
2. Create and activate a virtual environment using the Ubuntu terminal
3. Run the _make install-skore_ command.
4. Change directory into the sphinx directory
5. Run `make html`.
---

### **Solution:**
- Changed **:class:~skore.EstimatorReport`s** where the **s** was outside the backticks in the metrics_accessor.py file, to **:class:~skore.EstimatorReport(s)**

  *_before_*
  ```
  # metrics_accessor.py
         **kwargs : dict
              Any additional keyword arguments to be passed to the metric function.

          aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
              Function to aggregate the scores across the cross-validation splits.
              None will return the scores for each split.
              Ignored when comparison is between :class:`~skore.EstimatorReport`s.
  ```

  *_after_*
  ```
  # metrics_accessor.py
         **kwargs : dict
              Any additional keyword arguments to be passed to the metric function.
  
          aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
              Function to aggregate the scores across the cross-validation splits.
              None will return the scores for each split.
              Ignored when comparison is between :class:`~skore.EstimatorReport(s)`.
  ```

- Changed **:class:~skore.EstimatorReport`s** where the **s** was outside the backticks in the report.py file, to **:class:skore.EstimatorReport reports**.
 
  *_before_*
  ```
  # report,py
  class ComparisonReport(_BaseReport, DirNamesMixin):
      """Report for comparing reports.

      This object can be used to compare several :class:`skore.EstimatorReport`s,
      or several :class:`~skore.CrossValidationReport`s.
  ```

  *_after_*
  ```
  # report,py
  class ComparisonReport(_BaseReport, DirNamesMixin):
      """Report for comparing reports.

      This object can be used to compare several :class:`skore.EstimatorReport` reports,
      or several :class:`~skore.CrossValidationReport` reports.
  ```

_Note:_
I was unsure which of the modifications would be preferred - **class:\`skore.EstimatorReport\` reports** or **class:\`~skore.EstimatorReport(s)\`**, so I left both. 


cc @glemaitre @thomass-dev @auguste-probabl 