### PR TITLE
fix(skore-local-project): Clear the report cache instead of deleting it before serialization

### DIFF
--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -170,7 +170,9 @@ class Project:
         The report is pickled without its cache, to avoid salting the hash.
         """
         reports = [report] + getattr(report, "estimator_reports_", [])
-        caches = [report_to_clear.__dict__.pop("_cache") for report_to_clear in reports]
+        caches = [report_to_clear._cache for report_to_clear in reports]
+
+        report.clear_cache()
 
         try:
             with io.BytesIO() as stream:

--- a/skore-local-project/tests/unit/test_project.py
+++ b/skore-local-project/tests/unit/test_project.py
@@ -126,36 +126,56 @@ class TestProject:
     def test_pickle_estimator_report(self, regression):
         # Pickle the report once, without any value in the cache
         assert not regression._cache
-        pickle_1 = Project.pickle(regression)
+        hash1, pickle1 = Project.pickle(regression)
         assert not regression._cache
 
         # Pickle the same report, but with values in the cache
         regression.cache_predictions()
 
         assert regression._cache
-        pickle_2 = Project.pickle(regression)
+        hash2, pickle2 = Project.pickle(regression)
         assert regression._cache
 
         # Make sure that the two pickles on the report are not affected by the cache
-        assert pickle_1 == pickle_2
+        assert (hash1, pickle1) == (hash2, pickle2)
+
+        # Make sure that pickles are not broken
+        with BytesIO(pickle1) as stream:
+            report1 = joblib.load(stream)
+
+        with BytesIO(pickle2) as stream:
+            report2 = joblib.load(stream)
+
+        report1.cache_predictions()
+        report2.cache_predictions()
 
     def test_pickle_cross_validation_report(self, cv_regression):
         reports = [cv_regression] + cv_regression.estimator_reports_
 
         # Pickle the report once, without any value in the cache
         assert not any(report._cache for report in reports)
-        pickle_1 = Project.pickle(cv_regression)
+        hash1, pickle1 = Project.pickle(cv_regression)
         assert not any(report._cache for report in reports)
 
         # Pickle the same report, but with values in the cache
         cv_regression.cache_predictions()
 
         assert any(report._cache for report in reports)
-        pickle_2 = Project.pickle(cv_regression)
+        hash2, pickle2 = Project.pickle(cv_regression)
         assert any(report._cache for report in reports)
 
         # Make sure that the two pickles on the report are not affected by the cache
-        assert pickle_1 == pickle_2
+        assert (hash1, pickle1) == (hash2, pickle2)
+
+        # Make sure that pickles are not broken
+        with BytesIO(pickle1) as stream:
+            report1 = joblib.load(stream)
+
+        with BytesIO(pickle2) as stream:
+            report2 = joblib.load(stream)
+
+        report1.cache_predictions()
+        report2.cache_predictions()
 
     def test_init_with_envar(self, monkeypatch, tmp_path):
         monkeypatch.setenv("SKORE_WORKSPACE", str(tmp_path))


### PR DESCRIPTION
The attribute `_cache` can't be missing after depickling the report:

```python
File skore/_sklearn/_estimator/metrics_accessor.py:1461, in _MetricsAccessor._rmse(self, data_source, data_source_hash, X, y, multioutput)
   1439 @available_if(
   1440     _check_supported_ml_task(
   1441         supported_ml_tasks=["regression", "multioutput-regression"]
   (...)   1453     ) = "raw_values",
   1454 ) -> float | list:
   1455     """Private interface of `rmse` to be able to pass `data_source_hash`.
   1456 
   1457     `data_source_hash` is either an `int` when we already computed the hash
   1458     and are able to pass it around or `None` and thus trigger its computation
   1459     in the underlying process.
   1460     """
-> 1461     result = self._compute_metric_scores(
   1462         metrics.root_mean_squared_error,
   1463         X=X,
   1464         y_true=y,
   1465         data_source=data_source,
   1466         data_source_hash=data_source_hash,
   1467         response_method="predict",
   1468         multioutput=multioutput,
   1469     )
   1470     if (
   1471         self._parent._ml_task == "multioutput-regression"
   1472         and multioutput == "raw_values"
   1473     ):
   1474         return cast(list, result)

File skore/_sklearn/_estimator/metrics_accessor.py:475, in _MetricsAccessor._compute_metric_scores(self, metric_fn, X, y_true, response_method, data_source, data_source_hash, pos_label, **metric_kwargs)
    471         cache_key_parts.append(value)
    473 cache_key = tuple(cache_key_parts)
--> 475 if cache_key in self._parent._cache:
    476     score = self._parent._cache[cache_key]
    477 else:

AttributeError: 'EstimatorReport' object has no attribute '_cache'

```