### PR TITLE
fix(skore): Rename to MetricsSummaryDisplay and document it

### DIFF
--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -11,10 +11,10 @@ from skore.externals._pandas_accessors import DirNamesMixin
 from skore.sklearn._base import _BaseAccessor, _get_cached_response_values
 from skore.sklearn._comparison.report import ComparisonReport
 from skore.sklearn._plot.metrics import (
+    MetricsSummaryDisplay,
     PrecisionRecallCurveDisplay,
     PredictionErrorDisplay,
     RocCurveDisplay,
-    SummarizeDisplay,
 )
 from skore.sklearn.types import (
     _DEFAULT,
@@ -69,7 +69,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
         indicator_favorability: bool = False,
         flat_index: bool = False,
         aggregate: Optional[Aggregate] = ("mean", "std"),
-    ) -> SummarizeDisplay:
+    ) -> MetricsSummaryDisplay:
         """Report a set of metrics for the estimators.
 
         Parameters
@@ -131,7 +131,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
 
         Returns
         -------
-        SummarizeDisplay
+        MetricsSummaryDisplay
             A display containing the statistics for the metrics.
 
         Examples
@@ -179,7 +179,7 @@ class _MetricsAccessor(_BaseAccessor, DirNamesMixin):
                 results.index = results.index.str.replace(
                     r"\((.*)\)$", r"\1", regex=True
                 )
-        return SummarizeDisplay(results)
+        return MetricsSummaryDisplay(results)
 
     @progress_decorator(description="Compute metric for each estimator")
     def _compute_metric_scores(

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -12,10 +12,10 @@ from skore.externals._pandas_accessors import DirNamesMixin
 from skore.sklearn._base import _BaseAccessor, _get_cached_response_values
 from skore.sklearn._cross_validation.report import CrossValidationReport
 from skore.sklearn._plot import (
+    MetricsSummaryDisplay,
     PrecisionRecallCurveDisplay,
     PredictionErrorDisplay,
     RocCurveDisplay,
-    SummarizeDisplay,
 )
 from skore.sklearn.types import (
     _DEFAULT,
@@ -69,7 +69,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
         indicator_favorability: bool = False,
         flat_index: bool = False,
         aggregate: Optional[Aggregate] = ("mean", "std"),
-    ) -> SummarizeDisplay:
+    ) -> MetricsSummaryDisplay:
         """Report a set of metrics for our estimator.
 
         Parameters
@@ -131,7 +131,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
 
         Returns
         -------
-        SummarizeDisplay
+        MetricsSummaryDisplay
             A display containing the statistics for the metrics.
 
         Examples
@@ -177,7 +177,7 @@ class _MetricsAccessor(_BaseAccessor["CrossValidationReport"], DirNamesMixin):
                 results.index = results.index.str.replace(
                     r"\((.*)\)$", r"\1", regex=True
                 )
-        return SummarizeDisplay(summarize_data=results)
+        return MetricsSummaryDisplay(summarize_data=results)
 
     @progress_decorator(description="Compute metric for each split")
     def _compute_metric_scores(

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -17,10 +17,10 @@ from skore.sklearn._base import _BaseAccessor, _get_cached_response_values
 from skore.sklearn._estimator.report import EstimatorReport
 from skore.sklearn._plot import (
     ConfusionMatrixDisplay,
+    MetricsSummaryDisplay,
     PrecisionRecallCurveDisplay,
     PredictionErrorDisplay,
     RocCurveDisplay,
-    SummarizeDisplay,
 )
 from skore.sklearn.types import _DEFAULT, PositiveLabel, Scoring, ScoringName, YPlotData
 from skore.utils._accessor import (
@@ -70,7 +70,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
         pos_label: Optional[PositiveLabel] = _DEFAULT,
         indicator_favorability: bool = False,
         flat_index: bool = False,
-    ) -> SummarizeDisplay:
+    ) -> MetricsSummaryDisplay:
         """Report a set of metrics for our estimator.
 
         Parameters
@@ -127,7 +127,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
 
         Returns
         -------
-        SummarizeDisplay
+        MetricsSummaryDisplay
             A display containing the statistics for the metrics.
 
         Examples
@@ -422,7 +422,7 @@ class _MetricsAccessor(_BaseAccessor["EstimatorReport"], DirNamesMixin):
                 results.index = results.index.str.replace(
                     r"\((.*)\)$", r"\1", regex=True
                 )
-        return SummarizeDisplay(summarize_data=results)
+        return MetricsSummaryDisplay(summarize_data=results)
 
     def _compute_metric_scores(
         self,

--- a/skore/src/skore/sklearn/_plot/__init__.py
+++ b/skore/src/skore/sklearn/_plot/__init__.py
@@ -1,9 +1,9 @@
 from skore.sklearn._plot.metrics import (
     ConfusionMatrixDisplay,
+    MetricsSummaryDisplay,
     PrecisionRecallCurveDisplay,
     PredictionErrorDisplay,
     RocCurveDisplay,
-    SummarizeDisplay,
 )
 
 __all__ = [
@@ -11,5 +11,5 @@ __all__ = [
     "RocCurveDisplay",
     "PrecisionRecallCurveDisplay",
     "PredictionErrorDisplay",
-    "SummarizeDisplay",
+    "MetricsSummaryDisplay",
 ]

--- a/skore/src/skore/sklearn/_plot/metrics/__init__.py
+++ b/skore/src/skore/sklearn/_plot/metrics/__init__.py
@@ -4,12 +4,12 @@ from skore.sklearn._plot.metrics.precision_recall_curve import (
 )
 from skore.sklearn._plot.metrics.prediction_error import PredictionErrorDisplay
 from skore.sklearn._plot.metrics.roc_curve import RocCurveDisplay
-from skore.sklearn._plot.metrics.summarize import SummarizeDisplay
+from skore.sklearn._plot.metrics.summarize import MetricsSummaryDisplay
 
 __all__ = [
     "ConfusionMatrixDisplay",
     "PrecisionRecallCurveDisplay",
     "PredictionErrorDisplay",
     "RocCurveDisplay",
-    "SummarizeDisplay",
+    "MetricsSummaryDisplay",
 ]

--- a/skore/src/skore/sklearn/_plot/metrics/summarize.py
+++ b/skore/src/skore/sklearn/_plot/metrics/summarize.py
@@ -2,7 +2,7 @@ from skore.sklearn._plot.style import StyleDisplayMixin
 from skore.sklearn._plot.utils import HelpDisplayMixin
 
 
-class SummarizeDisplay(HelpDisplayMixin, StyleDisplayMixin):
+class MetricsSummaryDisplay(HelpDisplayMixin, StyleDisplayMixin):
     """Display for summarize.
 
     An instance of this class will be created by `Report.metrics.summarize()`.

--- a/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
+++ b/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
@@ -7,7 +7,7 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.metrics import accuracy_score, get_scorer
 from skore import ComparisonReport, CrossValidationReport
-from skore.sklearn._plot import SummarizeDisplay
+from skore.sklearn._plot import MetricsSummaryDisplay
 from skore.utils._testing import check_cache_changed, check_cache_unchanged
 
 
@@ -57,7 +57,7 @@ def report_regression():
 def test_aggregate_none(report):
     """`summarize` works as intended with `aggregate=None`."""
     result = report.metrics.summarize(aggregate=None)
-    assert isinstance(result, SummarizeDisplay)
+    assert isinstance(result, MetricsSummaryDisplay)
     result_df = result.frame()
 
     assert_index_equal(result_df.columns, pd.Index(["Value"]))

--- a/skore/tests/unit/sklearn/comparison/estimator/test_comparison.py
+++ b/skore/tests/unit/sklearn/comparison/estimator/test_comparison.py
@@ -12,7 +12,7 @@ from sklearn.metrics import (
 )
 from sklearn.model_selection import train_test_split
 from skore import ComparisonReport, EstimatorReport
-from skore.sklearn._plot.metrics import SummarizeDisplay
+from skore.sklearn._plot.metrics import MetricsSummaryDisplay
 
 
 @pytest.fixture
@@ -473,7 +473,7 @@ def test_cross_validation_report_flat_index(binary_classification_model):
     )
     report = ComparisonReport({"report_1": report_1, "report_2": report_2})
     result = report.metrics.summarize(flat_index=True)
-    assert isinstance(result, SummarizeDisplay)
+    assert isinstance(result, MetricsSummaryDisplay)
     result_df = result.frame()
     assert result_df.shape == (8, 2)
     assert isinstance(result_df.index, pd.Index)
@@ -493,7 +493,7 @@ def test_cross_validation_report_flat_index(binary_classification_model):
 def test_estimator_report_summarize_indicator_favorability(report):
     """Check that the behaviour of `indicator_favorability` is correct."""
     result = report.metrics.summarize(indicator_favorability=True)
-    assert isinstance(result, SummarizeDisplay)
+    assert isinstance(result, MetricsSummaryDisplay)
     result_df = result.frame()
     assert "Favorability" in result_df.columns
     indicator = result_df["Favorability"]

--- a/skore/tests/unit/sklearn/comparison/test_report_common.py
+++ b/skore/tests/unit/sklearn/comparison/test_report_common.py
@@ -13,7 +13,7 @@ from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import LinearSVC
 from skore import ComparisonReport, CrossValidationReport, EstimatorReport
-from skore.sklearn._plot import SummarizeDisplay
+from skore.sklearn._plot import MetricsSummaryDisplay
 
 
 @pytest.fixture(params=["report_estimator_reports", "report_cv_reports"])
@@ -102,7 +102,7 @@ def test_comparison_report_favorability_undefined_metrics(report):
     metrics = comparison_report.metrics.summarize(
         pos_label=1, indicator_favorability=True
     )
-    assert isinstance(metrics, SummarizeDisplay)
+    assert isinstance(metrics, MetricsSummaryDisplay)
     metrics_df = metrics.frame()
 
     assert "Brier score" in metrics_df.index

--- a/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
@@ -26,7 +26,7 @@ from skore.sklearn._cross_validation.report import (
     _generate_estimator_report,
 )
 from skore.sklearn._estimator import EstimatorReport
-from skore.sklearn._plot import RocCurveDisplay, SummarizeDisplay
+from skore.sklearn._plot import MetricsSummaryDisplay, RocCurveDisplay
 from skore.utils._testing import MockEstimator
 
 
@@ -280,7 +280,7 @@ def test_cross_validation_report_flat_index(binary_classification_data):
     estimator, X, y = binary_classification_data
     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
     result = report.metrics.summarize(flat_index=True)
-    assert isinstance(result, SummarizeDisplay)
+    assert isinstance(result, MetricsSummaryDisplay)
     result_df = result.frame()
     assert result_df.shape == (8, 2)
     assert isinstance(result_df.index, pd.Index)
@@ -464,7 +464,7 @@ def _check_results_summarize(
     report, params, expected_n_splits, expected_metrics, expected_nb_stats
 ):
     result = report.metrics.summarize(**params)
-    assert isinstance(result, SummarizeDisplay)
+    assert isinstance(result, MetricsSummaryDisplay)
     result_df = result.frame()
     assert isinstance(result_df, pd.DataFrame)
     assert "Favorability" not in result_df.columns


### PR DESCRIPTION
Follow-up to #1788

This PR:

- [x] renames `SummarizeDisplay` to `MetricsSummaryDisplay`
- [ ] document the display at several places in the documentation