### PR TITLE
docs: Fix internal links

### DIFF
--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -16,6 +16,8 @@ SPHINXOPTS  ?=
 SPHINXBUILD ?= sphinx-build
 SOURCEDIR   = .
 BUILDDIR    = build
+# https://github.com/sphinx-doc/sphinx/issues/8664#issuecomment-757087741
+SPHINX_APIDOC_OPTIONS = members,show-inheritance
 
 # Build the docs without the examples, which can take a long time to run
 # From https://sphinx-gallery.github.io/stable/advanced.html#id4

--- a/sphinx/_templates/base.rst
+++ b/sphinx/_templates/base.rst
@@ -9,7 +9,6 @@
 .. currentmodule:: {{ module }}
 
 .. autofunction:: {{ objname }}
-   :noindex:
 
 .. minigallery:: {{ module }}.{{ objname }}
    :add-heading: Gallery examples
@@ -23,7 +22,6 @@
    :members:
    :inherited-members:
    :special-members: __call__
-   :noindex:
 
 .. minigallery:: {{ module }}.{{ objname }} {% for meth in methods %}{{ module }}.{{ objname }}.{{ meth }} {% endfor %}
    :add-heading: Gallery examples

--- a/sphinx/reference/report/index.rst
+++ b/sphinx/reference/report/index.rst
@@ -43,7 +43,7 @@ scikit-learn estimators by cross-validation, and reporting the results.
    cross_validation_report
 
 Comparison Report
------------------------
+-----------------
 
 :class:`skore.ComparisonReport` provides comprehensive capabilities for comparing
 :class:`skore.EstimatorReport` instances, and reporting the results.


### PR DESCRIPTION
This fixes an issue where internal links to API docs were no longer recognized as links.

The bug originates from https://github.com/probabl-ai/skore/commit/830f2614ee943a853165bceba048c2eae856c1d8, which intended to remove sphinx warnings about "duplicate object descriptions".

https://github.com/sphinx-doc/sphinx/issues/8664 discusses these warnings, and applying the solution described in https://github.com/sphinx-doc/sphinx/issues/8664#issuecomment-757087741 resolves the issue (warnings disappear and links still work).