### PR TITLE
chore(skore)!: Rename `cv_splitter` to `splitter` in cross-validation

### DIFF
--- a/examples/getting_started/plot_skore_getting_started.py
+++ b/examples/getting_started/plot_skore_getting_started.py
@@ -127,7 +127,7 @@ plt.tight_layout()
 # %%
 from skore import CrossValidationReport
 
-cv_report = CrossValidationReport(rf, X, y, cv_splitter=5)
+cv_report = CrossValidationReport(rf, X, y, splitter=5)
 
 # %%
 # We display the cross-validation report helper:

--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -254,7 +254,7 @@ report._cache
 # in cross-validation by leveraging the previous :class:`~skore.EstimatorReport`:
 from skore import CrossValidationReport
 
-report = CrossValidationReport(model, X=df, y=y, cv_splitter=5, n_jobs=4)
+report = CrossValidationReport(model, X=df, y=y, splitter=5, n_jobs=4)
 report.help()
 
 # %%

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -107,7 +107,7 @@ model
 from skore import CrossValidationReport
 
 hgbt_model_report = CrossValidationReport(
-    estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4
+    estimator=model, X=df, y=y, splitter=5, n_jobs=4
 )
 hgbt_model_report.help()
 
@@ -239,7 +239,7 @@ model
 # For that, we use skore's :class:`~skore.CrossValidationReport` to investigate the
 # performance of our model.
 linear_model_report = CrossValidationReport(
-    estimator=model, X=df, y=y, cv_splitter=5, n_jobs=4
+    estimator=model, X=df, y=y, splitter=5, n_jobs=4
 )
 linear_model_report.help()
 

--- a/skore/src/skore/_config.py
+++ b/skore/src/skore/_config.py
@@ -143,7 +143,7 @@ def config_context(
     >>> with skore.config_context(show_progress=False, plot_backend="matplotlib"):
     ...     X, y = make_classification(random_state=42)
     ...     estimator = LogisticRegression()
-    ...     report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
+    ...     report = CrossValidationReport(estimator, X=X, y=y, splitter=2)
     """
     old_config = get_config()
     set_config(

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -137,7 +137,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> report.metrics.summarize(
         ...     scoring=["precision", "recall"],
         ...     pos_label=1,
@@ -301,7 +301,7 @@ class _MetricsAccessor(
         >>> X, y = make_classification(random_state=42)
         >>> estimator = LogisticRegression()
         >>> from skore import CrossValidationReport
-        >>> report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(estimator, X=X, y=y, splitter=2)
         >>> report.metrics.timings()
                           mean       std
         Fit time (s)       ...       ...
@@ -377,7 +377,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> report.metrics.accuracy()
                 LogisticRegression
                             mean      std
@@ -471,7 +471,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> report.metrics.precision()
                                 LogisticRegression
                                                 mean       std
@@ -569,7 +569,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> report.metrics.recall()
                             LogisticRegression
                                             mean       std
@@ -631,7 +631,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> report.metrics.brier_score()
                     LogisticRegression
                                 mean       std
@@ -725,7 +725,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> report.metrics.roc_auc()
                 LogisticRegression
                             mean       std
@@ -785,7 +785,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> report.metrics.log_loss()
                 LogisticRegression
                             mean       std
@@ -855,7 +855,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_diabetes(return_X_y=True)
         >>> regressor = Ridge()
-        >>> report = CrossValidationReport(regressor, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(regressor, X=X, y=y, splitter=2)
         >>> report.metrics.r2()
                 Ridge
                     mean       std
@@ -926,7 +926,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_diabetes(return_X_y=True)
         >>> regressor = Ridge()
-        >>> report = CrossValidationReport(regressor, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(regressor, X=X, y=y, splitter=2)
         >>> report.metrics.rmse()
                     Ridge
                     mean       std
@@ -1015,7 +1015,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_diabetes(return_X_y=True)
         >>> regressor = Ridge()
-        >>> report = CrossValidationReport(regressor, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(regressor, X=X, y=y, splitter=2)
         >>> report.metrics.custom_metric(
         ...     metric_function=mean_absolute_error,
         ...     response_method="predict",
@@ -1238,7 +1238,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> display = report.metrics.roc()
         >>> display.plot(roc_curve_kwargs={"color": "tab:red"})
         """
@@ -1306,7 +1306,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = CrossValidationReport(classifier, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(classifier, X=X, y=y, splitter=2)
         >>> display = report.metrics.precision_recall()
         >>> display.plot()
         """
@@ -1381,7 +1381,7 @@ class _MetricsAccessor(
         >>> from skore import CrossValidationReport
         >>> X, y = load_diabetes(return_X_y=True)
         >>> regressor = Ridge()
-        >>> report = CrossValidationReport(regressor, X=X, y=y, cv_splitter=2)
+        >>> report = CrossValidationReport(regressor, X=X, y=y, splitter=2)
         >>> display = report.metrics.prediction_error()
         >>> display.plot(
         ...     kind="actual_vs_predicted", perfect_model_kwargs={"color": "tab:red"}

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any, Literal
@@ -20,6 +22,8 @@ from skore._utils._parallel import Parallel, delayed
 from skore._utils._progress_bar import progress_decorator
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from skore._sklearn._cross_validation.metrics_accessor import _MetricsAccessor
 
 
@@ -130,7 +134,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     _ACCESSOR_CONFIG: dict[str, dict[str, str]] = {
         "metrics": {"name": "metrics"},
     }
-    metrics: "_MetricsAccessor"
+    metrics: _MetricsAccessor
 
     def __init__(
         self,
@@ -154,6 +158,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         self._cv_splitter = check_cv(
             cv_splitter, y, classifier=is_classifier(estimator)
         )
+        self._split_indices = tuple(self._cv_splitter.split(self._X, self._y))
         self.n_jobs = n_jobs
 
         self.estimator_reports_ = self._fit_estimator_reports()
@@ -189,8 +194,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         progress = self._progress_info["current_progress"]
         task = self._progress_info["current_task"]
 
-        n_splits = self._cv_splitter.get_n_splits(self._X, self._y)
-        progress.update(task, total=n_splits)
+        progress.update(task, total=len(self.split_indices))
 
         parallel = Parallel(
             **_validate_joblib_parallel_params(
@@ -207,7 +211,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                 train_indices,
                 test_indices,
             )
-            for train_indices, test_indices in self._cv_splitter.split(self._X, self._y)
+            for (train_indices, test_indices) in self.split_indices
         )
 
         estimator_reports = []
@@ -456,6 +460,10 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     @property
     def cv_splitter(self) -> SKLearnCrossValidator:
         return self._cv_splitter
+
+    @property
+    def split_indices(self) -> tuple[tuple[Iterable[int], Iterable[int]]]:
+        return self._split_indices
 
     @property
     def pos_label(self) -> PositiveLabel | None:

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -464,10 +464,6 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         return self._split_indices
 
     @property
-    def split_indices(self) -> tuple[tuple[Iterable[int], Iterable[int]]]:
-        return self._split_indices
-
-    @property
     def pos_label(self) -> PositiveLabel | None:
         return self._pos_label
 

--- a/skore/src/skore/_sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
+++ b/skore/src/skore/_sklearn/train_test_split/warning/high_class_imbalance_too_few_examples_warning.py
@@ -25,7 +25,7 @@ class HighClassImbalanceTooFewExamplesWarning(TrainTestSplitWarning):
         "may not be a good idea because of high variability in the scores obtained on "
         "the test set. We suggest three options to tackle this challenge: you can "
         "increase test_size, collect more data, or use skore's CrossValidationReport "
-        "with the `cv_splitter` parameter of your choice. "
+        "with the `splitter` parameter of your choice. "
     )
 
     @staticmethod

--- a/skore/src/skore/_sklearn/train_test_split/warning/high_class_imbalance_warning.py
+++ b/skore/src/skore/_sklearn/train_test_split/warning/high_class_imbalance_warning.py
@@ -25,7 +25,7 @@ class HighClassImbalanceWarning(TrainTestSplitWarning):
         "case, using train_test_split may not be a good idea because of high "
         "variability in the scores obtained on the test set. "
         "To tackle this challenge we suggest to use skore's "
-        "CrossValidationReport with the `cv_splitter` parameter "
+        "CrossValidationReport with the `splitter` parameter "
         "of your choice. "
     )
 

--- a/skore/tests/unit/sklearn/comparison/cross_validation/test_metrics.py
+++ b/skore/tests/unit/sklearn/comparison/cross_validation/test_metrics.py
@@ -28,7 +28,7 @@ def comparison_report_classification():
                 DummyClassifier(strategy="uniform", random_state=0), X, y
             ),
             CrossValidationReport(
-                DummyClassifier(strategy="uniform", random_state=0), X, y, cv_splitter=3
+                DummyClassifier(strategy="uniform", random_state=0), X, y, splitter=3
             ),
         ]
     )
@@ -42,7 +42,7 @@ def comparison_report_regression():
     report = ComparisonReport(
         [
             CrossValidationReport(DummyRegressor(), X, y),
-            CrossValidationReport(DummyRegressor(), X, y, cv_splitter=3),
+            CrossValidationReport(DummyRegressor(), X, y, splitter=3),
         ]
     )
 

--- a/skore/tests/unit/sklearn/comparison/cross_validation/test_report.py
+++ b/skore/tests/unit/sklearn/comparison/cross_validation/test_report.py
@@ -84,4 +84,4 @@ def test_get_predictions(report_cv_reports, classification_data, data_source):
 
     assert len(predictions) == len(report_cv_reports.reports_)
     for i, cv_report in enumerate(report_cv_reports.reports_):
-        assert len(predictions[i]) == cv_report._cv_splitter.n_splits
+        assert len(predictions[i]) == cv_report._splitter.n_splits

--- a/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
+++ b/skore/tests/unit/sklearn/comparison/cross_validation/test_report_metrics.py
@@ -32,7 +32,7 @@ def report(classification_data):
     report = ComparisonReport(
         [
             CrossValidationReport(make_classifier(), X, y),
-            CrossValidationReport(make_classifier(), X, y, cv_splitter=3),
+            CrossValidationReport(make_classifier(), X, y, splitter=3),
         ]
     )
 
@@ -47,7 +47,7 @@ def report_regression():
     report = ComparisonReport(
         [
             CrossValidationReport(DummyRegressor(), X, y),
-            CrossValidationReport(DummyRegressor(), X, y, cv_splitter=3),
+            CrossValidationReport(DummyRegressor(), X, y, splitter=3),
         ]
     )
 

--- a/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
@@ -134,7 +134,7 @@ def test_generate_estimator_report(binary_classification_data):
 def test_cross_validation_report_attributes(fixture_name, request, cv, n_jobs):
     """Test the attributes of the cross-validation report."""
     estimator, X, y = request.getfixturevalue(fixture_name)
-    report = CrossValidationReport(estimator, X, y, cv_splitter=cv, n_jobs=n_jobs)
+    report = CrossValidationReport(estimator, X, y, splitter=cv, n_jobs=n_jobs)
     assert isinstance(report, CrossValidationReport)
     assert isinstance(report.estimator_reports_, list)
     for estimator_report in report.estimator_reports_:
@@ -195,7 +195,7 @@ def test_cross_validation_report_cache_predictions(
 ):
     """Check that calling cache_predictions fills the cache."""
     estimator, X, y = request.getfixturevalue(fixture_name)
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2, n_jobs=n_jobs)
+    report = CrossValidationReport(estimator, X, y, splitter=2, n_jobs=n_jobs)
     report.cache_predictions(n_jobs=n_jobs)
     # no effect on the actual cache of the cross-validation report but only on the
     # underlying estimator reports
@@ -221,7 +221,7 @@ def test_cross_validation_report_get_predictions(
     """Check the behaviour of the `get_predictions` method."""
     X, y = make_classification(n_classes=2, random_state=42)
     estimator = LogisticRegression()
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     if data_source == "X_y":
         predictions = report.get_predictions(
@@ -251,7 +251,7 @@ def test_cross_validation_report_get_predictions_error():
     """Check that we raise an error when the data source is invalid."""
     X, y = make_classification(n_classes=2, random_state=42)
     estimator = LogisticRegression()
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     with pytest.raises(ValueError, match="Invalid data source"):
         report.get_predictions(data_source="invalid")
@@ -267,7 +267,7 @@ def test_cross_validation_report_pickle(tmp_path, binary_classification_data):
     the progress bar to be able to test that the progress bar is pickable.
     """
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     report.cache_predictions()
     joblib.dump(report, tmp_path / "report.joblib")
 
@@ -279,7 +279,7 @@ def test_cross_validation_report_flat_index(binary_classification_data):
     Here, we force to have a single-index by passing `flat_index=True`.
     """
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=2)
     result = report.metrics.summarize(flat_index=True)
     assert isinstance(result, MetricsSummaryDisplay)
     result_df = result.frame()
@@ -306,12 +306,12 @@ def test_cross_validation_summarize_data_source_external(
 ):
     """Check that the `data_source` parameter works when using external data."""
     estimator, X, y = binary_classification_data
-    cv_splitter = 2
-    report = CrossValidationReport(estimator, X, y, cv_splitter=cv_splitter)
+    splitter = 2
+    report = CrossValidationReport(estimator, X, y, splitter=splitter)
     result = report.metrics.summarize(
         data_source="X_y", X=X, y=y, aggregate=None
     ).frame()
-    for split_idx in range(cv_splitter):
+    for split_idx in range(splitter):
         # check that it is equivalent to call the individual estimator report
         report_result = (
             report.estimator_reports_[split_idx]
@@ -331,7 +331,7 @@ def test_cross_validation_summarize_data_source_external(
 def test_cross_validation_report_plot_roc(binary_classification_data):
     """Check that the ROC plot method works."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     assert isinstance(report.metrics.roc(), RocCurveDisplay)
 
 
@@ -341,7 +341,7 @@ def test_cross_validation_report_display_binary_classification(
 ):
     """General behaviour of the function creating display on binary classification."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     assert hasattr(report.metrics, display)
     display_first_call = getattr(report.metrics, display)()
     assert report._cache != {}
@@ -353,7 +353,7 @@ def test_cross_validation_report_display_binary_classification(
 def test_cross_validation_report_display_regression(pyplot, regression_data, display):
     """General behaviour of the function creating display on regression."""
     estimator, X, y = regression_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     assert hasattr(report.metrics, display)
     display_first_call = getattr(report.metrics, display)(seed=0)
     assert report._cache != {}
@@ -386,7 +386,7 @@ def test_cross_validation_report_display_binary_classification_pos_label(
 def test_seed_none(regression_data):
     """If `seed` is None (the default) the call should not be cached."""
     estimator, X, y = regression_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     report.metrics.prediction_error(seed=None)
     # skore should store the y_pred of the internal estimators, but not the plot
@@ -401,7 +401,7 @@ def test_seed_none(regression_data):
 def test_cross_validation_report_metrics_help(capsys, binary_classification_data):
     """Check that the help method writes to the console."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     report.metrics.help()
     captured = capsys.readouterr()
@@ -411,7 +411,7 @@ def test_cross_validation_report_metrics_help(capsys, binary_classification_data
 def test_cross_validation_report_metrics_repr(binary_classification_data):
     """Check that __repr__ returns a string starting with the expected prefix."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     repr_str = repr(report.metrics)
     assert "skore.CrossValidationReport.metrics" in repr_str
@@ -529,7 +529,7 @@ def test_cross_validation_report_metrics_binary_classification(
     classification.
     """
     (estimator, X, y), cv = binary_classification_data, 2
-    report = CrossValidationReport(estimator, X, y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X, y, splitter=cv)
     _check_results_single_metric(report, metric, cv, nb_stats)
 
 
@@ -550,7 +550,7 @@ def test_cross_validation_report_metrics_multiclass_classification(
     classification.
     """
     (estimator, X, y), cv = multiclass_classification_data, 2
-    report = CrossValidationReport(estimator, X, y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X, y, splitter=cv)
     _check_results_single_metric(report, metric, cv, nb_stats)
 
 
@@ -558,7 +558,7 @@ def test_cross_validation_report_metrics_multiclass_classification(
 def test_cross_validation_report_metrics_regression(regression_data, metric, nb_stats):
     """Check the behaviour of the metrics methods available for regression."""
     (estimator, X, y), cv = regression_data, 2
-    report = CrossValidationReport(estimator, X, y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X, y, splitter=cv)
     _check_results_single_metric(report, metric, cv, nb_stats)
 
 
@@ -568,7 +568,7 @@ def test_cross_validation_report_metrics_regression_multioutput(
 ):
     """Check the behaviour of the metrics methods available for regression."""
     (estimator, X, y), cv = regression_multioutput_data, 2
-    report = CrossValidationReport(estimator, X, y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X, y, splitter=cv)
     _check_results_single_metric(report, metric, cv, nb_stats)
 
 
@@ -587,7 +587,7 @@ def test_cross_validation_report_summarize_scoring_single_list_equivalence(
     """Check that passing a single string, callable, scorer is equivalent to passing a
     list with a single element."""
     (estimator, X, y), cv = binary_classification_data, 2
-    report = CrossValidationReport(estimator, X, y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X, y, splitter=cv)
     result_single = report.metrics.summarize(
         scoring=scoring, scoring_kwargs=scoring_kwargs
     ).frame()
@@ -609,7 +609,7 @@ def test_cross_validation_report_summarize_binary(
     RandomForestClassifier that does.
     """
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     expected_metrics = (
         "precision",
         "recall",
@@ -634,7 +634,7 @@ def test_cross_validation_report_summarize_binary(
     target_names = np.array(["neg", "pos"], dtype=object)
     pos_label_name = target_names[pos_label] if pos_label is not None else pos_label
     y = target_names[y]
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     expected_metrics = (
         "precision",
         "recall",
@@ -655,7 +655,7 @@ def test_cross_validation_report_summarize_binary(
     )
 
     estimator, X, y = binary_classification_data_svc
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     expected_metrics = (
         "precision",
         "recall",
@@ -682,7 +682,7 @@ def test_cross_validation_report_summarize_multiclass(
     classification.
     """
     estimator, X, y = multiclass_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     expected_metrics = (
         "precision",
         "recall",
@@ -703,7 +703,7 @@ def test_cross_validation_report_summarize_multiclass(
     )
 
     estimator, X, y = multiclass_classification_data_svc
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     expected_metrics = ("precision", "recall", "fit_time_s", "predict_time_s")
     # since we are not averaging by default, we report 3 statistics for
     # precision and recall
@@ -720,7 +720,7 @@ def test_cross_validation_report_summarize_multiclass(
 def test_cross_validation_report_summarize_regression(regression_data):
     """Check the behaviour of the `summarize` method with regression."""
     estimator, X, y = regression_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     expected_metrics = ("r2", "rmse", "fit_time_s", "predict_time_s")
     _check_results_summarize(
         report,
@@ -736,7 +736,7 @@ def test_cross_validation_report_summarize_scoring_kwargs_regression(
 ):
     """Check the behaviour of the `summarize` method with scoring kwargs."""
     estimator, X, y = regression_multioutput_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     assert hasattr(report.metrics, "summarize")
     result = report.metrics.summarize(
         scoring_kwargs={"multioutput": "raw_values"}
@@ -751,7 +751,7 @@ def test_cross_validation_report_summarize_scoring_kwargs_multi_class(
 ):
     """Check the behaviour of the `summarize` method with scoring kwargs."""
     estimator, X, y = multiclass_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     assert hasattr(report.metrics, "summarize")
     result = report.metrics.summarize(scoring_kwargs={"average": None}).frame()
     assert result.shape == (12, 2)
@@ -792,7 +792,7 @@ def test_cross_validation_report_summarize_overwrite_scoring_names(
 ):
     """Test that we can overwrite the scoring names in summarize."""
     estimator, X, y = request.getfixturevalue(fixture_name)
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     result = report.metrics.summarize(scoring_names=scoring_names).frame()
     assert result.shape == (len(expected_index), 2)
 
@@ -811,7 +811,7 @@ def test_cross_validation_report_summarize_error_scoring_strings(
 ):
     """Check that we raise an error if a scoring string is not a valid metric."""
     estimator, X, y = regression_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     err_msg = re.escape(f"Invalid metric: {scoring!r}.")
     with pytest.raises(ValueError, match=err_msg):
         report.metrics.summarize(scoring=[scoring])
@@ -821,7 +821,7 @@ def test_cross_validation_report_summarize_with_scorer(regression_data):
     """Check that we can pass scikit-learn scorer with different parameters to
     the `summarize` method."""
     estimator, X, y = regression_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     median_absolute_error_scorer = make_scorer(
         median_absolute_error, response_method="predict"
@@ -877,7 +877,7 @@ def test_cross_validation_report_summarize_with_scorer_binary_classification(
     `summarize` method or consistently to both.
     """
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     result = report.metrics.summarize(
         scoring=["accuracy", accuracy_score, scorer],
@@ -892,7 +892,7 @@ def test_cross_validation_report_summarize_with_scorer_pos_label_error(
     """Check that we raise an error when pos_label is passed both in the scorer and
     globally conducting to a mismatch."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     f1_scorer = make_scorer(
         f1_score, response_method="predict", average="macro", pos_label=1
@@ -907,7 +907,7 @@ def test_cross_validation_report_summarize_with_scorer_pos_label_error(
 def test_cross_validation_report_summarize_invalid_metric_type(regression_data):
     """Check that we raise the expected error message if an invalid metric is passed."""
     estimator, X, y = regression_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     err_msg = re.escape("Invalid type of metric: <class 'int'> for 1")
     with pytest.raises(ValueError, match=err_msg):
@@ -920,7 +920,7 @@ def test_cross_validation_report_summarize_indicator_favorability(
 ):
     """Check that the behaviour of `indicator_favorability` is correct."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     result = report.metrics.summarize(
         indicator_favorability=True, aggregate=aggregate
     ).frame()
@@ -938,7 +938,7 @@ def test_cross_validation_report_summarize_indicator_favorability(
 def test_cross_validation_report_custom_metric(binary_classification_data):
     """Check that we can compute a custom metric."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     result = report.metrics.custom_metric(
         metric_function=accuracy_score,
@@ -964,7 +964,7 @@ def test_cross_validation_report_interrupted(
     _, X, y = binary_classification_data
 
     estimator = MockEstimator(error=error, n_call=0, fail_after_n_clone=8)
-    report = CrossValidationReport(estimator, X, y, cv_splitter=10, n_jobs=n_jobs)
+    report = CrossValidationReport(estimator, X, y, splitter=10, n_jobs=n_jobs)
 
     captured = capsys.readouterr()
     assert all(word in captured.out for word in error_message.split(" "))
@@ -987,7 +987,7 @@ def test_cross_validation_report_brier_score_requires_probabilities():
     estimator = SVC()  # SVC does not implement `predict_proba` with default parameters
     X, y = make_classification(n_classes=2, random_state=42)
 
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=2)
     assert not hasattr(report.metrics, "brier_score")
 
 
@@ -1005,7 +1005,7 @@ def test_cross_validation_timings(
 ):
     """Check the general behaviour of the `timings` method."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
     timings = report.metrics.timings(aggregate=aggregate)
     assert isinstance(timings, pd.DataFrame)
     assert timings.index.tolist() == ["Fit time (s)"]
@@ -1045,7 +1045,7 @@ def test_cross_validation_report_failure_all_splits(n_jobs):
 def test_cross_validation_timings_flat_index(binary_classification_data):
     """Check the behaviour of the `timings` method display formatting."""
     estimator, X, y = binary_classification_data
-    report = CrossValidationReport(estimator, X, y, cv_splitter=2)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
 
     report.get_predictions(data_source="train")
     report.get_predictions(data_source="test")
@@ -1154,7 +1154,7 @@ def test_cross_validation_report_split_indices(strategy, binary_classification_d
     X = X[:4]
     y = y[:4]
 
-    cvr = CrossValidationReport(classifier, X, y, cv_splitter=strategy)
+    cvr = CrossValidationReport(classifier, X, y, splitter=strategy)
     splitter = check_cv(strategy, y, classifier=True)
 
     assert_equal(cvr.split_indices, tuple(splitter.split(X=X, y=y)))

--- a/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/cross_validation/test_cross_validation.py
@@ -17,6 +17,7 @@ from sklearn.metrics import (
     median_absolute_error,
     r2_score,
 )
+from sklearn.model_selection import KFold, check_cv
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
@@ -1133,3 +1134,27 @@ def test_cross_validation_report_precision_recall_pos_label_overwrite(
             (metric.capitalize(), "A"), (report.estimator_name_, "mean")
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    (
+        2,
+        KFold(n_splits=2, random_state=42, shuffle=True),
+        (
+            ((0,), (1,)),
+            ((2,), (3,)),
+        ),
+    ),
+)
+def test_cross_validation_report_split_indices(strategy, binary_classification_data):
+    from numpy.testing import assert_equal
+
+    classifier, X, y = binary_classification_data
+    X = X[:4]
+    y = y[:4]
+
+    cvr = CrossValidationReport(classifier, X, y, cv_splitter=strategy)
+    splitter = check_cv(strategy, y, classifier=True)
+
+    assert_equal(cvr.split_indices, tuple(splitter.split(X=X, y=y)))

--- a/skore/tests/unit/sklearn/plot/precision_recall_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/precision_recall_curve/test_comparison_cross_validation.py
@@ -223,9 +223,9 @@ def test_multiclass_classification_kwargs(pyplot, multiclass_classification_repo
 def test_binary_classification_constructor(binary_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
-    report_1 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report_1 = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     # add a different number of splits for the second report
-    report_2 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv + 1)
+    report_2 = CrossValidationReport(estimator, X=X, y=y, splitter=cv + 1)
     report = ComparisonReport(
         reports={"estimator_1": report_1, "estimator_2": report_2}
     )
@@ -249,8 +249,8 @@ def test_binary_classification_constructor(binary_classification_data_no_split):
 def test_multiclass_classification_constructor(multiclass_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
-    report_1 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    report_2 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv + 1)
+    report_1 = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
+    report_2 = CrossValidationReport(estimator, X=X, y=y, splitter=cv + 1)
     report = ComparisonReport(
         reports={"estimator_1": report_1, "estimator_2": report_2}
     )

--- a/skore/tests/unit/sklearn/plot/precision_recall_curve/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/precision_recall_curve/test_cross_validation.py
@@ -20,7 +20,7 @@ def test_binary_classification(
     precision-recall curve plot with binary data.
     """
     (estimator, X, y), cv = binary_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     if data_source == "X_y":
         precision_recall_kwargs = {"data_source": data_source, "X": X, "y": y}
     else:
@@ -76,7 +76,7 @@ def test_multiclass_classification(
     curve plot with multiclass data.
     """
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     if data_source == "X_y":
         precision_recall_kwargs = {"data_source": data_source, "X": X, "y": y}
     else:
@@ -135,7 +135,7 @@ def test_wrong_kwargs(pyplot, fixture_name, request, pr_curve_kwargs):
     value for the `pr_curve_kwargs` argument."""
     (estimator, X, y), cv = request.getfixturevalue(fixture_name), 3
 
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.precision_recall()
     err_msg = (
         "You intend to plot multiple curves. We expect `pr_curve_kwargs` to be a list "
@@ -151,7 +151,7 @@ def test_frame_binary_classification(
 ):
     """Test the frame method with binary classification data."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     df = report.metrics.precision_recall().frame(
         with_average_precision=with_average_precision
     )
@@ -174,7 +174,7 @@ def test_frame_multiclass_classification(
 ):
     """Test the frame method with multiclass classification data."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     df = report.metrics.precision_recall().frame(
         with_average_precision=with_average_precision
     )
@@ -199,21 +199,21 @@ def test_legend(
 
     # binary classification <= 5 folds
     estimator, X, y = binary_classification_data_no_split
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=5)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=5)
     display = report.metrics.precision_recall()
     display.plot()
     check_legend_position(display.ax_, loc="lower left", position="inside")
 
     # binary classification > 5 folds
     estimator, X, y = binary_classification_data_no_split
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=10)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=10)
     display = report.metrics.precision_recall()
     display.plot()
     check_legend_position(display.ax_, loc="upper left", position="outside")
 
     # multiclass classification <= 5 classes
     estimator, X, y = multiclass_classification_data_no_split
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=5)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=5)
     display = report.metrics.precision_recall()
     display.plot()
     check_legend_position(display.ax_, loc="lower left", position="inside")
@@ -227,7 +227,7 @@ def test_legend(
         n_informative=10,
         random_state=42,
     )
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=10)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=10)
     display = report.metrics.precision_recall()
     display.plot()
     check_legend_position(display.ax_, loc="upper left", position="outside")
@@ -236,7 +236,7 @@ def test_legend(
 def test_binary_classification_constructor(binary_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.precision_recall()
 
     index_columns = ["estimator_name", "split_index", "label"]
@@ -252,7 +252,7 @@ def test_binary_classification_constructor(binary_classification_data_no_split):
 def test_multiclass_classification_constructor(multiclass_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.precision_recall()
 
     index_columns = ["estimator_name", "split_index", "label"]

--- a/skore/tests/unit/sklearn/plot/prediction_error/test_comparison_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/prediction_error/test_comparison_cross_validation.py
@@ -133,9 +133,9 @@ def test_wrong_kwargs(pyplot, report, data_points_kwargs):
 def test_constructor(regression_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = regression_data_no_split, 3
-    report_1 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report_1 = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     # add a different number of splits for the second report
-    report_2 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv + 1)
+    report_2 = CrossValidationReport(estimator, X=X, y=y, splitter=cv + 1)
     report = ComparisonReport(
         reports={"estimator_1": report_1, "estimator_2": report_2}
     )

--- a/skore/tests/unit/sklearn/plot/prediction_error/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/prediction_error/test_cross_validation.py
@@ -18,7 +18,7 @@ def test_regression(pyplot, regression_data_no_split, data_source):
     else:
         prediction_error_kwargs = {"data_source": data_source}
 
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error(**prediction_error_kwargs)
     assert isinstance(display, PredictionErrorDisplay)
 
@@ -61,7 +61,7 @@ def test_regression(pyplot, regression_data_no_split, data_source):
 def test_regression_actual_vs_predicted(pyplot, regression_data_no_split):
     """Check the attributes when switching to the "actual_vs_predicted" kind."""
     (estimator, X, y), cv = regression_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error()
     display.plot(kind="actual_vs_predicted")
     assert isinstance(display, PredictionErrorDisplay)
@@ -94,7 +94,7 @@ def test_kwargs(pyplot, regression_data_no_split):
     """Check that we can pass keyword arguments to the prediction error plot when
     there is a cross-validation report."""
     (estimator, X, y), cv = regression_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error()
     display.plot(
         data_points_kwargs=[{"color": "red"}, {"color": "green"}, {"color": "blue"}],
@@ -115,7 +115,7 @@ def test_wrong_kwargs(pyplot, regression_data_no_split, data_points_kwargs):
     """Check that we raise an error when we pass keyword arguments to the prediction
     error plot if there is a cross-validation report."""
     (estimator, X, y), cv = regression_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error()
 
     err_msg = (
@@ -131,7 +131,7 @@ def test_wrong_kwargs(pyplot, regression_data_no_split, data_points_kwargs):
 def test_frame(regression_data_no_split):
     """Test the frame method with cross-validation data."""
     (estimator, X, y), cv = regression_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error()
     df = display.frame()
 
@@ -147,7 +147,7 @@ def test_legend(pyplot, regression_data_no_split):
     `CrossValidationReport`."""
 
     (estimator, X, y), cv = regression_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error()
     display.plot()
     check_legend_position(display.ax_, loc="upper left", position="outside")
@@ -156,7 +156,7 @@ def test_legend(pyplot, regression_data_no_split):
     check_legend_position(display.ax_, loc="lower right", position="inside")
 
     cv = 10
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error()
     display.plot()
     check_legend_position(display.ax_, loc="upper left", position="outside")
@@ -168,7 +168,7 @@ def test_legend(pyplot, regression_data_no_split):
 def test_constructor(regression_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = regression_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.prediction_error()
 
     index_columns = ["estimator_name", "split_index"]

--- a/skore/tests/unit/sklearn/plot/roc_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/roc_curve/test_comparison_cross_validation.py
@@ -51,7 +51,7 @@ def test_binary_classification(pyplot, binary_classification_report):
 
     pos_label = 1
     n_reports = len(report.reports_)
-    n_splits = report.reports_[0]._cv_splitter.n_splits
+    n_splits = report.reports_[0]._splitter.n_splits
 
     display.plot()
     assert isinstance(display.lines_, list)
@@ -97,7 +97,7 @@ def test_multiclass_classification(pyplot, multiclass_classification_report):
 
     labels = display.roc_curve["label"].unique()
     n_reports = len(report.reports_)
-    n_splits = report.reports_[0]._cv_splitter.n_splits
+    n_splits = report.reports_[0]._splitter.n_splits
 
     display.plot()
     assert isinstance(display.lines_, list)
@@ -237,9 +237,9 @@ def test_multiclass_classification_kwargs(pyplot, multiclass_classification_repo
 def test_binary_classification_constructor(binary_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
-    report_1 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report_1 = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     # add a different number of splits for the second report
-    report_2 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv + 1)
+    report_2 = CrossValidationReport(estimator, X=X, y=y, splitter=cv + 1)
     report = ComparisonReport(
         reports={"estimator_1": report_1, "estimator_2": report_2}
     )
@@ -263,8 +263,8 @@ def test_binary_classification_constructor(binary_classification_data_no_split):
 def test_multiclass_classification_constructor(multiclass_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
-    report_1 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
-    report_2 = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv + 1)
+    report_1 = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
+    report_2 = CrossValidationReport(estimator, X=X, y=y, splitter=cv + 1)
     report = ComparisonReport(
         reports={"estimator_1": report_1, "estimator_2": report_2}
     )

--- a/skore/tests/unit/sklearn/plot/roc_curve/test_cross_validation.py
+++ b/skore/tests/unit/sklearn/plot/roc_curve/test_cross_validation.py
@@ -22,7 +22,7 @@ def test_binary_classification(
     else:
         roc_kwargs = {"data_source": data_source}
 
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.roc(**roc_kwargs)
     assert isinstance(display, RocCurveDisplay)
 
@@ -84,7 +84,7 @@ def test_multiclass_classification(
     else:
         roc_kwargs = {"data_source": data_source}
 
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.roc(**roc_kwargs)
     assert isinstance(display, RocCurveDisplay)
 
@@ -153,7 +153,7 @@ def test_binary_classification_kwargs(
     cross-validation."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
 
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.roc()
     display.plot(roc_curve_kwargs=roc_curve_kwargs)
     if isinstance(roc_curve_kwargs, list):
@@ -177,7 +177,7 @@ def test_multiple_roc_curve_kwargs_error(
     value for the `roc_curve_kwargs` argument."""
     (estimator, X, y), cv = request.getfixturevalue(fixture_name), 3
 
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.roc()
     err_msg = "You intend to plot multiple curves"
     with pytest.raises(ValueError, match=err_msg):
@@ -188,7 +188,7 @@ def test_multiple_roc_curve_kwargs_error(
 def test_frame_binary_classification(binary_classification_data_no_split, with_roc_auc):
     """Test the frame method with binary classification data."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     df = report.metrics.roc().frame(with_roc_auc=with_roc_auc)
     expected_index = ["split_index"]
     expected_columns = ["threshold", "fpr", "tpr"]
@@ -209,7 +209,7 @@ def test_frame_multiclass_classification(
 ):
     """Test the frame method with multiclass classification data."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     df = report.metrics.roc().frame(with_roc_auc=with_roc_auc)
     expected_index = ["split_index", "label"]
     expected_columns = ["threshold", "fpr", "tpr"]
@@ -233,21 +233,21 @@ def test_legend(
 
     # binary classification <= 5 folds
     estimator, X, y = binary_classification_data_no_split
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=5)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=5)
     display = report.metrics.roc()
     display.plot()
     check_legend_position(display.ax_, loc="lower right", position="inside")
 
     # binary classification > 5 folds
     estimator, X, y = binary_classification_data_no_split
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=10)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=10)
     display = report.metrics.roc()
     display.plot()
     check_legend_position(display.ax_, loc="upper left", position="outside")
 
     # multiclass classification <= 5 classes
     estimator, X, y = multiclass_classification_data_no_split
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=5)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=5)
     display = report.metrics.roc()
     display.plot()
     check_legend_position(display.ax_, loc="lower right", position="inside")
@@ -261,7 +261,7 @@ def test_legend(
         n_informative=10,
         random_state=42,
     )
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=10)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=10)
     display = report.metrics.roc()
     display.plot()
     check_legend_position(display.ax_, loc="upper left", position="outside")
@@ -270,7 +270,7 @@ def test_legend(
 def test_binary_classification_constructor(binary_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = binary_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.roc()
 
     index_columns = ["estimator_name", "split_index", "label"]
@@ -286,7 +286,7 @@ def test_binary_classification_constructor(binary_classification_data_no_split):
 def test_multiclass_classification_constructor(multiclass_classification_data_no_split):
     """Check that the dataframe has the correct structure at initialization."""
     (estimator, X, y), cv = multiclass_classification_data_no_split, 3
-    report = CrossValidationReport(estimator, X=X, y=y, cv_splitter=cv)
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
     display = report.metrics.roc()
 
     index_columns = ["estimator_name", "split_index", "label"]


### PR DESCRIPTION
> [!CAUTION]
> Must be merged after https://github.com/probabl-ai/skore/issues/1955.

> Can i rename `cv_splitter` in `splitter` 👼🏻 ?
> It looks obvious that splitter in the `CrossValidationReport` is the splitter of the cross-validation.


_Originally posted by @thomass-dev in https://github.com/probabl-ai/skore/pull/1956#discussion_r2245737102_
            