### PR TITLE
fix(skore): Force the upgrade of python dependencies on `make install-skore`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 install-skore:
-	python -m pip install -e './skore[test,sphinx,dev]'
+	python -m pip install --upgrade --editable './skore[test,sphinx,dev]'
 	pre-commit install
 
 install-skore-lts-cpu:
-	python -m pip install -e './skore[test-lts-cpu,sphinx-lts-cpu,dev]'
+	python -m pip install --upgrade --editable './skore[test-lts-cpu,sphinx-lts-cpu,dev]'
 	pre-commit install
 
 lint:


### PR DESCRIPTION
@sylvaincom had troubles caused by the non-automatic update of `skore-local-project`.