### PR TITLE
refactor: Let `_get_cached_response_values` save values to the cache

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -1239,9 +1239,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                         data_source_hash=None,
                         pos_label=display_kwargs.get("pos_label"),
                     )
-                    for key, value, is_cached in results:
-                        if not is_cached:
-                            report._cache[key] = value
+                    for key, value in results:
                         if key[-1] != "predict_time":
                             y_pred.append(
                                 YPlotData(
@@ -1296,9 +1294,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                             data_source_hash=None,
                             pos_label=display_kwargs.get("pos_label"),
                         )
-                        for key, value, is_cached in results:
-                            if not is_cached:
-                                report._cache[key] = value
+                        for key, value in results:
                             if key[-1] != "predict_time":
                                 y_pred.append(
                                     YPlotData(

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1160,9 +1160,7 @@ class _MetricsAccessor(
                     data_source_hash=data_source_hash,
                     pos_label=display_kwargs.get("pos_label"),
                 )
-                for key, value, is_cached in results:
-                    if not is_cached:
-                        report._cache[key] = value
+                for key, value in results:
                     if key[-1] != "predict_time":
                         y_pred.append(
                             YPlotData(

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -519,10 +519,8 @@ class _MetricsAccessor(
                 data_source=data_source,
                 data_source_hash=data_source_hash,
             )
-            for key_tuple, value, is_cached in results:
-                if not is_cached:
-                    self._parent._cache[key_tuple] = value
-                if key_tuple[-1] != "predict_time":
+            for key, value in results:
+                if key[-1] != "predict_time":
                     y_pred = value
 
             score = metric_fn(y_true, y_pred, **kwargs)
@@ -1717,10 +1715,7 @@ class _MetricsAccessor(
                 data_source=data_source,
                 data_source_hash=data_source_hash,
             )
-            for key, value, is_cached in results:
-                key = cast(tuple[Any, ...], key)
-                if not is_cached:
-                    cache[key] = value
+            for key, value in results:
                 if key[-1] != "predict_time":
                     y_pred = value
 

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -294,16 +294,8 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         total_iterations = len(response_methods) * len(pos_labels) * len(data_sources)
         progress.update(task, total=total_iterations)
 
-        # do not mutate directly `self._cache` during the execution of Parallel
-        results_to_cache: dict[tuple[Any, ...], Any] = {}
-        for results in generator:
-            results_to_cache.update(
-                (key, value) for key, value, is_cached in results if not is_cached
-            )
+        for _ in generator:
             progress.update(task, advance=1, refresh=True)
-
-        if results_to_cache:
-            self._cache.update(results_to_cache)
 
     def get_predictions(
         self,
@@ -397,9 +389,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
             pos_label=pos_label,
             data_source=data_source,
         )
-        for key, value, is_cached in results:
-            if not is_cached:
-                self._cache[key] = value
         return results[0][1]  # return the predictions only
 
     @property

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -211,6 +211,7 @@ def test_cache_predictions(
     else:
         report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
+    breakpoint()
     assert report._cache == {}
     report.cache_predictions(n_jobs=n_jobs)
     assert len(report._cache) == expected_n_keys

--- a/skore/tests/unit/reports/test_base.py
+++ b/skore/tests/unit/reports/test_base.py
@@ -102,14 +102,10 @@ def test_get_cached_response_values(
         f"Expected 1 call for {response_method}, got {initial_calls}"
     )
 
-    # cache the results
-    cache.update((key, value) for key, value, _ in results)
-
     # Reload from the cache
     results = _get_cached_response_values(cache=cache, **params)
     assert len(results) == 1
-    _, response_values, is_cached = results[0]
-    assert is_cached
+    _, response_values, = results[0]
     assert response_values.shape == y.shape
     current_calls = getattr(estimator, f"n_call_{response_method}")
     assert current_calls == initial_calls, (
@@ -126,24 +122,19 @@ def test_get_cached_response_values(
     if pos_label_sensitive:
         assert len(results) == 2
         assert current_calls == initial_calls + 1
-        _, response_values, is_cached = results[0]
-        assert not is_cached
+        _, response_values  = results[0]
         assert response_values.shape == y.shape
-
-        cache.update((key, value) for key, value, _ in results)
 
     else:
         assert len(results) == 1
         assert current_calls == initial_calls
-        _, response_values, is_cached = results[0]
-        assert is_cached
+        _, response_values = results[0]
         assert response_values.shape == y.shape
 
     # Should reload completely from the cache
     results = _get_cached_response_values(cache=cache, **params)
     assert len(results) == 1
-    _, response_values, is_cached = results[0]
-    assert is_cached
+    _, response_values = results[0]
     assert response_values.shape == y.shape
 
 
@@ -176,21 +167,16 @@ def test_get_cached_response_values_different_data_source_hash(
     }
     results = _get_cached_response_values(cache=cache, **params)
     assert len(results) == 2
-    _, response_values, is_cached = results[0]
-    assert not is_cached
+    _, response_values = results[0]
     assert response_values.shape == y.shape
     initial_calls = getattr(estimator, f"n_call_{response_method}")
-
-    # cache the results
-    cache.update((key, value) for key, value, _ in results)
 
     # Second call by passing the hash of the data should not trigger new computation
     # because we consider it trustworthy
     params["data_source_hash"] = joblib.hash(X)
     results = _get_cached_response_values(cache=cache, **params)
     assert len(results) == 1
-    _, response_values, is_cached = results[0]
-    assert is_cached
+    _, response_values = results[0]
     assert response_values.shape == y.shape
     current_calls = getattr(estimator, f"n_call_{response_method}")
     assert current_calls == initial_calls, (
@@ -203,8 +189,7 @@ def test_get_cached_response_values_different_data_source_hash(
     params["data_source_hash"] = 456
     results = _get_cached_response_values(cache=cache, **params)
     assert len(results) == 2
-    _, response_values, is_cached = results[0]
-    assert not is_cached
+    _, response_values = results[0]
     assert response_values.shape == y.shape
     current_calls = getattr(estimator, f"n_call_{response_method}")
     assert current_calls == initial_calls + 1, (


### PR DESCRIPTION
This contributes to #2153 

When used in the context of `joblib.Parallel` with `n_jobs != 1` we still have to keep the saving logic in the caller because `joblib` parallelism is process-wise, not thread-wise.