### PR TITLE
docs: Fix math notation in the `Comparison report` section of the user guide

### DIFF
--- a/sphinx/user_guide/reporters.rst
+++ b/sphinx/user_guide/reporters.rst
@@ -132,7 +132,7 @@ performance of the different models.
 
 In order for the comparison to make sense, the reports must all have the same test target.
 However, they may have different training data or target; this might be the case when comparing a new model with the current production model, for example.
-They may also have different testing data ($X_\text{test}$), which means the compared model pipelines do not necessarily need to be the same.
+They may also have different testing data (:math:`X_{test}`), which means the compared model pipelines do not necessarily need to be the same.
 The comparison of test targets is done by computing a hash of the arrays. Therefore, if
 the y_test are functionally equal, but have different data types, they will be
 considered as different.


### PR DESCRIPTION
The $X_{test}$ math notation wasn't showing properly in the [Structuring Data Science -> Comparison Report section](https://docs.skore.probabl.ai/dev/user_guide/reporters.html#comparison-report) 

### Before (using "$X_\text{test}$"):

<img width="1606" height="664" alt="image" src="https://github.com/user-attachments/assets/2e9c6e9f-177e-45d0-9694-5c12305c5c12" />

### After (using: ":math:`X_{test}`"):

<img width="1656" height="696" alt="image" src="https://github.com/user-attachments/assets/e48f797e-c837-4aaf-aacd-e2f3b485ff76" />

###### Got the example from the [scikit-learn docs](https://scikit-learn.org/stable/_sources/modules/linear_model.rst.txt)
