### PR TITLE
fix: Make sure to not mutate cache during Parallel processing

### DIFF
--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -272,6 +272,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         total_iterations = len(response_methods) * len(pos_labels) * len(data_sources)
         progress.update(task, total=total_iterations)
 
+        # do not mutate directly `self._cache` during the execution of Parallel
         results_to_cache = {}
         for results in generator:
             for key, value, is_cached in results:

--- a/skore/src/skore/sklearn/_estimator/report.py
+++ b/skore/src/skore/sklearn/_estimator/report.py
@@ -271,11 +271,16 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         task = self._progress_info["current_task"]
         total_iterations = len(response_methods) * len(pos_labels) * len(data_sources)
         progress.update(task, total=total_iterations)
+
+        results_to_cache = {}
         for results in generator:
             for key, value, is_cached in results:
                 if not is_cached:
-                    self._cache[key] = value
+                    results_to_cache[key] = value
             progress.update(task, advance=1, refresh=True)
+
+        if results_to_cache:
+            self._cache.update(results_to_cache)
 
     def get_predictions(
         self,


### PR DESCRIPTION
We see some flakyness in https://github.com/probabl-ai/skore/actions/runs/15188333231/job/42714438658?pr=1593

I'm thinking that it could be due to this code: since we have a generator, we can modify `self._cache` before/during that it is consume by `Parallel`, making the pickling of the task to fail.

Let's see if it works.