### PR TITLE
feat(train_test_split): Allow positional arguments with `as_dict=True`

### DIFF
--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -155,13 +155,13 @@ def train_test_split(
     keys = []
 
     if X is not None:
-        keys.append("X")
         new_arrays.append(X)
+        keys.append("X")
     if y is not None:
-        keys.append("y")
         new_arrays.append(y)
+        keys.append("y")
 
-    if as_dict:
+    if as_dict and arrays:
         # case when X or y is implicit as first 2 args for as_dict=True
         if len(arrays) == 1:
             warnings.warn(
@@ -183,7 +183,11 @@ def train_test_split(
                 "\nEx: train_test_split(X=X, y=y, z=z, sw=sample_weight, as_dict=True)"
             )
 
-    if keyword_arrays:  # case when keyword arg is specified but as_dict isn't used
+    if keyword_arrays:
+        if X is None and y is None:
+            arrays = tuple(
+                keyword_arrays.values()
+            )  # if X and y is not passed but other variables
         new_arrays.extend(keyword_arrays.values())
         keys.extend(keyword_arrays.keys())
 

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -138,12 +138,13 @@ def train_test_split(
 
     new_arrays = list(arrays)
     keys = []
+
     if X is not None:
+        keys.append("X")
         new_arrays.append(X)
-        keys += ["X"]
     if y is not None:
+        keys.append("y")
         new_arrays.append(y)
-        keys += ["y"]
 
     if as_dict:
         if len(arrays) == 1:
@@ -157,13 +158,9 @@ def train_test_split(
                 "Example: train_test_split(X, y, z=z, sw=sample_weight, as_dict=True)"
             )
 
-    if keyword_arrays:
-        if X is None and y is None:
-            arrays = tuple(
-                keyword_arrays.values()
-            )  # if X and y is not passed but other variables
-        keys += list(keyword_arrays.keys())
-        new_arrays += list(keyword_arrays.values())
+    if keyword_arrays:  # case when keyword arg is specified but as_dict isn't used
+        new_arrays.extend(keyword_arrays.values())
+        keys.extend(keyword_arrays.keys())
 
     output = sklearn.model_selection.train_test_split(
         *new_arrays,

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -176,8 +176,10 @@ def train_test_split(
             keys.extend(["X", "y"])
         elif len(arrays) > 2:
             raise ValueError(
-                "With as_dict=True, more than two arguments must be keyword arguments."
-                "\nEx: train_test_split(X=X, y=y, z=z, sw=sample_weight, as_dict=True)"
+                "With as_dict=True, expected no more than two positional arguments "
+                "(which will be interpreted as X and y). "
+                "The remaining arrays must be passed by keyword, "
+                "e.g. train_test_split(X, y, z=z, sw=sample_weights, as_dict=True)."
             )
 
     if keyword_arrays:

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -159,6 +159,12 @@ def train_test_split(
         keys.append("y")
 
     if as_dict and arrays:
+        # if X is passed as both keyword and pos args
+        if len(arrays) <= 2 and (X is not None or y is not None):
+            raise ValueError(
+                "With as_dict=True, X/y cannot be passed by both position and keyword."
+            )
+
         # if X or y are passed by position
         if len(arrays) == 1:
             warnings.warn(
@@ -174,6 +180,7 @@ def train_test_split(
                 stacklevel=2,
             )
             keys.extend(["X", "y"])
+
         elif len(arrays) > 2:
             raise ValueError(
                 "With as_dict=True, expected no more than two positional arguments "

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -145,11 +145,17 @@ def train_test_split(
         new_arrays.append(y)
         keys += ["y"]
 
-    if as_dict and arrays:
-        raise ValueError(
-            "When as_dict=True, arrays must be passed as keyword arguments.\n"
-            "Example: train_test_split(X=X, y=y, sw=sample_weight, as_dict=True)"
-        )
+    if as_dict:
+        if len(arrays) == 1:
+            keys += ["X"]
+        elif len(arrays) == 2:
+            keys.extend(["X", "y"])
+        elif len(arrays) > 2:
+            raise ValueError(
+                ""
+                "With as_dict=True, arguments must be passed as keyword arguments.\n"
+                "Example: train_test_split(X, y, z=z, sw=sample_weight, as_dict=True)"
+            )
 
     if keyword_arrays:
         if X is None and y is None:

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -162,12 +162,12 @@ def train_test_split(
         # if X or y is passed both by keyword and by position
         if X is not None:
             raise ValueError(
-                f"With as_dict=True, expected X to be passed either "
+                "With as_dict=True, expected X to be passed either "
                 "by position or keyword, not both."
             )
         if y is not None:
             raise ValueError(
-                f"With as_dict=True, expected y to be passed either "
+                "With as_dict=True, expected y to be passed either "
                 "by position or keyword, not both."
             )
 

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -172,7 +172,7 @@ def train_test_split(
             keys.append("X")
         elif len(arrays) == 2:
             warnings.warn(
-                "With as_dict=True, two arguments defaults to 'X' & 'y'."
+                "With as_dict=True, first 2 positional arguments defaults to 'X' & 'y'."
                 "\nSpecify as keyword argument to rename.",
                 stacklevel=2,
             )

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -135,16 +135,13 @@ def train_test_split(
      'y_train': ..., 'y_test': ...,
      'sample_weights_train': ..., 'sample_weights_test': ...}
 
-    >>> # With as_dict is True, first 2 arguments are implicitly treated as X and y.
-    >>> split_dict = train_test_split(X, as_dict=True)
-    >>> split_dict
+    >>> # With as_dict is True, the first 2 arguments are implicitly treated as X and y
+    >>> train_test_split(X, as_dict=True)
     {'X_train': ..., 'X_test': ...}
-    >>> split_dict = train_test_split(X, y, as_dict=True)
-    >>> split_dict
+    >>> train_test_split(X, y, as_dict=True)
     {'X_train': ..., 'X_test': ...,
      'y_train': ..., 'y_test': ...}
-    >>> split_dict = train_test_split(X, y, sample_weights=sample_weights, as_dict=True)
-    >>> split_dict
+    >>> train_test_split(X, y, sample_weights=sample_weights, as_dict=True)
     {'X_train': ..., 'X_test': ...,
      'y_train': ..., 'y_test': ...,
      'sample_weights_train': ..., 'sample_weights_test': ...}
@@ -162,7 +159,7 @@ def train_test_split(
         keys.append("y")
 
     if as_dict and arrays:
-        # case when X or y is implicit as first 2 args for as_dict=True
+        # if X or y are passed by position
         if len(arrays) == 1:
             warnings.warn(
                 "With as_dict=True, single argument defaults to 'X'."
@@ -177,7 +174,7 @@ def train_test_split(
                 stacklevel=2,
             )
             keys.extend(["X", "y"])
-        elif len(arrays) > 2:  # case when as_dict=True and given # arrays > 3
+        elif len(arrays) > 2:
             raise ValueError(
                 "With as_dict=True, more than two arguments must be keyword arguments."
                 "\nEx: train_test_split(X=X, y=y, z=z, sw=sample_weight, as_dict=True)"

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -160,16 +160,14 @@ def train_test_split(
 
     if as_dict and arrays:
         # if X or y is passed both by keyword and by position
-        err = []
         if X is not None:
-            err.append("X")
-        if y is not None:
-            err.append("y")
-
-        if err:
-            args = " and ".join(err)
             raise ValueError(
-                f"With as_dict=True, expected {args} to be passed either "
+                f"With as_dict=True, expected X to be passed either "
+                "by position or keyword, not both."
+            )
+        if y is not None:
+            raise ValueError(
+                f"With as_dict=True, expected y to be passed either "
                 "by position or keyword, not both."
             )
 

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -147,15 +147,25 @@ def train_test_split(
         new_arrays.append(y)
 
     if as_dict:
+        # case when X or y is implicit as first 2 args for as_dict=True
         if len(arrays) == 1:
-            keys += ["X"]
+            warnings.warn(
+                "With as_dict=True, single argument defaults to 'X'."
+                "\nSpecify as keyword argument to rename.",
+                stacklevel=2,
+            )
+            keys.append("X")
         elif len(arrays) == 2:
+            warnings.warn(
+                "With as_dict=True, two arguments defaults to 'X' & 'y'."
+                "\nSpecify as keyword argument to rename.",
+                stacklevel=2,
+            )
             keys.extend(["X", "y"])
-        elif len(arrays) > 2:
+        elif len(arrays) > 2:  # case when as_dict=True and given # arrays > 3
             raise ValueError(
-                ""
-                "With as_dict=True, arguments must be passed as keyword arguments.\n"
-                "Example: train_test_split(X, y, z=z, sw=sample_weight, as_dict=True)"
+                "With as_dict=True, more than two arguments must be keyword arguments."
+                "\nEx: train_test_split(X=X, y=y, z=z, sw=sample_weight, as_dict=True)"
             )
 
     if keyword_arrays:  # case when keyword arg is specified but as_dict isn't used

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -73,7 +73,8 @@ def train_test_split(
     as_dict : bool, default is False
         If True, returns a Dictionary with keys values ``X_train``, ``X_test``,
         ``y_train``, and ``y_test`` instead of a List. Requires data to be
-        passed as keyword arguments.
+        passed as keyword arguments, though the first two positional arguments are
+        implicitly treated as X and y.
     **keyword_arrays : array-like, optional
         Additional array-like arguments passed by keyword. Used to determine the keys
         of the output dict when ``as_dict=True``.
@@ -129,6 +130,20 @@ def train_test_split(
     >>> sample_weights = np.arange(10).reshape((5, 2))
     >>> split_dict = train_test_split(
     ...     X=X, y=y, sample_weights=sample_weights, as_dict=True, random_state=0)
+    >>> split_dict
+    {'X_train': ..., 'X_test': ...,
+     'y_train': ..., 'y_test': ...,
+     'sample_weights_train': ..., 'sample_weights_test': ...}
+
+    >>> # With as_dict is True, first 2 arguments are implicitly treated as X and y.
+    >>> split_dict = train_test_split(X, as_dict=True)
+    >>> split_dict
+    {'X_train': ..., 'X_test': ...}
+    >>> split_dict = train_test_split(X, y, as_dict=True)
+    >>> split_dict
+    {'X_train': ..., 'X_test': ...,
+     'y_train': ..., 'y_test': ...}
+    >>> split_dict = train_test_split(X, y, sample_weights=sample_weights, as_dict=True)
     >>> split_dict
     {'X_train': ..., 'X_test': ...,
      'y_train': ..., 'y_test': ...,

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -167,20 +167,9 @@ def train_test_split(
 
         # if X or y are passed by position
         if len(arrays) == 1:
-            warnings.warn(
-                "With as_dict=True, single argument defaults to 'X'."
-                "\nSpecify as keyword argument to rename.",
-                stacklevel=2,
-            )
             keys.append("X")
         elif len(arrays) == 2:
-            warnings.warn(
-                "With as_dict=True, first 2 positional arguments defaults to 'X' & 'y'."
-                "\nSpecify as keyword argument to rename.",
-                stacklevel=2,
-            )
             keys.extend(["X", "y"])
-
         elif len(arrays) > 2:
             raise ValueError(
                 "With as_dict=True, expected no more than two positional arguments "

--- a/skore/src/skore/sklearn/train_test_split/train_test_split.py
+++ b/skore/src/skore/sklearn/train_test_split/train_test_split.py
@@ -159,10 +159,18 @@ def train_test_split(
         keys.append("y")
 
     if as_dict and arrays:
-        # if X is passed as both keyword and pos args
-        if len(arrays) <= 2 and (X is not None or y is not None):
+        # if X or y is passed both by keyword and by position
+        err = []
+        if X is not None:
+            err.append("X")
+        if y is not None:
+            err.append("y")
+
+        if err:
+            args = " and ".join(err)
             raise ValueError(
-                "With as_dict=True, X/y cannot be passed by both position and keyword."
+                f"With as_dict=True, expected {args} to be passed either "
+                "by position or keyword, not both."
             )
 
         # if X or y are passed by position

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -188,10 +188,8 @@ def test_train_test_split_single_posargs():
     X = [[1]] * 20
 
     output = train_test_split(X, as_dict=True)
-    # assert that first key contains X
-    assert next(iter(output)).startswith("X")
-    # assert that output is a dict
-    assert type(output) is dict
+    assert isinstance(output, dict)
+    assert set(output.keys()) == {"X_train", "X_test"}
 
 
 def test_train_test_split_two_posargs():
@@ -201,11 +199,8 @@ def test_train_test_split_two_posargs():
     y = [0] * 10 + [1] * 10
 
     output = train_test_split(X, y, as_dict=True)
-    keys = set(output.keys())
-    # assert that keys have X and y
-    assert keys == {"X_train", "X_test", "y_train", "y_test"}
-    # assert that output is a dict
     assert isinstance(output, dict)
+    assert set(output.keys()) == {"X_train", "X_test", "y_train", "y_test"}
 
 
 def test_train_test_split_dict_pos_kwargs_conflict():
@@ -235,11 +230,8 @@ def test_train_test_split_mix_args():
     z = [0] * 10 + [1] * 10
 
     output = train_test_split(X, y, z=z, as_dict=True)
-    keys = set(output.keys())
-    # assert that keys have X, y, z
-    assert keys == {"X_train", "X_test", "y_train", "y_test", "z_train", "z_test"}
-    # assert that output is a dict
     assert isinstance(output, dict)
+    assert set(output.keys()) == {"X_train", "X_test", "y_train", "y_test", "z_train", "z_test"}
 
 
 def test_train_test_split_dict_kwargs():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -201,11 +201,11 @@ def test_train_test_split_two_posargs():
     y = [0] * 10 + [1] * 10
 
     output = train_test_split(X, y, as_dict=True)
-    keys = list(output.keys())
+    keys = set(output.keys())
     # assert that keys have X and y
-    assert keys[0].startswith("X") and keys[2].startswith("y")
+    assert keys == {"X_train", "X_test", "y_train", "y_test"}
     # assert that output is a dict
-    assert type(output) is dict
+    assert isinstance(output, dict)
 
 
 def test_train_test_split_mix_args():
@@ -217,13 +217,11 @@ def test_train_test_split_mix_args():
     z = [0] * 10 + [1] * 10
 
     output = train_test_split(X, y, z=z, as_dict=True)
-    keys = list(output.keys())
+    keys = set(output.keys())
     # assert that keys have X, y, z
-    assert (
-        keys[0].startswith("X") and keys[2].startswith("y") and keys[4].startswith("z")
-    )
+    assert keys == {"X_train", "X_test", "y_train", "y_test", "z_train", "z_test"}
     # assert that output is a dict
-    assert type(output) is dict
+    assert isinstance(output, dict)
 
 
 def test_train_test_split_dict_kwargs():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -220,7 +220,10 @@ def test_train_test_split_dict_pos_kwargs_conflict():
 
     with pytest.raises(ValueError, match=re.escape(err_msg)):
         train_test_split(X, X=X, as_dict=True)
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
         train_test_split(y, y=y, as_dict=True)
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
+        train_test_split(X, y, X=X, y=y, as_dict=True)
 
 
 def test_train_test_split_mix_args():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -183,21 +183,22 @@ def test_train_test_split_kwargs():
 
 
 def test_train_test_split_dict_kwargs():
-    """Passing data without keyword arguments with return_dict=True
+    """Passing three or more keyword arguments with as_dict=True
     should raise ValueError."""
 
     X = [[1]] * 20
     y = [0] * 10 + [1] * 10
+    z = [0] * 10 + [1] * 10
 
     with pytest.raises(
         ValueError,
         match="When as_dict=True, arrays must be passed as keyword arguments",
     ):
-        train_test_split(X, y, random_state=0, as_dict=True)
+        train_test_split(X, y, z, random_state=0, as_dict=True)
 
 
 def test_train_test_split_check_dict():
-    """If `return_dict` is True then the result is a dict."""
+    """If `as_dict` is True then the result is a dict."""
     X = [[1]] * 20
     y = [0] * 10 + [1] * 10
     output = train_test_split(X=X, y=y, random_state=0, as_dict=True)
@@ -205,7 +206,7 @@ def test_train_test_split_check_dict():
 
 
 def test_train_test_split_check_dict_unsupervised_case():
-    """If `return_dict` is True and only `X` is passed,
+    """If `as_dict` is True and only `X` is passed,
     the result is a dict with 2 keys."""
 
     X = [[1]] * 20

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -182,6 +182,50 @@ def test_train_test_split_kwargs():
     assert output1 == output2
 
 
+def test_train_test_split_single_posargs():
+    """Passing single positional argument with as_dict=True should return as dict."""
+
+    X = [[1]] * 20
+
+    output = train_test_split(X, as_dict=True)
+    # assert that first key contains X
+    assert next(iter(output)).startswith("X")
+    # assert that output is a dict
+    assert type(output) is dict
+
+
+def test_train_test_split_two_posargs():
+    """Passing two positional argument with as_dict=True should return as dict."""
+
+    X = [[1]] * 20
+    y = [0] * 10 + [1] * 10
+
+    output = train_test_split(X, y, as_dict=True)
+    keys = list(output.keys())
+    # assert that keys have X and y
+    assert keys[0].startswith("X") and keys[2].startswith("y")
+    # assert that output is a dict
+    assert type(output) is dict
+
+
+def test_train_test_split_mix_args():
+    """Passing mixed positional and keyword argument with as_dict=True
+    should return as dict."""
+
+    X = [[1]] * 20
+    y = [0] * 10 + [1] * 10
+    z = [0] * 10 + [1] * 10
+
+    output = train_test_split(X, y, z=z, as_dict=True)
+    keys = list(output.keys())
+    # assert that keys have X, y, z
+    assert (
+        keys[0].startswith("X") and keys[2].startswith("y") and keys[4].startswith("z")
+    )
+    # assert that output is a dict
+    assert type(output) is dict
+
+
 def test_train_test_split_dict_kwargs():
     """Passing three or more keyword arguments with as_dict=True
     should raise ValueError."""

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -221,8 +221,6 @@ def test_train_test_split_dict_pos_kwargs_conflict():
         train_test_split(X, X=X, as_dict=True)
     with pytest.raises(ValueError, match=re.escape(err_msg.format("y"))):
         train_test_split(y, y=y, as_dict=True)
-    with pytest.raises(ValueError, match=re.escape(err_msg.format("X and y"))):
-        train_test_split(X, y, X=X, y=y, as_dict=True)
 
 
 def test_train_test_split_mix_args():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -237,17 +237,10 @@ def test_train_test_split_dict_kwargs():
         "\nEx: train_test_split(X=X, y=y, z=z, sw=sample_weight, as_dict=True)"
     )
 
-    with pytest.raises(ValueError) as err:
-        train_test_split(X, y, z, random_state=0, as_dict=True)
-    assert str(err.value) == err_msg
+    import re
 
-
-def test_train_test_split_check_dict():
-    """If `as_dict` is True then the result is a dict."""
-    X = [[1]] * 20
-    y = [0] * 10 + [1] * 10
-    output = train_test_split(X=X, y=y, random_state=0, as_dict=True)
-    assert type(output) is dict
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
+        train_test_split(X, y, z, as_dict=True)
 
 
 def test_train_test_split_check_dict_unsupervised_case():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -208,6 +208,21 @@ def test_train_test_split_two_posargs():
     assert isinstance(output, dict)
 
 
+def test_train_test_split_dict_pos_kwargs_conflict():
+    """Passing X or y by both position and keyword with as_dict=True
+    should throw an error."""
+
+    X = [[1]] * 20
+    y = [0] * 10 + [1] * 10
+
+    err_msg = "With as_dict=True, X/y cannot be passed by both position and keyword."
+    import re
+
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
+        train_test_split(X, X=X, as_dict=True)
+        train_test_split(y, y=y, as_dict=True)
+
+
 def test_train_test_split_mix_args():
     """Passing mixed positional and keyword argument with as_dict=True
     should return as dict."""

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -233,10 +233,11 @@ def test_train_test_split_dict_kwargs():
     z = [0] * 10 + [1] * 10
 
     err_msg = (
-        "With as_dict=True, more than two arguments must be keyword arguments."
-        "\nEx: train_test_split(X=X, y=y, z=z, sw=sample_weight, as_dict=True)"
+        "With as_dict=True, expected no more than two positional arguments "
+        "(which will be interpreted as X and y). "
+        "The remaining arrays must be passed by keyword, "
+        "e.g. train_test_split(X, y, z=z, sw=sample_weights, as_dict=True)."
     )
-
     import re
 
     with pytest.raises(ValueError, match=re.escape(err_msg)):

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -234,11 +234,14 @@ def test_train_test_split_dict_kwargs():
     y = [0] * 10 + [1] * 10
     z = [0] * 10 + [1] * 10
 
-    with pytest.raises(
-        ValueError,
-        match="When as_dict=True, arrays must be passed as keyword arguments",
-    ):
+    err_msg = (
+        "With as_dict=True, more than two arguments must be keyword arguments."
+        "\nEx: train_test_split(X=X, y=y, z=z, sw=sample_weight, as_dict=True)"
+    )
+
+    with pytest.raises(ValueError) as err:
         train_test_split(X, y, z, random_state=0, as_dict=True)
+    assert str(err.value) == err_msg
 
 
 def test_train_test_split_check_dict():

--- a/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
+++ b/skore/tests/unit/sklearn/train_test_split/test_train_test_split.py
@@ -210,14 +210,18 @@ def test_train_test_split_dict_pos_kwargs_conflict():
     X = [[1]] * 20
     y = [0] * 10 + [1] * 10
 
-    err_msg = "With as_dict=True, X/y cannot be passed by both position and keyword."
+    err_msg = (
+        "With as_dict=True, expected {} to be passed either "
+        "by position or keyword, not both."
+    )
+
     import re
 
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
+    with pytest.raises(ValueError, match=re.escape(err_msg.format("X"))):
         train_test_split(X, X=X, as_dict=True)
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
+    with pytest.raises(ValueError, match=re.escape(err_msg.format("y"))):
         train_test_split(y, y=y, as_dict=True)
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
+    with pytest.raises(ValueError, match=re.escape(err_msg.format("X and y"))):
         train_test_split(X, y, X=X, y=y, as_dict=True)
 
 
@@ -231,7 +235,14 @@ def test_train_test_split_mix_args():
 
     output = train_test_split(X, y, z=z, as_dict=True)
     assert isinstance(output, dict)
-    assert set(output.keys()) == {"X_train", "X_test", "y_train", "y_test", "z_train", "z_test"}
+    assert set(output.keys()) == {
+        "X_train",
+        "X_test",
+        "y_train",
+        "y_test",
+        "z_train",
+        "z_test",
+    }
 
 
 def test_train_test_split_dict_kwargs():


### PR DESCRIPTION
Fixes #1544.

- Allows the user to specify X and y positional arguments. 
- Warn users that single/double positional arguments default to 'X'/'y' names when as_dict=True.
- Updated docstrings.
- Added new and fixed old tests.