### PR TITLE
fix: Log loss only available with estimator exposing predict_proba

### DIFF
--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1189,8 +1189,16 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         )
 
     @available_if(
-        _check_supported_ml_task(
-            supported_ml_tasks=["binary-classification", "multiclass-classification"]
+        _check_all_checks(
+            checks=[
+                _check_supported_ml_task(
+                    supported_ml_tasks=[
+                        "binary-classification",
+                        "multiclass-classification",
+                    ]
+                ),
+                _check_estimator_has_method(method_name="predict_proba"),
+            ]
         )
     )
     def _log_loss(

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -1297,12 +1297,14 @@ def test_estimator_has_no_deep_copy():
         )
 
 
-def test_estimator_report_brier_score_requires_probabilities():
-    """Check that the Brier score is not defined for estimator that do not
-    implement `predict_proba`.
+@pytest.mark.parametrize("metric", ["brier_score", "log_loss"])
+def test_estimator_report_brier_log_loss_requires_probabilities(metric):
+    """Check that the Brier score and the Log loss is not defined for estimator
+    that do not implement `predict_proba`.
 
     Non-regression test for:
     https://github.com/probabl-ai/skore/pull/1471
+    https://github.com/probabl-ai/skore/issues/1736
     """
     estimator = SVC()  # SVC does not implement `predict_proba` with default parameters
     X, y = make_classification(n_classes=2, random_state=42)
@@ -1311,7 +1313,7 @@ def test_estimator_report_brier_score_requires_probabilities():
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-    assert not hasattr(report.metrics, "brier_score")
+    assert not hasattr(report.metrics, metric)
 
 
 def test_estimator_report_brier_score_requires_binary_classification():


### PR DESCRIPTION
closes https://github.com/probabl-ai/skore/issues/1736

This PR is making sure that we expose the `log_loss` only for estimator exposing a `predict_proba` method.