### PR TITLE
chore(all): Improve `pytest` configuration

### DIFF
--- a/skore-hub-project/pyproject.toml
+++ b/skore-hub-project/pyproject.toml
@@ -54,13 +54,18 @@ package = ["src/skore_hub_project/"]
 
 [tool.pytest.ini_options]
 addopts = [
+  "-ra",
+  "--strict-markers",
+  "--strict-config",
   "--xdoctest",
   "--import-mode=importlib",
   "--no-header",
   "--verbosity=2",
   "--dist=loadscope",
 ]
+xfail_strict = true
 filterwarnings = ["error"]
+log_cli_level = "info"
 
 [tool.coverage.run]
 branch = true

--- a/skore-local-project/pyproject.toml
+++ b/skore-local-project/pyproject.toml
@@ -45,13 +45,18 @@ package = ["src/skore_local_project/"]
 
 [tool.pytest.ini_options]
 addopts = [
+  "-ra",
+  "--strict-markers",
+  "--strict-config",
   "--xdoctest",
   "--import-mode=importlib",
   "--no-header",
   "--verbosity=2",
   "--dist=loadscope",
 ]
+xfail_strict = true
 filterwarnings = ["error"]
+log_cli_level = "info"
 
 [tool.coverage.run]
 branch = true

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -107,12 +107,17 @@ package = ["src/skore/"]
 
 [tool.pytest.ini_options]
 addopts = [
+  "-ra",
+  "--strict-markers",
+  "--strict-config",
   "--xdoctest",
   "--import-mode=importlib",
   "--no-header",
   "--verbosity=2",
   "--dist=loadscope",
 ]
+xfail_strict = true
+log_cli_level = "info"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Start applying the [settings suggested](https://learn.scientific-python.org/development/guides/pytest/#configuring-pytest) by [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=probabl-ai%2Fskore&ref=HEAD&refType=branch):
* **PP308**: `-ra` will print a summary “r”eport of “a”ll results, which gives you a quick way to review what tests failed and were skipped, and why.
* **PP307**: `--strict-markers` will make sure you don’t try to use an unspecified fixture.
* **PP306**: And `--strict-config` will error if you make a mistake in your config.
* **PP305**: `xfail_strict` will change the default for `xfail` to fail the tests if it doesn’t fail - you can still override locally in a specific xfail for a flaky failure.
* **PP304**: `log_cli_level` will report INFO and above log messages on a failure.

This PR comes as a complement of #2082, which applies this suggestion:
* **PP309**: `filter_warnings` will cause all warnings to be errors (you can add allowed warnings here too).