### PR TITLE
docs: Dot not fail on `examples/` when cleanup cant be achieved

### DIFF
--- a/examples/getting_started/plot_quick_start.py
+++ b/examples/getting_started/plot_quick_start.py
@@ -66,7 +66,7 @@ import skore
 import os
 import tempfile
 
-temp_dir = tempfile.TemporaryDirectory()
+temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
 os.environ["SKORE_WORKSPACE"] = temp_dir.name
 # sphinx_gallery_end_ignore
 my_project = skore.Project("my_project")

--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -280,7 +280,7 @@ _ = skore.train_test_split(
 import os
 import tempfile
 
-temp_dir = tempfile.TemporaryDirectory()
+temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
 os.environ["SKORE_WORKSPACE"] = temp_dir.name
 # sphinx_gallery_end_ignore
 my_project = skore.Project("my_project")


### PR DESCRIPTION
Since we only support `python>=3.10`, use `ignore_cleanup_errors` parameter.

Source: https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory.cleanup