### PR TITLE
feat(plots)!: Remove the ability to pass `ax`

### DIFF
--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -262,21 +262,11 @@ comparator.metrics.report_metrics(
 )
 
 # %%
-# Finally, we can even get the individual :class:`~skore.EstimatorReport` for each fold
-# from the cross-validation to make further analysis.
-# Here, we plot the actual vs predicted values for each fold.
-from itertools import zip_longest
+# Finally, we can even get a deeper understanding by analyzing each fold in the
+# :class:`~skore.CrossValidationReport`.
+# Here, we plot the actual-vs-predicted values for each fold.
 import matplotlib.pyplot as plt
 
-fig, axs = plt.subplots(ncols=2, nrows=3, figsize=(12, 18))
-for split_idx, (ax, estimator_report) in enumerate(
-    zip_longest(axs.flatten(), linear_model_report.estimator_reports_)
-):
-    if estimator_report is None:
-        ax.axis("off")
-        continue
-    estimator_report.metrics.prediction_error().plot(kind="actual_vs_predicted", ax=ax)
-    ax.set_title(f"Split #{split_idx + 1}")
-    ax.legend(loc="lower right")
+linear_model_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
 
 plt.tight_layout()

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -429,7 +429,6 @@ class PrecisionRecallCurveDisplay(
     @StyleDisplayMixin.style_plot
     def plot(
         self,
-        ax: Optional[Axes] = None,
         *,
         estimator_name: Optional[str] = None,
         pr_curve_kwargs: Optional[Union[dict[str, Any], list[dict[str, Any]]]] = None,
@@ -441,10 +440,6 @@ class PrecisionRecallCurveDisplay(
 
         Parameters
         ----------
-        ax : Matplotlib Axes, default=None
-            Axes object to plot on. If `None`, a new figure and axes is
-            created.
-
         estimator_name : str, default=None
             Name of the estimator used to plot the precision-recall curve. If
             `None`, we use the inferred name from the estimator.
@@ -480,7 +475,7 @@ class PrecisionRecallCurveDisplay(
         >>> display = report.metrics.precision_recall()
         >>> display.plot(pr_curve_kwargs={"color": "tab:red"})
         """
-        self.figure_, self.ax_ = (ax.figure, ax) if ax is not None else plt.subplots()
+        self.figure_, self.ax_ = plt.subplots()
 
         if pr_curve_kwargs is None:
             pr_curve_kwargs = self._default_pr_curve_kwargs

--- a/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/sklearn/_plot/metrics/prediction_error.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import colormaps
 from matplotlib.artist import Artist
-from matplotlib.axes import Axes
 from numpy.typing import NDArray
 from sklearn.utils.validation import _num_samples, check_array
 
@@ -381,7 +380,6 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
     @StyleDisplayMixin.style_plot
     def plot(
         self,
-        ax: Optional[Axes] = None,
         *,
         estimator_name: Optional[str] = None,
         kind: Literal[
@@ -452,7 +450,7 @@ class PredictionErrorDisplay(StyleDisplayMixin, HelpDisplayMixin):
         else:  # kind == "residual_vs_predicted"
             xlabel, ylabel = "Predicted values", "Residuals (actual - predicted)"
 
-        self.figure_, self.ax_ = (ax.figure, ax) if ax is not None else plt.subplots()
+        self.figure_, self.ax_ = plt.subplots()
 
         perfect_model_kwargs_validated = _validate_style_kwargs(
             {

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -511,7 +511,6 @@ class RocCurveDisplay(
     @StyleDisplayMixin.style_plot
     def plot(
         self,
-        ax: Optional[Axes] = None,
         *,
         estimator_name: Optional[str] = None,
         roc_curve_kwargs: Optional[Union[dict[str, Any], list[dict[str, Any]]]] = None,
@@ -525,10 +524,6 @@ class RocCurveDisplay(
 
         Parameters
         ----------
-        ax : matplotlib axes, default=None
-            Axes object to plot on. If `None`, a new figure and axes is
-            created.
-
         estimator_name : str, default=None
             Name of the estimator used to plot the ROC curve. If `None`, we use
             the inferred name from the estimator.
@@ -560,7 +555,7 @@ class RocCurveDisplay(
         >>> display = report.metrics.roc()
         >>> display.plot(roc_curve_kwargs={"color": "tab:red"})
         """
-        self.figure_, self.ax_ = (ax.figure, ax) if ax is not None else plt.subplots()
+        self.figure_, self.ax_ = plt.subplots()
 
         if roc_curve_kwargs is None:
             roc_curve_kwargs = self._default_roc_curve_kwargs

--- a/skore/tests/unit/sklearn/plot/test_common.py
+++ b/skore/tests/unit/sklearn/plot/test_common.py
@@ -93,31 +93,6 @@ def test_display_repr(pyplot, plot_func, estimator, dataset):
         ("prediction_error", LinearRegression(), make_regression(random_state=42)),
     ],
 )
-def test_display_provide_ax(pyplot, plot_func, estimator, dataset):
-    """Check that we can provide an ax to the plot method."""
-    X_train, X_test, y_train, y_test = train_test_split(*dataset, random_state=42)
-    report = EstimatorReport(
-        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
-    )
-    display = getattr(report.metrics, plot_func)()
-
-    _, ax = pyplot.subplots()
-    display.plot(ax=ax)
-    assert display.ax_ is ax
-
-
-@pytest.mark.parametrize(
-    "plot_func, estimator, dataset",
-    [
-        ("roc", LogisticRegression(), make_classification(random_state=42)),
-        (
-            "precision_recall",
-            LogisticRegression(),
-            make_classification(random_state=42),
-        ),
-        ("prediction_error", LinearRegression(), make_regression(random_state=42)),
-    ],
-)
 def test_display_protocol(pyplot, capsys, plot_func, estimator, dataset):
     """Check that the display object adheres to the Display protocol."""
 


### PR DESCRIPTION
Starting from https://github.com/probabl-ai/skore/pull/1669, it is sometimes possible to draw plots onto (a `ndarray` of) several Axes rather than just a single Axes. In fact, starting from https://github.com/probabl-ai/skore/pull/1720, the same data might be drawn on one or the other depending on user parameters.

In this context, allowing the user to pass `ax` might add too much complexity compared to how useful it might be; it is considered an advanced use-case which is difficult to motivate.

This PR thus removes the ability to pass user-created `ax`.