### PR TITLE
chore: Correct test to be compliant with several skrub versions

### DIFF
--- a/ci/requirements/skore/python-3.10/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.4/test-requirements.txt
@@ -93,7 +93,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -129,13 +128,17 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -180,7 +183,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -93,7 +93,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -129,13 +128,17 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -180,7 +183,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.4/test-requirements.txt
@@ -91,7 +91,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -127,6 +126,8 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
@@ -134,7 +135,9 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -179,7 +182,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.7/test-requirements.txt
@@ -91,7 +91,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -127,6 +126,8 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
@@ -134,7 +135,9 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -179,7 +182,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.4/test-requirements.txt
@@ -91,7 +91,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -127,6 +126,8 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
@@ -134,7 +135,9 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -179,7 +182,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.7/test-requirements.txt
@@ -91,7 +91,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -127,6 +126,8 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
@@ -134,7 +135,9 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -179,7 +182,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -91,7 +91,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -127,6 +126,8 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
@@ -134,7 +135,9 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -179,7 +182,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -91,7 +91,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -127,6 +126,8 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
@@ -134,7 +135,9 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -179,7 +182,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -91,7 +91,6 @@ packaging==25.0
     #   matplotlib
     #   plotly
     #   pytest
-    #   skrub
 pandas==2.3.1
     # via
     #   skore (skore/pyproject.toml)
@@ -127,6 +126,8 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==20.0.0
     # via skore (skore/pyproject.toml)
+pydot==4.0.1
+    # via skrub
 pygments==2.19.2
     # via
     #   ipython
@@ -134,7 +135,9 @@ pygments==2.19.2
     #   pytest
     #   rich
 pyparsing==3.2.3
-    # via matplotlib
+    # via
+    #   matplotlib
+    #   pydot
 pytest==8.4.1
     # via
     #   skore (skore/pyproject.toml)
@@ -179,7 +182,7 @@ six==1.17.0
     # via python-dateutil
 skore-local-project==0.0.3
     # via skore (skore/pyproject.toml)
-skrub==0.5.4
+skrub==0.6.0
     # via skore (skore/pyproject.toml)
 stack-data==0.6.3
     # via ipython

--- a/skore/tests/unit/sklearn/plot/table_report/test_estimator.py
+++ b/skore/tests/unit/sklearn/plot/table_report/test_estimator.py
@@ -379,7 +379,7 @@ def test_corr_plot(pyplot, estimator_report):
 
 def test_json_dump(display):
     json_dict = json.loads(display._to_json())
-    assert isinstance(json_dict, dict)
+    assert set(json_dict.keys()).issubset(display.summary.keys())
 
 
 def test_repr(display):

--- a/skore/tests/unit/sklearn/plot/table_report/test_estimator.py
+++ b/skore/tests/unit/sklearn/plot/table_report/test_estimator.py
@@ -379,7 +379,7 @@ def test_corr_plot(pyplot, estimator_report):
 
 def test_json_dump(display):
     json_dict = json.loads(display._to_json())
-    assert set(json_dict.keys()).issubset(display.summary.keys())
+    assert isinstance(json_dict, dict)
 
 
 def test_repr(display):

--- a/skore/tests/unit/sklearn/plot/table_report/test_estimator.py
+++ b/skore/tests/unit/sklearn/plot/table_report/test_estimator.py
@@ -188,18 +188,6 @@ def test_table_report_display_constructor(display):
 
     assert hasattr(display, "summary")
     assert isinstance(display.summary, dict)
-    assert list(display.summary.keys()) == [
-        "dataframe",
-        "dataframe_module",
-        "n_rows",
-        "n_columns",
-        "columns",
-        "dataframe_is_empty",
-        "plots_skipped",
-        "sample_table",
-        "n_constant_columns",
-        "top_associations",
-    ]
 
 
 def test_table_report_display_frame_error(display):
@@ -391,16 +379,7 @@ def test_corr_plot(pyplot, estimator_report):
 
 def test_json_dump(display):
     json_dict = json.loads(display._to_json())
-    assert list(json_dict.keys()) == [
-        "dataframe_module",
-        "n_rows",
-        "n_columns",
-        "columns",
-        "dataframe_is_empty",
-        "plots_skipped",
-        "n_constant_columns",
-        "top_associations",
-    ]
+    assert isinstance(json_dict, dict)
 
 
 def test_repr(display):


### PR DESCRIPTION
With current assertions, we are actually testing the `summarize_dataframe` function of skrub (cf [code](https://github.com/skrub-data/skrub/blob/693bff1afb3b87832c242f858be605cfbc87c47b/skrub/_reporting/_summarize.py#L12)), which changes over versions.  
For instance, they added with_associations parameter to the function, and the same key to the output: therefore these tests are ok with skrub 0.5.4, but fail with 0.6.0, while it doesn't affect skore.  

Fixes #1954 