### PR TITLE
chore(all-packages): Remove upper bound on Python version

### DIFF
--- a/skore-hub-project/pyproject.toml
+++ b/skore-hub-project/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "skore-hub-project"
 dynamic = ["license", "readme", "version"]
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.9"
 maintainers = [{ name = "skore developers", email = "skore@signal.probabl.ai" }]
 dependencies = [
   "httpx",

--- a/skore-local-project/pyproject.toml
+++ b/skore-local-project/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "skore-local-project"
 dynamic = ["license", "readme", "version"]
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.9"
 maintainers = [{ name = "skore developers", email = "skore@signal.probabl.ai" }]
 dependencies = [
   "diskcache",

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -2,7 +2,7 @@
 name = "skore"
 description = "the scikit-learn sidekick"
 dynamic = ["license", "readme", "version"]
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.9"
 maintainers = [{ name = "skore developers", email = "skore@signal.probabl.ai" }]
 classifiers = [
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
This is in preparation for adding Python 3.13 as a supported (tested) version.