### PR TITLE
chore: Fix warning in sphinx about duplicate object

### DIFF
--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -30,33 +30,33 @@ class Project:
     Two mutually exclusive modes are available and can be configured using the ``name``
     parameter of the constructor:
 
-    - mode : hub
+    .. rubric:: Local mode
 
-        If the ``name`` takes the form of the URI ``hub://<tenant>/<name>``, the project
-        is configured to the ``hub`` mode to communicate with the ``skore hub``.
+    Otherwise, the project is configured to the ``local`` mode to be persisted on
+    the user machine in a directory called ``workspace``.
 
-        A tenant is a ``skore hub`` concept that must be configured on the ``skore hub``
-        interface. It represents an isolated entity managing users, projects, and
-        resources. It can be a company, organization, or team that operates
-        independently within the system.
+    The workspace can be shared between all the projects.
+    The workspace can be set using kwargs or the envar ``SKORE_WORKSPACE``.
+    If not, it will be by default set to a ``skore/`` directory in the USER
+    cache directory:
 
-        In this mode, you must have an account to the ``skore hub`` and must be
-        authorized to the specified tenant. You must also be authenticated beforehand,
-        using the ``skore-hub-login`` CLI.
+    - in Windows, usually ``C:\Users\%USER%\AppData\Local\skore``,
+    - in Linux, usually ``${HOME}/.cache/skore``,
+    - in macOS, usually ``${HOME}/Library/Caches/skore``.
 
-    - mode : local
+    .. rubric:: Hub mode
 
-        Otherwise, the project is configured to the ``local`` mode to be persisted on
-        the user machine in a directory called ``workspace``.
+    If the ``name`` takes the form of the URI ``hub://<tenant>/<name>``, the project
+    is configured to the ``hub`` mode to communicate with the ``skore hub``.
 
-        The workspace can be shared between all the projects.
-        The workspace can be set using kwargs or the envar ``SKORE_WORKSPACE``.
-        If not, it will be by default set to a ``skore/`` directory in the USER
-        cache directory:
+    A tenant is a ``skore hub`` concept that must be configured on the ``skore hub``
+    interface. It represents an isolated entity managing users, projects, and
+    resources. It can be a company, organization, or team that operates
+    independently within the system.
 
-        - in Windows, usually ``C:\Users\%USER%\AppData\Local\skore``,
-        - in Linux, usually ``${HOME}/.cache/skore``,
-        - in macOS, usually ``${HOME}/Library/Caches/skore``.
+    In this mode, you must have an account to the ``skore hub`` and must be
+    authorized to the specified tenant. You must also be authenticated beforehand,
+    using the ``skore-hub-login`` CLI.
 
     Parameters
     ----------

--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -30,20 +30,6 @@ class Project:
     Two mutually exclusive modes are available and can be configured using the ``name``
     parameter of the constructor:
 
-    .. rubric:: Local mode
-
-    Otherwise, the project is configured to the ``local`` mode to be persisted on
-    the user machine in a directory called ``workspace``.
-
-    The workspace can be shared between all the projects.
-    The workspace can be set using kwargs or the envar ``SKORE_WORKSPACE``.
-    If not, it will be by default set to a ``skore/`` directory in the USER
-    cache directory:
-
-    - in Windows, usually ``C:\Users\%USER%\AppData\Local\skore``,
-    - in Linux, usually ``${HOME}/.cache/skore``,
-    - in macOS, usually ``${HOME}/Library/Caches/skore``.
-
     .. rubric:: Hub mode
 
     If the ``name`` takes the form of the URI ``hub://<tenant>/<name>``, the project
@@ -57,6 +43,20 @@ class Project:
     In this mode, you must have an account to the ``skore hub`` and must be
     authorized to the specified tenant. You must also be authenticated beforehand,
     using the ``skore-hub-login`` CLI.
+
+    .. rubric:: Local mode
+
+    Otherwise, the project is configured to the ``local`` mode to be persisted on
+    the user machine in a directory called ``workspace``.
+
+    The workspace can be shared between all the projects.
+    The workspace can be set using kwargs or the envar ``SKORE_WORKSPACE``.
+    If not, it will be by default set to a ``skore/`` directory in the USER
+    cache directory:
+
+    - in Windows, usually ``C:\Users\%USER%\AppData\Local\skore``,
+    - in Linux, usually ``${HOME}/.cache/skore``,
+    - in macOS, usually ``${HOME}/Library/Caches/skore``.
 
     Parameters
     ----------

--- a/skore/src/skore/sklearn/_comparison/report.py
+++ b/skore/src/skore/sklearn/_comparison/report.py
@@ -27,7 +27,8 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
     This object can be used to compare several :class:`skore.EstimatorReport` instances,
     or several :class:`~skore.CrossValidationReport` instances.
 
-    .. caution:: Reports passed to `ComparisonReport` are not copied. If you pass
+    .. caution::
+       Reports passed to `ComparisonReport` are not copied. If you pass
        a report to `ComparisonReport`, and then modify the report outside later, it
        will affect the report stored inside the `ComparisonReport` as well, which
        can lead to inconsistent results. For this reason, modifying reports after
@@ -49,8 +50,8 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
 
     Attributes
     ----------
-    reports_ : list of :class:`~skore.EstimatorReport` or list of
-               :class:`~skore.CrossValidationReport`
+    reports_ : list of :class:`~skore.EstimatorReport` or list \
+            of :class:`~skore.CrossValidationReport`
         The compared reports.
 
     report_names_ : list of str

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -101,6 +101,9 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     skore.EstimatorReport
         Report for a fitted estimator.
 
+    skore.ComparisonReport
+        Report of comparison between estimators.
+
     Examples
     --------
     >>> from sklearn.datasets import make_classification

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -67,8 +67,11 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
 
     See Also
     --------
-    skore.sklearn.cross_validation.report.CrossValidationReport
+    skore.CrossValidationReport
         Report of cross-validation results.
+
+    skore.ComparisonReport
+        Report of comparison between estimators.
 
     Examples
     --------

--- a/sphinx/_templates/autosummary/accessor.rst
+++ b/sphinx/_templates/autosummary/accessor.rst
@@ -3,3 +3,4 @@
 .. currentmodule:: {{ module.split('.')[0] }}
 
 .. autoaccessor:: {{ (module.split('.')[1:] + [objname]) | join('.') }}
+   :no-index:

--- a/sphinx/_templates/base.rst
+++ b/sphinx/_templates/base.rst
@@ -21,7 +21,6 @@
 .. autoclass:: {{ objname }}
    :members:
    :inherited-members:
-   :exclude-members: _*Accessor
    :special-members: __call__
 
 .. minigallery:: {{ module }}.{{ objname }} {% for meth in methods %}{{ module }}.{{ objname }}.{{ meth }} {% endfor %}

--- a/sphinx/_templates/base.rst
+++ b/sphinx/_templates/base.rst
@@ -21,6 +21,7 @@
 .. autoclass:: {{ objname }}
    :members:
    :inherited-members:
+   :exclude-members: _*Accessor
    :special-members: __call__
 
 .. minigallery:: {{ module }}.{{ objname }} {% for meth in methods %}{{ module }}.{{ objname }}.{{ meth }} {% endfor %}

--- a/sphinx/_templates/class_methods_no_index.rst
+++ b/sphinx/_templates/class_methods_no_index.rst
@@ -1,0 +1,6 @@
+{{ objname | escape | underline(line="=") }}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}
+   :no-index:

--- a/sphinx/reference/project.rst
+++ b/sphinx/reference/project.rst
@@ -10,5 +10,19 @@ These functions and classes are meant for managing a Project and its reports.
     :template: base.rst
 
     Project
+
+.. rubric:: Methods
+
+.. autosummary::
+   :toctree: ../api/
+   :template: class_methods_no_index.rst
+
     Project.put
+
+.. rubric:: Reports
+
+.. autosummary::
+   :toctree: ../api/
+   :template: autosummary/accessor.rst
+
     Project.reports

--- a/sphinx/reference/report/comparison_report.rst
+++ b/sphinx/reference/report/comparison_report.rst
@@ -3,22 +3,25 @@ Report for a comparison of :class:`EstimatorReport`
 
 .. currentmodule:: skore
 
-The class :class:`ComparisonReport` provides a report allowing to compare :class:`EstimatorReport` instances in an interactive way. The functionalities of the report are accessible through accessors.
+The class :class:`ComparisonReport` provides a report allowing to compare
+:class:`EstimatorReport` instances in an interactive way. The functionalities of the
+report are accessible through accessors.
 
 .. autosummary::
     :toctree: ../api/
     :template: base.rst
 
     ComparisonReport
-    ComparisonReport.cache_predictions
-    ComparisonReport.clear_cache
+
+.. rubric:: Methods
 
 .. autosummary::
     :toctree: ../api/
-    :nosignatures:
-    :template: autosummary/accessor_method.rst
+    :template: class_methods_no_index.rst
 
     ComparisonReport.help
+    ComparisonReport.cache_predictions
+    ComparisonReport.clear_cache
     ComparisonReport.get_predictions
 
 .. autosummary::
@@ -37,7 +40,6 @@ get the common performance metric representations.
 
 .. autosummary::
     :toctree: ../api/
-    :nosignatures:
     :template: autosummary/accessor_method.rst
 
     ComparisonReport.metrics.help

--- a/sphinx/reference/report/cross_validation_report.rst
+++ b/sphinx/reference/report/cross_validation_report.rst
@@ -17,7 +17,7 @@ functionalities of the report are exposed through accessors.
 
 .. autosummary::
    :toctree: ../api/
-   :template: autosummary/accessor_method.rst
+   :template: class_methods_no_index.rst
 
    CrossValidationReport.help
    CrossValidationReport.cache_predictions
@@ -40,7 +40,6 @@ estimator across cross-validation folds.
 
 .. autosummary::
     :toctree: ../api/
-    :nosignatures:
     :template: autosummary/accessor_method.rst
 
     CrossValidationReport.metrics.help

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -17,7 +17,7 @@ report are accessible through accessors.
 
 .. autosummary::
    :toctree: ../api/
-   :template: autosummary/accessor_method.rst
+   :template: class_methods_no_index.rst
 
    EstimatorReport.help
    EstimatorReport.cache_predictions
@@ -48,7 +48,6 @@ estimator.
 
 .. autosummary::
     :toctree: ../api/
-    :nosignatures:
     :template: autosummary/accessor_method.rst
 
     EstimatorReport.metrics.help
@@ -75,7 +74,6 @@ used to train your estimator.
 
 .. autosummary::
     :toctree: ../api/
-    :nosignatures:
     :template: autosummary/accessor_method.rst
 
     EstimatorReport.feature_importance.help


### PR DESCRIPTION
This PR tries to solve the issues regarding the warning raised by `sphinx`, e.g.

```
/Users/xxx/skore/src/skore/project/project.py:docstring of skore.Project.reports:1: WARNING: duplicate object description of skore.Project.reports, other instance in api/skore.Project.reports, use :no-index: for one of them
```

It solves as well a couple rendering issues spotted when debugging. It remains a single warning due to the `skore.Project` class but the current solution in conjunction with the changes proposed in https://github.com/probabl-ai/skore/pull/1740 will solve the issue.