### PR TITLE
feat(skore): Import `importlib.metadata` on python>=3.8

### DIFF
--- a/skore/src/skore/project/project.py
+++ b/skore/src/skore/project/project.py
@@ -3,13 +3,8 @@
 from __future__ import annotations
 
 import re
-import sys
+from importlib.metadata import entry_points
 from typing import Any
-
-if sys.version_info < (3, 10):  # pragma: no cover
-    from importlib_metadata import entry_points
-else:
-    from importlib.metadata import entry_points
 
 from skore.project.summary import Summary
 from skore.sklearn._estimator.report import EstimatorReport


### PR DESCRIPTION
Since `importlib.metadata` is available since `python==3.8`, use it in state.

![image](https://github.com/user-attachments/assets/764a1af6-716c-4342-8352-70b6e11fa15e)
https://docs.python.org/3/library/importlib.metadata.html


