### PR TITLE
chore(skore-hub-project/tests): Improve `test_metrics_raises_exception`

### DIFF
--- a/skore-hub-project/tests/unit/report/test_cross_validation_report.py
+++ b/skore-hub-project/tests/unit/report/test_cross_validation_report.py
@@ -338,11 +338,6 @@ class TestCrossValidationReportPayload:
             PredictTimeTrainStd,
         ]
 
-    @mark.filterwarnings(
-        # ignore precision warning due to the low number of labels in
-        # `small_cv_binary_classification`, raised by `scikit-learn`
-        "ignore:Precision is ill-defined.*:sklearn.exceptions.UndefinedMetricWarning"
-    )
     def test_metrics_raises_exception(self, monkeypatch, payload):
         """
         Since metrics compute is multi-threaded, ensure that any exceptions thrown in a
@@ -353,7 +348,11 @@ class TestCrossValidationReportPayload:
             raise Exception("test_metrics_raises_exception")
 
         monkeypatch.setattr(
-            "skore_hub_project.metric.metric.CrossValidationReportMetric.compute",
+            "skore_hub_project.report.cross_validation_report.CrossValidationReportPayload.METRICS",
+            [AccuracyTestMean],
+        )
+        monkeypatch.setattr(
+            "skore_hub_project.metric.AccuracyTestMean.compute",
             raise_exception,
         )
 

--- a/skore-hub-project/tests/unit/report/test_estimator_report.py
+++ b/skore-hub-project/tests/unit/report/test_estimator_report.py
@@ -132,8 +132,11 @@ class TestEstimatorReportPayload:
             raise Exception("test_metrics_raises_exception")
 
         monkeypatch.setattr(
-            "skore_hub_project.metric.metric.EstimatorReportMetric.compute",
-            raise_exception,
+            "skore_hub_project.report.estimator_report.EstimatorReportPayload.METRICS",
+            [AccuracyTest],
+        )
+        monkeypatch.setattr(
+            "skore_hub_project.metric.AccuracyTest.compute", raise_exception
         )
 
         with raises(Exception, match="test_metrics_raises_exception"):


### PR DESCRIPTION
Following https://github.com/probabl-ai/skore/pull/2307, slightly refactor the `test_metrics_raises_exception` tests so that they only run one metric.