### PR TITLE
fix(ci): Fix pre-commit mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,23 @@ repos:
     rev: v1.18.2
     hooks:
       - id: mypy
-        files: ^(skore|skore-hub-project|skore-local-project)/src/
+        pass_filenames: false
+        alias: mypy-skore
+        name: mypy skore/
+        files: ^skore/
+        args: [--config-file=skore/pyproject.toml, skore]
+        additional_dependencies: [IPython, matplotlib, numpy, polars, rich]
+      - id: mypy
+        pass_filenames: false
+        alias: mypy-skore-hub-project
+        name: mypy skore-hub-project/
+        files: ^skore-hub-project/
+        args: [--config-file=skore-hub-project/pyproject.toml, skore-hub-project]
+        additional_dependencies: [skore, blake3, httpx, orjson, pydantic]
+      - id: mypy
+        pass_filenames: false
+        alias: mypy-skore-local-project
+        name: mypy skore-local-project/
+        files: ^skore-local-project/
+        args: [--config-file=skore-local-project/pyproject.toml, skore-local-project]
+        additional_dependencies: [skore]


### PR DESCRIPTION
Ensure that the pre-commit `mypy` hook in our monorepo context is strictly equivalent to running `mypy` manually.

Note that `additional_dependencies` must be now synchronized with `pyproject.toml`. Otherwise, the hook fails in a good way:

```bash
error: Cannot find implementation or library stub for module named "<module>  [import-not-found]
```

---

You will be able to run the hooks using:

```bash
$ pre-commit run --all-files mypy                                                                                                                                                                                                         

mypy skore/..............................................................Passed
mypy skore-hub-project/..................................................Passed
mypy skore-local-project/................................................Passed

$ pre-commit run --all-files mypy-skore

mypy skore/..............................................................Passed

$ pre-commit run --all-files mypy-skore-hub-project

mypy skore-hub-project/..................................................Passed

$ pre-commit run --all-files mypy-skore-local-project

mypy skore-local-project/................................................Passed
```