### PR TITLE
fix(skore): Strip rich HTML to avoid blank output cell

### DIFF
--- a/skore/src/skore/_utils/_patch.py
+++ b/skore/src/skore/_utils/_patch.py
@@ -1,4 +1,5 @@
 import os
+import re
 from collections.abc import Iterable
 
 from rich import jupyter
@@ -8,19 +9,41 @@ _original_render_segments = jupyter._render_segments
 
 
 def patched_render_segments(segments: Iterable[Segment]) -> str:
-    """Patched version of rich.jupyter._render_segments that includes VS Code styling.
+    """Patched version of rich.jupyter._render_segments for Jupyter notebooks.
 
-    This is to make sure that the CSS style exposed by jupyter notebook and used
-    by ipywidgets is applied to rich output.
-    Currently, the VS Code extension does not support the CSS style exposed by jupyter
-    notebook and used by ipywidgets.
-    We should track the progress in the following issue:
-    https://github.com/microsoft/vscode-jupyter/issues/7161
+    This patch applies two fixes:
 
+    1. **VS Code styling support**: Ensures that the CSS style exposed by jupyter
+       notebook and used by ipywidgets is applied to rich output. Currently, the VS Code
+       extension does not support the CSS style exposed by jupyter notebook and used by
+       ipywidgets. We should track the progress in the following issue:
+       https://github.com/microsoft/vscode-jupyter/issues/7161
+
+    2. **Empty progress bar cleanup**: Prevents empty <pre> tags from being rendered
+       when progress bars are destroyed, which would otherwise create unwanted vertical
+       spacing in notebook outputs. When a progress bar completes or is removed, Rich
+       may render empty segments that result in empty HTML <pre> tags. This patch checks
+       if the rendered HTML only contains an empty <pre> tag and returns an empty string
+       instead, preventing vertical space accumulation when multiple progress bars are
+       used in loops.
     """
     html = _original_render_segments(segments)
-    # Apply VS Code styling if we're in VS Code
-    if "VSCODE_PID" in os.environ:
+
+    # Fix 1: Prevent empty <pre> tags from creating unwanted vertical space.
+    # This happens when progress bars are destroyed and leave behind empty HTML.
+    # Check if the HTML is just an empty <pre> tag (possibly with whitespace)
+    if html:
+        pre_pattern = r"<pre[^>]*>(.*?)</pre>"
+        match = re.search(pre_pattern, html, re.DOTALL)
+        if match:
+            pre_content = match.group(1)
+            # If the content inside the pre tag is empty or only whitespace,
+            # return empty string to avoid creating vertical space
+            if not pre_content or not pre_content.strip():
+                html = ""
+
+    # Fix 2: Apply VS Code styling if we're in VS Code
+    if html and "VSCODE_PID" in os.environ:
         css = """
         <style>
         .cell-output-ipywidget-background {


### PR DESCRIPTION
closes #2141

This PR forces `rich` to not show empty output cell in notebook.

It is a bit of a brute force approach since we interfere with the HTML output and strip empty `<pre>` section. It should not impact anything else since it is restricted to `rich` in `Jupyter`.