### PR TITLE
feat: Add support for `data_source="both"` in `ComparisonReport.metrics.summary`

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -67,12 +67,14 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
 
         Parameters
         ----------
-        data_source : {"test", "train", "X_y"}, default="test"
+        data_source : {"test", "train", "X_y", "both"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
             - "X_y" : use the provided `X` and `y` to compute the metric.
+            - "both" : use both the train and test sets to compute the metrics and
+              present them side-by-side.
 
         X : array-like of shape (n_samples, n_features), default=None
             New data on which to compute the metric. By default, we use the validation
@@ -254,6 +256,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                     indicator_favorability=metric_kwargs.get(
                         "indicator_favorability", False
                     ),
+                    data_source=data_source,
                 )
             else:  # "CrossValidationReport"
                 results = _combine_cross_validation_results(

--- a/skore/src/skore/_sklearn/_comparison/utils.py
+++ b/skore/src/skore/_sklearn/_comparison/utils.py
@@ -1,14 +1,16 @@
 import copy
+from typing import Literal
 
 import pandas as pd
 
-from skore._sklearn.types import Aggregate
+from skore._sklearn.types import Aggregate, DataSource
 
 
 def _combine_estimator_results(
     individual_results: list[pd.DataFrame],
     estimator_names: list[str],
     indicator_favorability: bool,
+    data_source: DataSource | Literal["both"],
 ) -> pd.DataFrame:
     """Combine a list of dataframes provided by `EstimatorReport`s.
 
@@ -23,6 +25,9 @@ def _combine_estimator_results(
 
     indicator_favorability : bool
         Whether to keep the Favorability column.
+
+    data_source : {"test", "train", "X_y", "both"}
+        The data source.
 
     Examples
     --------
@@ -55,6 +60,7 @@ def _combine_estimator_results(
     ...     individual_results,
     ...     estimator_names,
     ...     indicator_favorability=False,
+    ...     data_source="test",
     ... )
     Estimator    LogisticRegression_1  LogisticRegression_2
     Metric
@@ -73,7 +79,17 @@ def _combine_estimator_results(
     else:
         favorability = None
 
-    results.columns = pd.Index(estimator_names, name="Estimator")
+    if data_source == "both":
+        results.columns = pd.Index(
+            [
+                x
+                for name in estimator_names
+                for x in [f"{name} (train)", f"{name} (test)"]
+            ],
+            name="Estimator",
+        )
+    else:
+        results.columns = pd.Index(estimator_names, name="Estimator")
 
     if favorability is not None:
         results["Favorability"] = favorability

--- a/skore/tests/unit/displays/metrics_summary/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_comparison_estimator.py
@@ -43,6 +43,48 @@ def test_data_source_external(
     pd.testing.assert_index_equal(cached_result.columns, expected_columns)
 
 
+def test_data_source_both(
+    binary_classification_data, comparison_estimator_reports_binary_classification
+):
+    """Check that `MetricsSummaryDisplay` works with `data_source="both"`."""
+    X, y = binary_classification_data
+
+    report = comparison_estimator_reports_binary_classification
+    result = report.metrics.summarize(data_source="both", X=X[:10], y=y[:10]).frame()
+    assert "Favorability" not in result.columns
+
+    expected_index = pd.MultiIndex.from_tuples(
+        [
+            ("Precision", 0),
+            ("Precision", 1),
+            ("Recall", 0),
+            ("Recall", 1),
+            ("ROC AUC", ""),
+            ("Brier score", ""),
+            ("Fit time (s)", ""),
+            ("Predict time (s)", ""),
+        ],
+        names=["Metric", "Label / Average"],
+    )
+    expected_columns = pd.Index(
+        [
+            "DummyClassifier_1 (train)",
+            "DummyClassifier_1 (test)",
+            "DummyClassifier_2 (train)",
+            "DummyClassifier_2 (test)",
+        ],
+        name="Estimator",
+    )
+
+    pd.testing.assert_index_equal(result.index, expected_index)
+    pd.testing.assert_index_equal(result.columns, expected_columns)
+
+    assert len(report._cache) == 1
+    cached_result = next(iter(report._cache.values()))
+    pd.testing.assert_index_equal(cached_result.index, expected_index)
+    pd.testing.assert_index_equal(cached_result.columns, expected_columns)
+
+
 def test_flat_index(estimator_reports_binary_classification):
     """Check that the index is flattened when `flat_index` is True.
 


### PR DESCRIPTION
For ComparisonReports of EstimatorReports specifically.

Closes #2151 