### PR TITLE
fix(skore-hub-project): Fix splitting strategy name when splitter doe…

### DIFF
--- a/skore-hub-project/src/skore_hub_project/report/cross_validation_report.py
+++ b/skore-hub-project/src/skore_hub_project/report/cross_validation_report.py
@@ -6,7 +6,6 @@ from typing import ClassVar, cast
 
 import numpy as np
 from pydantic import Field, computed_field
-from sklearn.model_selection import BaseCrossValidator
 from sklearn.model_selection._split import _CVIterableWrapper
 
 from skore_hub_project.artefact import CrossValidationReportArtefact
@@ -160,12 +159,10 @@ class CrossValidationReportPayload(ReportPayload):
     @cached_property
     def splitting_strategy_name(self) -> str:
         """The name of the splitting strategy used by the report."""
-        is_sklearn_splitter = isinstance(self.report.splitter, BaseCrossValidator)
         is_iterable_splitter = isinstance(self.report.splitter, _CVIterableWrapper)
-        is_standard_strategy = is_sklearn_splitter and (not is_iterable_splitter)
 
         return (
-            is_standard_strategy and self.report.splitter.__class__.__name__ or "custom"
+            is_iterable_splitter and "custom" or self.report.splitter.__class__.__name__
         )
 
     @computed_field  # type: ignore[prop-decorator]


### PR DESCRIPTION
…snt inherit from old style `BaseCrossValidator`.

Closes https://github.com/probabl-ai/skore-hub/issues/718.