### PR TITLE
chore(skore-hub-project): Remove deprecated `project.reports` namespace

### DIFF
--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -8,7 +8,6 @@ from collections.abc import Callable
 from functools import cached_property, wraps
 from operator import itemgetter
 from tempfile import TemporaryFile
-from types import SimpleNamespace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -303,33 +302,6 @@ class Project:
             )
 
         return sorted(map(dto, responses), key=itemgetter("date"))
-
-    @property
-    @ensure_project_is_created
-    def reports(self) -> SimpleNamespace:
-        """Accessor for interaction with the persisted reports."""
-
-        def get(urn: str) -> EstimatorReport | CrossValidationReport:
-            """
-            Get a persisted report by its URN.
-
-            .. deprecated
-              The ``Project.reports.get`` function will be removed in favor of
-              ``Project.get`` in a near future.
-            """
-            return self.get(urn)
-
-        def metadata() -> list[Metadata]:
-            """
-            Obtain metadata/metrics for all persisted reports in insertion order.
-
-            .. deprecated
-              The ``Project.reports.metadata`` function will be removed in favor of
-              ``Project.summarize`` in a near future.
-            """
-            return self.summarize()
-
-        return SimpleNamespace(get=get, metadata=metadata)
 
     def __repr__(self) -> str:  # noqa: D105
         return f"Project(mode='hub', name='{self.name}', tenant='{self.tenant}')"

--- a/skore-hub-project/tests/unit/project/test_project.py
+++ b/skore-hub-project/tests/unit/project/test_project.py
@@ -1,7 +1,6 @@
 from functools import partialmethod
 from io import BytesIO
 from json import dumps, loads
-from types import SimpleNamespace
 from urllib.parse import urljoin
 
 import joblib
@@ -161,16 +160,7 @@ class TestProject:
         # Compare content with the desired output
         assert content == desired
 
-    def test_reports(self, respx_mock):
-        respx_mock.post("projects/<tenant>/<name>").mock(Response(200))
-
-        project = Project("<tenant>", "<name>")
-
-        assert isinstance(project.reports, SimpleNamespace)
-        assert hasattr(project.reports, "get")
-        assert hasattr(project.reports, "metadata")
-
-    def test_reports_get_estimator_report(self, respx_mock, regression):
+    def test_get_estimator_report(self, respx_mock, regression):
         # Mock hub routes that will be called
         respx_mock.post("projects/<tenant>/<name>").mock(Response(200))
 
@@ -187,7 +177,7 @@ class TestProject:
 
         # Test
         project = Project("<tenant>", "<name>")
-        report = project.reports.get("skore:report:estimator:<report_id>")
+        report = project.get("skore:report:estimator:<report_id>")
 
         assert isinstance(report, EstimatorReport)
         assert report.estimator_name_ == regression.estimator_name_
@@ -210,13 +200,13 @@ class TestProject:
 
         # Test
         project = Project("<tenant>", "<name>")
-        report = project.reports.get("skore:report:cross-validation:<report_id>")
+        report = project.get("skore:report:cross-validation:<report_id>")
 
         assert isinstance(report, CrossValidationReport)
         assert report.estimator_name_ == cv_regression.estimator_name_
         assert report.ml_task == cv_regression.ml_task
 
-    def test_reports_metadata(self, nowstr, respx_mock):
+    def test_summarize(self, nowstr, respx_mock):
         respx_mock.post("projects/<tenant>/<name>").mock(Response(200))
 
         url = "projects/<tenant>/<name>/estimator-reports/"
@@ -277,9 +267,9 @@ class TestProject:
         )
 
         project = Project("<tenant>", "<name>")
-        metadata = project.reports.metadata()
+        summary = project.summarize()
 
-        assert metadata == [
+        assert summary == [
             {
                 "id": "skore:report:estimator:<report_id_0>",
                 "key": "<key>",


### PR DESCRIPTION
This is not used anymore in `skore`.