### PR TITLE
fix(roc-curve): Show chance level in the legend

### DIFF
--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -179,6 +179,8 @@ class RocCurveDisplay(
         *,
         estimator_name: str,
         roc_curve_kwargs: list[dict[str, Any]],
+        plot_chance_level: bool = True,
+        chance_level_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[Axes, list[Line2D], Union[str, None]]:
         """Plot ROC curve for a single estimator.
 
@@ -191,6 +193,13 @@ class RocCurveDisplay(
             Additional keyword arguments to pass to matplotlib's plot function. In
             binary case, we should have a single dict. In multiclass case, we should
             have a list of dicts, one per class.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
+
+        chance_level_kwargs : dict, default=None
+            Keyword arguments to be passed to matplotlib's `plot` for rendering
+            the chance level line.
 
         Returns
         -------
@@ -261,6 +270,15 @@ class RocCurveDisplay(
 
             info_pos_label = None  # irrelevant for multiclass
 
+        if plot_chance_level:
+            self.chance_level_ = _add_chance_level(
+                self.ax_,
+                chance_level_kwargs,
+                self._default_chance_level_kwargs,
+            )
+        else:
+            self.chance_level_ = None
+
         self.ax_.legend(bbox_to_anchor=(1.02, 1), title=estimator_name)
 
         return self.ax_, lines, info_pos_label
@@ -270,6 +288,8 @@ class RocCurveDisplay(
         *,
         estimator_name: str,
         roc_curve_kwargs: list[dict[str, Any]],
+        plot_chance_level: bool = True,
+        chance_level_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[Axes, list[Line2D], Union[str, None]]:
         """Plot ROC curve for a cross-validated estimator.
 
@@ -281,6 +301,13 @@ class RocCurveDisplay(
         roc_curve_kwargs : list of dict
             List of dictionaries containing keyword arguments to customize the ROC
             curves. The length of the list should match the number of curves to plot.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
+
+        chance_level_kwargs : dict, default=None
+            Keyword arguments to be passed to matplotlib's `plot` for rendering
+            the chance level line.
 
         Returns
         -------
@@ -356,6 +383,15 @@ class RocCurveDisplay(
                     )
                     lines.append(line)
 
+        if plot_chance_level:
+            self.chance_level_ = _add_chance_level(
+                self.ax_,
+                chance_level_kwargs,
+                self._default_chance_level_kwargs,
+            )
+        else:
+            self.chance_level_ = None
+
         if self.data_source in ("train", "test"):
             title = f"{estimator_name} on $\\bf{{{self.data_source}}}$ set"
         else:
@@ -369,6 +405,8 @@ class RocCurveDisplay(
         *,
         estimator_names: list[str],
         roc_curve_kwargs: list[dict[str, Any]],
+        plot_chance_level: bool = True,
+        chance_level_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[Axes, list[Line2D], Union[str, None]]:
         """Plot ROC curve of several estimators.
 
@@ -380,6 +418,13 @@ class RocCurveDisplay(
         roc_curve_kwargs : list of dict
             List of dictionaries containing keyword arguments to customize the ROC
             curves. The length of the list should match the number of curves to plot.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
+
+        chance_level_kwargs : dict, default=None
+            Keyword arguments to be passed to matplotlib's `plot` for rendering
+            the chance level line.
 
         Returns
         -------
@@ -446,6 +491,15 @@ class RocCurveDisplay(
                         fpr_est_class, tpr_est_class, **line_kwargs_validated
                     )
                     lines.append(line)
+
+        if plot_chance_level:
+            self.chance_level_ = _add_chance_level(
+                self.ax_,
+                chance_level_kwargs,
+                self._default_chance_level_kwargs,
+            )
+        else:
+            self.chance_level_ = None
 
         self.ax_.legend(
             bbox_to_anchor=(1.02, 1),
@@ -525,6 +579,8 @@ class RocCurveDisplay(
                     else estimator_name
                 ),
                 roc_curve_kwargs=roc_curve_kwargs,
+                plot_chance_level=plot_chance_level,
+                chance_level_kwargs=chance_level_kwargs,
             )
         elif self.report_type == "cross-validation":
             self.ax_, self.lines_, info_pos_label = (
@@ -535,12 +591,16 @@ class RocCurveDisplay(
                         else estimator_name
                     ),
                     roc_curve_kwargs=roc_curve_kwargs,
+                    plot_chance_level=plot_chance_level,
+                    chance_level_kwargs=chance_level_kwargs,
                 )
             )
         elif self.report_type == "comparison-estimator":
             self.ax_, self.lines_, info_pos_label = self._plot_comparison_estimator(
                 estimator_names=self.estimator_names,
                 roc_curve_kwargs=roc_curve_kwargs,
+                plot_chance_level=plot_chance_level,
+                chance_level_kwargs=chance_level_kwargs,
             )
         else:
             raise ValueError(
@@ -549,15 +609,6 @@ class RocCurveDisplay(
             )
 
         _set_axis_labels(self.ax_, info_pos_label)
-
-        if plot_chance_level:
-            self.chance_level_ = _add_chance_level(
-                self.ax_,
-                chance_level_kwargs,
-                self._default_chance_level_kwargs,
-            )
-        else:
-            self.chance_level_ = None
 
         if despine:
             _despine_matplotlib_axis(self.ax_)

--- a/skore/tests/unit/sklearn/plot/test_roc_curve.py
+++ b/skore/tests/unit/sklearn/plot/test_roc_curve.py
@@ -79,7 +79,7 @@ def test_roc_curve_display_binary_classification(pyplot, binary_classification_d
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
     assert legend.get_title().get_text() == estimator.__class__.__name__
-    assert len(legend.get_texts()) == 1
+    assert len(legend.get_texts()) == 1 + 1
 
     assert display.ax_.get_xlabel() == "False Positive Rate\n(Positive label: 1)"
     assert display.ax_.get_ylabel() == "True Positive Rate\n(Positive label: 1)"
@@ -132,7 +132,7 @@ def test_roc_curve_display_multiclass_classification(
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
     assert legend.get_title().get_text() == estimator.__class__.__name__
-    assert len(legend.get_texts()) == len(estimator.classes_)
+    assert len(legend.get_texts()) == len(estimator.classes_) + 1
 
     assert display.ax_.get_xlabel() == "False Positive Rate"
     assert display.ax_.get_ylabel() == "True Positive Rate"
@@ -331,7 +331,7 @@ def test_roc_curve_display_cross_validation_binary_classification(
         legend.get_title().get_text()
         == f"LogisticRegression on $\\bf{{{data_source_title}}}$ set"
     )
-    assert len(legend.get_texts()) == cv
+    assert len(legend.get_texts()) == cv + 1
 
     assert display.ax_.get_xlabel() == "False Positive Rate\n(Positive label: 1)"
     assert display.ax_.get_ylabel() == "True Positive Rate\n(Positive label: 1)"
@@ -394,7 +394,7 @@ def test_roc_curve_display_cross_validation_multiclass_classification(
         legend.get_title().get_text()
         == f"LogisticRegression on $\\bf{{{data_source_title}}}$ set"
     )
-    assert len(legend.get_texts()) == cv
+    assert len(legend.get_texts()) == cv + 1
 
     assert display.ax_.get_xlabel() == "False Positive Rate"
     assert display.ax_.get_ylabel() == "True Positive Rate"
@@ -504,7 +504,7 @@ def test_roc_curve_display_comparison_report_binary_classification(
     assert isinstance(display.ax_, mpl.axes.Axes)
     legend = display.ax_.get_legend()
     assert legend.get_title().get_text() == r"Binary-Classification on $\bf{test}$ set"
-    assert len(legend.get_texts()) == 2
+    assert len(legend.get_texts()) == 2 + 1
 
     assert display.ax_.get_xlabel() == "False Positive Rate\n(Positive label: 1)"
     assert display.ax_.get_ylabel() == "True Positive Rate\n(Positive label: 1)"
@@ -579,7 +579,7 @@ def test_roc_curve_display_comparison_report_multiclass_classification(
     assert (
         legend.get_title().get_text() == r"Multiclass-Classification on $\bf{test}$ set"
     )
-    assert len(legend.get_texts()) == 6
+    assert len(legend.get_texts()) == 6 + 1
 
     assert display.ax_.get_xlabel() == "False Positive Rate"
     assert display.ax_.get_ylabel() == "True Positive Rate"


### PR DESCRIPTION
The chance level line label now appears in the legend.

Before/After:
<img src="https://github.com/user-attachments/assets/fb671a91-a046-4173-8838-601639a35269" />
<img src="https://github.com/user-attachments/assets/14843720-318b-4676-810d-1318c3b81819" />

---

Depends on #1668 