### PR TITLE
fix(skore-hub-project,skore-local-project): Remove adherence to private `skore` modules

### DIFF
--- a/skore-hub-project/src/skore_hub_project/item/skore_estimator_report_item.py
+++ b/skore-hub-project/src/skore_hub_project/item/skore_estimator_report_item.py
@@ -13,7 +13,7 @@ from math import isfinite
 from operator import attrgetter
 from typing import TYPE_CHECKING
 
-from .item import ItemTypeError, lazy_is_instance, switch_mpl_backend
+from .item import ItemTypeError, switch_mpl_backend
 from .matplotlib_figure_item import MatplotlibFigureItem
 from .media_item import MediaItem
 from .pandas_dataframe_item import PandasDataFrameItem
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from typing import Any, Literal, TypedDict
 
-    from skore.sklearn import EstimatorReport
+    from skore import EstimatorReport
 
     class MetadataFunction:  # noqa: D101
         metadata: Any
@@ -416,7 +416,9 @@ class SkoreEstimatorReportItem(PickleItem):
         ItemTypeError
             If ``value`` is not an instance of ``skore.EstimatorReport``.
         """
-        if lazy_is_instance(value, "skore.sklearn._estimator.report.EstimatorReport"):
+        from skore import EstimatorReport
+
+        if isinstance(value, EstimatorReport):
             return super().factory(value)
 
         raise ItemTypeError(f"Type '{value.__class__}' is not supported.")

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -9,12 +9,11 @@ from typing import TYPE_CHECKING
 
 from .. import item as item_module
 from ..client.client import AuthenticatedClient, HTTPStatusError
-from ..item.item import lazy_is_instance
 
 if TYPE_CHECKING:
     from typing import TypedDict
 
-    from skore.sklearn import EstimatorReport
+    from skore import EstimatorReport
 
     class Metadata(TypedDict):  # noqa: D101
         id: str
@@ -129,9 +128,9 @@ class Project:
         if not isinstance(key, str):
             raise TypeError(f"Key must be a string (found '{type(key)}')")
 
-        if not lazy_is_instance(
-            report, "skore.sklearn._estimator.report.EstimatorReport"
-        ):
+        from skore import EstimatorReport
+
+        if not isinstance(report, EstimatorReport):
             raise TypeError(
                 f"Report must be a `skore.EstimatorReport` (found '{type(report)}')"
             )

--- a/skore-hub-project/tests/unit/item/test_skore_estimator_report_item.py
+++ b/skore-hub-project/tests/unit/item/test_skore_estimator_report_item.py
@@ -121,15 +121,15 @@ class TestSkoreEstimatorReportItem:
         item2 = SkoreEstimatorReportItem(report_b64_str)
 
         monkeypatch.setattr(
-            "skore.sklearn._estimator.metrics_accessor._MetricsAccessor.r2",
+            "skore.EstimatorReport.metrics.r2",
             lambda self, data_source: float(data_source == "train"),
         )
         monkeypatch.setattr(
-            "skore.sklearn._estimator.metrics_accessor._MetricsAccessor.rmse",
+            "skore.EstimatorReport.metrics.rmse",
             lambda self, data_source: float("nan"),
         )
         monkeypatch.setattr(
-            "skore.sklearn._estimator.metrics_accessor._MetricsAccessor.timings",
+            "skore.EstimatorReport.metrics.timings",
             lambda self: {
                 "fit_time": hash("fit_time"),
                 "predict_time_test": hash("predict_time_test"),

--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -18,9 +18,9 @@ import platformdirs
 from .storage import DiskCacheStorage
 
 if TYPE_CHECKING:
-    from typing import Any, TypedDict
+    from typing import TypedDict
 
-    from skore.sklearn import EstimatorReport
+    from skore import EstimatorReport
 
     class PersistedMetadata:  # noqa: D101
         artifact_id: str
@@ -50,13 +50,6 @@ if TYPE_CHECKING:
         roc_auc: float | None
         fit_time: float
         predict_time: float
-
-
-def lazy_is_instance_skore_estimator_report(value: Any) -> bool:
-    """Return True if value is an instance of ``skore.EstimatorReport``."""
-    return "skore.sklearn._estimator.report.EstimatorReport" in {
-        f"{cls.__module__}.{cls.__name__}" for cls in value.__class__.__mro__
-    }
 
 
 class Project:
@@ -214,7 +207,9 @@ class Project:
         if not isinstance(key, str):
             raise TypeError(f"Key must be a string (found '{type(key)}')")
 
-        if not lazy_is_instance_skore_estimator_report(report):
+        from skore import EstimatorReport
+
+        if not isinstance(report, EstimatorReport):
             raise TypeError(
                 f"Report must be a `skore.EstimatorReport` (found '{type(report)}')"
             )

--- a/skore-local-project/tests/unit/test_project.py
+++ b/skore-local-project/tests/unit/test_project.py
@@ -6,7 +6,7 @@ from pytest import fixture, raises
 from sklearn.datasets import make_classification, make_regression
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
-from skore.sklearn import EstimatorReport
+from skore import EstimatorReport
 from skore_local_project import Project
 from skore_local_project.storage import DiskCacheStorage
 
@@ -49,11 +49,11 @@ class TestProject:
     @fixture(autouse=True)
     def monkeypatch_metrics(self, monkeypatch, Datetime):
         monkeypatch.setattr(
-            "skore.sklearn._estimator.metrics_accessor._MetricsAccessor.rmse",
+            "skore.EstimatorReport.metrics.rmse",
             lambda _, data_source: float(hash(f"<rmse_{data_source}>")),
         )
         monkeypatch.setattr(
-            "skore.sklearn._estimator.metrics_accessor._MetricsAccessor.timings",
+            "skore.EstimatorReport.metrics.timings",
             lambda self: {
                 "fit_time": float(hash("<fit_time>")),
                 "predict_time_test": float(hash("<predict_time_test>")),


### PR DESCRIPTION
Needed for https://github.com/probabl-ai/skore/pull/1900 to be merged.

Knowing that `skore-hub-project` and `skore-local-project` are always used in combination of `skore`, we can compare objects type using directly `EstimatorReport` class instead of diving into the MRO.