### PR TITLE
chore: Remove useless code

### DIFF
--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -326,12 +326,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             timings.index = timings.index.str.replace("_", " ").str.capitalize()
 
             # Add (s) to time measurements
-            new_index = []
-            for idx in timings.index:
-                if "time" in idx.lower():
-                    new_index.append(f"{idx} (s)")
-                else:
-                    new_index.append(idx)
+            new_index = [f"{idx} (s)" for idx in timings.index]
 
             timings.index = pd.Index(new_index)
 


### PR DESCRIPTION
Useless code in this function, where we filter on timing columns, while we are in a function with only timing.  
As a result, the line couldn't be covered in test.