### PR TITLE
fix: Clarify error when using response_method in ComparisonReport.metrics.summarize

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -156,9 +156,11 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
         """
         if response_method is not None:
             raise TypeError(
-                "`response_method` is not supported in `ComparisonReport.metrics.summarize`. "
+                "`response_method` is not supported in "
+                "`ComparisonReport.metrics.summarize`. "
                 "To compute a custom metric with an explicit response method, use "
-                "`ComparisonReport.metrics.custom_metric(metric_function=..., response_method=...)`, "
+                "`ComparisonReport.metrics.custom_metric("
+                "metric_function=..., response_method=...)`, "
                 "or pass a scikit-learn scorer created with "
                 "`sklearn.metrics.make_scorer(..., response_method=...)` via `metric=`."
             )

--- a/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
@@ -369,6 +369,7 @@ def test_precision_recall_pos_label_overwrite(metric):
             == result_both_labels.loc[(metric.capitalize(), "A"), ("mean", report_name)]
         )
 
+
 @pytest.mark.parametrize("response_method", ["predict", "predict_proba"])
 def test_summarize_response_method_guidance(
     comparison_cross_validation_reports_regression,
@@ -379,7 +380,7 @@ def test_summarize_response_method_guidance(
 
     def business_loss(y_true_list, y_pred_list):
         loss = 0
-        for y_true_, y_pred_ in zip(y_true_list, y_pred_list):
+        for y_true_, y_pred_ in zip(y_true_list, y_pred_list, strict=True):
             # If under the market: 100% loss for me
             if y_true_ > y_pred_:
                 loss = loss + float(y_true_ - y_pred_)
@@ -394,4 +395,3 @@ def test_summarize_response_method_guidance(
             metric=business_loss,
             response_method=response_method,
         )
-


### PR DESCRIPTION
Clarifies `response_method` handling in `ComparisonReport.metrics.summarize`.

Passing `response_method=` previously raised a generic "unexpected keyword argument"
TypeError, which is confusing given that `ComparisonReport.metrics.custom_metric`
and sklearn scorers (`make_scorer`) are the intended APIs for controlling the
prediction method (`predict`, `predict_proba`, etc.).

This PR:
- adds `response_method` to the `summarize` signature to raise a clear, actionable
  error message guiding users to `custom_metric(..., response_method=...)` or
  `make_scorer(..., response_method=...)`.
- adds a regression test covering both `predict` and `predict_proba`.

Refs #2206