### PR TITLE
chore(skore): cleanup unused estimator_names variable

### DIFF
--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -1289,7 +1289,6 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                     y_pred=y_pred,
                     report_type="comparison-estimator",
                     estimators=[report.estimator_ for report in self._parent.reports_],
-                    estimator_names=self._parent.report_names_,
                     ml_task=self._parent._ml_task,
                     data_source=data_source,
                     **display_kwargs,
@@ -1351,7 +1350,6 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                         for report in self._parent.reports_
                         for estimator_report in report.estimator_reports_
                     ],
-                    estimator_names=self._parent.report_names_,
                     ml_task=self._parent._ml_task,
                     data_source=data_source,
                     **display_kwargs,

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -1177,7 +1177,6 @@ class _MetricsAccessor(
                 estimators=[
                     report.estimator_ for report in self._parent.estimator_reports_
                 ],
-                estimator_names=[self._parent.estimator_name_],
                 ml_task=self._parent._ml_task,
                 data_source=data_source,
                 **display_kwargs,

--- a/skore/src/skore/sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/metrics_accessor.py
@@ -1684,7 +1684,6 @@ class _MetricsAccessor(
                 ],
                 report_type="estimator",
                 estimators=[self._parent.estimator_],
-                estimator_names=[self._parent.estimator_name_],
                 ml_task=self._parent._ml_task,
                 data_source=data_source,
                 **display_kwargs,

--- a/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/precision_recall_curve.py
@@ -71,9 +71,6 @@ class PrecisionRecallCurveDisplay(
         - "label"
         - "average_precision".
 
-    estimator_names : list of str
-        Name of the estimators.
-
     pos_label : int, float, bool, str or None
         The class considered as the positive class. If None, the class will not
         be shown in the legend.
@@ -767,7 +764,6 @@ class PrecisionRecallCurveDisplay(
         *,
         report_type: ReportType,
         estimators: Sequence[BaseEstimator],
-        estimator_names: list[str],
         ml_task: MLTask,
         data_source: Literal["train", "test", "X_y"],
         pos_label: PositiveLabel | None,
@@ -791,9 +787,6 @@ class PrecisionRecallCurveDisplay(
 
         estimators : list of estimator instances
             The estimators from which `y_pred` is obtained.
-
-        estimator_names : list of str
-            Name of the estimators used to plot the precision-recall curve.
 
         ml_task : {"binary-classification", "multiclass-classification"}
             The machine learning task.

--- a/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/sklearn/_plot/metrics/roc_curve.py
@@ -843,7 +843,6 @@ class RocCurveDisplay(
         *,
         report_type: ReportType,
         estimators: Sequence[BaseEstimator],
-        estimator_names: list[str],
         ml_task: MLTask,
         data_source: Literal["train", "test", "X_y"],
         pos_label: PositiveLabel | None,
@@ -867,9 +866,6 @@ class RocCurveDisplay(
 
         estimators : list of estimator instances
             The estimators from which `y_pred` is obtained.
-
-        estimator_names : list of str
-            Name of the estimators used to plot the ROC curve.
 
         ml_task : {"binary-classification", "multiclass-classification"}
             The machine learning task.


### PR DESCRIPTION
Just a small clean that remove `estimator_names` that is not necessary anymore since the refactoring of @auguste-probabl