### PR TITLE
chore(skore): Clean up docs references to seaborn

### DIFF
--- a/skore/src/skore/_sklearn/_plot/data/table_report.py
+++ b/skore/src/skore/_sklearn/_plot/data/table_report.py
@@ -266,26 +266,26 @@ class TableReportDisplay(ReprHTMLMixin, DisplayMixin):
             Only used when ``kind='dist'``.
 
         scatterplot_kwargs: dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`seaborn.scatterplot` for
+            Keyword arguments to be passed to :func:`seaborn.scatterplot` for
             rendering the distribution 2D plot, when both ``x`` and ``y`` are numeric.
 
         stripplot_kwargs: dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`searborn.stripplot` for
+            Keyword arguments to be passed to :func:`seaborn.stripplot` for
             rendering the distribution 2D plot, when either ``x`` or ``y`` is numeric,
             and the other is categorical. This plot is drawn on top of the boxplot.
 
         boxplot_kwargs: dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`seaborn.boxplot` for
+            Keyword arguments to be passed to :func:`seaborn.boxplot` for
             rendering the distribution 2D plot, when either ``x`` or ``y`` is numeric,
             and the other is categorical. This plot is drawn below the stripplot.
 
         heatmap_kwargs: dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`seaborn.heatmap` for
+            Keyword arguments to be passed to :func:`seaborn.heatmap` for
             rendering Cramer's V correlation matrix, when ``kind='corr'`` or when
             ``kind='dist'`` and both ``x`` and ``y`` are categorical.
 
         histplot_kwargs: dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`seaborn.histplot` for
+            Keyword arguments to be passed to :func:`seaborn.histplot` for
             rendering the distribution 1D plot, when only ``x`` is provided.
 
         Examples
@@ -399,7 +399,7 @@ class TableReportDisplay(ReprHTMLMixin, DisplayMixin):
             The number of most frequent categories to plot.
 
         histplot_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's :ref:`histplot
+            Keyword arguments to be passed to :ref:`histplot
             <https://seaborn.pydata.org/generated/seaborn.histplot.html>`_ for rendering
             the distribution 1D plot.
         """
@@ -495,16 +495,16 @@ class TableReportDisplay(ReprHTMLMixin, DisplayMixin):
             The number of most frequent categories to plot.
 
         heatmap_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's heatmap.
+            Keyword arguments to be passed to heatmap.
 
         stripplot_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's stripplot.
+            Keyword arguments to be passed to stripplot.
 
         boxplot_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's boxplot.
+            Keyword arguments to be passed to boxplot.
 
         scatterplot_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's scatterplot.
+            Keyword arguments to be passed to scatterplot.
         """
         x = sbd.col(self.summary["dataframe"], x) if x is not None else None
         y = sbd.col(self.summary["dataframe"], y) if y is not None else None
@@ -653,7 +653,7 @@ class TableReportDisplay(ReprHTMLMixin, DisplayMixin):
         Parameters
         ----------
         heatmap_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's heatmap.
+            Keyword arguments to be passed to heatmap.
         """
         if heatmap_kwargs is None:
             heatmap_kwargs = self._default_heatmap_kwargs or {}

--- a/skore/src/skore/_sklearn/_plot/feature_importance/coefficients.py
+++ b/skore/src/skore/_sklearn/_plot/feature_importance/coefficients.py
@@ -180,17 +180,17 @@ class CoefficientsDisplay(DisplayMixin):
             - when comparing estimators for which the input features are different.
 
         barplot_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`seaborn.barplot` for
+            Keyword arguments to be passed to :func:`seaborn.barplot` for
             rendering the coefficients with an :class:`~skore.EstimatorReport` or
             :class:`~skore.ComparisonReport` of :class:`~skore.EstimatorReport`.
 
         boxplot_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`seaborn.boxplot` for
+            Keyword arguments to be passed to :func:`seaborn.boxplot` for
             rendering the coefficients with a :class:`~skore.CrossValidationReport` or
             :class:`~skore.ComparisonReport` of :class:`~skore.CrossValidationReport`.
 
         stripplot_kwargs : dict, default=None
-            Keyword arguments to be passed to seaborn's :func:`seaborn.stripplot` for
+            Keyword arguments to be passed to :func:`seaborn.stripplot` for
             rendering the coefficients with a :class:`~skore.CrossValidationReport` or
             :class:`~skore.ComparisonReport` of :class:`~skore.CrossValidationReport`.
 
@@ -391,15 +391,15 @@ class CoefficientsDisplay(DisplayMixin):
             The column to use for subplotting and dividing the coefficients into
             subplots.
         barplot_kwargs : dict
-            Keyword arguments to be passed to seaborn's :func:`seaborn.barplot` for
+            Keyword arguments to be passed to :func:`seaborn.barplot` for
             rendering the coefficients with an :class:`~skore.EstimatorReport` or
             :class:`~skore.ComparisonReport` of :class:`~skore.EstimatorReport`.
         boxplot_kwargs : dict
-            Keyword arguments to be passed to seaborn's :func:`seaborn.boxplot` for
+            Keyword arguments to be passed to :func:`seaborn.boxplot` for
             rendering the coefficients with a :class:`~skore.CrossValidationReport` or
             :class:`~skore.ComparisonReport` of :class:`~skore.CrossValidationReport`.
         stripplot_kwargs : dict
-            Keyword arguments to be passed to seaborn's :func:`seaborn.stripplot` for
+            Keyword arguments to be passed to :func:`seaborn.stripplot` for
             rendering the coefficients with a :class:`~skore.CrossValidationReport` or
             :class:`~skore.ComparisonReport` of :class:`~skore.CrossValidationReport`.
         """
@@ -482,15 +482,15 @@ class CoefficientsDisplay(DisplayMixin):
             subplots. If `None`, an automatic choice is made depending on the type of
             reports at hand.
         barplot_kwargs : dict
-            Keyword arguments to be passed to seaborn's :func:`seaborn.barplot` for
+            Keyword arguments to be passed to :func:`seaborn.barplot` for
             rendering the coefficients with an :class:`~skore.ComparisonReport` of
             :class:`~skore.EstimatorReport`.
         boxplot_kwargs : dict
-            Keyword arguments to be passed to seaborn's :func:`seaborn.boxplot` for
+            Keyword arguments to be passed to :func:`seaborn.boxplot` for
             rendering the coefficients with a :class:`~skore.ComparisonReport` of
             :class:`~skore.CrossValidationReport`.
         stripplot_kwargs : dict
-            Keyword arguments to be passed to seaborn's :func:`seaborn.stripplot` for
+            Keyword arguments to be passed to :func:`seaborn.stripplot` for
             rendering the coefficients with a :class:`~skore.ComparisonReport` of
             :class:`~skore.CrossValidationReport`.
         """

--- a/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
@@ -595,12 +595,10 @@ class ConfusionMatrixDisplay(_ClassifierDisplayMixin, DisplayMixin):
             previously unset are changed.
 
         heatmap_kwargs : dict, default=None
-            Additional keyword arguments to be passed to seaborn's
-            :func:`seaborn.heatmap`.
+            Additional keyword arguments to be passed to :func:`seaborn.heatmap`.
 
         facet_grid_kwargs : dict, default=None
-            Additional keyword arguments to be passed to seaborn's
-            :class:`seaborn.FacetGrid`.
+            Additional keyword arguments to be passed to :class:`seaborn.FacetGrid`.
 
         Returns
         -------


### PR DESCRIPTION
In the documentation, some references to seaborn functions are redundant:

<img width="919" height="183" alt="image" src="https://github.com/user-attachments/assets/e8b41e37-e19a-432b-9d93-486768526280" />
so let's remove the "seaborn's" mention.

 
An alternative fix would be to write 
```
seaborn's :func:`heatmap<seaborn.heatmap>`
```
instead of the current
```
seaborn's :func:`seaborn.heatmap`
```
but that feels a bit overkill.