### PR TITLE
docs: Improve hyperlink text in user guide

### DIFF
--- a/sphinx/user_guide/index.rst
+++ b/sphinx/user_guide/index.rst
@@ -10,7 +10,7 @@ When it comes to data science, many libraries are available to help you experime
 `pandas` or `polars` are great tools to explore and transform your data. `skrub` is the
 one tool that brings the necessary *statefullness* to those transformations required by
 the machine learning pipeline
-(`refer to <https://skrub-data.org/stable/documentation.html>`_).
+(refer to `skrub's documentation <https://skrub-data.org/stable/documentation.html>`_).
 `scikit-learn` and other `scikit-learn` compatible libraries (e.g. `xgboost`,
 `lightgbm`) provide a set of algorithms to ingest those transformed data and create
 predictive models. `scikit-learn`


### PR DESCRIPTION
## Summary
  - Replace 'refer to' with descriptive text 'skrub's documentation'
  - Improves readability and user experience in the user guide

  ## Changes
  - Updated `sphinx/user_guide/index.rst` line 13
  - Changed hyperlink from generic 'refer to' to descriptive 'skrub's documentation'

  ## Testing
  - ✅ Documentation builds successfully with `make html-noplot`
  - ✅ Pre-commit hooks pass
  
  Fixes #1860