### PR TITLE
docs: Update the train-test split example to use as_dict parameter 

### DIFF
--- a/examples/model_evaluation/plot_train_test_split.py
+++ b/examples/model_evaluation/plot_train_test_split.py
@@ -152,7 +152,7 @@ from sklearn.linear_model import LogisticRegression
 from skore import EstimatorReport
 
 split_data = skore.train_test_split(X=X, y=y, random_state=42, as_dict=True)
-estimator = LogisticRegression(max_iter=10_000, random_state=42)
+estimator = LogisticRegression(random_state=42)
 estimator_report = EstimatorReport(estimator, **split_data)
 
 

--- a/examples/model_evaluation/plot_train_test_split.py
+++ b/examples/model_evaluation/plot_train_test_split.py
@@ -143,7 +143,7 @@ print("When expliciting, with the small typo, are the `X_train`'s still the same
 print(np.allclose(X_train_explicit, X_train_explicit_inverted))
 
 # %%
-# Returning a dictionnray instead of positional arguments
+# Returning a dictionary instead of positional arguments
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 # %%

--- a/examples/model_evaluation/plot_train_test_split.py
+++ b/examples/model_evaluation/plot_train_test_split.py
@@ -142,6 +142,19 @@ X_train_explicit_inverted = X_train.copy()
 print("When expliciting, with the small typo, are the `X_train`'s still the same?")
 print(np.allclose(X_train_explicit, X_train_explicit_inverted))
 
+# %%
+# Returning a dictionnray instead of positional arguments
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+# %%
+
+from sklearn.linear_model import LogisticRegression
+from skore import EstimatorReport
+
+split_data = skore.train_test_split(X=X, y=y, random_state=42, as_dict=True)
+estimator = LogisticRegression(max_iter=10_000, random_state=42)
+estimator_report = EstimatorReport(estimator, **split_data)
+
 
 # %%
 # Automatic diagnostics: raising methodological warnings
@@ -232,3 +245,4 @@ X.head(2)
 X_train, X_test, y_train, y_test = skore.train_test_split(
     X, y, random_state=0, shuffle=False
 )
+

--- a/examples/model_evaluation/plot_train_test_split.py
+++ b/examples/model_evaluation/plot_train_test_split.py
@@ -145,6 +145,8 @@ print(np.allclose(X_train_explicit, X_train_explicit_inverted))
 # %%
 # Returning a dictionary instead of positional arguments
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Sending the 4 arrays to skore's EstimatorReport can be done easily this an additional
+# parameter `as_dict`:
 
 # %%
 

--- a/examples/model_evaluation/plot_train_test_split.py
+++ b/examples/model_evaluation/plot_train_test_split.py
@@ -245,4 +245,3 @@ X.head(2)
 X_train, X_test, y_train, y_test = skore.train_test_split(
     X, y, random_state=0, shuffle=False
 )
-


### PR DESCRIPTION
closes #1863