### PR TITLE
fix(Comparison[CVReport]): Avoid mutating DataFrames in cache

### DIFF
--- a/skore/src/skore/sklearn/_comparison/utils.py
+++ b/skore/src/skore/sklearn/_comparison/utils.py
@@ -293,6 +293,8 @@ def _combine_cross_validation_results(
 
         return df
 
+    # Deepcopy the contained dataframes to avoid mutating them;
+    # in particular, they might be provided by a report cache
     results = copy.deepcopy(individual_results)
 
     # Pop the favorability column if it exists, to:

--- a/skore/src/skore/sklearn/_comparison/utils.py
+++ b/skore/src/skore/sklearn/_comparison/utils.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Optional
 
 import pandas as pd
@@ -292,7 +293,7 @@ def _combine_cross_validation_results(
 
         return df
 
-    results = individual_results.copy()
+    results = copy.deepcopy(individual_results)
 
     # Pop the favorability column if it exists, to:
     # - not use it in the aggregate operation

--- a/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
+++ b/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
@@ -234,3 +234,26 @@ def test_X_y(report, classification_data):
         ),
     )
     assert len(result) == 8
+
+
+def test_cache_poisoning(classification_data):
+    """Computing metrics for a ComparisonReport should not influence the
+    metrics computation for the internal CVReports.
+
+    Non-regression test for https://github.com/probabl-ai/skore/issues/1706
+    """
+    X, y = classification_data
+
+    report_1 = CrossValidationReport(
+        DummyClassifier(strategy="uniform", random_state=1), X=X, y=y
+    )
+    report_2 = CrossValidationReport(
+        DummyClassifier(strategy="uniform", random_state=2), X=X, y=y
+    )
+    report = ComparisonReport({"model_1": report_1, "model_2": report_2})
+    report.metrics.report_metrics(indicator_favorability=True)
+    result = report_1.metrics.report_metrics(
+        aggregate=None, indicator_favorability=True
+    )
+
+    assert "Favorability" in result.columns


### PR DESCRIPTION
Closes #1706
Closes #1704

The issue is a consequence of pandas DataFrame mutability.
Specifically, `_combine_cross_validation_results` manipulates
a list of DataFrames mutably, and since the DataFrames come
from a cache (which is a mutable dict), the DataFrames inside
the cache end up mutated.

https://github.com/probabl-ai/skore/blob/9bbfdb34fc8a62555aa8d3cc79a8f914dd22dd43/skore/src/skore/sklearn/_comparison/metrics_accessor.py#L250

`_combine_cross_validation_results` already performs a copy
of its input (a list of DataFrames) to prevent this sort of problem,
but apparently this is not enough: the copied list still references
the same DataFrames.

https://github.com/probabl-ai/skore/blob/9bbfdb34fc8a62555aa8d3cc79a8f914dd22dd43/skore/src/skore/sklearn/_comparison/utils.py#L295
