### PR TITLE
feat(skore-hub-project): Send a heavy report in several chunks

### DIFF
--- a/skore-hub-project/src/skore_hub_project/project/artefact.py
+++ b/skore-hub-project/src/skore_hub_project/project/artefact.py
@@ -123,7 +123,7 @@ def upload_chunk(
             url=url,
             content=file.read(length),
             headers={"Content-Type": "application/octet-stream"},
-            timeout=None,
+            timeout=30,
         )
 
         return response.headers["etag"]

--- a/skore-hub-project/src/skore_hub_project/project/artefact.py
+++ b/skore-hub-project/src/skore_hub_project/project/artefact.py
@@ -1,3 +1,5 @@
+"""Function definition of the artefact ``upload``."""
+
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -38,7 +40,7 @@ Progress = partial(
 
 
 class Serializer:
-    """Serialize an object using ``joblib``, on disk to avoid RAM overhead."""
+    """Serialize an object using ``joblib``, on disk to reduce RAM footprint."""
 
     def __init__(self, o: Any):
         with self.filepath.open("wb") as file:
@@ -58,7 +60,18 @@ class Serializer:
 
     @cached_property
     def checksum(self) -> str:
-        """The checksum of the serialized object."""
+        """
+        The checksum of the serialized object.
+
+        Notes
+        -----
+        Depending on the size of the serialized object, the checksum can be computed on
+        one or more threads:
+
+            Note that this can be slower for inputs shorter than ~1 MB
+
+        https://github.com/oconnor663/blake3-py
+        """
         hasher = Blake3(max_threads=(1 if self.size < 1e6 else Blake3.AUTO))
         checksum = hasher.update_mmap(self.filepath).digest()
 
@@ -77,7 +90,32 @@ def upload_chunk(
     offset: int,
     length: int,
 ) -> str:
-    """"""
+    """
+    Upload a chunk of the serialized object to the artefacts storage.
+
+    Parameters
+    ----------
+    filepath : ``Path``
+        The path of the file containing the serialized object.
+    client : ``httpx.Client``
+        The client used to upload the chunk to the artefacts storage.
+    url : str
+        The url used to upload the chunk to the artefacts storage.
+    offset : int
+        The start of the chunk in the file containing the serialized object.
+    length: int
+        The length of the chunk in the file containing the serialized object.
+
+    Returns
+    -------
+    etag : str
+        The ETag assigned by the artefacts storage to the chunk, used to acknowledge the
+        upload.
+
+    Notes
+    -----
+    This function is in charge of reading its own chunk to reduce RAM footprint.
+    """
     with filepath.open("rb") as file:
         file.seek(offset)
 
@@ -92,7 +130,31 @@ def upload_chunk(
 
 
 def upload(project: Project, o: Any, type: str, chunk_size: int) -> str:
-    """"""
+    """
+    Upload an object to the artefacts storage.
+
+    Parameters
+    ----------
+    project : ``Project``
+        The project where to upload the object.
+    o : Any
+        The object to upload.
+    type : str
+        The type to associate to object in the artefacts storage.
+    chunk_size : int
+        The size of the object not to be exceeded before to be uploaded in chunks.
+        The size of the chunks to upload.
+
+    Returns
+    -------
+    checksum : str
+        The checksum of the object after upload to the artefacts storage, based on its
+        ``joblib`` serialization.
+
+    Notes
+    -----
+    An object that was already uploaded in its whole will be ignored.
+    """
     with (
         Serializer(o) as serializer,
         AuthenticatedClient(raises=True) as authenticated_client,
@@ -115,11 +177,11 @@ def upload(project: Project, o: Any, type: str, chunk_size: int) -> str:
         if urls := response.json():
             task_to_chunk_id = {}
 
-            # Upload each chunk of the pickled report to the artefacts storage, using
+            # Upload each chunk of the serialized object to the artefacts storage, using
             # disk temporary file.
             #
-            # Each task is in charge of reading its own file chunk at runtime, to avoid
-            # RAM overhead.
+            # Each task is in charge of reading its own file chunk at runtime, to reduce
+            # RAM footprint.
             #
             # Use `threading` over `asyncio` to ensure compatibility with Jupyter
             # notebooks, where the event loop is already running.

--- a/skore-hub-project/src/skore_hub_project/project/artefact.py
+++ b/skore-hub-project/src/skore_hub_project/project/artefact.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import cached_property
+from math import ceil
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING
+
+import blake3.blake3 as Blake3
+import joblib
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
+
+from ..client.api import Client
+from ..client.client import AuthenticatedClient
+from ..item.item import bytes_to_b64_str
+
+if TYPE_CHECKING:
+    ...
+
+from pathlib import Path
+
+
+class Artefact:
+    def __init__(self, o):
+        with self.filepath.open("wb") as file:
+            joblib.dump(o, file)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.filepath.unlink(True)
+
+    @cached_property
+    def filepath(self) -> Path:
+        with NamedTemporaryFile(mode="w+b", delete=False) as file:
+            return Path(file.name)
+
+    @cached_property
+    def checksum(self):
+        hasher = Blake3(max_threads=(1 if self.size < 1e6 else Blake3.AUTO))
+        checksum = hasher.update_mmap(self.filepath).digest()
+
+        return f"blake3-{bytes_to_b64_str(checksum)}"
+
+    @cached_property
+    def size(self):
+        return self.filepath.stat().st_size
+
+    @cached_property
+    def progress(self):
+        return Progress(
+            TextColumn("[bold cyan blink]Uploading..."),
+            BarColumn(
+                complete_style="dark_orange",
+                finished_style="dark_orange",
+                pulse_style="orange1",
+            ),
+            TextColumn("[orange1]{task.percentage:>3.0f}%"),
+            TimeElapsedColumn(),
+            transient=True,
+        )
+
+    def __upload_chunk(self, client, url, offset, length) -> str:
+        with self.filepath.open("rb") as file:
+            file.seek(offset)
+
+            response = client.put(
+                url=url,
+                content=file.read(length),
+                headers={"Content-Type": "application/octet-stream"},
+                timeout=None,
+            )
+
+            return response.headers["etag"]
+
+    def upload(self, project, *, chunk_size: int = int(1e7)):
+        # Ask for upload urls if not already uploaded.
+        with AuthenticatedClient(raises=True) as client:
+            response = client.post(
+                url=f"projects/{project.tenant}/{project.name}/artefacts",
+                json=[
+                    {
+                        "checksum": self.checksum,
+                        "content_type": "estimator-report-pickle",
+                        "chunk_number": ceil(self.size / chunk_size),
+                    }
+                ],
+            )
+
+        if not (urls := response.json()):
+            return
+
+        # Upload each chunk of the pickled report.
+        with Client() as client, ThreadPoolExecutor() as pool:
+            task_to_chunk_id = {}
+
+            for url in urls:
+                chunk_id = url["chunk_id"] or 1
+                task = pool.submit(
+                    self.__upload_chunk,
+                    client=client,
+                    url=url["upload_url"],
+                    offset=((chunk_id - 1) * chunk_size),
+                    length=chunk_size,
+                )
+
+                task_to_chunk_id[task] = chunk_id
+
+            try:
+                with self.progress:
+                    etags = dict(
+                        sorted(
+                            (task_to_chunk_id[task], task.result())
+                            for task in self.progress.track(
+                                as_completed(task_to_chunk_id),
+                                total=len(task_to_chunk_id),
+                            )
+                        )
+                    )
+            except BaseException:
+                for task in task_to_chunk_id:
+                    task.cancel()
+
+                raise
+
+        # Acknowledgement of upload.
+        with AuthenticatedClient(raises=True) as client:
+            client.post(
+                url=f"projects/{project.tenant}/{project.name}/artefacts/complete",
+                json=[
+                    {
+                        "checksum": self.checksum,
+                        "etags": etags,
+                    }
+                ],
+            )

--- a/skore-hub-project/src/skore_hub_project/project/artefact.py
+++ b/skore-hub-project/src/skore_hub_project/project/artefact.py
@@ -175,12 +175,13 @@ def upload(project: Project, o: Any, type: str) -> str:
             ],
         )
 
-        # If no url, it has been already uploaded.
+        # An empty response means that an artefact with the same checksum already
+        # exists. The object doesn't have to be re-uploaded.
         if urls := response.json():
             task_to_chunk_id = {}
 
             # Upload each chunk of the serialized object to the artefacts storage, using
-            # disk temporary file.
+            # a disk temporary file.
             #
             # Each task is in charge of reading its own file chunk at runtime, to reduce
             # RAM footprint.

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -205,7 +205,7 @@ class Project:
             with (
                 TemporaryFile(mode="w+b") as tmpfile,
                 Client() as client,
-                client.stream(method="GET", url=url, timeout=None) as response,
+                client.stream(method="GET", url=url, timeout=30) as response,
             ):
                 for data in response.iter_bytes():
                     tmpfile.write(data)

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -13,7 +13,7 @@ import joblib
 from ..client.api import Client
 from ..client.client import AuthenticatedClient, HTTPStatusError
 from ..item import skore_estimator_report_item
-from .artefact import Artefact
+from . import artefact
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -162,8 +162,7 @@ class Project:
         report._cache = {}
 
         try:
-            with Artefact(report) as artefact:
-                artefact.upload(self)
+            checksum = artefact.upload(self, report, "estimator-report-pickle")
         finally:
             report._cache = cache
 
@@ -178,7 +177,7 @@ class Project:
                             "related_items",
                             list(skore_estimator_report_item.Representations(report)),
                         ),
-                        ("parameters", {"checksum": artefact.checksum}),
+                        ("parameters", {"checksum": checksum}),
                         ("key", key),
                         ("run_id", self.run_id),
                     )

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -227,7 +227,7 @@ class Project:
                     tasks = []
 
                     for url in urls:
-                        chunk_id = url["chunk_id"]
+                        chunk_id = url["chunk_id"] or 1
                         chunk_start = (int(chunk_id) - 1) * chunk_size
                         chunk_end = chunk_start + chunk_size
                         chunk = pickle[chunk_start:chunk_end]

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -111,7 +111,7 @@ class Project:
 
             return run["id"]
 
-    def put(self, key: str, report: EstimatorReport, *, chunk_size: int = int(1e7)):
+    def put(self, key: str, report: EstimatorReport):
         """
         Put a key-report pair to the hub project.
 
@@ -124,8 +124,6 @@ class Project:
             The key to associate with ``report`` in the hub project.
         report : skore.EstimatorReport
             The report to associate with ``key`` in the hub project.
-        chunk_size : int, optional
-            The maximum size of chunks to upload in bytes, default ~10mb.
 
         Raises
         ------
@@ -150,9 +148,7 @@ class Project:
         report._cache = {}
 
         try:
-            checksum = artefact.upload(
-                self, report, "estimator-report-pickle", chunk_size
-            )
+            checksum = artefact.upload(self, report, "estimator-report-pickle")
         finally:
             report._cache = cache
 

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -214,6 +214,7 @@ class Project:
                         url=url,
                         content=chunk,
                         headers={"Content-Type": "application/octet-stream"},
+                        timeout=None,
                     )
 
                 response.raise_for_status()
@@ -306,7 +307,7 @@ class Project:
             with (
                 TemporaryFile(mode="w+b") as tmpfile,
                 Client() as client,
-                client.stream(method="GET", url=url) as response,
+                client.stream(method="GET", url=url, timeout=None) as response,
             ):
                 for data in response.iter_bytes():
                     tmpfile.write(data)

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -221,7 +221,7 @@ class Project:
                         chunk = pickle[chunk_start:chunk_end]
 
                         tasks.append(
-                            asyncio.ensure_future(
+                            asyncio.create_task(
                                 put(
                                     client,
                                     chunk_id,

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -111,15 +111,7 @@ class Project:
 
             return run["id"]
 
-    def put(
-        self,
-        key: str,
-        report: EstimatorReport,
-        *,
-        chunk_size: int = int(1e7),
-        max_workers: int = 3,
-        disable_progress_bar: bool = False,
-    ):
+    def put(self, key: str, report: EstimatorReport, *, chunk_size: int = int(1e7)):
         """
         Put a key-report pair to the hub project.
 
@@ -134,10 +126,6 @@ class Project:
             The report to associate with ``key`` in the hub project.
         chunk_size : int, optional
             The maximum size of chunks to upload in bytes, default ~10mb.
-        max_workers : int, optional
-            The maximum number of chunks uploaded in concurrence, default 3.
-        disable_progress_bar : bool, optional
-            Disable the progress bar that is displayed during upload, default False.
 
         Raises
         ------
@@ -154,7 +142,7 @@ class Project:
                 f"Report must be a `skore.EstimatorReport` (found '{type(report)}')"
             )
 
-        # Send report to artefacts storage.
+        # Upload report to artefacts storage.
         #
         # The report is pickled without its cache, to avoid salting the checksum.
         # The report is pickled on disk to reduce RAM footprint.
@@ -162,7 +150,9 @@ class Project:
         report._cache = {}
 
         try:
-            checksum = artefact.upload(self, report, "estimator-report-pickle")
+            checksum = artefact.upload(
+                self, report, "estimator-report-pickle", chunk_size
+            )
         finally:
             report._cache = cache
 

--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -153,7 +153,7 @@ class Project:
         key: str,
         report: EstimatorReport,
         *,
-        chunk_size: int = int(5e6),
+        chunk_size: int = int(1e7),
         chunks_concurrent_number: int = 3,
     ):
         """
@@ -169,7 +169,7 @@ class Project:
         report : skore.EstimatorReport
             The report to associate with ``key`` in the hub project.
         chunk_size : int, optional
-            The maximum size of chunks to upload in bytes, default 5mb.
+            The maximum size of chunks to upload in bytes, default ~10mb.
         chunks_concurrent_number : int, optional
             The maximum number of chunks uploaded in concurrence, default 3.
 

--- a/skore-hub-project/tests/unit/project/test_artefact.py
+++ b/skore-hub-project/tests/unit/project/test_artefact.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from urllib.parse import urljoin
+
+from blake3 import blake3 as Blake3
+from httpx import Client
+from pytest import fixture
+from skore_hub_project.item.item import bytes_to_b64_str
+from skore_hub_project.project.artefact import Serializer
+
+
+class FakeClient(Client):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def request(self, method, url, **kwargs):
+        response = super().request(method, urljoin("http://localhost", url), **kwargs)
+        response.raise_for_status()
+
+        return response
+
+
+@fixture(autouse=True)
+def monkeypatch_client(monkeypatch):
+    monkeypatch.setattr(
+        "skore_hub_project.project.artefact.AuthenticatedClient",
+        FakeClient,
+    )
+
+
+class TestSerialize:
+    def test_init(self, tmp_path):
+        with Serializer(1) as serializer:
+            assert serializer.filepath.read_bytes() == b"\x80\x04K\x01."
+
+    def test_enter(self, tmp_path):
+        with Serializer(1):
+            assert len(list(tmp_path.glob("*"))) == 1
+
+    def test_exit(self, tmp_path):
+        with Serializer(1):
+            ...
+
+        assert len(list(tmp_path.glob("*"))) == 0
+
+    def test_filepath(self, tmp_path):
+        with Serializer(1) as serializer:
+            assert isinstance(serializer.filepath, Path)
+            assert serializer.filepath.parent == tmp_path
+
+    def test_checksum(self):
+        checksum = Blake3(b"\x80\x04K\x01.").digest()
+        checksum = f"blake3-{bytes_to_b64_str(checksum)}"
+
+        with Serializer(1) as serializer:
+            assert serializer.checksum == checksum
+
+    def test_size(self):
+        with Serializer(1) as serializer:
+            assert serializer.size == len(b"\x80\x04K\x01.")

--- a/skore-hub-project/tests/unit/project/test_project.py
+++ b/skore-hub-project/tests/unit/project/test_project.py
@@ -77,7 +77,7 @@ class TestProject:
         with raises(TypeError, match="Report must be a `skore.EstimatorReport`"):
             Project("<tenant>", "<name>").put("<key>", "<value>")
 
-    def test_upload_in_put(self, respx_mock, regression):
+    def test_upload_in_put(self, monkeypatch, respx_mock, regression):
         cache = regression._cache
         regression._cache = {}
 
@@ -89,6 +89,7 @@ class TestProject:
         finally:
             regression._cache = cache
 
+        monkeypatch.setattr("skore_hub_project.project.artefact.CHUNK_SIZE", chunk_size)
         respx_mock.post("projects/<tenant>/<name>/artefacts").mock(
             Response(
                 200,
@@ -110,7 +111,7 @@ class TestProject:
         )
         respx_mock.post("projects/<tenant>/<name>/items")
 
-        Project("<tenant>", "<name>").put("<key>", regression, chunk_size=chunk_size)
+        Project("<tenant>", "<name>").put("<key>", regression)
 
         requests = [call.request for call in respx_mock.calls]
 

--- a/skore-hub-project/tests/unit/project/test_project.py
+++ b/skore-hub-project/tests/unit/project/test_project.py
@@ -1,14 +1,16 @@
-import io
+from io import BytesIO
 from json import loads
 from math import ceil
 from types import SimpleNamespace
 from urllib.parse import urljoin
 
 import joblib
+from blake3 import blake3 as Blake3
 from httpx import Client, Response
 from pytest import fixture, mark, raises
 from skore import EstimatorReport
 from skore_hub_project import Project
+from skore_hub_project.item.item import bytes_to_b64_str
 from skore_hub_project.project.project import dumps
 
 
@@ -23,32 +25,55 @@ class FakeClient(Client):
         return response
 
 
+@fixture(scope="module")
+def regression():
+    from sklearn.datasets import make_regression
+    from sklearn.linear_model import LinearRegression
+    from sklearn.model_selection import train_test_split
+    from skore import EstimatorReport
+
+    X, y = make_regression()
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+
+    return EstimatorReport(
+        LinearRegression(),
+        X_train=X_train,
+        y_train=y_train,
+        X_test=X_test,
+        y_test=y_test,
+    )
+
+
+@fixture(autouse=True)
+def monkeypatch_client(monkeypatch):
+    monkeypatch.setattr(
+        "skore_hub_project.project.project.AuthenticatedClient",
+        FakeClient,
+    )
+
+
+def test_dumps(regression):
+    cache = regression._cache
+    regression._cache = {}
+
+    with BytesIO() as stream:
+        try:
+            joblib.dump(regression, stream)
+        finally:
+            regression._cache = cache
+
+        pickle = stream.getvalue()
+        size = len(pickle)
+        hasher = Blake3(max_threads=(1 if size < 1e6 else Blake3.AUTO))
+        checksum = f"blake3-{bytes_to_b64_str(hasher.update(pickle).digest())}"
+
+    with dumps(regression) as (tmpfile, checksum_to_compare, size_to_compare):
+        assert tmpfile.read() == pickle
+        assert checksum_to_compare == checksum
+        assert size_to_compare == size
+
+
 class TestProject:
-    @fixture(scope="class")
-    def regression(self):
-        from sklearn.datasets import make_regression
-        from sklearn.linear_model import LinearRegression
-        from sklearn.model_selection import train_test_split
-        from skore import EstimatorReport
-
-        X, y = make_regression()
-        X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-
-        return EstimatorReport(
-            LinearRegression(),
-            X_train=X_train,
-            y_train=y_train,
-            X_test=X_test,
-            y_test=y_test,
-        )
-
-    @fixture(autouse=True)
-    def monkeypatch_client(self, monkeypatch):
-        monkeypatch.setattr(
-            "skore_hub_project.project.project.AuthenticatedClient",
-            FakeClient,
-        )
-
     def test_tenant(self):
         assert Project("<tenant>", "<name>").tenant == "<tenant>"
 
@@ -71,8 +96,9 @@ class TestProject:
             Project("<tenant>", "<name>").put("<key>", "<value>")
 
     def test_upload_in_put(self, respx_mock, regression):
-        pickle, checksum = dumps(regression)
-        chunk_size = ceil(len(pickle) / 2)
+        with dumps(regression) as (tmpfile, checksum, _):
+            pickle = tmpfile.read()
+            chunk_size = ceil(len(pickle) / 2)
 
         respx_mock.post("projects/<tenant>/<name>/artefacts").mock(
             Response(
@@ -134,7 +160,8 @@ class TestProject:
 
         Project("<tenant>", "<name>").put("<key>", regression)
 
-        _, checksum = dumps(regression)
+        with dumps(regression) as (_, checksum, _):
+            ...
 
         # Retrieve the content of the request
         content = loads(respx_mock.calls.last.request.content.decode())
@@ -305,7 +332,7 @@ class TestProject:
         response = Response(200, json=[{"url": "http://url.com"}])
         respx_mock.get(url).mock(response)
 
-        with io.BytesIO() as stream:
+        with BytesIO() as stream:
             joblib.dump(regression, stream)
 
             url = "http://url.com"


### PR DESCRIPTION
Closes https://github.com/probabl-ai/skore/issues/1910.

---

Tested both on linux and windows.
Tested across scripts, IPython and notebooks.

Also, i tested other back-ends to parallelize IO:
- `asyncio`, issues with notebooks,
- `asyncio` x `threading` (use new event loop in a dedicated thread), works, but i decided to use only `threading` for simplicity,
- `anyio`, same issues as `asyncio`,
- `trio`, lower performance that `threading`.

https://github.com/user-attachments/assets/a20169a9-405f-4350-bff1-d9eb7d940e1e


