### PR TITLE
fix(skore): Show versions of extra "hub" requirements

### DIFF
--- a/skore/src/skore/_utils/_show_versions.py
+++ b/skore/src/skore/_utils/_show_versions.py
@@ -46,11 +46,18 @@ def _get_deps_info() -> dict[str, Any]:
     from importlib.metadata import PackageNotFoundError, version
 
     deps = ["pip"]
+    extras = ["'hub'"]
 
     raw_requirements = importlib.metadata.requires("skore")
     requirements: list[str] = [] if raw_requirements is None else raw_requirements
 
-    for requirement in filter(lambda r: "; extra" not in r, requirements):
+    for requirement in requirements:
+        if len(split := requirement.split("; extra == ")) > 1:
+            requirement, extra = split
+
+            if extra not in extras:
+                continue
+
         # Extract just the package name before any version specifiers
         package_name: str = re.split(r"[<>=~!]", requirement)[0].strip()
         deps.append(package_name)


### PR DESCRIPTION
```
In [1]: import skore; skore.show_versions()

System:
[...]

Python dependencies:
        skore: 0.0.0+unknown
          pip: 25.2
    anywidget: 0.9.18
      ipython: 9.3.0
   ipywidgets: 8.1.7
       joblib: 1.5.1
   matplotlib: 3.10.3
        numpy: 2.3.0
       pandas: 2.3.0
       plotly: 5.24.1
         rich: 14.0.0
 scikit-learn: 1.7.0
      seaborn: 0.13.2
skore-local-project: 0.0.0+unknown
        skrub: 0.5.4
skore-hub-project: 0.0.0+unknown

```