### PR TITLE
chore(skore): Improve test time of `data` accessor

### DIFF
--- a/skore/tests/unit/displays/table_report/test_common.py
+++ b/skore/tests/unit/displays/table_report/test_common.py
@@ -13,7 +13,7 @@ from skore._sklearn._plot.data.table_report import (
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def X_y():
     X, y = make_regression(n_samples=100, n_features=5, random_state=42)
     X = pd.DataFrame(X, columns=[f"Feature_{i}" for i in range(5)])
@@ -21,20 +21,20 @@ def X_y():
     return X, y
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def estimator_report(X_y):
     X, y = X_y
     split_data = train_test_split(X, y, random_state=0, as_dict=True)
     return EstimatorReport(tabular_pipeline("regressor"), **split_data)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def cross_validation_report(X_y):
     X, y = X_y
     return CrossValidationReport(tabular_pipeline("regressor"), X=X, y=y)
 
 
-@pytest.fixture(params=["estimator_report", "cross_validation_report"])
+@pytest.fixture(params=["estimator_report", "cross_validation_report"], scope='module')
 def display(request):
     report = request.getfixturevalue(request.param)
     return report.data.analyze()

--- a/skore/tests/unit/displays/table_report/test_cross_validation.py
+++ b/skore/tests/unit/displays/table_report/test_cross_validation.py
@@ -3,20 +3,21 @@ import pandas as pd
 import pytest
 from sklearn.cluster import KMeans
 from sklearn.datasets import make_regression
+from sklearn.dummy import DummyRegressor
 
 from skore import CrossValidationReport, Display, TableReportDisplay
 from skore._externals._skrub_compat import tabular_pipeline
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def cross_validation_report():
     X, y = make_regression(n_samples=100, n_features=5, random_state=42)
     X = pd.DataFrame(X, columns=[f"Feature_{i}" for i in range(5)])
     y = pd.Series(y, name="Target_")
-    return CrossValidationReport(tabular_pipeline("regressor"), X=X, y=y)
+    return CrossValidationReport(tabular_pipeline(DummyRegressor()), X=X, y=y)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def display(cross_validation_report):
     return cross_validation_report.data.analyze()
 
@@ -44,9 +45,8 @@ def test_table_report_display_constructor(display):
     )
 
 
-def test_table_report_display_frame(cross_validation_report):
+def test_table_report_display_frame(cross_validation_report, display):
     """Check that we return the expected kind of data when calling `.frame`."""
-    display = cross_validation_report.data.analyze()
     dataset = display.frame(kind="dataset")
 
     pd.testing.assert_frame_equal(
@@ -81,7 +81,7 @@ def test_table_report_display_frame(cross_validation_report):
 )
 def test_display_creation(X, y):
     """Check that the display can be created with different types of X and y."""
-    report = CrossValidationReport(tabular_pipeline("regressor"), X=X, y=y)
+    report = CrossValidationReport(tabular_pipeline(DummyRegressor()), X=X, y=y)
     display = report.data.analyze()
     assert isinstance(display, TableReportDisplay)
 


### PR DESCRIPTION
Use a simpler model and re-use fixtures.

Test time of `tests/unit/displays/table_report/` goes from 45s to 12s.