### PR TITLE
fix: Leverage `get_scorer` and the fact it is a `_BaseScorer`

### DIFF
--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -83,13 +83,18 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             provided when creating the report.
 
         scoring : list of str, callable, or scorer, default=None
-            The metrics to report. You can get the possible list of strings by calling
-            `report.metrics.help()`. When passing a callable, it should take as
-            arguments ``y_true``, ``y_pred`` as the two first arguments. Additional
-            arguments can be passed as keyword arguments and will be forwarded with
-            `scoring_kwargs`. If the callable API is too restrictive (e.g. need to pass
-            same parameter name with different values), you can use scikit-learn scorers
-            as provided by :func:`sklearn.metrics.make_scorer`.
+            The metrics to report. The possible values in the list are:
+
+            - if a string, either one of the built-in metrics or a scikit-learn scorer
+              name. You can get the possible list of string using
+              `report.metrics.help()` or :func:`sklearn.metrics.get_scorer_names` for
+              the built-in metrics or the scikit-learn scorers, respectively.
+            - if a callable, it should take as arguments `y_true`, `y_pred` as the two
+              first arguments. Additional arguments can be passed as keyword arguments
+              and will be forwarded with `scoring_kwargs`.
+            - if the callable API is too restrictive (e.g. need to pass
+              same parameter name with different values), you can use scikit-learn
+              scorers as provided by :func:`sklearn.metrics.make_scorer`.
 
         scoring_names : list of str, default=None
             Used to overwrite the default scoring names in the report. It should be of

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -83,13 +83,18 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             provided when creating the report.
 
         scoring : list of str, callable, or scorer, default=None
-            The metrics to report. You can get the possible list of string by calling
-            `report.metrics.help()`. When passing a callable, it should take as
-            arguments `y_true`, `y_pred` as the two first arguments. Additional
-            arguments can be passed as keyword arguments and will be forwarded with
-            `scoring_kwargs`. If the callable API is too restrictive (e.g. need to pass
-            same parameter name with different values), you can use scikit-learn scorers
-            as provided by :func:`sklearn.metrics.make_scorer`.
+            The metrics to report. The possible values in the list are:
+
+            - if a string, either one of the built-in metrics or a scikit-learn scorer
+              name. You can get the possible list of string using
+              `report.metrics.help()` or :func:`sklearn.metrics.get_scorer_names` for
+              the built-in metrics or the scikit-learn scorers, respectively.
+            - if a callable, it should take as arguments `y_true`, `y_pred` as the two
+              first arguments. Additional arguments can be passed as keyword arguments
+              and will be forwarded with `scoring_kwargs`.
+            - if the callable API is too restrictive (e.g. need to pass
+              same parameter name with different values), you can use scikit-learn
+              scorers as provided by :func:`sklearn.metrics.make_scorer`.
 
         scoring_names : list of str, default=None
             Used to overwrite the default scoring names in the report. It should be of

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -202,7 +202,6 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                 (metric.startswith("_") and metric[1:] in self._SCORE_OR_LOSS_INFO)
                 or metric in self._SCORE_OR_LOSS_INFO
             ):
-                # Potentially a scikit-learn metric
                 try:
                     metric = metrics.get_scorer(metric)
                 except ValueError as err:
@@ -213,6 +212,13 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                         f"{list(self._SCORE_OR_LOSS_INFO.keys())} "
                         "or a valid scikit-learn scoring string."
                     ) from err
+                if scoring_kwargs is not None:
+                    raise ValueError(
+                        "The `scoring_kwargs` parameter is not supported when "
+                        "`scoring` is a scikit-learn scorer name. Use the function "
+                        "`sklearn.metrics.make_scorer` to create a scorer with "
+                        "additional parameters."
+                    )
 
             # NOTE: we have to check specifically for `_BaseScorer` first because this
             # is also a callable but it has a special private API that we can leverage

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -90,13 +90,18 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
             provided when creating the report.
 
         scoring : list of str, callable, or scorer, default=None
-            The metrics to report. You can get the possible list of string by calling
-            `report.metrics.help()`. When passing a callable, it should take as
-            arguments `y_true`, `y_pred` as the two first arguments. Additional
-            arguments can be passed as keyword arguments and will be forwarded with
-            `scoring_kwargs`. If the callable API is too restrictive (e.g. need to pass
-            same parameter name with different values), you can use scikit-learn scorers
-            as provided by :func:`sklearn.metrics.make_scorer`.
+            The metrics to report. The possible values in the list are:
+
+            - if a string, either one of the built-in metrics or a scikit-learn scorer
+              name. You can get the possible list of string using
+              `report.metrics.help()` or :func:`sklearn.metrics.get_scorer_names` for
+              the built-in metrics or the scikit-learn scorers, respectively.
+            - if a callable, it should take as arguments `y_true`, `y_pred` as the two
+              first arguments. Additional arguments can be passed as keyword arguments
+              and will be forwarded with `scoring_kwargs`.
+            - if the callable API is too restrictive (e.g. need to pass
+              same parameter name with different values), you can use scikit-learn
+              scorers as provided by :func:`sklearn.metrics.make_scorer`.
 
         scoring_names : list of str, default=None
             Used to overwrite the default scoring names in the report. It should be of
@@ -138,14 +143,13 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         Recall                 0.93...         (↗︎)
         ROC AUC                0.99...         (↗︎)
         Brier score            0.03...         (↘︎)
-
         >>> # Using scikit-learn metrics
         >>> report.metrics.report_metrics(
-        scoring=["neg_log_loss"],
-        indicator_favorability=True)
-                    LogisticRegression Favorability
-        Metric
-        Negative Log Loss      -0.10...        (↘︎)
+        ...     scoring=["f1"], pos_label=1, indicator_favorability=True
+        ... )
+                                  LogisticRegression Favorability
+        Metric   Label / Average
+        F1 Score 1                              0.96...      (↗︎)
         """
         if data_source == "X_y":
             # optimization of the hash computation to avoid recomputing it
@@ -238,7 +242,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                         metrics_kwargs["pos_label"] = pos_label
                 if metric_name is None:
                     metric_name = metric._score_func.__name__.replace("_", " ").title()
-                metric_favorability = "↗︎" if metric._sign == 1 else "↘︎"
+                metric_favorability = "(↗︎)" if metric._sign == 1 else "(↘︎)"
                 favorability_indicator.append(metric_favorability)
             elif isinstance(metric, str) or callable(metric):
                 if isinstance(metric, str):

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -149,7 +149,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         ... )
                                   LogisticRegression Favorability
         Metric   Label / Average
-        F1 Score 1                              0.96...      (↗︎)
+        F1 Score               1             0.96...          (↗︎)
         """
         if data_source == "X_y":
             # optimization of the hash computation to avoid recomputing it

--- a/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
@@ -885,7 +885,7 @@ def test_cross_validation_report_custom_metric(binary_classification_data):
         response_method="predict",
     )
     assert result.shape == (1, 2)
-    assert result.index == ["accuracy_score"]
+    assert result.index == ["Accuracy Score"]
 
 
 @pytest.mark.parametrize(
@@ -936,7 +936,7 @@ def test_cross_validation_report_interrupted(
         response_method="predict",
     )
     assert result.shape == (1, 2)
-    assert result.index == ["accuracy_score"]
+    assert result.index == ["Accuracy Score"]
 
 
 def test_cross_validation_report_brier_score_requires_probabilities():

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -15,7 +15,6 @@ from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import (
     accuracy_score,
     f1_score,
-    get_scorer,
     make_scorer,
     median_absolute_error,
     r2_score,
@@ -1349,25 +1348,11 @@ def test_estimator_report_average_return_float(binary_classification_data):
 def test_estimator_report_metric_with_neg_metrics(binary_classification_data):
     """Check that scikit-learn metrics with 'neg_' prefix are handled correctly."""
     classifier, X_test, y_test = binary_classification_data
-    report = EstimatorReport(
-        classifier,
-        X_test=X_test,
-        y_test=y_test,
-    )
+    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
 
-    # Use scikit-learn's get_scorer to handle neg_log_loss
-    scorer = get_scorer("neg_log_loss")
-    result = report.metrics.report_metrics(scoring=[scorer])
-
-    # Check that the metric name is displayed properly (as 'log_loss')
-    assert "log_loss" in result.index
-
-    # Get the neg_log_loss score directly - use the fitted model from the report
-    neg_log_loss_value = get_scorer("neg_log_loss")(report.estimator_, X_test, y_test)
-
-    # Check that the reported log_loss matches the absolute value of neg_log_loss
-    log_loss_value = result.loc["log_loss", classifier.__class__.__name__]
-    assert np.isclose(log_loss_value, abs(neg_log_loss_value))
+    result = report.metrics.report_metrics(scoring=["neg_log_loss"])
+    assert "Log Loss" in result.index
+    assert result.loc["Log Loss", "RandomForestClassifier"] == report.metrics.log_loss()
 
 
 def test_estimator_report_with_sklearn_scoring_strings(binary_classification_data):
@@ -1379,11 +1364,9 @@ def test_estimator_report_with_sklearn_scoring_strings(binary_classification_dat
         y_test=y_test,
     )
 
-    # Test single scikit-learn metric string
     result = class_report.metrics.report_metrics(scoring=["neg_log_loss"])
     assert "Log Loss" in result.index.get_level_values(0)
 
-    # Test with multiple scikit-learn metrics
     result_multi = class_report.metrics.report_metrics(
         scoring=["accuracy", "neg_log_loss", "roc_auc"], indicator_favorability=True
     )
@@ -1391,7 +1374,6 @@ def test_estimator_report_with_sklearn_scoring_strings(binary_classification_dat
     assert "Log Loss" in result_multi.index.get_level_values(0)
     assert "ROC AUC" in result_multi.index.get_level_values(0)
 
-    # Test favorability indicators
     favorability = result_multi.loc["Accuracy"]["Favorability"]
     assert favorability == "(↗︎)"
     favorability = result_multi.loc["Log Loss"]["Favorability"]
@@ -1401,13 +1383,8 @@ def test_estimator_report_with_sklearn_scoring_strings(binary_classification_dat
 def test_estimator_report_with_sklearn_scoring_strings_regression(regression_data):
     """Test scikit-learn regression metric strings in report_metrics."""
     regressor, X_test, y_test = regression_data
-    reg_report = EstimatorReport(
-        regressor,
-        X_test=X_test,
-        y_test=y_test,
-    )
+    reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
 
-    # Test regression metrics
     reg_result = reg_report.metrics.report_metrics(
         scoring=["neg_mean_squared_error", "neg_mean_absolute_error", "r2"],
         indicator_favorability=True,
@@ -1417,7 +1394,6 @@ def test_estimator_report_with_sklearn_scoring_strings_regression(regression_dat
     assert "Mean Absolute Error" in reg_result.index.get_level_values(0)
     assert "R²" in reg_result.index.get_level_values(0)
 
-    # Check favorability
     assert reg_result.loc["Mean Squared Error"]["Favorability"] == "(↘︎)"
     assert reg_result.loc["R²"]["Favorability"] == "(↗︎)"
 
@@ -1425,13 +1401,8 @@ def test_estimator_report_with_sklearn_scoring_strings_regression(regression_dat
 def test_estimator_report_with_scoring_strings_regression(regression_data):
     """Test scikit-learn regression metric strings in report_metrics."""
     regressor, X_test, y_test = regression_data
-    reg_report = EstimatorReport(
-        regressor,
-        X_test=X_test,
-        y_test=y_test,
-    )
+    reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
 
-    # Test regression metrics
     reg_result = reg_report.metrics.report_metrics(
         scoring=["neg_mean_squared_error", "neg_mean_absolute_error", "r2"],
         indicator_favorability=True,
@@ -1441,6 +1412,5 @@ def test_estimator_report_with_scoring_strings_regression(regression_data):
     assert "Mean Absolute Error" in reg_result.index.get_level_values(0)
     assert "R²" in reg_result.index.get_level_values(0)
 
-    # Check favorability
     assert reg_result.loc["Mean Squared Error"]["Favorability"] == "(↘︎)"
     assert reg_result.loc["R²"]["Favorability"] == "(↗︎)"


### PR DESCRIPTION
closes https://github.com/probabl-ai/skore/issues/1715
closes #1714
closes https://github.com/probabl-ai/skore/pull/1716
closes https://github.com/probabl-ai/skore/issues/1686

This PR:

- fixes the way we handle scikit-learn scorer names
- update the API documentation to provide the difference between built-in metrics and scikit-learn scorer names
- fixes the tests that are available
- add more tests for metrics that takes additional parameters