### PR TITLE
docs: Resolve `duplicate object description` warnings

### DIFF
--- a/sphinx/_templates/base.rst
+++ b/sphinx/_templates/base.rst
@@ -9,6 +9,7 @@
 .. currentmodule:: {{ module }}
 
 .. autofunction:: {{ objname }}
+   :noindex:
 
 .. minigallery:: {{ module }}.{{ objname }}
    :add-heading: Gallery examples
@@ -22,6 +23,7 @@
    :members:
    :inherited-members:
    :special-members: __call__
+   :noindex:
 
 .. minigallery:: {{ module }}.{{ objname }} {% for meth in methods %}{{ module }}.{{ objname }}.{{ meth }} {% endfor %}
    :add-heading: Gallery examples


### PR DESCRIPTION
### **Description**
This PR addresses the `duplicate object description` warnings encountered during the Sphinx `make html` build process (Issue #1202).

These warnings occurred because some object descriptions were documented in multiple places (the manual .rst files, and automatically generated ones), which caused Sphinx to index the same object multiple times.

```python
# ComparisonReport`:
skore/skore/src/skore/sklearn/_comparison/report.py:docstring of skore.sklearn._comparison.report.ComparisonReport.cache_predictions:1: WARNING: duplicate object description of skore.ComparisonReport.cache_predictions, other instance in reference/api/skore.ComparisonReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_comparison/report.py:docstring of skore.sklearn._comparison.report.ComparisonReport.clear_cache:1: WARNING: duplicate object description of skore.ComparisonReport.clear_cache, other instance in reference/api/skore.ComparisonReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_comparison/report.py:docstring of skore.sklearn._comparison.report.ComparisonReport.get_predictions:1: WARNING: duplicate object description of skore.ComparisonReport.get_predictions, other instance in reference/api/skore.ComparisonReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_base.py:docstring of skore.sklearn._base._HelpMixin.help:1: WARNING: duplicate object description of skore.ComparisonReport.help, other instance in reference/api/skore.ComparisonReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_comparison/metrics_accessor.py:docstring of skore.sklearn._comparison.metrics_accessor._MetricsAccessor:1: WARNING: duplicate object description of skore.ComparisonReport.metrics, other instance in reference/api/skore.ComparisonReport, use :no-index: for one of them

# CrossValidationReport
skore/skore/src/skore/sklearn/_cross_validation/report.py:docstring of skore.sklearn._cross_validation.report.CrossValidationReport.cache_predictions:1: WARNING: duplicate object description of skore.CrossValidationReport.cache_predictions, other instance in reference/api/skore.CrossValidationReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_cross_validation/report.py:docstring of skore.sklearn._cross_validation.report.CrossValidationReport.clear_cache:1: WARNING: duplicate object description of skore.CrossValidationReport.clear_cache, other instance in reference/api/skore.CrossValidationReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_cross_validation/report.py:docstring of skore.sklearn._cross_validation.report.CrossValidationReport.get_predictions:1: WARNING: duplicate object description of skore.CrossValidationReport.get_predictions, other instance in reference/api/skore.CrossValidationReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_base.py:docstring of skore.sklearn._base._HelpMixin.help:1: WARNING: duplicate object description of skore.CrossValidationReport.help, other instance in reference/api/skore.CrossValidationReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py:docstring of skore.sklearn._cross_validation.metrics_accessor._MetricsAccessor:1: WARNING: duplicate object description of skore.CrossValidationReport.metrics, other instance in reference/api/skore.CrossValidationReport, use :no-index: for one of them.

# EstimatorReport
skore/skore/src/skore/sklearn/_estimator/report.py:docstring of skore.sklearn._estimator.report.EstimatorReport.cache_predictions:1: WARNING: duplicate object description of skore.EstimatorReport.cache_predictions, other instance in reference/api/skore.EstimatorReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_estimator/report.py:docstring of skore.sklearn._estimator.report.EstimatorReport.clear_cache:1: WARNING: duplicate object description of skore.EstimatorReport.clear_cache, other instance in reference/api/skore.EstimatorReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py:docstring of skore.sklearn._estimator.feature_importance_accessor._FeatureImportanceAccessor:1: WARNING: duplicate object description of skore.EstimatorReport.feature_importance, other instance in reference/api/skore.EstimatorReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_estimator/report.py:docstring of skore.sklearn._estimator.report.EstimatorReport.get_predictions:1: WARNING: duplicate object description of skore.EstimatorReport.get_predictions, other instance in reference/api/skore.EstimatorReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_base.py:docstring of skore.sklearn._base._HelpMixin.help:1: WARNING: duplicate object description of skore.EstimatorReport.help, other instance in reference/api/skore.EstimatorReport, use :no-index: for one of them
skore/skore/src/skore/sklearn/_estimator/metrics_accessor.py:docstring of skore.sklearn._estimator.metrics_accessor._MetricsAccessor:1: WARNING: duplicate object description of skore.EstimatorReport.metrics, other instance in reference/api/skore.EstimatorReport, use :no-index: for one of them

# Project
skore/skore/src/skore/project/project.py:docstring of skore.project.project.Project.get:1: WARNING: duplicate object description of skore.Project.get, other instance in reference/api/skore.Project, use :no-index: for one of them
skore/skore/src/skore/project/project.py:docstring of skore.project.project.Project.put:1: WARNING: duplicate object description of skore.Project.put, other instance in reference/api/skore.Project, use :no-index: for one of them
```

---

### **Environment**

- Model: Dell Latitude E7440
- RAM: 12GB 
- OS: Windows 10 pro
- Python Version: Python 3.12
- Terminal: Ubuntu 22.04 LTS

---

### **Steps to reproduce:**
1. Clone the skore repository
2. Create and activate a virtual environment using the Ubuntu terminal
3. Run the _make install-skore_ command.
4. Change directory into the sphinx directory
5. Run `make html`.
---

### **Solution:**
- Summary:
   - Modified the template used to generate the .rst files.
   - Added :noindex: to the ..autoclass:: and ..autofunction::  base.rst file (skore\sphinx\_templates\base.rst)
  
   *_before_*
   ```python
    # base.rst
    .. autoclass:: {{ objname }}
       :members:
       :inherited-members:
       :special-members: __call__

     .. autofunction:: {{ objname }}
   ```
   
   *_after_*
   ```
    # base.rst   
    .. autoclass:: {{ objname }}
       :members:
       :inherited-members:
       :special-members: __call__
       :noindex:

     .. autofunction:: {{ objname }}
       :noindex:
   ```

- _Pros:_ 
   - Removes duplicate object warnings.
   - Avoid issues with cross referencing and indexing.
   - The original HTML files are unchanged, which was an issue with previous fixes.

- _Cons:_
  - These objects won't show up in the Sphinx generated index or search results, unless they’re documented somewhere else.
  
cc  @thomass-dev