### PR TITLE
fix(skore-hub-project): Make `skore-hub-login` more user-friendly

### DIFF
--- a/skore-hub-project/src/skore_hub_project/authentication/login.py
+++ b/skore-hub-project/src/skore_hub_project/authentication/login.py
@@ -16,28 +16,32 @@ from . import token as Token
 
 def login(*, timeout=600):
     """Login to ``skore hub``."""
-    print('hello')
     with suppress(HTTPError):
         if Token.exists() and (Token.access() is not None):
+            console.print(
+                Panel(
+                    Align(
+                        "Already logged in!",
+                        align="center",
+                    ),
+                    title="[cyan]Skore Hub[/cyan]",
+                    border_style="orange1",
+                    expand=False,
+                    padding=1,
+                    title_align="center",
+                )
+            )
             return
 
     url, device_code, user_code = api.get_oauth_device_login()
 
-    print(url)
+    console.rule("[cyan]Skore Hub[/cyan]")
     console.print(
-        Panel(
-            Align(
-                f"Please visit this URL to log in: {url}",
-                align="center",
-            ),
-            title="[cyan]Skore HUB[/cyan]",
-            border_style="orange1",
-            expand=False,
-            padding=1,
-            title_align="center",
-        )
+        f"Opening browser; if this fails, please visit this URL to log in:\n{url}",
+        soft_wrap=True,
     )
-    # open_webbrowser(url)
+
+    open_webbrowser(url)
 
     api.get_oauth_device_code_probe(device_code, timeout=timeout)
     api.post_oauth_device_callback(device_code, user_code)


### PR DESCRIPTION
- Display
```
╭──── Skore Hub ─────╮
│                    │
│ Already logged in! │
│                    │
╰────────────────────╯
```
if user is already logged in (i.e. if token is found at `/tmp/skore.token`), rather than showing nothing. A better fix would be to show a log of "found token at /tmp/skore.token") I guess; let me know what you think.
- Display login URL in full, without line-wrapping, regardless of whether opening the browser succeeds. This way, the user can always fall back to copy-pasting the URL. Disabling line-wrapping is important because otherwise the URL is hard to copy-paste:
```
╭───────────────────────────────────── Skore HUB ──────────────────────────────────────╮
│                                                                                      │
│ Please visit this URL to log in:                                                     │
│ https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.com/oauth2/auth?response_type=code&cli │
│ ent_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&redirect_uri=http%3A%2F%2Flocalhost%3A80 │
│ 00%2Fidentity%2Foauth%2Fdevice%2Fcallback&scope=openid+profile+email+offline_access& │
│ state=xxxxx                                                                          │
│                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────╯
```
