### PR TITLE
feat: Show permutation at different stages of a pipeline

### DIFF
--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -1072,6 +1072,55 @@ plot_permutation_train_test(tree_report)
 # and ``AveOccup``.
 
 # %%
+# Computing permutation importance at different stages of a pipeline
+# =================================================================
+#
+# When working with pipelines that contain feature engineering steps, we might be interested
+# in measuring feature importance at different stages:
+#
+# - At the beginning of the pipeline (raw features)
+# - Before the final estimator (engineered features)
+#
+# The `stage` parameter in the `permutation` method allows us to control where the feature
+# importance is calculated.
+
+# %%
+# Here's a pipeline with feature engineering (standardization) and a Ridge regression:
+
+# %%
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+pipeline_model = make_pipeline(StandardScaler(), Ridge())
+pipeline_model.fit(X_train, y_train)
+
+pipeline_report = EstimatorReport(
+    pipeline_model,
+    X_train=X_train,
+    y_train=y_train,
+    X_test=X_test,
+    y_test=y_test,
+)
+
+# %%
+# Now we can compute feature importance at the beginning of the pipeline (default behavior):
+
+# %%
+pipeline_report.feature_importance.permutation(seed=0, stage="start")
+
+# %%
+# And also at the end of feature engineering, right before the Ridge regression:
+
+# %%
+pipeline_report.feature_importance.permutation(seed=0, stage="end")
+
+# %%
+# This capability is particularly useful we want to understand:
+#
+# 1. Which raw input features are most important overall (stage="start")
+# 2. Which engineered features are most important for the final model (stage="end")
+
+# %%
 # Conclusion
 # ==========
 #

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -1115,7 +1115,7 @@ pipeline_report.feature_importance.permutation(seed=0, stage="start")
 pipeline_report.feature_importance.permutation(seed=0, stage="end")
 
 # %%
-# This capability is particularly useful we want to understand:
+# This capability is particularly useful when we want to understand:
 #
 # 1. Which raw input features are most important overall (stage="start")
 # 2. Which engineered features are most important for the final model (stage="end")

--- a/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
@@ -22,6 +22,7 @@ from skore.utils._accessor import _check_has_coef, _check_has_feature_importance
 from skore.utils._index import flatten_multi_index
 
 DataSource = Literal["test", "train", "X_y"]
+Stage = Literal["start", "end"]
 
 Metric = Literal[
     "accuracy",
@@ -302,6 +303,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         n_jobs: int | None = None,
         seed: int | None = None,
         flat_index: bool = False,
+        stage: Stage = "start",
     ) -> pd.DataFrame:
         """Report the permutation feature importance.
 
@@ -453,6 +455,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             n_jobs=n_jobs,
             seed=seed,
             flat_index=flat_index,
+            stage=stage,
         )
 
     def _feature_permutation(
@@ -469,6 +472,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         n_jobs: int | None = None,
         seed: int | None = None,
         flat_index: bool = False,
+        stage: Stage = "start",
     ) -> pd.DataFrame:
         """Private interface of `feature_permutation` to pass `data_source_hash`.
 
@@ -494,6 +498,7 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
                 self._parent._hash,
                 "permutation_importance",
                 data_source,
+                stage,
             ]
 
             if data_source_hash is not None:

--- a/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
+++ b/skore/src/skore/sklearn/_estimator/feature_importance_accessor.py
@@ -442,6 +442,22 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         r2_feature_0  0.792...  0.131...
         r2_feature_1  2.478...  0.223...
         r2_feature_2  0.025...  0.003...
+
+        # If using a pipeline, compute feature importance at the end of feature eng
+        >>> from sklearn.pipeline import make_pipeline
+        >>> from sklearn.preprocessing import StandardScaler
+        >>> pipeline = make_pipeline(StandardScaler(), Ridge())
+        >>> pipeline_report = EstimatorReport(pipeline, **split_data)
+        >>> pipeline_report.feature_importance.permutation(
+        ...    n_repeats=2,
+        ...    seed=0,
+        ...    stage="end",
+        ... )
+        Repeat             Repeat #0  Repeat #1
+        Metric Feature
+        r2     Feature #0   0.699...   0.884...
+               Feature #1   2.318...   2.633...
+               Feature #2   0.028...   0.022...
         """
         return self._feature_permutation(
             data_source=data_source,
@@ -553,8 +569,8 @@ class _FeatureImportanceAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             score = sklearn_score.get("importances")
 
             feature_names = (
-                self._parent.estimator_.feature_names_in_
-                if hasattr(self._parent.estimator_, "feature_names_in_")
+                feature_names_source.feature_names_in_
+                if hasattr(feature_names_source, "feature_names_in_")
                 else [f"Feature #{i}" for i in range(X_.shape[1])]
             )
 


### PR DESCRIPTION
Closes #1398 

Added support for calculating permutation importance at different stages of a pipeline. One can choose to compute feature importance either at the start of the pipeline or at the end.

Added a new `stage` parameter to `permutation()` and `_feature_permutation()` methods with values:
  - `start` (default): Computes importance using raw input features.
  - `end`: Computes importance using engineered features after pipeline transformations.

- [x] Added documentation and tests for the implementation.

CC: @MarieSacksick @glemaitre 
