### PR TITLE
feat: Add pos_label directly to EstimatorReport constructor

### DIFF
--- a/examples/getting_started/plot_quick_start.py
+++ b/examples/getting_started/plot_quick_start.py
@@ -23,7 +23,12 @@ X, y = make_classification(n_classes=2, n_samples=20_000, n_informative=4)
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
 log_report = EstimatorReport(
-    LogisticRegression(), X_train=X_train, X_test=X_test, y_train=y_train, y_test=y_test
+    LogisticRegression(),
+    X_train=X_train,
+    X_test=X_test,
+    y_train=y_train,
+    y_test=y_test,
+    pos_label=1,
 )
 
 # %%
@@ -37,7 +42,7 @@ log_report.help()
 # Display the report metrics that was computed for you:
 
 # %%
-df_report_metrics = log_report.metrics.report_metrics(pos_label=1)
+df_report_metrics = log_report.metrics.report_metrics()
 df_report_metrics
 
 # %%
@@ -125,7 +130,7 @@ pprint(report_get)
 temp_dir.cleanup()
 # sphinx_gallery_end_ignore
 
-report_get[0].metrics.report_metrics(pos_label=1)
+report_get[0].metrics.report_metrics()
 
 # %%
 # .. seealso::

--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -56,7 +56,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 rf = RandomForestClassifier(random_state=0)
 
 rf_report = EstimatorReport(
-    rf, X_train=X_train, X_test=X_test, y_train=y_train, y_test=y_test
+    rf, X_train=X_train, X_test=X_test, y_train=y_train, y_test=y_test, pos_label=1
 )
 
 # %%
@@ -81,7 +81,7 @@ rf_report.help()
 # fit and prediction times):
 
 # %%
-rf_report.metrics.report_metrics(pos_label=1, indicator_favorability=True)
+rf_report.metrics.report_metrics(indicator_favorability=True)
 
 # %%
 # For inspection, we can also retrieve the predictions, on the train set for example
@@ -139,13 +139,13 @@ cv_report.help()
 # We display the mean and standard deviation for each metric:
 
 # %%
-cv_report.metrics.report_metrics(pos_label=1)
+cv_report.metrics.report_metrics()
 
 # %%
 # or by individual fold:
 
 # %%
-cv_report.metrics.report_metrics(aggregate=None, pos_label=1)
+cv_report.metrics.report_metrics(aggregate=None)
 
 # %%
 # We display the ROC curves for each fold:
@@ -159,7 +159,7 @@ roc_plot_cv.plot()
 # for example getting the report metrics for the first fold only:
 
 # %%
-cv_report.estimator_reports_[0].metrics.report_metrics(pos_label=1)
+cv_report.estimator_reports_[0].metrics.report_metrics()
 
 # %%
 # .. seealso::
@@ -205,7 +205,7 @@ comparator.help()
 # Let us display the result of our benchmark:
 
 # %%
-comparator.metrics.report_metrics(pos_label=1, indicator_favorability=True)
+comparator.metrics.report_metrics(indicator_favorability=True)
 
 # %%
 # Thus, we easily have the result of our benchmark for several recommended metrics.
@@ -326,7 +326,7 @@ pprint(report_get)
 temp_dir.cleanup()
 # sphinx_gallery_end_ignore
 
-report_get[0].metrics.report_metrics(pos_label=1)
+report_get[0].metrics.report_metrics()
 
 # sphinx_gallery_start_ignore
 temp_dir.cleanup()

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -13,8 +13,9 @@ quickly get insights from any scikit-learn estimator.
 # Loading our dataset and defining our estimator
 # ==============================================
 #
-# First, we load a dataset from skrub. Our goal is to predict if a healthcare manufacturing companies paid a
-# medical doctors or hospitals, in order to detect potential conflict of interest.
+# First, we load a dataset from skrub. Our goal is to predict if a healthcare
+# manufacturing companies paid a medical doctors or hospitals, in order to detect
+# potential conflict of interest.
 
 # %%
 from skrub.datasets import fetch_open_payments
@@ -46,8 +47,8 @@ pos_label, neg_label = "allowed", "disallowed"
 # and a validation set.
 from skore import train_test_split
 
-# If you have many dataframes to split on, you can always ask train_test_split to return a dictionary.
-# Remember, it needs to be passed as a keyword argument!
+# If you have many dataframes to split on, you can always ask train_test_split to return
+# a dictionary. Remember, it needs to be passed as a keyword argument!
 split_data = train_test_split(X=df, y=y, random_state=42, as_dict=True)
 
 # %%
@@ -78,7 +79,7 @@ estimator
 # detect that our estimator is unfitted and will fit it for us on the training data.
 from skore import EstimatorReport
 
-report = EstimatorReport(estimator, **split_data)
+report = EstimatorReport(estimator, **split_data, pos_label=pos_label)
 
 # %%
 #
@@ -105,7 +106,7 @@ report.metrics.help()
 import time
 
 start = time.time()
-metric_report = report.metrics.report_metrics(pos_label=pos_label)
+metric_report = report.metrics.report_metrics()
 end = time.time()
 metric_report
 
@@ -123,7 +124,7 @@ print(f"Time taken to compute the metrics: {end - start:.2f} seconds")
 # requesting the same metrics report again.
 
 start = time.time()
-metric_report = report.metrics.report_metrics(pos_label=pos_label)
+metric_report = report.metrics.report_metrics()
 end = time.time()
 metric_report
 
@@ -188,10 +189,7 @@ report.metrics.log_loss(data_source="train")
 
 start = time.time()
 metric_report = report.metrics.report_metrics(
-    data_source="X_y",
-    X=split_data["X_test"],
-    y=split_data["y_test"],
-    pos_label=pos_label,
+    data_source="X_y", X=split_data["X_test"], y=split_data["y_test"]
 )
 end = time.time()
 metric_report
@@ -208,10 +206,7 @@ print(f"Time taken to compute the metrics: {end - start:.2f} seconds")
 # %%
 start = time.time()
 metric_report = report.metrics.report_metrics(
-    data_source="X_y",
-    X=split_data["X_test"],
-    y=split_data["y_test"],
-    pos_label=pos_label,
+    data_source="X_y", X=split_data["X_test"], y=split_data["y_test"]
 )
 end = time.time()
 metric_report
@@ -298,7 +293,6 @@ print(f"Time taken to compute the cost: {end - start:.2f} seconds")
 report.metrics.report_metrics(
     scoring=["precision", "recall", operational_decision_cost],
     scoring_names=["Precision", "Recall", "Operational Decision Cost"],
-    pos_label=pos_label,
     scoring_kwargs={"amount": amount, "response_method": "predict"},
 )
 
@@ -310,7 +304,7 @@ report.metrics.report_metrics(
 # function.
 from sklearn.metrics import make_scorer, f1_score
 
-f1_scorer = make_scorer(f1_score, response_method="predict", pos_label=pos_label)
+f1_scorer = make_scorer(f1_score, response_method="predict")
 operational_decision_cost_scorer = make_scorer(
     operational_decision_cost, response_method="predict", amount=amount
 )
@@ -332,7 +326,7 @@ report.metrics.help()
 # %%
 #
 # Let's start by plotting the ROC curve for our binary classification task.
-display = report.metrics.roc(pos_label=pos_label)
+display = report.metrics.roc()
 display.plot()
 
 # %%
@@ -358,7 +352,7 @@ _ = display.ax_.set_title("Example of a ROC curve")
 # performance gain we can get.
 start = time.time()
 # we already trigger the computation of the predictions in a previous call
-display = report.metrics.roc(pos_label=pos_label)
+display = report.metrics.roc()
 display.plot()
 end = time.time()
 
@@ -372,7 +366,7 @@ report.clear_cache()
 
 # %%
 start = time.time()
-display = report.metrics.roc(pos_label=pos_label)
+display = report.metrics.roc()
 display.plot()
 end = time.time()
 
@@ -403,14 +397,15 @@ cm_display.plot()
 plt.show()
 
 # %%
-# More plotting options are available, check out the API on the confusion matrix for more information.
-# We can customize the display labels:
+# More plotting options are available, check out the API on the confusion matrix for
+# more information. We can customize the display labels:
 cm_display = report.metrics.confusion_matrix(display_labels=["Disallowed", "Allowed"])
 cm_display.plot()
 plt.show()
 
 # %%
-# Finally, the confusion matrix can also be exported as a pandas DataFrame for further analysis:
+# Finally, the confusion matrix can also be exported as a pandas DataFrame for further
+# analysis:
 cm_frame = cm_display.frame()
 cm_frame
 


### PR DESCRIPTION
Partially addressing #1749 
Partially addressing #1719

This PR allows the following demo to work:

```python
import skore
from skore import EstimatorReport, Project
from sklearn.datasets import fetch_openml
from skrub import tabular_learner

# %%
X, y = fetch_openml("adult", version=2, as_frame=True, return_X_y=True)

# %%
X_train, X_test, y_train, y_test = skore.train_test_split(
    X, y, random_state=1
)

# %%
baseline = tabular_learner('classification')
baseline_report = EstimatorReport(
    baseline,
    X_train=X_train,
    y_train=y_train,
    X_test=X_test,
    y_test=y_test,
    pos_label=">50K"
)
baseline_report.help()

# %%
# create project
project = Project(name="hub://Probabl/test-adult-pos-label")
# %%
project.put("baseline", baseline_report)
```

`pos_label` is passed together with `y` and can overwritten in the metric/plotting methods. But actually remove the need to encode the target if it is not 0/1 or -1/1 in the case of binary classification when we try to serialize the report to send it to the hub.