### PR TITLE
feat(skore-hub-project): Rename `splits` to `splitting_strategy`

### DIFF
--- a/skore-hub-project/src/skore_hub_project/report/cross_validation_report.py
+++ b/skore-hub-project/src/skore_hub_project/report/cross_validation_report.py
@@ -165,13 +165,16 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
-    def splits(self) -> dict[str, Any]:
+    def splitting_strategy(self) -> dict[str, Any]:
         """
-        Distribution between train and test by split.
+        Splitting strategy used to split the dataset into train and test sets.
+
+        This includes the number of splits, the number of repeats, the seed,
+        and the distribution of the train and test sets.
 
         The distribution of each split is computed by dividing the split into a maximum
         of 200 buckets, and averaging the number of samples belonging to the test-set in
-        each of these buckets.
+        each of these buckets. @TODO: find a better representation of the distribution.
         """
         splits = []
 

--- a/skore-hub-project/tests/unit/report/test_cross_validation_report.py
+++ b/skore-hub-project/tests/unit/report/test_cross_validation_report.py
@@ -95,7 +95,7 @@ class TestCrossValidationReportPayload:
         assert payload.dataset_size == 10
 
     def test_splits(self, payload):
-        assert payload.splits == {
+        assert payload.splitting_strategy == {
             "repeat_count": 1,
             "seed": "None",
             "splits": [
@@ -141,7 +141,7 @@ class TestCrossValidationReportPayload:
             ),
             key="<key>",
         )
-        assert payload.splits == {
+        assert payload.splitting_strategy == {
             "repeat_count": 2,
             "seed": "42",
             "splits": [
@@ -322,7 +322,7 @@ class TestCrossValidationReportPayload:
         payload_dict.pop("estimators")
         payload_dict.pop("metrics")
         payload_dict.pop("medias")
-        payload_dict.pop("splits")
+        payload_dict.pop("splitting_strategy")
 
         assert payload_dict == {
             "key": "<key>",


### PR DESCRIPTION
This avoid strange syntax like `report.splits.splits`.