### PR TITLE
fix(skore-local-project): Go through storage in insertion order

### DIFF
--- a/skore-local-project/src/skore_local_project/storage.py
+++ b/skore-local-project/src/skore_local_project/storage.py
@@ -75,7 +75,7 @@ class DiskCacheStorage:
 
     def __iter__(self) -> Iterator[str]:
         """
-        Yield the keys in the storage.
+        Yield the keys in the storage in insertion order.
 
         Returns
         -------
@@ -139,7 +139,7 @@ class DiskCacheStorage:
 
     def keys(self) -> Iterator[str]:
         """
-        Get an iterator over the keys in the storage.
+        Get an iterator over the keys in the storage in insertion order.
 
         Returns
         -------
@@ -147,11 +147,11 @@ class DiskCacheStorage:
             An iterator yielding all keys in the storage.
         """
         with Cache(self.directory) as storage:
-            return storage.iterkeys()
+            yield from storage
 
     def values(self) -> Iterator[Any]:
         """
-        Get an iterator over the values in the storage.
+        Get an iterator over the values in the storage in insertion order.
 
         Returns
         -------
@@ -159,12 +159,12 @@ class DiskCacheStorage:
             An iterator yielding all values in the storage.
         """
         with Cache(self.directory) as storage:
-            for key in storage.iterkeys():
+            for key in storage:
                 yield storage[key]
 
     def items(self) -> Iterator[tuple[str, Any]]:
         """
-        Get an iterator over the (key, value) pairs in the storage.
+        Get an iterator over the (key, value) pairs in the storage in insertion order.
 
         Returns
         -------
@@ -172,7 +172,7 @@ class DiskCacheStorage:
             An iterator yielding all (key, value) pairs in the storage.
         """
         with Cache(self.directory) as storage:
-            for key in storage.iterkeys():
+            for key in storage:
                 yield (key, storage[key])
 
     def __repr__(self) -> str:

--- a/skore-local-project/tests/unit/test_storage.py
+++ b/skore-local-project/tests/unit/test_storage.py
@@ -56,16 +56,16 @@ class TestDiskCacheStorage:
         assert len(storage) == 0
 
     def test_keys(self, storage):
-        storage["<key1>"] = "<value1>"
         storage["<key2>"] = "<value2>"
+        storage["<key1>"] = "<value1>"
 
-        assert list(storage.keys()) == ["<key1>", "<key2>"]
+        assert list(storage.keys()) == ["<key2>", "<key1>"]
 
     def test_values(self, storage):
-        storage["<key1>"] = "<value1>"
         storage["<key2>"] = "<value2>"
+        storage["<key1>"] = "<value1>"
 
-        assert list(storage.values()) == ["<value1>", "<value2>"]
+        assert list(storage.values()) == ["<value2>", "<value1>"]
 
     def test_items(self, storage):
         storage["<key1>"] = "<value1>"


### PR DESCRIPTION
Rather than in alphabetical key order.

> Caches may be iterated by either insertion order or sorted order. The default ordering uses insertion order. To iterate by sorted order, use iterkeys. The sort order is determined by the database which makes it valid only for str, bytes, int, and float data types. Other types of keys will be serialized which is likely to have a meaningless sorted order.
> 
> ```python
> >>> for key in 'cab':
> ...     cache[key] = None
> >>> list(cache)
> ['c', 'a', 'b']
> >>> list(cache.iterkeys())
> ['a', 'b', 'c']
> >>> cache.peekitem()
> ('b', None)
> >>> cache.peekitem(last=False)
> ('c', None)
> ```

https://grantjenks.com/docs/diskcache/tutorial.html