### PR TITLE
chore(deps): Bump urllib3 in lockfiles

### DIFF
--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.4/test-requirements.txt
@@ -279,7 +279,7 @@ typing-extensions==4.14.0
     #   rich
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -279,7 +279,7 @@ typing-extensions==4.14.0
     #   rich
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.4/test-requirements.txt
@@ -273,7 +273,7 @@ typing-extensions==4.14.0
     #   referencing
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.7/test-requirements.txt
@@ -273,7 +273,7 @@ typing-extensions==4.14.0
     #   referencing
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.7/test-requirements.txt
@@ -270,7 +270,7 @@ typing-extensions==4.14.0
     #   referencing
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -268,7 +268,7 @@ typing-extensions==4.14.0
     #   huggingface-hub
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -268,7 +268,7 @@ typing-extensions==4.14.0
     #   huggingface-hub
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -268,7 +268,7 @@ typing-extensions==4.14.0
     #   huggingface-hub
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.10/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.4/test-requirements.txt
@@ -197,7 +197,7 @@ typing-extensions==4.14.0
     #   rich
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -197,7 +197,7 @@ typing-extensions==4.14.0
     #   rich
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.4/test-requirements.txt
@@ -192,7 +192,7 @@ typing-extensions==4.14.0
     #   ipython
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.7/test-requirements.txt
@@ -192,7 +192,7 @@ typing-extensions==4.14.0
     #   ipython
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.4/test-requirements.txt
@@ -188,7 +188,7 @@ typing-extensions==4.14.0
     # via anywidget
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.7/test-requirements.txt
@@ -188,7 +188,7 @@ typing-extensions==4.14.0
     # via anywidget
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -188,7 +188,7 @@ typing-extensions==4.14.0
     # via anywidget
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -188,7 +188,7 @@ typing-extensions==4.14.0
     # via anywidget
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -188,7 +188,7 @@ typing-extensions==4.14.0
     # via anywidget
 tzdata==2025.2
     # via pandas
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 virtualenv==20.31.2
     # via pre-commit


### PR DESCRIPTION
Following https://github.com/probabl-ai/skore/pull/1850, and to close dependabot security issues.

Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.4 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.4 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.10/scikit-learn-1.4 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.10/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.11/scikit-learn-1.4 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.11/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.12/scikit-learn-1.4 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.12/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.13/scikit-learn-1.5 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.13/scikit-learn-1.6 directory: [urllib3](https://github.com/urllib3/urllib3).
Bumps the pip group with 1 update in the /ci/requirements/skore/python-3.13/scikit-learn-1.7 directory: [urllib3](https://github.com/urllib3/urllib3).

Updates urllib3 from 2.4.0 to 2.5.0.