### PR TITLE
chore(skore): Identical ruff settings across packages

### DIFF
--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -135,30 +135,7 @@ exclude_also = [
 ]
 
 [tool.ruff.lint]
-select = [
-  # pycodestyle
-  "E",
-  # Pyflakes
-  "F",
-  # pyupgrade
-  "UP",
-  # flake8-bugbear
-  "B",
-  # flake8-comprehensions
-  "C4",
-  # flake8-simplify
-  "SIM",
-  # flake8-print
-  "T",
-  # flake8-pytest-style
-  "PT003", "PT014",
-  # isort
-  "I",
-  # pydocstyle
-  "D",
-  # Ruff-specific rules
-  "RUF010", "RUF015",
-]
+select = ["E", "F", "UP", "B", "C4", "SIM", "T", "PT003", "PT014", "I", "D", "RUF010", "RUF015"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
Consistency between packages:

https://github.com/probabl-ai/skore/blob/67193cff51e6ff4c8cba1009b608ccb117baf87d/skore-hub-project/pyproject.toml#L85-L86

https://github.com/probabl-ai/skore/blob/67193cff51e6ff4c8cba1009b608ccb117baf87d/skore-local-project/pyproject.toml#L76-L77

https://github.com/probabl-ai/skore/blob/67193cff51e6ff4c8cba1009b608ccb117baf87d/skore/pyproject.toml#L137-L142

I chose to remove the comments because anyone messing with ruff rules should be more or less familiar with the main rule sets. Additionally, the comment for `T` was slightly  misleading: `T` stands not only for [`T20`](https://docs.astral.sh/ruff/rules/#flake8-print-t20) (flake8-print) but also [`T10`](https://docs.astral.sh/ruff/rules/#flake8-debugger-t10) (flake8-debugger).