### PR TITLE
feat: Rename `estimator_reports_` to `reports_` in `CrossValidationReport`

### DIFF
--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -159,7 +159,7 @@ roc_plot_cv.plot()
 # for example getting the report metrics for the first fold only:
 
 # %%
-cv_report.estimator_reports_[0].metrics.summarize()
+cv_report.reports_[0].metrics.summarize()
 
 # %%
 # .. seealso::

--- a/skore/src/skore/sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_comparison/metrics_accessor.py
@@ -1299,9 +1299,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                 for report, report_name in zip(
                     self._parent.reports_, self._parent.report_names_, strict=False
                 ):
-                    for split_index, estimator_report in enumerate(
-                        report.estimator_reports_
-                    ):
+                    for split_index, estimator_report in enumerate(report.reports_):
                         report_X, report_y, _ = (
                             estimator_report.metrics._get_X_y_and_data_source_hash(
                                 data_source=data_source,
@@ -1349,7 +1347,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                     estimators=[
                         estimator_report.estimator_
                         for report in self._parent.reports_
-                        for estimator_report in report.estimator_reports_
+                        for estimator_report in report.reports_
                     ],
                     estimator_names=self._parent.report_names_,
                     ml_task=self._parent._ml_task,

--- a/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/sklearn/_cross_validation/metrics_accessor.py
@@ -172,7 +172,7 @@ class _MetricsAccessor(
                 )
         return MetricsSummaryDisplay(summarize_data=results)
 
-    @progress_decorator(description="Compute metric for each split")
+    @progress_decorator(description="Compute metric for each split", allow_nested=False)
     def _compute_metric_scores(
         self,
         report_metric_name: str,
@@ -215,7 +215,7 @@ class _MetricsAccessor(
         progress = self._parent._progress_info["current_progress"]
         main_task = self._parent._progress_info["current_task"]
 
-        total_estimators = len(self._parent.estimator_reports_)
+        total_estimators = len(self._parent.reports_)
         progress.update(main_task, total=total_estimators)
 
         if cache_key in self._parent._cache:
@@ -230,7 +230,7 @@ class _MetricsAccessor(
                 delayed(getattr(report.metrics, report_metric_name))(
                     data_source=data_source, X=X, y=y, **metric_kwargs
                 )
-                for report in self._parent.estimator_reports_
+                for report in self._parent.reports_
             )
             results = []
             for result in generator:
@@ -310,12 +310,9 @@ class _MetricsAccessor(
         Predict time train (s)       ...       ...
         """
         timings: pd.DataFrame = pd.concat(
-            [
-                pd.Series(report.metrics.timings())
-                for report in self._parent.estimator_reports_
-            ],
+            [pd.Series(report.metrics.timings()) for report in self._parent.reports_],
             axis=1,
-            keys=[f"Split #{i}" for i in range(len(self._parent.estimator_reports_))],
+            keys=[f"Split #{i}" for i in range(len(self._parent.reports_))],
         )
         if aggregate:
             if isinstance(aggregate, str):
@@ -1125,7 +1122,7 @@ class _MetricsAccessor(
         assert self._parent._progress_info is not None, "Progress info not set"
         progress = self._parent._progress_info["current_progress"]
         main_task = self._parent._progress_info["current_task"]
-        total_estimators = len(self._parent.estimator_reports_)
+        total_estimators = len(self._parent.reports_)
         progress.update(main_task, total=total_estimators)
 
         if cache_key in self._parent._cache:
@@ -1133,7 +1130,7 @@ class _MetricsAccessor(
         else:
             y_true: list[YPlotData] = []
             y_pred: list[YPlotData] = []
-            for report_idx, report in enumerate(self._parent.estimator_reports_):
+            for report_idx, report in enumerate(self._parent.reports_):
                 if data_source != "X_y":
                     # only retrieve data stored in the reports when we don't want to
                     # use an external common X and y
@@ -1174,9 +1171,7 @@ class _MetricsAccessor(
                 y_true=y_true,
                 y_pred=y_pred,
                 report_type="cross-validation",
-                estimators=[
-                    report.estimator_ for report in self._parent.estimator_reports_
-                ],
+                estimators=[report.estimator_ for report in self._parent.reports_],
                 estimator_names=[self._parent.estimator_name_],
                 ml_task=self._parent._ml_task,
                 data_source=data_source,

--- a/skore/src/skore/sklearn/_cross_validation/report.py
+++ b/skore/src/skore/sklearn/_cross_validation/report.py
@@ -106,7 +106,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     estimator_name_ : str
         The name of the estimator.
 
-    estimator_reports_ : list of EstimatorReport
+    reports_ : list of EstimatorReport
         The estimator reports for each split.
 
     See Also
@@ -156,16 +156,14 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         )
         self.n_jobs = n_jobs
 
-        self.estimator_reports_ = self._fit_estimator_reports()
+        self.reports_ = self._fit_estimator_reports()
 
         self._rng = np.random.default_rng(time.time_ns())
         self._hash = self._rng.integers(
             low=np.iinfo(np.int64).min, high=np.iinfo(np.int64).max
         )
         self._cache: dict[tuple[Any, ...], Any] = {}
-        self._ml_task = _find_ml_task(
-            y, estimator=self.estimator_reports_[0]._estimator
-        )
+        self._ml_task = _find_ml_task(y, estimator=self.reports_[0]._estimator)
 
     @progress_decorator(
         description=lambda self: (
@@ -280,7 +278,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         >>> report._cache
         {}
         """
-        for report in self.estimator_reports_:
+        for report in self.reports_:
             report.clear_cache()
         self._cache = {}
 
@@ -323,10 +321,10 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         progress = self._progress_info["current_progress"]
         main_task = self._progress_info["current_task"]
 
-        total_estimators = len(self.estimator_reports_)
+        total_estimators = len(self.reports_)
         progress.update(main_task, total=total_estimators)
 
-        for fold_idx, estimator_report in enumerate(self.estimator_reports_, 1):
+        for fold_idx, estimator_report in enumerate(self.reports_, 1):
             # Share the parent's progress bar with child report
             estimator_report._progress_info = {
                 "current_progress": progress,
@@ -426,7 +424,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                 X=X,
                 pos_label=pos_label,
             )
-            for report in self.estimator_reports_
+            for report in self.reports_
         ]
 
     @property

--- a/skore/src/skore/utils/_accessor.py
+++ b/skore/src/skore/utils/_accessor.py
@@ -103,7 +103,7 @@ def _check_estimator_report_has_method(
     method_name: str,
 ) -> Callable:
     def check(accessor: Any) -> bool:
-        estimator_report = accessor._parent.estimator_reports_[0]
+        estimator_report = accessor._parent.reports_[0]
 
         if not hasattr(estimator_report, accessor_name):
             raise AttributeError(

--- a/skore/src/skore/utils/_progress_bar.py
+++ b/skore/src/skore/utils/_progress_bar.py
@@ -17,6 +17,7 @@ DescriptionType = str | Callable[..., str]
 
 def progress_decorator(
     description: DescriptionType,
+    allow_nested: bool = True,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Decorate class methods to add a progress bar.
 
@@ -28,6 +29,11 @@ def progress_decorator(
     description : str or callable
         The description of the progress bar. If a callable, it should take the
         self object as an argument and return a string.
+
+    allow_nested : bool, default=True
+       Whether to allow nested progress bars. Disabling progress bars is useful when
+       the nested reports will need to be pickled and that we cannot pass the
+       progress bar containing a lock.
 
     Returns
     -------
@@ -69,7 +75,7 @@ def progress_decorator(
 
             # assigning progress to child reports
             reports_to_cleanup: list[Any] = []
-            if hasattr(self_obj, "reports_"):
+            if allow_nested and hasattr(self_obj, "reports_"):
                 for report in self_obj.reports_:
                     if hasattr(report, "_progress_info"):
                         report._progress_info = {"current_progress": progress}

--- a/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
@@ -135,13 +135,13 @@ def test_cross_validation_report_attributes(fixture_name, request, cv, n_jobs):
     estimator, X, y = request.getfixturevalue(fixture_name)
     report = CrossValidationReport(estimator, X, y, cv_splitter=cv, n_jobs=n_jobs)
     assert isinstance(report, CrossValidationReport)
-    assert isinstance(report.estimator_reports_, list)
-    for estimator_report in report.estimator_reports_:
+    assert isinstance(report.reports_, list)
+    for estimator_report in report.reports_:
         assert isinstance(estimator_report, EstimatorReport)
     assert report.X is X
     assert report.y is y
     assert report.n_jobs == n_jobs
-    assert len(report.estimator_reports_) == cv
+    assert len(report.reports_) == cv
     if isinstance(estimator, Pipeline):
         assert report.estimator_name_ == estimator[-1].__class__.__name__
     else:
@@ -200,12 +200,12 @@ def test_cross_validation_report_cache_predictions(
     # underlying estimator reports
     assert report._cache == {}
 
-    for estimator_report in report.estimator_reports_:
+    for estimator_report in report.reports_:
         assert len(estimator_report._cache) == expected_n_keys
 
     report.clear_cache()
     assert report._cache == {}
-    for estimator_report in report.estimator_reports_:
+    for estimator_report in report.reports_:
         assert estimator_report._cache == {}
 
 
@@ -238,9 +238,9 @@ def test_cross_validation_report_get_predictions(
     assert len(predictions) == 2
     for split_idx, split_predictions in enumerate(predictions):
         if data_source == "train":
-            expected_shape = report.estimator_reports_[split_idx].y_train.shape
+            expected_shape = report.reports_[split_idx].y_train.shape
         elif data_source == "test":
-            expected_shape = report.estimator_reports_[split_idx].y_test.shape
+            expected_shape = report.reports_[split_idx].y_test.shape
         else:  # data_source == "X_y"
             expected_shape = (X.shape[0],)
         assert split_predictions.shape == expected_shape
@@ -313,7 +313,7 @@ def test_cross_validation_summarize_data_source_external(
     for split_idx in range(cv_splitter):
         # check that it is equivalent to call the individual estimator report
         report_result = (
-            report.estimator_reports_[split_idx]
+            report.reports_[split_idx]
             .metrics.summarize(data_source="X_y", X=X, y=y)
             .frame()
         )
@@ -840,7 +840,7 @@ def test_cross_validation_report_summarize_with_scorer(regression_data):
                 est_rep.y_test, est_rep.estimator_.predict(est_rep.X_test)
             ),
         ]
-        for est_rep in report.estimator_reports_
+        for est_rep in report.reports_
     ]
     np.testing.assert_allclose(
         result.to_numpy(),

--- a/skore/tests/unit/sklearn/plot/precision_recall_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/precision_recall_curve/test_comparison_cross_validation.py
@@ -55,7 +55,7 @@ def test_binary_classification(pyplot, binary_classification_report):
 
     pos_label = 1
     n_reports = len(report.reports_)
-    n_splits = len(report.reports_[0].estimator_reports_)
+    n_splits = len(report.reports_[0].reports_)
 
     display.plot()
     assert isinstance(display.lines_, list)
@@ -101,7 +101,7 @@ def test_multiclass_classification(pyplot, multiclass_classification_report):
 
     labels = display.precision_recall["label"].cat.categories
     n_reports = len(report.reports_)
-    n_splits = len(report.reports_[0].estimator_reports_)
+    n_splits = len(report.reports_[0].reports_)
 
     display.plot()
     assert isinstance(display.lines_, list)

--- a/skore/tests/unit/sklearn/plot/precision_recall_curve/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/precision_recall_curve/test_cross_validation.py
@@ -32,7 +32,7 @@ def test_binary_classification(
 
     display.plot()
 
-    pos_label = report.estimator_reports_[0].estimator_.classes_[1]
+    pos_label = report.reports_[0].estimator_.classes_[1]
 
     assert hasattr(display, "ax_")
     assert hasattr(display, "figure_")
@@ -88,7 +88,7 @@ def test_multiclass_classification(
 
     display.plot()
 
-    class_labels = report.estimator_reports_[0].estimator_.classes_
+    class_labels = report.reports_[0].estimator_.classes_
 
     assert isinstance(display.lines_, list)
     assert len(display.lines_) == len(class_labels) * cv

--- a/skore/tests/unit/sklearn/plot/roc_curve/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/roc_curve/test_cross_validation.py
@@ -27,7 +27,7 @@ def test_binary_classification(
     assert isinstance(display, RocCurveDisplay)
 
     check_display_data(display)
-    pos_label = report.estimator_reports_[0].estimator_.classes_[1]
+    pos_label = report.reports_[0].estimator_.classes_[1]
     assert (
         list(display.roc_curve["label"].unique())
         == list(display.roc_auc["label"].unique())
@@ -90,7 +90,7 @@ def test_multiclass_classification(
 
     # check the structure of the attributes
     check_display_data(display)
-    class_labels = report.estimator_reports_[0].estimator_.classes_
+    class_labels = report.reports_[0].estimator_.classes_
     assert (
         list(display.roc_curve["label"].unique())
         == list(display.roc_auc["label"].unique())

--- a/sphinx/user_guide/reporters.rst
+++ b/sphinx/user_guide/reporters.rst
@@ -107,7 +107,7 @@ difference is in the initialization. It accepts an estimator, a dataset (i.e. `X
 `y`) and a cross-validation strategy. Internally, the dataset is split according to the
 cross-validation strategy and an estimator report is created for each split. Therefore,
 a :class:`CrossValidationReport` is a collection of :class:`EstimatorReport` instances,
-available through the :obj:`CrossValidationReport.estimator_reports_` attribute.
+available through the :obj:`CrossValidationReport.reports_` attribute.
 
 For metrics and displays, the same API is exposed with an extra
 parameter, `aggregate`, to aggregate the metrics across the splits.


### PR DESCRIPTION
Closes https://github.com/probabl-ai/skore/issues/1760

Hi @MarieSacksick , @glemaitre !


1. I've renamed `estimator_reports_` to `reports_` throughout the `CrossValidationReport` class, aligning the API with `ComparisonReport`.

2. Solved the pickling error by introducing `allow_nested = False` inside in `progress_decorator` of function `_compute_metric_scores` in `metrics_acessor.py`  and `allow_nested = True` in `_progress_bar.py` .

3. Add the requested unittest in `test_progress_bar.py` .