### PR TITLE
feat(skore): Create a "custom" metrics registry under each report

### DIFF
--- a/skore/src/skore/_sklearn/_metric/registry.py
+++ b/skore/src/skore/_sklearn/_metric/registry.py
@@ -15,9 +15,6 @@ from skore._sklearn.types import DataSource, PositiveLabel
 
 
 class Metric(_BaseAccessor[EstimatorReport]):  # or Protocol
-    # est-ce qu'on hérite de basescorer ? qu'on puisse intergenger un Metric/BaseScorer
-    # ou est-ce qu'on fait un wrapper qui a un attribute scorer ?
-
     NAME: str
     VERBOSE_NAME: str
     SCORE_FUNC: Callable  # foo(y_true, y_pred) -> float | Any
@@ -46,15 +43,6 @@ class Metric(_BaseAccessor[EstimatorReport]):  # or Protocol
         pos_label: PositiveLabel | None = None,
         **kwargs: Any,
     ) -> float | list[float] | dict[Any, float]:
-        # changer _compute_metric_scores pour l'intégrer ici dans "compute"
-        #
-        # implémenter ici la logique de cache
-        # pour le moment, ne mettre en cache que les prédictions, ne pas mettre en cache le résultat (à voir)
-        #
-        # -> cast(float, metric)
-        #
-        # integrer dans la clé de cache la signature de score_func, pour intégrer les partial
-        # les kwargs etc ?
         if data_source_hash is None:
             X, y, data_source_hash = self._get_X_y_and_data_source_hash(
                 data_source=data_source, X=X, y=y,

--- a/skore/src/skore/_sklearn/_metric/registry.py
+++ b/skore/src/skore/_sklearn/_metric/registry.py
@@ -250,7 +250,7 @@ class MetricRegistry:
                 metric._score_func.__name__.replace("_", " ").title(),
                 partial(metric._score_func, **metric._kwargs),
                 metric._response_method,
-                bool(metric._sign),
+                (metric._sign > 0),
                 self.__report,
             )
         elif callable(metric):

--- a/skore/src/skore/_sklearn/_metric/registry.py
+++ b/skore/src/skore/_sklearn/_metric/registry.py
@@ -231,10 +231,9 @@ class MetricRegistry(UserList[Metric]):
                 or (not metric_cls.available(self.__report))
                 or (metric_cls in self.__classes)
             ):
-                # logger.debug()
-                self.__classes.add(metric_cls)
                 continue
 
+            self.__classes.add(metric_cls)
             super().append(metric_cls(self.__report))
 
 

--- a/skore/src/skore/_sklearn/_metric/registry.py
+++ b/skore/src/skore/_sklearn/_metric/registry.py
@@ -24,11 +24,25 @@ class Metric(ABC):  # or Protocol
     GREATER_IS_BETTER: bool
     CUSTOM: bool
 
+    def __init__(self, report, /):
+        self.report = report
+
     @staticmethod
     def available(estimator, ml_task) -> bool:
         raise NotImplementedError
 
-    def compute(self, *, data_source="test", X=None, y=None) -> float | Any:
+    def compute(
+        self,
+        *,
+        X: ArrayLike | None = None,
+        y: ArrayLike | None = None,
+        data_source: DataSource = "test",
+        data_source_hash: int | None = None,
+        pos_label: PositiveLabel | None = None,
+    ) -> float:
+        # cast(float, metric)
+
+    def compute2(self, *, data_source="test", X=None, y=None) -> float | Any:
         # changer _compute_metric_scores pour l'intégrer ici dans "compute"
         #
         # implémenter ici la logique de cache

--- a/skore/src/skore/_sklearn/_metric/registry.py
+++ b/skore/src/skore/_sklearn/_metric/registry.py
@@ -1,0 +1,90 @@
+from abc import ABC
+from collections import UserList
+
+from sklearn.metrics._scorer import _BaseScorer
+
+# https://github.com/scikit-learn/scikit-learn/blob/e9752287ffffecb2d2878ce1ed97a77a43941579/sklearn/metrics/_scorer.py#L228
+#
+# def __init__(self, score_func, sign, kwargs# , response_method="predict"):
+#     self._score_func = score_func
+#     self._sign = sign
+#     self._kwargs = kwargs
+#     self._response_method = response_method
+#
+
+
+class Metric(ABC, _BaseScorer):  # or Protocol
+    name: str
+    verbose_name: str
+    function: Callable[[Any, Any], float | Any]
+    custom: bool = False
+
+    # Fields inherited from `sklearn.metrics._Scorer` or something similar:
+    #
+    # greater_is_better: bool | None
+    # prediction_method: str | list[str]
+    # data_source: DataSource = "test"
+    # X: ArrayLike | None = None
+    # y: ArrayLike | None = None
+
+    @staticmethod
+    def compatibility(estimator, ml_task) -> bool:
+        # equivalent of `available_if`
+        return True
+
+    def compute(self, y_true, y_pred) -> float | Any:
+        # implémenter ici la logique de cache
+        # pour le moment, ne mettre en cache que les prédictions, ne pas mettre en cache le résultat (à voir)
+        ...
+
+
+# redefinir les metriques actuelles comme des Metric
+# les register dynamiqument dans les init des reports si elles sont compatibles
+#
+# faire une factory qui acceptent des _base_scorer, des callables ou des nom de scorer scikit et qui transforme ça en Metric
+# changer _compute_metric_scores pour l'intégrer ici dans "compute"
+
+# case 1 : str -> find in scikit-learn the corresponding scorer
+# case 2 : scorer -> scikit-learn scorer
+# case 3 : callable -> create a custom scorer based on the provided callable (optional verbose_name + greater_is_better)
+
+# https://github.com/scikit-learn/scikit-learn/blob/e9752287ffffecb2d2878ce1ed97a77a43941579/sklearn/metrics/_scorer.py#L798
+
+
+class AggregateCustomMetricFormula(CustomMetricFormula, ABC):  # or Protocol
+    aggregate: Aggregate = ("mean", "std")
+
+
+class MetricRegistry(UserList[type[Metric]]):
+    def __init__(self, *, report: Report):
+        super().__init__()
+
+        self.__report = report
+
+    def append(self, metric_cls: type[CustomMetricFormula]):
+        # ensure metric_cls is valid
+        # ensure metric_cls is not already present in the registry
+        # append to the list
+        # expose the tuple (name, compute) under the "report.metrics" accessor
+        ...
+
+
+class Report:
+    def __init__(self):
+        self.custom_metric_formula_registry: list[type[CustomMetricFormula]] = (
+            CustomMetricFormulaRegistry(report=self)
+        )
+
+
+# note important
+# pour toutes les string de scorer commencant par "neg_" (genre "neg_rmse") -> on garde le greater_is_better,
+# mais on change le signe pour n'avoir que des résultats positifs
+
+# -------------------------
+
+
+def foobar(y_true, y_pred):
+    return 1
+
+
+report.registry.append(foobar, verbose_name="Ma métrique", greater_is_better=True)

--- a/skore/src/skore/_sklearn/_metric/registry.py
+++ b/skore/src/skore/_sklearn/_metric/registry.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
-from typing import Any, Literal, runtime_checkable, Protocol
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from numpy.typing import ArrayLike
+from sklearn.metrics import accuracy_score, get_scorer, precision_score, r2_score
 from sklearn.metrics._scorer import _BaseScorer
-from sklearn.metrics import accuracy_score, precision_score, r2_score, get_scorer
 
 from skore import EstimatorReport
 from skore._sklearn._base import _BaseAccessor, _get_cached_response_values
@@ -47,7 +47,9 @@ class Metric(_BaseAccessor[EstimatorReport], MetricProtocol):  # or Protocol
     ) -> float | list[float] | dict[Any, float]:
         if data_source_hash is None:
             X, y, data_source_hash = self._get_X_y_and_data_source_hash(
-                data_source=data_source, X=X, y=y,
+                data_source=data_source,
+                X=X,
+                y=y,
             )
 
         results = _get_cached_response_values(


### PR DESCRIPTION
> [!CAUTION]
> Just a notebook for reflection for now.

Points to cover:
- redefine `__call__` in each metric subclass to provide a more user-friendly API
    - equivalent of the current implementation with `r2` calling `_r2`
- show the docstr from the metric `r2 = R2(); help(r2)`
- show the helper
    - standard metrics
    - custom metrics
- deal with CrossValidation (only metrics)

---

Closes https://github.com/probabl-ai/skore-hub/issues/940.