### PR TITLE
fix(skore-hub-project/tests): Ignore `Precision is ill-defined` warning

### DIFF
--- a/skore-hub-project/tests/unit/report/test_cross_validation_report.py
+++ b/skore-hub-project/tests/unit/report/test_cross_validation_report.py
@@ -338,6 +338,11 @@ class TestCrossValidationReportPayload:
             PredictTimeTrainStd,
         ]
 
+    @mark.filterwarnings(
+        # ignore precision warning due to the low number of labels in
+        # `small_cv_binary_classification`, raised by `scikit-learn`
+        "ignore:Precision is ill-defined.*:sklearn.exceptions.UndefinedMetricWarning"
+    )
     def test_metrics_raises_exception(self, monkeypatch, payload):
         """
         Since metrics compute is multi-threaded, ensure that any exceptions thrown in a


### PR DESCRIPTION
Fixing the flaky 🔴 CI on main.

```python-traceback
FAILED tests/unit/report/test_cross_validation_report.py::TestCrossValidationReportPayload::test_metrics_raises_exception - AssertionError: Regex pattern did not match.
  Expected regex: 'test_metrics_raises_exception'
  Actual message: 'Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.'
```