### PR TITLE
docs(skore): Add Project.reports methods to the documentation

### DIFF
--- a/skore/src/skore/project/__init__.py
+++ b/skore/src/skore/project/__init__.py
@@ -1,9 +1,5 @@
 """Alias top level function and class of the project submodule."""
 
-from skore.externals._pandas_accessors import _register_accessor
 from skore.project.project import Project
-from skore.project.reports import _ReportsAccessor
-
-_register_accessor("reports", Project)(_ReportsAccessor)
 
 __all__ = ["Project"]

--- a/skore/src/skore/project/__init__.py
+++ b/skore/src/skore/project/__init__.py
@@ -1,5 +1,9 @@
 """Alias top level function and class of the project submodule."""
 
-from .project import Project
+from skore.externals._pandas_accessors import _register_accessor
+from skore.project.project import Project
+from skore.project.reports import _ReportsAccessor
+
+_register_accessor("reports", Project)(_ReportsAccessor)
 
 __all__ = ["Project"]

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -4,18 +4,21 @@ from __future__ import annotations
 
 import re
 import sys
-import types
+from typing import TYPE_CHECKING
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
 else:
     from importlib.metadata import entry_points
 
-from ..sklearn._estimator.report import EstimatorReport
-from .metadata import Metadata
+from skore.externals._pandas_accessors import DirNamesMixin
+from skore.sklearn._estimator.report import EstimatorReport
+
+if TYPE_CHECKING:
+    from skore.project.reports import _ReportsAccessor
 
 
-class Project:
+class Project(DirNamesMixin):
     r"""
     API to manage a collection of key-report pairs.
 
@@ -146,6 +149,7 @@ class Project:
     """
 
     __HUB_NAME_PATTERN = re.compile(r"hub://(?P<tenant>[^/]+)/(?P<name>.+)")
+    reports: _ReportsAccessor
 
     def __init__(self, name: str, **kwargs):
         if not (PLUGINS := entry_points(group="skore.plugins.project")):
@@ -207,20 +211,6 @@ class Project:
             )
 
         return self.__project.put(key=key, report=report)
-
-    @property
-    def reports(self):
-        """Accessor for interaction with the persisted reports."""
-
-        def get(id: str) -> EstimatorReport:  # hide underlying functions from user
-            """Get a persisted report by its id."""
-            return self.__project.reports.get(id)
-
-        def metadata() -> Metadata:  # hide underlying functions from user
-            """Obtain metadata/metrics for all persisted reports."""
-            return Metadata.factory(self.__project)
-
-        return types.SimpleNamespace(get=get, metadata=metadata)
 
     def __repr__(self) -> str:  # noqa: D105
         return self.__project.__repr__()

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
@@ -14,9 +14,6 @@ else:
 from skore.externals._pandas_accessors import DirNamesMixin, _register_accessor
 from skore.project.reports import _ReportsAccessor
 from skore.sklearn._estimator.report import EstimatorReport
-
-if TYPE_CHECKING:
-    from skore.project.reports import _ReportsAccessor
 
 
 class Project(DirNamesMixin):

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
@@ -150,6 +150,9 @@ class Project(DirNamesMixin):
 
     __HUB_NAME_PATTERN = re.compile(r"hub://(?P<tenant>[^/]+)/(?P<name>.+)")
     reports: _ReportsAccessor
+    _Project__project: Any
+    _Project__mode: str
+    _Project__name: str
 
     def __init__(self, name: str, **kwargs):
         if not (PLUGINS := entry_points(group="skore.plugins.project")):

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -11,7 +11,8 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import entry_points
 
-from skore.externals._pandas_accessors import DirNamesMixin
+from skore.externals._pandas_accessors import DirNamesMixin, _register_accessor
+from skore.project.reports import _ReportsAccessor
 from skore.sklearn._estimator.report import EstimatorReport
 
 if TYPE_CHECKING:
@@ -217,3 +218,6 @@ class Project(DirNamesMixin):
 
     def __repr__(self) -> str:  # noqa: D105
         return self.__project.__repr__()
+
+
+_register_accessor("reports", Project)(_ReportsAccessor)

--- a/skore/src/skore/project/reports.py
+++ b/skore/src/skore/project/reports.py
@@ -9,13 +9,13 @@ from skore.sklearn import EstimatorReport
 class _ReportsAccessor(DirNamesMixin):
     """Accessor for interaction with the persisted reports."""
 
-    def __init__(self, project: Project) -> None:
-        self.__project = project
+    def __init__(self, parent: Project) -> None:
+        self._parent = parent
 
     def get(self, id: str) -> EstimatorReport:  # hide underlying functions from user
         """Get a persisted report by its id."""
-        return self.__project.reports.get(id)
+        return self._parent._Project__project.reports.get(id)
 
     def metadata(self) -> Metadata:  # hide underlying functions from user
         """Obtain metadata/metrics for all persisted reports."""
-        return Metadata.factory(self.__project)
+        return Metadata.factory(self._parent._Project__project)

--- a/skore/src/skore/project/reports.py
+++ b/skore/src/skore/project/reports.py
@@ -1,0 +1,21 @@
+"""Module to manage the persisted reports."""
+
+from skore.externals._pandas_accessors import DirNamesMixin
+from skore.project import Project
+from skore.project.metadata import Metadata
+from skore.sklearn import EstimatorReport
+
+
+class _ReportsAccessor(DirNamesMixin):
+    """Accessor for interaction with the persisted reports."""
+
+    def __init__(self, project: Project) -> None:
+        self.__project = project
+
+    def get(self, id: str) -> EstimatorReport:  # hide underlying functions from user
+        """Get a persisted report by its id."""
+        return self.__project.reports.get(id)
+
+    def metadata(self) -> Metadata:  # hide underlying functions from user
+        """Obtain metadata/metrics for all persisted reports."""
+        return Metadata.factory(self.__project)

--- a/skore/src/skore/project/reports.py
+++ b/skore/src/skore/project/reports.py
@@ -1,9 +1,15 @@
 """Module to manage the persisted reports."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from skore.externals._pandas_accessors import DirNamesMixin
-from skore.project import Project
-from skore.project.metadata import Metadata
-from skore.sklearn import EstimatorReport
+
+if TYPE_CHECKING:
+    from skore.project import Project
+    from skore.project.metadata import Metadata
+    from skore.sklearn import EstimatorReport
 
 
 class _ReportsAccessor(DirNamesMixin):

--- a/skore/src/skore/project/reports.py
+++ b/skore/src/skore/project/reports.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from skore.externals._pandas_accessors import DirNamesMixin
+from skore.project.metadata import Metadata
 
 if TYPE_CHECKING:
     from skore.project import Project
-    from skore.project.metadata import Metadata
     from skore.sklearn import EstimatorReport
 
 

--- a/skore/tests/unit/project/test_project.py
+++ b/skore/tests/unit/project/test_project.py
@@ -1,5 +1,4 @@
 from sys import version_info
-from types import SimpleNamespace
 from unittest.mock import Mock
 
 from pytest import fixture, raises
@@ -148,7 +147,7 @@ class TestProject:
     def test_reports(self):
         project = Project("<name>")
 
-        assert isinstance(project.reports, SimpleNamespace)
+        assert hasattr(project, "reports")
         assert hasattr(project.reports, "get")
         assert hasattr(project.reports, "metadata")
 

--- a/sphinx/reference/project.rst
+++ b/sphinx/reference/project.rst
@@ -11,4 +11,16 @@ These functions and classes are meant for managing a Project and its reports.
 
     Project
     Project.put
-    Project.reports
+
+.. autosummary::
+   :toctree: ../api/
+   :template: autosummary/accessor.rst
+
+   Project.reports
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/accessor_method.rst
+
+   Project.reports.get
+   Project.reports.metadata


### PR DESCRIPTION
Change `Project.reports` from `types.SimpleNamespace` to `pandas` style accessor, to let sphinx documents:

- `Project.reports.get`
- `Project.reports.metadata`