### PR TITLE
docs: Resolve `Bullet list [..], unexpected unindent` warnings

### DIFF
--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -1226,7 +1226,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             - "train" : use the train set provided when creating the report.
             - "X_y" : use the provided `X` and `y` to compute the metric.
 
-                X : array-like of shape (n_samples, n_features), default=None
+        X : array-like of shape (n_samples, n_features), default=None
             New data on which to compute the metric. By default, we use the validation
             set provided when creating the report.
 


### PR DESCRIPTION
### **Description**
This PR addresses the `Bullet list ends without a blank line; unexpected unindent. [docutils]` warnings encountered during the Sphinx `make html` build process (Issue #1671).

These warnings occurred because a section was not properly indented in the code, and there was no blank line after a bulleted list.

```python   
# bullet list unindent warnings
~/src/skore/sklearn/_cross_validation/metrics_accessor.py:docstring of skore.sklearn._cross_validation.metrics_accessor._MetricsAccessor.roc:15: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
```
---

### **Environment**

- Model: Dell Latitude E7440
- RAM: 12GB 
- OS: Windows 10 pro
- Python Version: Python 3.12
- Terminal: Ubuntu 22.04 LTS

---

### **Steps to reproduce:**
1. Clone the skore repository
2. Create and activate a virtual environment using the Ubuntu terminal
3. Run the _make install-skore_ command.
4. Change directory into the sphinx directory
5. Run `make html`.
---

### **Solution:**
- Summary:
   - Bullet list unident: To resolve this warning, I ensured that the affected line "X : array-like of shape (n_samples, n_features), default=None" was properly indented.
 
   *_before_*
   ```python
   Parameters
   ----------
    data_source : {"test", "train"}, default="test"
        The data source to use.
        .......

            X : array-like of shape (n_samples, n_features), default=None # <== affected line
        New data on which to compute the metric. By default, we use the validation
        
        .......
   ```

   *_after_*
   ```python
     Parameters
     ----------
     data_source : {"test", "train"}, default="test"
        The data source to use.
        .......

     X : array-like of shape (n_samples, n_features), default=None # modified
        New data on which to compute the metric. By default, we use the validation
        .......
   ```  

cc @thomass-dev