### PR TITLE
fix(skore-hub-project): Use `orjson` to serialize payload, especially for nan

### DIFF
--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.4/test-requirements.txt
@@ -127,6 +127,8 @@ numpy==2.2.6
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -127,6 +127,8 @@ numpy==2.2.6
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.4/test-requirements.txt
@@ -124,6 +124,8 @@ numpy==2.3.2
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.7/test-requirements.txt
@@ -124,6 +124,8 @@ numpy==2.3.2
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.4/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.4/test-requirements.txt
@@ -124,6 +124,8 @@ numpy==2.3.2
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.7/test-requirements.txt
@@ -124,6 +124,8 @@ numpy==2.3.2
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -124,6 +124,8 @@ numpy==2.3.2
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -124,6 +124,8 @@ numpy==2.3.2
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -124,6 +124,8 @@ numpy==2.3.2
     #   skops
     #   skore
     #   skrub
+orjson==3.11.3
+    # via skore-hub-project (skore-hub-project/pyproject.toml)
 packaging==25.0
     # via
     #   altair

--- a/skore-hub-project/pyproject.toml
+++ b/skore-hub-project/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "httpx",
   "joblib",
   "matplotlib",
+  "orjson",
   "pydantic",
   "rich",
   "scikit-learn",


### PR DESCRIPTION
```python
from skrub import TableVectorizer, TextEncoder
from sklearn.ensemble import HistGradientBoostingRegressor
from sklearn.pipeline import make_pipeline
from skrub.datasets import fetch_employee_salaries

if not "hgbt_model_report" in globals():
    datasets = fetch_employee_salaries()
    df, y = datasets.X, datasets.y

    model = make_pipeline(
        TableVectorizer(high_cardinality=TextEncoder()),
        HistGradientBoostingRegressor(),
    )

    from skore import CrossValidationReport


    hgbt_model_report = CrossValidationReport(
        estimator=model, X=df, y=y, splitter=5, n_jobs=-1
    )

from skore import Project

project = Project("hub://<tenant>/<project>")
project.put("hgbt_model_report", hgbt_model_report)
```

raises error while serializing the `TableReport` medias.

```python
ValueError                                Traceback (most recent call last)
Cell In[1], line 33
     29 project = Project("<project>")
     31 assert project.mode == "hub"
---> 33 project.put("hgbt_model_report", hgbt_model_report)

[...]

ValueError: Out of range float values are not JSON compliant: nan
```