### PR TITLE
fix(data_accessor): Correct behaviour when data are DataFrames without column names

### DIFF
--- a/skore/tests/unit/displays/table_report/test_estimator.py
+++ b/skore/tests/unit/displays/table_report/test_estimator.py
@@ -69,6 +69,7 @@ def test_constructor(display):
         pd.DataFrame(
             np.ones((100, 5)), columns=[f"Feature number {i}" for i in range(5)]
         ),
+        pd.DataFrame(np.ones((100, 5))),
     ],
 )
 @pytest.mark.parametrize(
@@ -78,6 +79,7 @@ def test_constructor(display):
         np.ones(100),
         pd.Series(np.ones(100)),
         pd.DataFrame(np.ones((100, 1)), columns=["Target"]),
+        pd.DataFrame(np.ones((100, 1))),
     ],
 )
 def test_X_y(X, y):


### PR DESCRIPTION
Check if it's not already solved by #2034