### PR TITLE
fix(ci): Temporary pin `3.13.6` in `actions/setup-python`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -163,7 +163,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         id: setup-python
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ (matrix.python == '3.13') && '3.13.6' || matrix.python }}
           check-latest: True
           cache: pip
 


### PR DESCRIPTION
The `skore/` CI seems to be broken on `windows` x `python 3.13`  with the error `ModuleNotFoundError: No module named '_posixsubprocess'`.

It occurs since the new version of `cpython==3.13.7`, which was released on August 14 in the afternoon.
I hope it will be resolved in the next few days in a more robust way.

One example of red workflow https://github.com/probabl-ai/skore/actions/runs/17026024107/job/48262977756

<img width="1531" height="535" alt="image" src="https://github.com/user-attachments/assets/98cc317a-9b64-4dc8-9b7d-14d1cfe4a1ef" />
