### PR TITLE
ci: Change workflow to release `skore|skore-(local|remote)-project`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
+# Release a package.
 #
-# p-a-c-k-a-g-e/X.Y.Z
-# p-a-c-k-a-g-e/X.Y.Z-rc.1
-#
+# Package versions are of the form `<package-name>/X.Y.Z` or `<package-name>/X.Y.Z-rc.1`
 
 name: release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,76 @@
+#
+# p-a-c-k-a-g-e/X.Y.Z
+# p-a-c-k-a-g-e/X.Y.Z-rc.1
+#
+
 name: release
 
 on:
   release:
     types: [released, prereleased]
 
+env:
+  UUID: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+
+permissions: {}
+
 jobs:
-  tag-restriction:
-    name: Tag must match semantic versioning pattern
+  tag-decomposition:
+    name: Decompose tag to retrieve package and version
     runs-on: ubuntu-latest
+    outputs: ${{ steps.tag-decomposition.outputs }}
     steps:
       - shell: bash
+        id: tag-decomposition
         run: |
-          if ! [[ "${GITHUB_REF_NAME}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.(1|[1-9][0-9]*))?$ ]]; then
-              exit -1
-          fi
+          package="${GITHUB_REF_NAME%/*}"
+          version="${GITHUB_REF_NAME#*/}"
+
+          [[ "${package}" == "${version}" ]] && { >&2 echo "Invalid tag: no package"; exit 1; }
+          [[ "${package}" =~ ^(skore|skore-(local|remote)-project)$ ]] || { >&2 echo "Invalid tag: invalid package"; exit 1; }
+          [[ "${version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.(1|[1-9][0-9]*))?$ ]] || { >&2 echo "Invalid tag: invalid version"; exit 1; }
+
+          echo "package=${package}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
   build:
     name: Build package distributions
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: tag-restriction
+    needs: [tag-decomposition]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Override VERSION.txt with tag
-        run: echo "${GITHUB_REF_NAME}" > skore/VERSION.txt
+        working-directory: ${{ needs.tag-decomposition.outputs.package }}
+        run: echo "${VERSION}" > VERSION.txt
+        env:
+          VERSION: ${{ needs.tag-decomposition.outputs.version }}
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: "3.12"
 
       - name: Build package distributions
-        run: |
-          cd skore
-
-          python -m pip install build
-          python -m build
+        working-directory: ${{ needs.tag-decomposition.outputs.package }}
+        run: python -m pip install build && python -m build
 
       - name: Checks whether distribution’s long description will render correctly on PyPI
+        working-directory: ${{ needs.tag-decomposition.outputs.package }}
         continue-on-error: true
         run: |
           python -m pip install twine
-          python -m twine check skore/dist/*
+          python -m twine check dist/*
 
       - name: Upload package distributions
-        uses: actions/upload-artifact@v4
+        working-directory: ${{ needs.tag-decomposition.outputs.package }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: python-package-distributions
-          path: skore/dist/
+          name: ${{ UUID }}
+          path: dist/
 
   publish:
     name: Publish package distributions to PyPI using trusted publisher
@@ -62,27 +78,27 @@ jobs:
     environment: release
     permissions:
       id-token: write
-    needs: build
+    needs: [tag-decomposition, build]
     steps:
       - name: Download package distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          name: python-package-distributions
+          name: ${{ UUID }}
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           verify-metadata: false
 
   communicate:
     name: Communicate on slack about the new release
     runs-on: ubuntu-latest
-    needs: publish
+    needs: [tag-decomposition, publish]
     continue-on-error: true
     steps:
       - name: Post to slack
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -103,8 +119,8 @@ jobs:
     name: Delete package distributions artifacts
     runs-on: ubuntu-latest
     if: always()
-    needs: publish
+    needs: [tag-decomposition, publish]
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         with:
-          name: python-package-distributions
+          name: ${{ UUID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
   tag-decomposition:
     name: Decompose tag to retrieve package and version
     runs-on: ubuntu-latest
-    outputs: ${{ steps.tag-decomposition.outputs }}
+    outputs:
+      package: ${{ steps.tag-decomposition.outputs.package }}
+      version: ${{ steps.tag-decomposition.outputs.version }}
     steps:
       - shell: bash
         id: tag-decomposition
@@ -30,8 +32,10 @@ jobs:
           [[ "${package}" =~ ^(skore|skore-(local|remote)-project)$ ]] || { >&2 echo "Invalid tag: invalid package"; exit 1; }
           [[ "${version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.(1|[1-9][0-9]*))?$ ]] || { >&2 echo "Invalid tag: invalid version"; exit 1; }
 
-          echo "package=${package}" >> "${GITHUB_OUTPUT}"
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "::group::Details"
+          echo "package=${package}" | tee --append "${GITHUB_OUTPUT}"
+          echo "version=${version}" | tee --append "${GITHUB_OUTPUT}"
+          echo "::endgroup::"
 
   build:
     name: Build package distributions
@@ -66,11 +70,10 @@ jobs:
           python -m twine check dist/*
 
       - name: Upload package distributions
-        working-directory: ${{ needs.tag-decomposition.outputs.package }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ UUID }}
-          path: dist/
+          name: ${{ env.UUID }}
+          path: ${{ needs.tag-decomposition.outputs.package }}/dist/
 
   publish:
     name: Publish package distributions to PyPI using trusted publisher
@@ -83,7 +86,7 @@ jobs:
       - name: Download package distributions
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          name: ${{ UUID }}
+          name: ${{ env.UUID }}
           path: dist/
 
       - name: Publish package distributions to PyPI
@@ -123,4 +126,4 @@ jobs:
     steps:
       - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         with:
-          name: ${{ UUID }}
+          name: ${{ env.UUID }}

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -49,10 +49,8 @@ name: sphinx
 on:
   pull_request:
   push:
-    branches:
-      - main
-  release:
-    types: [released]
+    branches: [main]
+    tags: ['skore/[0-9]+.[0-9]+.[0-9]+']
   merge_group:
     types: [checks_requested]
 
@@ -88,7 +86,7 @@ jobs:
   sphinx-version:
     runs-on: ubuntu-latest
     needs: [sphinx-changes]
-    if: ${{ (contains(fromJSON('["push", "release"]'), github.event_name)) || (needs.sphinx-changes.outputs.changes == 'true') }}
+    if: ${{ (github.event_name == 'push') || (needs.sphinx-changes.outputs.changes == 'true') }}
     outputs:
       SPHINX_VERSION: ${{ steps.sphinx-version.outputs.SPHINX_VERSION }}
       SPHINX_RELEASE: ${{ steps.sphinx-version.outputs.SPHINX_RELEASE }}
@@ -98,7 +96,7 @@ jobs:
         run: |
           set -u
 
-          if [[ "${GITHUB_EVENT_NAME}" != "release" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" != "push"  ]] || [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
               echo "SPHINX_VERSION=dev" >> "${GITHUB_OUTPUT}"
               echo "SPHINX_RELEASE=0.0.0+dev" >> "${GITHUB_OUTPUT}"
               exit 0
@@ -106,15 +104,15 @@ jobs:
 
           set -e
 
-          if [[ "${GITHUB_REF_NAME}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)?$ ]]; then
-              echo "SPHINX_VERSION=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}" >> "${GITHUB_OUTPUT}"
-              echo "SPHINX_RELEASE=${GITHUB_REF_NAME}" >> "${GITHUB_OUTPUT}"
+          if [[ "${GITHUB_REF_NAME}" =~ ^skore/((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$ ]]; then
+              echo "SPHINX_VERSION=${BASH_REMATCH[2]}.${BASH_REMATCH[3]}" >> "${GITHUB_OUTPUT}"
+              echo "SPHINX_RELEASE=${BASH_REMATCH[1]}" >> "${GITHUB_OUTPUT}"
           fi
 
   sphinx-build:
     runs-on: ubuntu-latest
     needs: [sphinx-version]
-    if: ${{ (contains(fromJSON('["push", "release"]'), github.event_name)) || (needs.sphinx-changes.outputs.changes == 'true') }}
+    if: ${{ (github.event_name == 'push') || (needs.sphinx-changes.outputs.changes == 'true') }}
     permissions:
       contents: read
     steps:
@@ -137,7 +135,7 @@ jobs:
           path: sphinx/build/html/
 
   sphinx-deploy-html:
-    if: ${{ (contains(fromJSON('["push", "release"]'), github.event_name)) }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: [sphinx-version, sphinx-build]
     permissions:
@@ -163,7 +161,7 @@ jobs:
           DESTINATION: ${{ needs.sphinx-version.outputs.SPHINX_VERSION }}/
 
   sphinx-deploy-root-files:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ (github.event_name == 'push') && (github.ref_type == 'tag') }}
     runs-on: ubuntu-latest
     needs: [sphinx-version, sphinx-build, sphinx-deploy-html]
     permissions:


### PR DESCRIPTION
Change release workflow to release `skore|skore-(local|remote)-project` package.

Tags must be prefixed by package:
- `p-a-c-k-a-g-e/X.Y.Z`     
- `p-a-c-k-a-g-e/X.Y.Z-rc.A`

Examples of valid tags: `skore/1.0.0`, `skore-local-project/0.0.1`.

---

Various:
- name artifacts in `release.yml` using UUID to allow parallel releases,
- deploy documentation in `sphinx.yml` only on `skore` tags (and not RC).
