### PR TITLE
ci: Set dependabot cooldown to 14 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,20 @@
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: "chore(dependencies): GITHUB-ACTIONS"
-
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
+      semver-patch-days: 7
     commit-message:
       prefix: "chore(dependencies): PIP"
     groups:


### PR DESCRIPTION
> Dependency cooldowns are a free, easy, and incredibly effective way to mitigate the large majority of open source supply chain attacks. More individual projects should apply cooldowns (via tools like Dependabot and Renovate) to their dependencies, and packaging ecosystems should invest in first-class support for cooldowns directly in their package managers.

https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns