### PR TITLE
chore(skore): Remove constraints from `transformers` and `sentence-transformers`

### DIFF
--- a/ci/requirements/skore/python-3.13/scikit-learn-1.7/sphinx-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.7/sphinx-requirements.txt
@@ -203,7 +203,6 @@ pexpect==4.9.0
 pillow==12.0.0
     # via
     #   matplotlib
-    #   sentence-transformers
     #   sphinx-gallery
 platformdirs==4.5.1
     # via skore-local-project
@@ -291,7 +290,7 @@ scipy==1.16.3
     #   xgboost
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
-sentence-transformers==3.4.1
+sentence-transformers==5.2.0
     # via skore (skore/pyproject.toml)
 setuptools==80.9.0
     # via torch
@@ -372,6 +371,7 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   huggingface-hub
     #   pydata-sphinx-theme
+    #   sentence-transformers
     #   torch
 tzdata==2025.3
     # via pandas

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -63,7 +63,7 @@ sphinx-base = [
   "plotly>=6,<7", # plotly <6 conflicting with kaleido
   "pydata-sphinx-theme",
   "seaborn",
-  "sentence-transformers<4",  # core dumped on `>=4,<4.0.2`
+  "sentence-transformers",
   "skrub",
   "sphinx-copybutton",
   "sphinx-design",


### PR DESCRIPTION
Incidentally, fixes CVE-2025-3264.