### PR TITLE
feat: Get the best estimator from a comparison

### DIFF
--- a/skore/src/skore/_sklearn/types.py
+++ b/skore/src/skore/_sklearn/types.py
@@ -1,10 +1,11 @@
 """Types between parts of the sklearn module."""
 
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from numpy.typing import ArrayLike
+from pandas._typing import AggFuncType
 
 PlotBackend = Literal["matplotlib", "plotly"]
 
@@ -32,7 +33,8 @@ class _DefaultType:
 
 _DEFAULT = _DefaultType()
 PositiveLabel = int | float | bool | str | None | _DefaultType
-Aggregate = Literal["mean", "std"] | Sequence[Literal["mean", "std"]]
+
+Aggregate = AggFuncType
 
 
 @dataclass

--- a/skore/tests/unit/reports/comparison/test_report.py
+++ b/skore/tests/unit/reports/comparison/test_report.py
@@ -8,11 +8,17 @@ from io import BytesIO
 
 import joblib
 import pytest
-from sklearn.datasets import make_classification
-from sklearn.linear_model import LogisticRegression
+from sklearn.datasets import make_classification, make_regression
+from sklearn.linear_model import LinearRegression, LogisticRegression, Ridge
 from sklearn.svm import LinearSVC
+from sklearn.tree import DecisionTreeClassifier
 
-from skore import ComparisonReport, CrossValidationReport, EstimatorReport
+from skore import (
+    ComparisonReport,
+    CrossValidationReport,
+    EstimatorReport,
+    train_test_split,
+)
 
 
 @pytest.fixture(
@@ -127,3 +133,146 @@ def test_pos_label_mismatch(report):
     err_msg = "Expected all estimators to have the same positive label."
     with pytest.raises(ValueError, match=err_msg):
         ComparisonReport(reports)
+
+
+class Test_get_best_report:
+    """Test get_best_model."""
+
+    @pytest.fixture
+    def classification_estimator_reports(
+        self,
+    ):
+        """Fixture providing classification EstimatorReports for comparison."""
+        X, y = make_classification(n_samples=100, random_state=42)
+        split_data = train_test_split(X=X, y=y, random_state=42, as_dict=True)
+
+        estimator_report_1 = EstimatorReport(
+            LogisticRegression(random_state=42), **split_data
+        )
+        estimator_report_2 = EstimatorReport(
+            DecisionTreeClassifier(max_depth=1, random_state=42), **split_data
+        )
+
+        return estimator_report_1, estimator_report_2
+
+    @pytest.fixture
+    def classification_cv_reports(self):
+        X, y = make_classification(n_samples=100, random_state=42)
+
+        report_1 = CrossValidationReport(LogisticRegression(random_state=42), X=X, y=y)
+        report_2 = CrossValidationReport(
+            DecisionTreeClassifier(max_depth=1, random_state=42), X=X, y=y
+        )
+
+        return report_1, report_2
+
+    @pytest.fixture
+    def regression_estimator_reports(self):
+        X, y = make_regression(n_samples=100, random_state=42)
+        split_data = train_test_split(X=X, y=y, random_state=42, as_dict=True)
+
+        report_1 = EstimatorReport(LinearRegression(), **split_data)
+        report_2 = EstimatorReport(Ridge(alpha=10.0), **split_data)
+
+        return report_1, report_2
+
+    def test_default_metric(self, classification_estimator_reports):
+        """Test with EstimatorReport using default metric."""
+        report_1, report_2 = classification_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        best_report = report.get_best_model()
+
+        assert best_report == report_1
+
+    def test_precision(self, classification_estimator_reports):
+        """Test with EstimatorReport using precision."""
+        report_1, report_2 = classification_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        best_report = report.get_best_model(metric="precision")
+
+        assert best_report == report_1
+
+    def test_precision_with_pos_label(self, classification_estimator_reports):
+        """Test with EstimatorReport using precision with pos_label."""
+        report_1, report_2 = classification_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        best_report = report.get_best_model(metric="precision", pos_label=0)
+
+        assert best_report == report_1
+
+    def test_roc_auc(self, classification_estimator_reports):
+        """Test with EstimatorReport using roc_auc metric."""
+        report_1, report_2 = classification_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        best_report = report.get_best_model(metric="roc_auc")
+
+        assert best_report == report_1
+
+    def test_cross_validation_report_default_metric(self, classification_cv_reports):
+        """Test with CrossValidationReport using default metric."""
+        cv_report_1, cv_report_2 = classification_cv_reports
+        report = ComparisonReport([cv_report_1, cv_report_2])
+
+        best_report = report.get_best_model()
+
+        assert best_report == cv_report_1
+
+    def test_cross_validation_report_custom_metric(self, classification_cv_reports):
+        """Test with CrossValidationReport using custom metric."""
+        cv_report_1, cv_report_2 = classification_cv_reports
+        report = ComparisonReport([cv_report_1, cv_report_2])
+
+        best_report = report.get_best_model(
+            metric="precision", metric_kwargs={"average": "macro"}
+        )
+
+        assert best_report == cv_report_1
+
+    def test_regression_default_metric(self, regression_estimator_reports):
+        """Test with regression task using default metric (r2)."""
+        report_1, report_2 = regression_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        best_report = report.get_best_model()
+
+        assert best_report == report_1
+
+    def test_lower_is_better_metric(self, regression_estimator_reports):
+        """Test with a metric where lower is better (RMSE)."""
+        report_1, report_2 = regression_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        best_report = report.get_best_model(metric="rmse")
+
+        assert best_report == report_1
+
+    def test_get_best_model_data_source_train(self, regression_estimator_reports):
+        """Test using train data source."""
+        report_1, report_2 = regression_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        best_report = report.get_best_model(data_source="train")
+
+        assert best_report == report_1
+
+    def test_get_best_model_custom_metric_callable(
+        self, classification_estimator_reports
+    ):
+        """Test with a custom metric defined as a callable."""
+        report_1, report_2 = classification_estimator_reports
+        report = ComparisonReport([report_1, report_2])
+
+        # Define a custom metric callable
+        def custom_accuracy(y_true, y_pred):
+            """Custom accuracy implementation."""
+            return (y_true == y_pred).sum() / len(y_true)
+
+        best_report = report.get_best_model(
+            metric=custom_accuracy, response_method="predict"
+        )
+
+        assert best_report == report_1


### PR DESCRIPTION
Implements `ComparisonReport.get_best_model`, which allows to extract the best report according to the given metric 

Example:
```python
from sklearn.datasets import make_classification
from sklearn.linear_model import LogisticRegression
from sklearn.tree import DecisionTreeClassifier
from skore import ComparisonReport, EstimatorReport, train_test_split
X, y = make_classification(random_state=42)
split_data = train_test_split(X=X, y=y, random_state=42, as_dict=True)
report_1 = EstimatorReport(LogisticRegression(), **split_data)
report_2 = EstimatorReport(DecisionTreeClassifier(), **split_data)
report = ComparisonReport([report_1, report_2])
report.get_best_model(metric="accuracy")  # the default
```