### PR TITLE
api(skore): Rename metrics.report_metrics to metrics.summarize

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ cv_report.help()
 
 ```python
 # Display the report metrics that was computed for you:
-df_cv_report_metrics = cv_report.metrics.report_metrics()
-df_cv_report_metrics
+metrics_summary = cv_report.metrics.summarize()
+metrics_summary
 ```
 
 ```python

--- a/examples/getting_started/plot_quick_start.py
+++ b/examples/getting_started/plot_quick_start.py
@@ -42,8 +42,8 @@ log_report.help()
 # Display the report metrics that was computed for you:
 
 # %%
-df_report_metrics = log_report.metrics.report_metrics()
-df_report_metrics
+metrics_summary = log_report.metrics.summarize()
+metrics_summary
 
 # %%
 # Display the ROC curve that was generated for you:
@@ -130,7 +130,7 @@ pprint(report_get)
 temp_dir.cleanup()
 # sphinx_gallery_end_ignore
 
-report_get[0].metrics.report_metrics()
+report_get[0].metrics.summarize()
 
 # %%
 # .. seealso::

--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -81,7 +81,7 @@ rf_report.help()
 # fit and prediction times):
 
 # %%
-rf_report.metrics.report_metrics(indicator_favorability=True)
+rf_report.metrics.summarize(indicator_favorability=True)
 
 # %%
 # For inspection, we can also retrieve the predictions, on the train set for example
@@ -139,13 +139,13 @@ cv_report.help()
 # We display the mean and standard deviation for each metric:
 
 # %%
-cv_report.metrics.report_metrics()
+cv_report.metrics.summarize()
 
 # %%
 # or by individual fold:
 
 # %%
-cv_report.metrics.report_metrics(aggregate=None)
+cv_report.metrics.summarize(aggregate=None)
 
 # %%
 # We display the ROC curves for each fold:
@@ -159,7 +159,7 @@ roc_plot_cv.plot()
 # for example getting the report metrics for the first fold only:
 
 # %%
-cv_report.estimator_reports_[0].metrics.report_metrics()
+cv_report.estimator_reports_[0].metrics.summarize()
 
 # %%
 # .. seealso::
@@ -205,7 +205,7 @@ comparator.help()
 # Let us display the result of our benchmark:
 
 # %%
-comparator.metrics.report_metrics(indicator_favorability=True)
+comparator.metrics.summarize(indicator_favorability=True)
 
 # %%
 # Thus, we easily have the result of our benchmark for several recommended metrics.
@@ -326,7 +326,7 @@ pprint(reports_get)
 
 # %%
 comparator = ComparisonReport(reports=reports_get)
-comparator.metrics.report_metrics(pos_label=1, indicator_favorability=True)
+comparator.metrics.summarize(pos_label=1, indicator_favorability=True)
 
 # %%
 # We can retrieve any accessor of our stored estimator reports, for example

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -102,11 +102,11 @@ report.metrics.help()
 # performance of our model on the validation set that we provided. We can access it
 # by calling any of the metrics displayed above. Since we are greedy, we want to get
 # several metrics at once and we will use the
-# :meth:`~skore.EstimatorReport.metrics.report_metrics` method.
+# :meth:`~skore.EstimatorReport.metrics.summarize` method.
 import time
 
 start = time.time()
-metric_report = report.metrics.report_metrics()
+metric_report = report.metrics.summarize()
 end = time.time()
 metric_report
 
@@ -124,7 +124,7 @@ print(f"Time taken to compute the metrics: {end - start:.2f} seconds")
 # requesting the same metrics report again.
 
 start = time.time()
-metric_report = report.metrics.report_metrics()
+metric_report = report.metrics.summarize()
 end = time.time()
 metric_report
 
@@ -188,7 +188,7 @@ report.metrics.log_loss(data_source="train")
 # a `X` and `y` parameters.
 
 start = time.time()
-metric_report = report.metrics.report_metrics(
+metric_report = report.metrics.summarize(
     data_source="X_y", X=split_data["X_test"], y=split_data["y_test"]
 )
 end = time.time()
@@ -205,7 +205,7 @@ print(f"Time taken to compute the metrics: {end - start:.2f} seconds")
 
 # %%
 start = time.time()
-metric_report = report.metrics.report_metrics(
+metric_report = report.metrics.summarize(
     data_source="X_y", X=split_data["X_test"], y=split_data["y_test"]
 )
 end = time.time()
@@ -290,7 +290,7 @@ print(f"Time taken to compute the cost: {end - start:.2f} seconds")
 # We observe that caching is working as expected. It is really handy because it means
 # that we can compute some additional metrics without having to recompute the
 # the predictions.
-report.metrics.report_metrics(
+report.metrics.summarize(
     scoring=["precision", "recall", operational_decision_cost],
     scoring_names=["Precision", "Recall", "Operational Decision Cost"],
     scoring_kwargs={"amount": amount, "response_method": "predict"},
@@ -308,7 +308,7 @@ f1_scorer = make_scorer(f1_score, response_method="predict")
 operational_decision_cost_scorer = make_scorer(
     operational_decision_cost, response_method="predict", amount=amount
 )
-report.metrics.report_metrics(
+report.metrics.summarize(
     scoring=[f1_scorer, operational_decision_cost_scorer],
     scoring_names=["F1 Score", "Operational Decision Cost"],
 )

--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -272,7 +272,7 @@ report.help()
 # exposed.
 # The first call will be slow because it computes the predictions for each fold.
 start = time.time()
-result = report.metrics.report_metrics()
+result = report.metrics.summarize()
 end = time.time()
 result
 
@@ -283,7 +283,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 #
 # But the subsequent calls are fast because the predictions are cached.
 start = time.time()
-result = report.metrics.report_metrics()
+result = report.metrics.summarize()
 end = time.time()
 result
 

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -117,7 +117,7 @@ hgbt_model_report.cache_predictions(n_jobs=4)
 # %%
 #
 # We can now have a look at the performance of the model with some standard metrics.
-hgbt_model_report.metrics.report_metrics()
+hgbt_model_report.metrics.summarize()
 
 
 # %%
@@ -226,7 +226,7 @@ with warnings.catch_warnings():
 
 # %%
 # We can now have a look at the performance of the model with some standard metrics.
-linear_model_report.metrics.report_metrics(indicator_favorability=True)
+linear_model_report.metrics.summarize(indicator_favorability=True)
 
 # %%
 # Comparing the models
@@ -239,7 +239,7 @@ linear_model_report.metrics.report_metrics(indicator_favorability=True)
 from skore import ComparisonReport
 
 comparator = ComparisonReport([hgbt_model_report, linear_model_report])
-comparator.metrics.report_metrics(indicator_favorability=True)
+comparator.metrics.summarize(indicator_favorability=True)
 
 # %%
 # In addition, if we forgot to compute a specific metric
@@ -255,7 +255,7 @@ scoring = ["r2", "rmse", mean_absolute_error]
 scoring_kwargs = {"response_method": "predict"}
 scoring_names = ["R²", "RMSE", "MAE"]
 
-comparator.metrics.report_metrics(
+comparator.metrics.summarize(
     scoring=scoring,
     scoring_kwargs=scoring_kwargs,
     scoring_names=scoring_names,

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -217,7 +217,7 @@ ridge_report = EstimatorReport(
     y_train=y_train,
     y_test=y_test,
 )
-ridge_report.metrics.report_metrics()
+ridge_report.metrics.summarize()
 
 # %%
 # From the report metrics, let us first explain the scores we have access to:
@@ -421,7 +421,7 @@ reports_to_compare = {
     "Ridge w/ feature engineering": engineered_ridge_report,
 }
 comparator = ComparisonReport(reports=reports_to_compare)
-comparator.metrics.report_metrics()
+comparator.metrics.summarize()
 
 # %%
 # We get a much better score!
@@ -667,7 +667,7 @@ selectk_ridge_report = EstimatorReport(
 )
 reports_to_compare["Ridge w/ feature engineering and selection"] = selectk_ridge_report
 comparator = ComparisonReport(reports=reports_to_compare)
-comparator.metrics.report_metrics()
+comparator.metrics.summarize()
 
 # %%
 # We get a good score and much less features:
@@ -775,7 +775,7 @@ reports_to_compare["Decision tree"] = tree_report
 
 # %%
 comparator = ComparisonReport(reports=reports_to_compare)
-comparator.metrics.report_metrics()
+comparator.metrics.summarize()
 
 # %%
 # We note that the performance is quite poor, so the derived feature importance is to
@@ -892,7 +892,7 @@ rf_report = EstimatorReport(
 reports_to_compare["Random forest"] = rf_report
 
 comparator = ComparisonReport(reports=reports_to_compare)
-comparator.metrics.report_metrics()
+comparator.metrics.summarize()
 
 # %%
 # Without any feature engineering and any grid search,

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -48,13 +48,13 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         "r2": {"name": "R²", "icon": "(↗︎)"},
         "rmse": {"name": "RMSE", "icon": "(↘︎)"},
         "custom_metric": {"name": "Custom metric", "icon": ""},
-        "report_metrics": {"name": "Report metrics", "icon": ""},
+        "summarize": {"name": "Metrics summary", "icon": ""},
     }
 
     def __init__(self, parent: ComparisonReport) -> None:
         super().__init__(parent)
 
-    def report_metrics(
+    def summarize(
         self,
         *,
         data_source: DataSource = "test",
@@ -144,7 +144,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         >>> comparison_report = ComparisonReport(
         ...     [estimator_report_1, estimator_report_2]
         ... )
-        >>> comparison_report.metrics.report_metrics(
+        >>> comparison_report.metrics.summarize(
         ...     scoring=["precision", "recall"],
         ...     pos_label=1,
         ... )
@@ -154,7 +154,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Recall                       0.97...               0.97...
         """
         results = self._compute_metric_scores(
-            report_metric_name="report_metrics",
+            report_metric_name="summarize",
             data_source=data_source,
             X=X,
             y=y,
@@ -415,7 +415,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Metric
         Accuracy                    0.96...               0.96...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["accuracy"],
             data_source=data_source,
             X=X,
@@ -518,7 +518,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Precision                 0               0.96...               0.96...
                                   1               0.96...               0.96...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["precision"],
             data_source=data_source,
             X=X,
@@ -624,7 +624,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Recall                    0              0.944...              0.944...
                                   1              0.977...              0.977...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["recall"],
             data_source=data_source,
             X=X,
@@ -694,7 +694,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Metric
         Brier score                   0.025...              0.025...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["brier_score"],
             data_source=data_source,
             X=X,
@@ -802,7 +802,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Metric
         ROC AUC                     0.99...               0.99...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["roc_auc"],
             data_source=data_source,
             X=X,
@@ -873,7 +873,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Metric
         Log loss                   0.082...              0.082...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["log_loss"],
             data_source=data_source,
             X=X,
@@ -954,7 +954,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Metric
         R²            0.43...    0.43...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["r2"],
             data_source=data_source,
             X=X,
@@ -1036,7 +1036,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         Metric
         RMSE          55.726...     55.726...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["rmse"],
             data_source=data_source,
             X=X,
@@ -1144,7 +1144,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
             response_method=response_method,
             **kwargs,
         )
-        return self.report_metrics(
+        return self.summarize(
             scoring=[scorer],
             data_source=data_source,
             X=X,
@@ -1162,14 +1162,14 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
     ) -> list[tuple[str, Callable]]:
         """Override sort method for metrics-specific ordering.
 
-        In short, we display the `report_metrics` first and then the `custom_metric`.
+        In short, we display the `summarize` first and then the `custom_metric`.
         """
 
         def _sort_key(method):
             name = method[0]
             if name == "custom_metric":
                 priority = 1
-            elif name == "report_metrics":
+            elif name == "summarize":
                 priority = 2
             else:
                 priority = 0

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -49,13 +49,13 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         "r2": {"name": "R²", "icon": "(↗︎)"},
         "rmse": {"name": "RMSE", "icon": "(↘︎)"},
         "custom_metric": {"name": "Custom metric", "icon": ""},
-        "report_metrics": {"name": "Report metrics", "icon": ""},
+        "summarize": {"name": "Metrics summary", "icon": ""},
     }
 
     def __init__(self, parent: CrossValidationReport) -> None:
         super().__init__(parent)
 
-    def report_metrics(
+    def summarize(
         self,
         *,
         data_source: DataSource = "test",
@@ -141,7 +141,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
         >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
-        >>> report.metrics.report_metrics(
+        >>> report.metrics.summarize(
         ...     scoring=["precision", "recall"],
         ...     pos_label=1,
         ...     indicator_favorability=True,
@@ -156,7 +156,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             pos_label = self._parent.pos_label
 
         results = self._compute_metric_scores(
-            report_metric_name="report_metrics",
+            report_metric_name="summarize",
             data_source=data_source,
             X=X,
             y=y,
@@ -383,7 +383,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Metric
         Accuracy           0.94...  0.00...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["accuracy"],
             data_source=data_source,
             aggregate=aggregate,
@@ -478,7 +478,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Precision 0                         0.93...  0.04...
                   1                         0.94...  0.02...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["precision"],
             data_source=data_source,
             aggregate=aggregate,
@@ -576,7 +576,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Recall 0                         0.91...  0.04...
                1                         0.96...  0.02...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["recall"],
             data_source=data_source,
             X=X,
@@ -637,7 +637,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Metric
         Brier score            0.04...  0.00...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["brier_score"],
             data_source=data_source,
             X=X,
@@ -731,7 +731,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Metric
         ROC AUC           0.98...  0.00...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["roc_auc"],
             data_source=data_source,
             X=X,
@@ -791,7 +791,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Metric
         Log loss            0.14...  0.03...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["log_loss"],
             data_source=data_source,
             X=X,
@@ -861,7 +861,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Metric
         R²      0.37...  0.02...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["r2"],
             data_source=data_source,
             X=X,
@@ -932,7 +932,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         Metric
         RMSE    60.7...  1.0...
         """
-        return self.report_metrics(
+        return self.summarize(
             scoring=["rmse"],
             data_source=data_source,
             X=X,
@@ -1034,7 +1034,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
             response_method=response_method,
             **kwargs,
         )
-        return self.report_metrics(
+        return self.summarize(
             scoring=[scorer],
             data_source=data_source,
             X=X,
@@ -1053,14 +1053,14 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
     ) -> list[tuple[str, Callable]]:
         """Override sort method for metrics-specific ordering.
 
-        In short, we display the `report_metrics` first and then the `custom_metric`.
+        In short, we display the `summarize` first and then the `custom_metric`.
         """
 
         def _sort_key(method):
             name = method[0]
             if name == "custom_metric":
                 priority = 1
-            elif name == "report_metrics":
+            elif name == "summarize":
                 priority = 2
             else:
                 priority = 0

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -50,14 +50,14 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         "r2": {"name": "R²", "icon": "(↗︎)"},
         "rmse": {"name": "RMSE", "icon": "(↘︎)"},
         "custom_metric": {"name": "Custom metric", "icon": ""},
-        "report_metrics": {"name": "Report metrics", "icon": ""},
+        "summarize": {"name": "Metrics summary", "icon": ""},
         "confusion_matrix": {"name": "Confusion Matrix", "icon": ""},
     }
 
     def __init__(self, parent: EstimatorReport) -> None:
         super().__init__(parent)
 
-    def report_metrics(
+    def summarize(
         self,
         *,
         data_source: DataSource = "test",
@@ -139,7 +139,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         >>> split_data = train_test_split(X=X, y=y, random_state=0, as_dict=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
         >>> report = EstimatorReport(classifier, **split_data, pos_label=1)
-        >>> report.metrics.report_metrics(indicator_favorability=True)
+        >>> report.metrics.summarize(indicator_favorability=True)
                     LogisticRegression Favorability
         Metric
         Precision              0.98...         (↗︎)
@@ -147,7 +147,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         ROC AUC                0.99...         (↗︎)
         Brier score            0.03...         (↘︎)
         >>> # Using scikit-learn metrics
-        >>> report.metrics.report_metrics(scoring=["f1"], indicator_favorability=True)
+        >>> report.metrics.summarize(scoring=["f1"], indicator_favorability=True)
                                   LogisticRegression Favorability
         Metric   Label / Average
         F1 Score               1             0.96...          (↗︎)
@@ -250,9 +250,9 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                         if pos_label != metrics_kwargs["pos_label"]:
                             raise ValueError(
                                 "`pos_label` is passed both in the scorer and to the "
-                                "`report_metrics` method. Please provide a consistent "
+                                "`summarize` method. Please provide a consistent "
                                 "`pos_label` or only pass it whether in the scorer or "
-                                "to the `report_metrics` method."
+                                "to the `summarize` method."
                             )
                     elif pos_label is not None:
                         metrics_kwargs["pos_label"] = pos_label
@@ -1586,14 +1586,14 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
     def _sort_methods_for_help(self, methods: list[tuple]) -> list[tuple]:
         """Override sort method for metrics-specific ordering.
 
-        In short, we display the `report_metrics` first and then the `custom_metric`.
+        In short, we display the `summarize` first and then the `custom_metric`.
         """
 
         def _sort_key(method):
             name = method[0]
             if name == "custom_metric":
                 priority = 1
-            elif name == "report_metrics":
+            elif name == "summarize":
                 priority = 2
             else:
                 priority = 0

--- a/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
+++ b/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
@@ -1,4 +1,4 @@
-"""Tests of `ComparisonReport.metrics.report_metrics`."""
+"""Tests of `ComparisonReport.metrics.summarize`."""
 
 import pandas as pd
 import pytest
@@ -54,8 +54,8 @@ def report_regression():
 
 
 def test_aggregate_none(report):
-    """`report_metrics` works as intended with `aggregate=None`."""
-    result = report.metrics.report_metrics(aggregate=None)
+    """`summarize` works as intended with `aggregate=None`."""
+    result = report.metrics.summarize(aggregate=None)
 
     assert_index_equal(result.columns, pd.Index(["Value"]))
     assert result.index.names == ["Metric", "Label / Average", "Estimator", "Split"]
@@ -64,9 +64,9 @@ def test_aggregate_none(report):
 
 def test_aggregate_none_flat_index(report):
     """
-    `report_metrics` works as intended with `aggregate=None` and `flat_index=True`.
+    `summarize` works as intended with `aggregate=None` and `flat_index=True`.
     """
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         aggregate=None,
         flat_index=True,
     )
@@ -76,8 +76,8 @@ def test_aggregate_none_flat_index(report):
 
 
 def test_default(report):
-    """`report_metrics` works as intended with its default attributes."""
-    result = report.metrics.report_metrics()
+    """`summarize` works as intended with its default attributes."""
+    result = report.metrics.summarize()
 
     assert_index_equal(
         result.columns,
@@ -96,10 +96,10 @@ def test_default(report):
 
 def test_default_regression(report_regression):
     """
-    `report_metrics` works as intended with its default attributes for regression
+    `summarize` works as intended with its default attributes for regression
     models.
     """
-    result = report_regression.metrics.report_metrics()
+    result = report_regression.metrics.summarize()
 
     assert_index_equal(
         result.columns,
@@ -122,25 +122,25 @@ def test_default_regression(report_regression):
 def test_aggregate_sequence_of_one_element(report):
     """Passing a list of one string is the same as passing the string itself."""
     assert_frame_equal(
-        report.metrics.report_metrics(aggregate="mean"),
-        report.metrics.report_metrics(aggregate=["mean"]),
+        report.metrics.summarize(aggregate="mean"),
+        report.metrics.summarize(aggregate=["mean"]),
     )
 
 
 def test_aggregate_is_used_in_cache(report):
     """`aggregate` should be used when computing the cache key.
 
-    In other words, if you call `report_metrics` twice with different values of
+    In other words, if you call `summarize` twice with different values of
     `aggregate`, you should get a different result.
     """
-    call1 = report.metrics.report_metrics(aggregate="mean")
-    call2 = report.metrics.report_metrics(aggregate=("mean", "std"))
+    call1 = report.metrics.summarize(aggregate="mean")
+    call2 = report.metrics.summarize(aggregate=("mean", "std"))
     assert list(call1.columns) != list(call2.columns)
 
 
 def test_scoring(report):
-    """`report_metrics` works as intended with the `scoring` parameter."""
-    result = report.metrics.report_metrics(
+    """`summarize` works as intended with the `scoring` parameter."""
+    result = report.metrics.summarize(
         scoring=["accuracy"],
         aggregate=None,
     )
@@ -165,8 +165,8 @@ def test_scoring(report):
 
 
 def test_favorability(report):
-    """`report_metrics` works as intended with `indicator_favorability=True`."""
-    result = report.metrics.report_metrics(indicator_favorability=True)
+    """`summarize` works as intended with `indicator_favorability=True`."""
+    result = report.metrics.summarize(indicator_favorability=True)
 
     assert_index_equal(
         result.columns,
@@ -185,13 +185,13 @@ def test_favorability(report):
 
 
 def test_cache(report):
-    """`report_metrics` results are cached."""
+    """`summarize` results are cached."""
 
     with check_cache_changed(report._cache):
-        result = report.metrics.report_metrics()
+        result = report.metrics.summarize()
 
     with check_cache_unchanged(report._cache):
-        cached_result = report.metrics.report_metrics()
+        cached_result = report.metrics.summarize()
 
     assert_frame_equal(result, cached_result)
 
@@ -209,7 +209,7 @@ def test_init_with_report_names(classification_data):
 
     assert_index_equal(
         (
-            comp.metrics.report_metrics(aggregate=None)
+            comp.metrics.summarize(aggregate=None)
             .index.get_level_values("Estimator")
             .unique()
         ),
@@ -218,9 +218,9 @@ def test_init_with_report_names(classification_data):
 
 
 def test_X_y(report, classification_data):
-    """`report_metrics` works as intended with `data_source="X_y"`."""
+    """`summarize` works as intended with `data_source="X_y"`."""
     X, y = classification_data
-    result = report.metrics.report_metrics(data_source="X_y", X=X, y=y)
+    result = report.metrics.summarize(data_source="X_y", X=X, y=y)
 
     assert_index_equal(
         result.columns,
@@ -252,10 +252,8 @@ def test_cache_poisoning(classification_data):
         DummyClassifier(strategy="uniform", random_state=2), X=X, y=y
     )
     report = ComparisonReport({"model_1": report_1, "model_2": report_2})
-    report.metrics.report_metrics(indicator_favorability=True)
-    result = report_1.metrics.report_metrics(
-        aggregate=None, indicator_favorability=True
-    )
+    report.metrics.summarize(indicator_favorability=True)
+    result = report_1.metrics.summarize(aggregate=None, indicator_favorability=True)
 
     assert "Favorability" in result.columns
 
@@ -269,15 +267,15 @@ def test_cache_poisoning(classification_data):
         (get_scorer("accuracy"), None),
     ],
 )
-def test_comparison_report_cv_report_metrics_scoring_single_list_equivalence(
+def test_comparison_report_cv_report_summarize_scoring_single_list_equivalence(
     report, scoring, scoring_kwargs
 ):
     """Check that passing a single string, callable, scorer is equivalent to passing a
     list with a single element."""
-    result_single = report.metrics.report_metrics(
+    result_single = report.metrics.summarize(
         scoring=scoring, scoring_kwargs=scoring_kwargs
     )
-    result_list = report.metrics.report_metrics(
+    result_list = report.metrics.summarize(
         scoring=[scoring], scoring_kwargs=scoring_kwargs
     )
     assert result_single.equals(result_list)

--- a/skore/tests/unit/sklearn/comparison/estimator/test_comparison.py
+++ b/skore/tests/unit/sklearn/comparison/estimator/test_comparison.py
@@ -60,7 +60,7 @@ def test_comparison_report_without_testing_data(binary_classification_model):
     report = ComparisonReport([estimator_report_1, estimator_report_2])
 
     with pytest.raises(ValueError, match="No test data"):
-        report.metrics.report_metrics(data_source="test")
+        report.metrics.summarize(data_source="test")
 
 
 def test_comparison_report_different_test_data(binary_classification_model):
@@ -284,7 +284,7 @@ def report(report_classification):
         ),
     ],
 )
-def test_comparison_report_metrics_binary_classification(
+def test_comparison_summarize_binary_classification(
     metric_name, expected, data_source, binary_classification_model, report
 ):
     """Check the metrics work."""
@@ -337,7 +337,7 @@ def test_comparison_report_metrics_binary_classification(
         ),
     ],
 )
-def test_comparison_report_metrics_linear_regression(
+def test_comparison_summarize_linear_regression(
     metric_name, expected, data_source, regression_model
 ):
     """Check the metrics work."""
@@ -378,11 +378,11 @@ def test_comparison_report_metrics_linear_regression(
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_comparison_report_report_metrics_X_y(binary_classification_model, report):
-    """Check that `report_metrics` works with an "X_y" data source."""
+def test_comparison_summarize_X_y(binary_classification_model, report):
+    """Check that `summarize` works with an "X_y" data source."""
     _, X_train, _, y_train, _ = binary_classification_model
 
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         data_source="X_y",
         X=X_train[:10],
         y=y_train[:10],
@@ -465,7 +465,7 @@ def test_cross_validation_report_flat_index(binary_classification_model):
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
     report = ComparisonReport({"report_1": report_1, "report_2": report_2})
-    result = report.metrics.report_metrics(flat_index=True)
+    result = report.metrics.summarize(flat_index=True)
     assert result.shape == (8, 2)
     assert isinstance(result.index, pd.Index)
     assert result.index.tolist() == [
@@ -481,9 +481,9 @@ def test_cross_validation_report_flat_index(binary_classification_model):
     assert result.columns.tolist() == ["report_1", "report_2"]
 
 
-def test_estimator_report_report_metrics_indicator_favorability(report):
+def test_estimator_report_summarize_indicator_favorability(report):
     """Check that the behaviour of `indicator_favorability` is correct."""
-    result = report.metrics.report_metrics(indicator_favorability=True)
+    result = report.metrics.summarize(indicator_favorability=True)
     assert "Favorability" in result.columns
     indicator = result["Favorability"]
     assert indicator["Precision"].tolist() == ["(↗︎)", "(↗︎)"]
@@ -496,8 +496,8 @@ def test_comparison_report_aggregate(report):
     """Passing `aggregate` should have no effect, as this argument is only relevant
     when comparing `CrossValidationReport`s."""
     assert_allclose(
-        report.metrics.report_metrics(aggregate="mean"),
-        report.metrics.report_metrics(),
+        report.metrics.summarize(aggregate="mean"),
+        report.metrics.summarize(),
     )
 
 
@@ -565,7 +565,7 @@ def test_comparison_report_timings_flat_index(report):
     report.get_predictions(data_source="test")
 
     # Get metrics with flat_index=True
-    results = report.metrics.report_metrics(flat_index=True)
+    results = report.metrics.summarize(flat_index=True)
 
     # Check that expected time measurements are in index with _s suffix
     assert "fit_time_s" in results.index
@@ -581,15 +581,15 @@ def test_comparison_report_timings_flat_index(report):
         (get_scorer("accuracy"), None),
     ],
 )
-def test_comparison_report_estimator_report_metrics_scoring_single_list_equivalence(
+def test_comparison_report_estimator_summarize_scoring_single_list_equivalence(
     report, scoring, scoring_kwargs
 ):
     """Check that passing a single string, callable, scorer is equivalent to passing a
     list with a single element."""
-    result_single = report.metrics.report_metrics(
+    result_single = report.metrics.summarize(
         scoring=scoring, scoring_kwargs=scoring_kwargs
     )
-    result_list = report.metrics.report_metrics(
+    result_list = report.metrics.summarize(
         scoring=[scoring], scoring_kwargs=scoring_kwargs
     )
     assert result_single.equals(result_list)

--- a/skore/tests/unit/sklearn/comparison/test_report_common.py
+++ b/skore/tests/unit/sklearn/comparison/test_report_common.py
@@ -60,7 +60,7 @@ def test_cross_validation_report_cleaned_up(report):
     Non-regression test for bug found in:
     https://github.com/probabl-ai/skore/pull/1512
     """
-    report.metrics.report_metrics()
+    report.metrics.summarize()
 
     with BytesIO() as stream:
         joblib.dump(report.reports_[0], stream)
@@ -97,7 +97,7 @@ def test_comparison_report_favorability_undefined_metrics(report):
         }
 
     comparison_report = ComparisonReport(reports)
-    metrics = comparison_report.metrics.report_metrics(
+    metrics = comparison_report.metrics.summarize(
         pos_label=1, indicator_favorability=True
     )
 

--- a/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
@@ -281,7 +281,7 @@ def test_cross_validation_report_flat_index(binary_classification_data):
     """
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
-    result = report.metrics.report_metrics(flat_index=True)
+    result = report.metrics.summarize(flat_index=True)
     assert result.shape == (8, 2)
     assert isinstance(result.index, pd.Index)
     assert result.index.tolist() == [
@@ -300,17 +300,17 @@ def test_cross_validation_report_flat_index(binary_classification_data):
     ]
 
 
-def test_cross_validation_report_metrics_data_source_external(
+def test_cross_validation_summarize_data_source_external(
     binary_classification_data,
 ):
     """Check that the `data_source` parameter works when using external data."""
     estimator, X, y = binary_classification_data
     cv_splitter = 2
     report = CrossValidationReport(estimator, X, y, cv_splitter=cv_splitter)
-    result = report.metrics.report_metrics(data_source="X_y", X=X, y=y, aggregate=None)
+    result = report.metrics.summarize(data_source="X_y", X=X, y=y, aggregate=None)
     for split_idx in range(cv_splitter):
         # check that it is equivalent to call the individual estimator report
-        report_result = report.estimator_reports_[split_idx].metrics.report_metrics(
+        report_result = report.estimator_reports_[split_idx].metrics.summarize(
             data_source="X_y", X=X, y=y
         )
         np.testing.assert_allclose(
@@ -396,7 +396,7 @@ def test_seed_none(regression_data):
 ########################################################################################
 
 
-def test_cross_validation_report_metrics_help(capsys, binary_classification_data):
+def test_cross_validation_summarize_help(capsys, binary_classification_data):
     """Check that the help method writes to the console."""
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
@@ -406,7 +406,7 @@ def test_cross_validation_report_metrics_help(capsys, binary_classification_data
     assert "Available metrics methods" in captured.out
 
 
-def test_cross_validation_report_metrics_repr(binary_classification_data):
+def test_cross_validation_summarize_repr(binary_classification_data):
     """Check that __repr__ returns a string starting with the expected prefix."""
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
@@ -462,12 +462,12 @@ def _check_results_single_metric(report, metric, expected_n_splits, expected_nb_
 def _check_results_report_metric(
     report, params, expected_n_splits, expected_metrics, expected_nb_stats
 ):
-    result = report.metrics.report_metrics(**params)
+    result = report.metrics.summarize(**params)
     assert isinstance(result, pd.DataFrame)
     assert "Favorability" not in result.columns
     assert result.shape[1] == expected_n_splits
     # check that we hit the cache
-    result_with_cache = report.metrics.report_metrics(**params)
+    result_with_cache = report.metrics.summarize(**params)
     pd.testing.assert_frame_equal(result, result_with_cache)
 
     # check that the columns contains the expected split names
@@ -480,13 +480,13 @@ def _check_results_report_metric(
 
     # check the aggregate parameter
     stats = ["mean", "std"]
-    result = report.metrics.report_metrics(aggregate=stats, **params)
+    result = report.metrics.summarize(aggregate=stats, **params)
     # check that the columns contains the expected split names
     split_names = result.columns.get_level_values(1).unique()
     assert list(split_names) == stats
 
     stats = "mean"
-    result = report.metrics.report_metrics(aggregate=stats, **params)
+    result = report.metrics.summarize(aggregate=stats, **params)
     # check that the columns contains the expected split names
     split_names = result.columns.get_level_values(1).unique()
     assert list(split_names) == [stats]
@@ -518,7 +518,7 @@ def _check_metrics_names(result, expected_metrics, expected_nb_stats):
         ("log_loss", 1),
     ],
 )
-def test_cross_validation_report_metrics_binary_classification(
+def test_cross_validation_summarize_binary_classification(
     binary_classification_data, metric, nb_stats
 ):
     """Check the behaviour of the metrics methods available for binary
@@ -539,7 +539,7 @@ def test_cross_validation_report_metrics_binary_classification(
         ("log_loss", 1),
     ],
 )
-def test_cross_validation_report_metrics_multiclass_classification(
+def test_cross_validation_summarize_multiclass_classification(
     multiclass_classification_data, metric, nb_stats
 ):
     """Check the behaviour of the metrics methods available for multiclass
@@ -551,7 +551,7 @@ def test_cross_validation_report_metrics_multiclass_classification(
 
 
 @pytest.mark.parametrize("metric, nb_stats", [("r2", 1), ("rmse", 1)])
-def test_cross_validation_report_metrics_regression(regression_data, metric, nb_stats):
+def test_cross_validation_summarize_regression(regression_data, metric, nb_stats):
     """Check the behaviour of the metrics methods available for regression."""
     (estimator, X, y), cv = regression_data, 2
     report = CrossValidationReport(estimator, X, y, cv_splitter=cv)
@@ -559,7 +559,7 @@ def test_cross_validation_report_metrics_regression(regression_data, metric, nb_
 
 
 @pytest.mark.parametrize("metric, nb_stats", [("r2", 2), ("rmse", 2)])
-def test_cross_validation_report_metrics_regression_multioutput(
+def test_cross_validation_summarize_regression_multioutput(
     regression_multioutput_data, metric, nb_stats
 ):
     """Check the behaviour of the metrics methods available for regression."""
@@ -577,30 +577,30 @@ def test_cross_validation_report_metrics_regression_multioutput(
         (get_scorer("accuracy"), None),
     ],
 )
-def test_cross_validation_report_report_metrics_scoring_single_list_equivalence(
+def test_cross_validation_report_summarize_scoring_single_list_equivalence(
     binary_classification_data, scoring, scoring_kwargs
 ):
     """Check that passing a single string, callable, scorer is equivalent to passing a
     list with a single element."""
     (estimator, X, y), cv = binary_classification_data, 2
     report = CrossValidationReport(estimator, X, y, cv_splitter=cv)
-    result_single = report.metrics.report_metrics(
+    result_single = report.metrics.summarize(
         scoring=scoring, scoring_kwargs=scoring_kwargs
     )
-    result_list = report.metrics.report_metrics(
+    result_list = report.metrics.summarize(
         scoring=[scoring], scoring_kwargs=scoring_kwargs
     )
     assert result_single.equals(result_list)
 
 
 @pytest.mark.parametrize("pos_label, nb_stats", [(None, 2), (1, 1)])
-def test_cross_validation_report_report_metrics_binary(
+def test_cross_validation_report_summarize_binary(
     binary_classification_data,
     binary_classification_data_svc,
     pos_label,
     nb_stats,
 ):
-    """Check the behaviour of the `report_metrics` method with binary
+    """Check the behaviour of the `summarize` method with binary
     classification. We test both with an SVC that does not support `predict_proba` and a
     RandomForestClassifier that does.
     """
@@ -671,10 +671,10 @@ def test_cross_validation_report_report_metrics_binary(
     )
 
 
-def test_cross_validation_report_report_metrics_multiclass(
+def test_cross_validation_report_summarize_multiclass(
     multiclass_classification_data, multiclass_classification_data_svc
 ):
-    """Check the behaviour of the `report_metrics` method with multiclass
+    """Check the behaviour of the `summarize` method with multiclass
     classification.
     """
     estimator, X, y = multiclass_classification_data
@@ -713,8 +713,8 @@ def test_cross_validation_report_report_metrics_multiclass(
     )
 
 
-def test_cross_validation_report_report_metrics_regression(regression_data):
-    """Check the behaviour of the `report_metrics` method with regression."""
+def test_cross_validation_report_summarize_regression(regression_data):
+    """Check the behaviour of the `summarize` method with regression."""
     estimator, X, y = regression_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
     expected_metrics = ("r2", "rmse", "fit_time_s", "predict_time_s")
@@ -727,27 +727,27 @@ def test_cross_validation_report_report_metrics_regression(regression_data):
     )
 
 
-def test_cross_validation_report_report_metrics_scoring_kwargs_regression(
+def test_cross_validation_report_summarize_scoring_kwargs_regression(
     regression_multioutput_data,
 ):
-    """Check the behaviour of the `report_metrics` method with scoring kwargs."""
+    """Check the behaviour of the `summarize` method with scoring kwargs."""
     estimator, X, y = regression_multioutput_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-    assert hasattr(report.metrics, "report_metrics")
-    result = report.metrics.report_metrics(scoring_kwargs={"multioutput": "raw_values"})
+    assert hasattr(report.metrics, "summarize")
+    result = report.metrics.summarize(scoring_kwargs={"multioutput": "raw_values"})
     assert result.shape == (6, 2)
     assert isinstance(result.index, pd.MultiIndex)
     assert result.index.names == ["Metric", "Output"]
 
 
-def test_cross_validation_report_report_metrics_scoring_kwargs_multi_class(
+def test_cross_validation_report_summarize_scoring_kwargs_multi_class(
     multiclass_classification_data,
 ):
-    """Check the behaviour of the `report_metrics` method with scoring kwargs."""
+    """Check the behaviour of the `summarize` method with scoring kwargs."""
     estimator, X, y = multiclass_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-    assert hasattr(report.metrics, "report_metrics")
-    result = report.metrics.report_metrics(scoring_kwargs={"average": None})
+    assert hasattr(report.metrics, "summarize")
+    result = report.metrics.summarize(scoring_kwargs={"average": None})
     assert result.shape == (12, 2)
     assert isinstance(result.index, pd.MultiIndex)
     assert result.index.names == ["Metric", "Label / Average"]
@@ -781,13 +781,13 @@ def test_cross_validation_report_report_metrics_scoring_kwargs_multi_class(
         ),
     ],
 )
-def test_cross_validation_report_report_metrics_overwrite_scoring_names(
+def test_cross_validation_report_summarize_overwrite_scoring_names(
     request, fixture_name, scoring_names, expected_index
 ):
-    """Test that we can overwrite the scoring names in report_metrics."""
+    """Test that we can overwrite the scoring names in summarize."""
     estimator, X, y = request.getfixturevalue(fixture_name)
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-    result = report.metrics.report_metrics(scoring_names=scoring_names)
+    result = report.metrics.summarize(scoring_names=scoring_names)
     assert result.shape == (len(expected_index), 2)
 
     # Get level 0 names if MultiIndex, otherwise get column names
@@ -800,7 +800,7 @@ def test_cross_validation_report_report_metrics_overwrite_scoring_names(
 
 
 @pytest.mark.parametrize("scoring", ["public_metric", "_private_metric"])
-def test_cross_validation_report_report_metrics_error_scoring_strings(
+def test_cross_validation_report_summarize_error_scoring_strings(
     regression_data, scoring
 ):
     """Check that we raise an error if a scoring string is not a valid metric."""
@@ -808,12 +808,12 @@ def test_cross_validation_report_report_metrics_error_scoring_strings(
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
     err_msg = re.escape(f"Invalid metric: {scoring!r}.")
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.report_metrics(scoring=[scoring])
+        report.metrics.summarize(scoring=[scoring])
 
 
-def test_cross_validation_report_report_metrics_with_scorer(regression_data):
+def test_cross_validation_report_summarize_with_scorer(regression_data):
     """Check that we can pass scikit-learn scorer with different parameters to
-    the `report_metrics` method."""
+    the `summarize` method."""
     estimator, X, y = regression_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
 
@@ -821,7 +821,7 @@ def test_cross_validation_report_report_metrics_with_scorer(regression_data):
         median_absolute_error, response_method="predict"
     )
 
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         scoring=[r2_score, median_absolute_error_scorer],
         scoring_kwargs={"response_method": "predict"},  # only dispatched to r2_score
         aggregate=None,
@@ -861,26 +861,26 @@ def test_cross_validation_report_report_metrics_with_scorer(regression_data):
         (make_scorer(f1_score, response_method="predict", average="macro"), 1),
     ],
 )
-def test_cross_validation_report_report_metrics_with_scorer_binary_classification(
+def test_cross_validation_report_summarize_with_scorer_binary_classification(
     binary_classification_data, scorer, pos_label
 ):
     """Check that we can pass scikit-learn scorer with different parameters to
-    the `report_metrics` method.
+    the `summarize` method.
 
     We also check that we can pass `pos_label` whether to the scorer or to the
-    `report_metrics` method or consistently to both.
+    `summarize` method or consistently to both.
     """
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
 
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         scoring=["accuracy", accuracy_score, scorer],
         scoring_kwargs={"response_method": "predict"},
     )
     assert result.shape == (3, 2)
 
 
-def test_cross_validation_report_report_metrics_with_scorer_pos_label_error(
+def test_cross_validation_report_summarize_with_scorer_pos_label_error(
     binary_classification_data,
 ):
     """Check that we raise an error when pos_label is passed both in the scorer and
@@ -892,32 +892,30 @@ def test_cross_validation_report_report_metrics_with_scorer_pos_label_error(
         f1_score, response_method="predict", average="macro", pos_label=1
     )
     err_msg = re.escape(
-        "`pos_label` is passed both in the scorer and to the `report_metrics` method."
+        "`pos_label` is passed both in the scorer and to the `summarize` method."
     )
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.report_metrics(scoring=[f1_scorer], pos_label=0)
+        report.metrics.summarize(scoring=[f1_scorer], pos_label=0)
 
 
-def test_cross_validation_report_report_metrics_invalid_metric_type(regression_data):
+def test_cross_validation_report_summarize_invalid_metric_type(regression_data):
     """Check that we raise the expected error message if an invalid metric is passed."""
     estimator, X, y = regression_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
 
     err_msg = re.escape("Invalid type of metric: <class 'int'> for 1")
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.report_metrics(scoring=[1])
+        report.metrics.summarize(scoring=[1])
 
 
 @pytest.mark.parametrize("aggregate", [None, "mean", ["mean", "std"]])
-def test_cross_validation_report_report_metrics_indicator_favorability(
+def test_cross_validation_report_summarize_indicator_favorability(
     binary_classification_data, aggregate
 ):
     """Check that the behaviour of `indicator_favorability` is correct."""
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X, y, cv_splitter=2)
-    result = report.metrics.report_metrics(
-        indicator_favorability=True, aggregate=aggregate
-    )
+    result = report.metrics.summarize(indicator_favorability=True, aggregate=aggregate)
     assert "Favorability" in result.columns
     indicator = result["Favorability"]
     assert indicator.shape == (8,)
@@ -1044,7 +1042,7 @@ def test_cross_validation_timings_flat_index(binary_classification_data):
     report.get_predictions(data_source="train")
     report.get_predictions(data_source="test")
 
-    results = report.metrics.report_metrics(flat_index=True)
+    results = report.metrics.summarize(flat_index=True)
     assert results.index.tolist() == [
         "precision_0",
         "precision_1",
@@ -1060,10 +1058,10 @@ def test_cross_validation_timings_flat_index(binary_classification_data):
 @pytest.mark.parametrize(
     "metric, metric_fn", [("precision", precision_score), ("recall", recall_score)]
 )
-def test_cross_validation_report_report_metrics_pos_label_overwrite(
+def test_cross_validation_report_summarize_pos_label_overwrite(
     binary_classification_data, metric, metric_fn
 ):
-    """Check that `pos_label` can be overwritten in `report_metrics`"""
+    """Check that `pos_label` can be overwritten in `summarize`"""
     X, y = make_classification(
         n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
     )
@@ -1072,12 +1070,12 @@ def test_cross_validation_report_report_metrics_pos_label_overwrite(
     classifier = LogisticRegression()
 
     report = CrossValidationReport(classifier, X, y)
-    result_both_labels = report.metrics.report_metrics(scoring=metric).reset_index()
+    result_both_labels = report.metrics.summarize(scoring=metric).reset_index()
     assert result_both_labels["Label / Average"].to_list() == ["A", "B"]
     result_both_labels = result_both_labels.set_index(["Metric", "Label / Average"])
 
     report = CrossValidationReport(classifier, X, y, pos_label="B")
-    result = report.metrics.report_metrics(scoring=metric).reset_index()
+    result = report.metrics.summarize(scoring=metric).reset_index()
     assert "Label / Average" not in result.columns
     result = result.set_index("Metric")
     assert (
@@ -1087,7 +1085,7 @@ def test_cross_validation_report_report_metrics_pos_label_overwrite(
         ]
     )
 
-    result = report.metrics.report_metrics(scoring=metric, pos_label="A").reset_index()
+    result = report.metrics.summarize(scoring=metric, pos_label="A").reset_index()
     assert "Label / Average" not in result.columns
     result = result.set_index("Metric")
     assert (
@@ -1104,7 +1102,7 @@ def test_cross_validation_report_report_metrics_pos_label_overwrite(
 def test_estimator_report_precision_recall_pos_label_overwrite(
     binary_classification_data, metric, metric_fn
 ):
-    """Check that `pos_label` can be overwritten in `report_metrics`"""
+    """Check that `pos_label` can be overwritten in `summarize`"""
     X, y = make_classification(
         n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
     )

--- a/skore/tests/unit/sklearn/estimator/test_estimator.py
+++ b/skore/tests/unit/sklearn/estimator/test_estimator.py
@@ -342,7 +342,7 @@ def test_estimator_report_flat_index(binary_classification_data):
     """
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics(flat_index=True)
+    result = report.metrics.summarize(flat_index=True)
     assert result.shape == (8, 1)
     assert isinstance(result.index, pd.Index)
     assert result.index.tolist() == [
@@ -594,7 +594,7 @@ def test_estimator_report_display_regression_switching_data_source(
 ########################################################################################
 
 
-def test_estimator_report_metrics_help(capsys, binary_classification_data):
+def test_estimator_summarize_help(capsys, binary_classification_data):
     """Check that the help method writes to the console."""
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
@@ -604,7 +604,7 @@ def test_estimator_report_metrics_help(capsys, binary_classification_data):
     assert "Available metrics methods" in captured.out
 
 
-def test_estimator_report_metrics_repr(binary_classification_data):
+def test_estimator_summarize_repr(binary_classification_data):
     """Check that __repr__ returns a string starting with the expected prefix."""
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
@@ -615,9 +615,7 @@ def test_estimator_report_metrics_repr(binary_classification_data):
 
 
 @pytest.mark.parametrize("metric", ["accuracy", "brier_score", "roc_auc", "log_loss"])
-def test_estimator_report_metrics_binary_classification(
-    binary_classification_data, metric
-):
+def test_estimator_summarize_binary_classification(binary_classification_data, metric):
     """Check the behaviour of the metrics methods available for binary
     classification.
     """
@@ -645,7 +643,7 @@ def test_estimator_report_metrics_binary_classification(
 
 
 @pytest.mark.parametrize("metric", ["precision", "recall"])
-def test_estimator_report_metrics_binary_classification_pr(
+def test_estimator_summarize_binary_classification_pr(
     binary_classification_data, metric
 ):
     """Check the behaviour of the precision and recall metrics available for binary
@@ -675,7 +673,7 @@ def test_estimator_report_metrics_binary_classification_pr(
 
 
 @pytest.mark.parametrize("metric", ["r2", "rmse"])
-def test_estimator_report_metrics_regression(regression_data, metric):
+def test_estimator_summarize_regression(regression_data, metric):
     """Check the behaviour of the metrics methods available for regression."""
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
@@ -710,7 +708,7 @@ def _normalize_metric_name(column):
     return re.sub(r"[^a-zA-Z]", "", s)
 
 
-def _check_results_report_metrics(result, expected_metrics, expected_nb_stats):
+def _check_results_summarize(result, expected_metrics, expected_nb_stats):
     assert isinstance(result, pd.DataFrame)
     assert len(result.index) == expected_nb_stats
 
@@ -730,21 +728,21 @@ def _check_results_report_metrics(result, expected_metrics, expected_nb_stats):
 
 @pytest.mark.parametrize("pos_label, nb_stats", [(None, 2), (1, 1)])
 @pytest.mark.parametrize("data_source", ["test", "X_y"])
-def test_estimator_report_report_metrics_binary(
+def test_estimator_report_summarize_binary(
     binary_classification_data,
     binary_classification_data_svc,
     pos_label,
     nb_stats,
     data_source,
 ):
-    """Check the behaviour of the `report_metrics` method with binary
+    """Check the behaviour of the `summarize` method with binary
     classification. We test both with an SVC that does not support `predict_proba` and a
     RandomForestClassifier that does.
     """
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         pos_label=pos_label, data_source=data_source, **kwargs
     )
     assert "Favorability" not in result.columns
@@ -759,7 +757,7 @@ def test_estimator_report_report_metrics_binary(
     # depending on `pos_label`, we report a stats for each class or not for
     # precision and recall
     expected_nb_stats = 2 * nb_stats + 4
-    _check_results_report_metrics(result, expected_metrics, expected_nb_stats)
+    _check_results_summarize(result, expected_metrics, expected_nb_stats)
 
     # Repeat the same experiment where we the target labels are not [0, 1] but
     # ["neg", "pos"]. We check that we don't get any error.
@@ -769,7 +767,7 @@ def test_estimator_report_report_metrics_binary(
     estimator = clone(estimator).fit(X_test, y_test)
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         pos_label=pos_label_name, data_source=data_source, **kwargs
     )
     expected_metrics = (
@@ -783,32 +781,32 @@ def test_estimator_report_report_metrics_binary(
     # depending on `pos_label`, we report a stats for each class or not for
     # precision and recall
     expected_nb_stats = 2 * nb_stats + 4
-    _check_results_report_metrics(result, expected_metrics, expected_nb_stats)
+    _check_results_summarize(result, expected_metrics, expected_nb_stats)
 
     estimator, X_test, y_test = binary_classification_data_svc
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         pos_label=pos_label, data_source=data_source, **kwargs
     )
     expected_metrics = ("precision", "recall", "roc_auc", "fit_time", "predict_time")
     # depending on `pos_label`, we report a stats for each class or not for
     # precision and recall
     expected_nb_stats = 2 * nb_stats + 3
-    _check_results_report_metrics(result, expected_metrics, expected_nb_stats)
+    _check_results_summarize(result, expected_metrics, expected_nb_stats)
 
 
 @pytest.mark.parametrize("data_source", ["test", "X_y"])
-def test_estimator_report_report_metrics_multiclass(
+def test_estimator_report_summarize_multiclass(
     multiclass_classification_data, multiclass_classification_data_svc, data_source
 ):
-    """Check the behaviour of the `report_metrics` method with multiclass
+    """Check the behaviour of the `summarize` method with multiclass
     classification.
     """
     estimator, X_test, y_test = multiclass_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
-    result = report.metrics.report_metrics(data_source=data_source, **kwargs)
+    result = report.metrics.summarize(data_source=data_source, **kwargs)
     assert "Favorability" not in result.columns
     expected_metrics = (
         "precision",
@@ -821,47 +819,47 @@ def test_estimator_report_report_metrics_multiclass(
     # since we are not averaging by default, we report 3 statistics for
     # precision, recall and roc_auc
     expected_nb_stats = 3 * 3 + 3
-    _check_results_report_metrics(result, expected_metrics, expected_nb_stats)
+    _check_results_summarize(result, expected_metrics, expected_nb_stats)
 
     estimator, X_test, y_test = multiclass_classification_data_svc
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
-    result = report.metrics.report_metrics(data_source=data_source, **kwargs)
+    result = report.metrics.summarize(data_source=data_source, **kwargs)
     expected_metrics = ("precision", "recall", "fit_time", "predict_time")
     # since we are not averaging by default, we report 3 statistics for
     # precision and recall
     expected_nb_stats = 3 * 2 + 2
-    _check_results_report_metrics(result, expected_metrics, expected_nb_stats)
+    _check_results_summarize(result, expected_metrics, expected_nb_stats)
 
 
 @pytest.mark.parametrize("data_source", ["test", "X_y"])
-def test_estimator_report_report_metrics_regression(regression_data, data_source):
-    """Check the behaviour of the `report_metrics` method with regression."""
+def test_estimator_report_summarize_regression(regression_data, data_source):
+    """Check the behaviour of the `summarize` method with regression."""
     estimator, X_test, y_test = regression_data
     kwargs = {"X": X_test, "y": y_test} if data_source == "X_y" else {}
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics(data_source=data_source, **kwargs)
+    result = report.metrics.summarize(data_source=data_source, **kwargs)
     assert "Favorability" not in result.columns
     expected_metrics = ("r2", "rmse", "fit_time", "predict_time")
-    _check_results_report_metrics(result, expected_metrics, len(expected_metrics))
+    _check_results_summarize(result, expected_metrics, len(expected_metrics))
 
 
-def test_estimator_report_report_metrics_scoring_kwargs(
+def test_estimator_report_summarize_scoring_kwargs(
     regression_multioutput_data, multiclass_classification_data
 ):
-    """Check the behaviour of the `report_metrics` method with scoring kwargs."""
+    """Check the behaviour of the `summarize` method with scoring kwargs."""
     estimator, X_test, y_test = regression_multioutput_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, "report_metrics")
-    result = report.metrics.report_metrics(scoring_kwargs={"multioutput": "raw_values"})
+    assert hasattr(report.metrics, "summarize")
+    result = report.metrics.summarize(scoring_kwargs={"multioutput": "raw_values"})
     assert result.shape == (6, 1)
     assert isinstance(result.index, pd.MultiIndex)
     assert result.index.names == ["Metric", "Output"]
 
     estimator, X_test, y_test = multiclass_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, "report_metrics")
-    result = report.metrics.report_metrics(scoring_kwargs={"average": None})
+    assert hasattr(report.metrics, "summarize")
+    result = report.metrics.summarize(scoring_kwargs={"average": None})
     assert result.shape == (12, 1)
     assert isinstance(result.index, pd.MultiIndex)
     assert result.index.names == ["Metric", "Label / Average"]
@@ -900,13 +898,13 @@ def test_estimator_report_report_metrics_scoring_kwargs(
         ),
     ],
 )
-def test_estimator_report_report_metrics_overwrite_scoring_names(
+def test_estimator_report_summarize_overwrite_scoring_names(
     request, fixture_name, scoring_names, expected_columns
 ):
-    """Test that we can overwrite the scoring names in report_metrics."""
+    """Test that we can overwrite the scoring names in summarize."""
     estimator, X_test, y_test = request.getfixturevalue(fixture_name)
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics(scoring_names=scoring_names)
+    result = report.metrics.summarize(scoring_names=scoring_names)
     assert result.shape == (len(expected_columns), 1)
 
     # Get level 0 names if MultiIndex, otherwise get column names
@@ -918,13 +916,13 @@ def test_estimator_report_report_metrics_overwrite_scoring_names(
     assert result_index == expected_columns
 
 
-def test_estimator_report_report_metrics_indicator_favorability(
+def test_estimator_report_summarize_indicator_favorability(
     binary_classification_data,
 ):
     """Check that the behaviour of `indicator_favorability` is correct."""
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.report_metrics(indicator_favorability=True)
+    result = report.metrics.summarize(indicator_favorability=True)
     assert "Favorability" in result.columns
     indicator = result["Favorability"]
     assert indicator["Precision"].tolist() == ["(↗︎)", "(↗︎)"]
@@ -942,17 +940,17 @@ def test_estimator_report_report_metrics_indicator_favorability(
         (get_scorer("accuracy"), "this_is_a_test", None),
     ],
 )
-def test_estimator_report_report_metrics_scoring_single_list_equivalence(
+def test_estimator_report_summarize_scoring_single_list_equivalence(
     binary_classification_data, scoring, scoring_names, scoring_kwargs
 ):
     """Check that passing a single string, callable, scorer is equivalent to passing a
     list with a single element, and it's possible to overwrite col name."""
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result_single = report.metrics.report_metrics(
+    result_single = report.metrics.summarize(
         scoring=scoring, scoring_names=scoring_names, scoring_kwargs=scoring_kwargs
     )
-    result_list = report.metrics.report_metrics(
+    result_list = report.metrics.summarize(
         scoring=[scoring], scoring_names=scoring_names, scoring_kwargs=scoring_kwargs
     )
     assert result_single.index[0] == "this_is_a_test"
@@ -1043,15 +1041,13 @@ def test_estimator_report_custom_metric(regression_data):
 
 
 @pytest.mark.parametrize("scoring", ["public_metric", "_private_metric"])
-def test_estimator_report_report_metrics_error_scoring_strings(
-    regression_data, scoring
-):
+def test_estimator_report_summarize_error_scoring_strings(regression_data, scoring):
     """Check that we raise an error if a scoring string is not a valid metric."""
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     err_msg = re.escape(f"Invalid metric: {scoring!r}.")
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.report_metrics(scoring=[scoring])
+        report.metrics.summarize(scoring=[scoring])
 
 
 def test_estimator_report_custom_function_kwargs_numpy_array(regression_data):
@@ -1086,9 +1082,9 @@ def test_estimator_report_custom_function_kwargs_numpy_array(regression_data):
     )
 
 
-def test_estimator_report_report_metrics_with_custom_metric(regression_data):
+def test_estimator_report_summarize_with_custom_metric(regression_data):
     """Check that we can pass a custom metric with specific kwargs into
-    `report_metrics`."""
+    `summarize`."""
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     weights = np.ones_like(y_test) * 2
@@ -1096,7 +1092,7 @@ def test_estimator_report_report_metrics_with_custom_metric(regression_data):
     def custom_metric(y_true, y_pred, some_weights):
         return np.mean((y_true - y_pred) * some_weights)
 
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         scoring=["r2", custom_metric],
         scoring_kwargs={"some_weights": weights, "response_method": "predict"},
     )
@@ -1110,9 +1106,9 @@ def test_estimator_report_report_metrics_with_custom_metric(regression_data):
     )
 
 
-def test_estimator_report_report_metrics_with_scorer(regression_data):
+def test_estimator_report_summarize_with_scorer(regression_data):
     """Check that we can pass scikit-learn scorer with different parameters to
-    the `report_metrics` method."""
+    the `summarize` method."""
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     weights = np.ones_like(y_test) * 2
@@ -1126,7 +1122,7 @@ def test_estimator_report_report_metrics_with_scorer(regression_data):
     custom_metric_scorer = make_scorer(
         custom_metric, response_method="predict", some_weights=weights
     )
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         scoring=[r2_score, median_absolute_error_scorer, custom_metric_scorer],
         scoring_kwargs={"response_method": "predict"},  # only dispatched to r2_score
     )
@@ -1189,19 +1185,19 @@ def test_estimator_report_custom_metric_compatible_estimator(
         (make_scorer(f1_score, response_method="predict", average="macro"), 1),
     ],
 )
-def test_estimator_report_report_metrics_with_scorer_binary_classification(
+def test_estimator_report_summarize_with_scorer_binary_classification(
     binary_classification_data, scorer, pos_label
 ):
     """Check that we can pass scikit-learn scorer with different parameters to
-    the `report_metrics` method.
+    the `summarize` method.
 
     We also check that we can pass `pos_label` whether to the scorer or to the
-    `report_metrics` method or consistently to both.
+    `summarize` method or consistently to both.
     """
     estimator, X_test, y_test = binary_classification_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
-    result = report.metrics.report_metrics(
+    result = report.metrics.summarize(
         scoring=["accuracy", accuracy_score, scorer],
         scoring_kwargs={"response_method": "predict"},
     )
@@ -1216,7 +1212,7 @@ def test_estimator_report_report_metrics_with_scorer_binary_classification(
     )
 
 
-def test_estimator_report_report_metrics_with_scorer_pos_label_error(
+def test_estimator_report_summarize_with_scorer_pos_label_error(
     binary_classification_data,
 ):
     """Check that we raise an error when pos_label is passed both in the scorer and
@@ -1228,20 +1224,20 @@ def test_estimator_report_report_metrics_with_scorer_pos_label_error(
         f1_score, response_method="predict", average="macro", pos_label=1
     )
     err_msg = re.escape(
-        "`pos_label` is passed both in the scorer and to the `report_metrics` method."
+        "`pos_label` is passed both in the scorer and to the `summarize` method."
     )
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.report_metrics(scoring=[f1_scorer], pos_label=0)
+        report.metrics.summarize(scoring=[f1_scorer], pos_label=0)
 
 
-def test_estimator_report_report_metrics_invalid_metric_type(regression_data):
+def test_estimator_report_summarize_invalid_metric_type(regression_data):
     """Check that we raise the expected error message if an invalid metric is passed."""
     estimator, X_test, y_test = regression_data
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
     err_msg = re.escape("Invalid type of metric: <class 'int'> for 1")
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.report_metrics(scoring=[1])
+        report.metrics.summarize(scoring=[1])
 
 
 def test_estimator_report_get_X_y_and_data_source_hash_error():
@@ -1437,7 +1433,7 @@ def test_estimator_report_metric_with_neg_metrics(binary_classification_data):
     classifier, X_test, y_test = binary_classification_data
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
 
-    result = report.metrics.report_metrics(scoring=["neg_log_loss"])
+    result = report.metrics.summarize(scoring=["neg_log_loss"])
     assert "Log Loss" in result.index
     assert result.loc["Log Loss", "RandomForestClassifier"] == pytest.approx(
         report.metrics.log_loss()
@@ -1445,14 +1441,14 @@ def test_estimator_report_metric_with_neg_metrics(binary_classification_data):
 
 
 def test_estimator_report_with_sklearn_scoring_strings(binary_classification_data):
-    """Test that scikit-learn metric strings can be passed to report_metrics."""
+    """Test that scikit-learn metric strings can be passed to summarize."""
     classifier, X_test, y_test = binary_classification_data
     class_report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
 
-    result = class_report.metrics.report_metrics(scoring=["neg_log_loss"])
+    result = class_report.metrics.summarize(scoring=["neg_log_loss"])
     assert "Log Loss" in result.index.get_level_values(0)
 
-    result_multi = class_report.metrics.report_metrics(
+    result_multi = class_report.metrics.summarize(
         scoring=["accuracy", "neg_log_loss", "roc_auc"], indicator_favorability=True
     )
     assert "Accuracy" in result_multi.index.get_level_values(0)
@@ -1466,11 +1462,11 @@ def test_estimator_report_with_sklearn_scoring_strings(binary_classification_dat
 
 
 def test_estimator_report_with_sklearn_scoring_strings_regression(regression_data):
-    """Test scikit-learn regression metric strings in report_metrics."""
+    """Test scikit-learn regression metric strings in summarize."""
     regressor, X_test, y_test = regression_data
     reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
 
-    reg_result = reg_report.metrics.report_metrics(
+    reg_result = reg_report.metrics.summarize(
         scoring=["neg_mean_squared_error", "neg_mean_absolute_error", "r2"],
         indicator_favorability=True,
     )
@@ -1484,11 +1480,11 @@ def test_estimator_report_with_sklearn_scoring_strings_regression(regression_dat
 
 
 def test_estimator_report_with_scoring_strings_regression(regression_data):
-    """Test scikit-learn regression metric strings in report_metrics."""
+    """Test scikit-learn regression metric strings in summarize."""
     regressor, X_test, y_test = regression_data
     reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
 
-    reg_result = reg_report.metrics.report_metrics(
+    reg_result = reg_report.metrics.summarize(
         scoring=["neg_mean_squared_error", "neg_mean_absolute_error", "r2"],
         indicator_favorability=True,
     )
@@ -1506,7 +1502,7 @@ def test_estimator_report_sklearn_scorer_names_pos_label(binary_classification_d
     classifier, X_test, y_test = binary_classification_data
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
 
-    result = report.metrics.report_metrics(scoring=["f1"], pos_label=0)
+    result = report.metrics.summarize(scoring=["f1"], pos_label=0)
     assert "F1 Score" in result.index.get_level_values(0)
     assert 0 in result.index.get_level_values(1)
     f1_scorer = make_scorer(
@@ -1531,18 +1527,16 @@ def test_estimator_report_sklearn_scorer_names_scoring_kwargs(
         "scikit-learn scorer name."
     )
     with pytest.raises(ValueError, match=err_msg):
-        report.metrics.report_metrics(
-            scoring=["f1"], scoring_kwargs={"average": "macro"}
-        )
+        report.metrics.summarize(scoring=["f1"], scoring_kwargs={"average": "macro"})
 
 
 @pytest.mark.parametrize(
     "metric, metric_fn", [("precision", precision_score), ("recall", recall_score)]
 )
-def test_estimator_report_report_metrics_pos_label_overwrite(
+def test_estimator_report_summarize_pos_label_overwrite(
     binary_classification_data, metric, metric_fn
 ):
-    """Check that `pos_label` can be overwritten in `report_metrics`"""
+    """Check that `pos_label` can be overwritten in `summarize`"""
     X, y = make_classification(
         n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
     )
@@ -1551,17 +1545,17 @@ def test_estimator_report_report_metrics_pos_label_overwrite(
     classifier = LogisticRegression().fit(X, y)
 
     report = EstimatorReport(classifier, X_test=X, y_test=y)
-    result = report.metrics.report_metrics(scoring=metric).reset_index()
+    result = report.metrics.summarize(scoring=metric).reset_index()
     assert result["Label / Average"].to_list() == ["A", "B"]
 
     report = EstimatorReport(classifier, X_test=X, y_test=y, pos_label="B")
-    result = report.metrics.report_metrics(scoring=metric).reset_index()
+    result = report.metrics.summarize(scoring=metric).reset_index()
     assert "Label / Average" not in result.columns
     assert result[report.estimator_name_].item() == pytest.approx(
         metric_fn(y, classifier.predict(X), pos_label="B")
     )
 
-    result = report.metrics.report_metrics(scoring=metric, pos_label="A").reset_index()
+    result = report.metrics.summarize(scoring=metric, pos_label="A").reset_index()
     assert "Label / Average" not in result.columns
     assert result[report.estimator_name_].item() == pytest.approx(
         metric_fn(y, classifier.predict(X), pos_label="A")
@@ -1574,7 +1568,7 @@ def test_estimator_report_report_metrics_pos_label_overwrite(
 def test_estimator_report_precision_recall_pos_label_overwrite(
     binary_classification_data, metric, metric_fn
 ):
-    """Check that `pos_label` can be overwritten in `report_metrics`"""
+    """Check that `pos_label` can be overwritten in `summarize`"""
     X, y = make_classification(
         n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
     )

--- a/skore/tests/unit/sklearn/estimator/test_timings.py
+++ b/skore/tests/unit/sklearn/estimator/test_timings.py
@@ -132,22 +132,22 @@ def test_predict_time(data_source, binary_classification_data):
     )
 
 
-def test_report_metrics_fit_time(binary_classification_data):
+def test_summarize_fit_time(binary_classification_data):
     estimator, data = binary_classification_data
     report = EstimatorReport(estimator, **data)
 
-    assert isinstance(report.metrics.report_metrics(scoring=["fit_time"]), pd.DataFrame)
+    assert isinstance(report.metrics.summarize(scoring=["fit_time"]), pd.DataFrame)
 
 
 @pytest.mark.parametrize("data_source", ["test", "train", "X_y"])
-def test_report_metrics_predict_time(data_source, binary_classification_data):
+def test_summarize_predict_time(data_source, binary_classification_data):
     estimator, data = binary_classification_data
     report = EstimatorReport(estimator, **data)
 
     X_, y_ = (data["X_test"], data["y_test"]) if data_source == "X_y" else (None, None)
 
     assert isinstance(
-        report.metrics.report_metrics(
+        report.metrics.summarize(
             scoring=["predict_time"], data_source=data_source, X=X_, y=y_
         ),
         pd.DataFrame,

--- a/sphinx/reference/report/comparison_report.rst
+++ b/sphinx/reference/report/comparison_report.rst
@@ -45,7 +45,7 @@ get the common performance metric representations.
     :template: autosummary/accessor_method.rst
 
     ComparisonReport.metrics.help
-    ComparisonReport.metrics.report_metrics
+    ComparisonReport.metrics.summarize
     ComparisonReport.metrics.custom_metric
     ComparisonReport.metrics.accuracy
     ComparisonReport.metrics.brier_score

--- a/sphinx/reference/report/cross_validation_report.rst
+++ b/sphinx/reference/report/cross_validation_report.rst
@@ -32,7 +32,7 @@ functionalities of the report are exposed through accessors.
 
    CrossValidationReport.metrics
 
-.. _cross_validation_report_metrics:
+.. _cross_validation_:
 
 Metrics
 -------
@@ -45,7 +45,7 @@ estimator across cross-validation folds.
     :template: autosummary/accessor_method.rst
 
     CrossValidationReport.metrics.help
-    CrossValidationReport.metrics.report_metrics
+    CrossValidationReport.metrics.
     CrossValidationReport.metrics.custom_metric
     CrossValidationReport.metrics.accuracy
     CrossValidationReport.metrics.brier_score

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -33,7 +33,7 @@ report are accessible through accessors.
    EstimatorReport.feature_importance
    EstimatorReport.metrics
 
-.. _estimator_report_metrics:
+.. _estimator_:
 
 Metrics
 -------
@@ -46,7 +46,7 @@ estimator.
     :template: autosummary/accessor_method.rst
 
     EstimatorReport.metrics.help
-    EstimatorReport.metrics.report_metrics
+    EstimatorReport.metrics.
     EstimatorReport.metrics.custom_metric
     EstimatorReport.metrics.timings
     EstimatorReport.metrics.accuracy

--- a/sphinx/user_guide/reporters.rst
+++ b/sphinx/user_guide/reporters.rst
@@ -48,7 +48,7 @@ addition, set `data_source` to `X_y` to pass a new dataset using the parameters 
 `y`. This is useful when you want to compare different models on a new left-out dataset.
 
 While there are individual methods to compute each metric specific to the problem at
-hand, we provide the :class:`EstimatorReport.metrics.report_metrics` method that
+hand, we provide the :class:`EstimatorReport.metrics.` method that
 aggregates metrics in a single dataframe. By default, a set of metrics is computed based
 on the type of target variable (e.g. classification or regression). Nevertheless, you
 can specify the metrics you want to compute thanks to the `scoring` parameter. We accept
@@ -63,7 +63,7 @@ methods: (i) `plot` that plots graphically the information contained in the disp
 method at each call.
 
 Refer to the :ref:`displays` section for more details regarding the `skore` display
-API. Refer to the :ref:`estimator_report_metrics` section for more details on all the
+API. Refer to the :ref:`estimator_` section for more details on all the
 available metrics in `skore`.
 
 Caching mechanism
@@ -110,7 +110,7 @@ parameter, `aggregate`, to aggregate the metrics across the splits.
 The :class:`CrossValidationReport` also comes with a caching mechanism by leveraging
 the :class:`EstimatorReport` caching mechanism and exposes the same methods.
 
-Refer to the :ref:`cross_validation_report_metrics` section for more details on the
+Refer to the :ref:`cross_validation_` section for more details on the
 metrics available in `skore` for cross-validation.
 
 .. _comparison_report:
@@ -129,5 +129,5 @@ performance of the different models.
 
 The caching mechanism is also available and exposes the same methods.
 
-Refer to the :ref:`cross_validation_report_metrics` section for more details on the
+Refer to the :ref:`cross_validation_` section for more details on the
 metrics available in `skore` for comparison.


### PR DESCRIPTION
closes #1794 

Rename the `.metrics.report_metrics()` method to `.metrics.summarize()`.