### PR TITLE
ci: Switch documentation preview to AWS S3

### DIFF
--- a/.github/actions/sphinx/deploy-aws/action.yml
+++ b/.github/actions/sphinx/deploy-aws/action.yml
@@ -1,0 +1,36 @@
+name: Deploy sphinx documentation
+
+inputs:
+  ACTION:
+    required: false
+    default: sync
+    type: choice
+    options:
+      - cp
+      - sync
+  BUCKET:
+    required: true
+  SOURCE:
+    required: true
+  DESTINATION:
+    required: true
+  ROLE_TO_ASSUME:
+    description: "IAM Role ARN to assume (Required for OIDC)"
+    required: true
+  AWS_REGION:
+    description: "AWS Region"
+    required: true
+    default: "eu-west-3"
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.ROLE_TO_ASSUME }}
+        aws-region: ${{ inputs.AWS_REGION }}
+
+    - name: Run AWS S3 Command
+      shell: bash
+      run: aws s3  ${{ inputs.ACTION }} "${{ inputs.SOURCE }}" "s3://${{ inputs.BUCKET }}/${{ inputs.DESTINATION }}" --delete

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -58,22 +58,17 @@ jobs:
   pr-clean-documentation-preview:
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Install `rclone`
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y rclone
-
-      - name: Copy configuration
-        shell: bash
-        run: echo "${CONFIGURATION}" > rclone.configuration
-        env:
-          CONFIGURATION: ${{ secrets.RCLONE_CONFIG_DOC_PREVIEW }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Clean documentation preview
-        run: rclone --config rclone.configuration purge "${PROVIDER}:${BUCKET}/${PULL_REQUEST_NUMBER}"
+        run: aws s3 rm "s3://${BUCKET}/${PULL_REQUEST_NUMBER}/" --recursive
         env:
-          PROVIDER: scaleway
           BUCKET: ${{ vars.DOCUMENTATION_PREVIEW_BUCKET }}
           PULL_REQUEST_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/pr-serve-documentation-preview.yml
+++ b/.github/workflows/pr-serve-documentation-preview.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      id-token: write
       pull-requests: write
     steps:
       - name: Checkout code
@@ -42,10 +43,10 @@ jobs:
 
       - name: Serve documentation preview
         if: ${{ steps.download-html-artifacts.outcome == 'success' }}
-        uses: ./.github/actions/sphinx/deploy
+        uses: ./.github/actions/sphinx/deploy-aws
         with:
-          CONFIGURATION: ${{ secrets.RCLONE_CONFIG_DOC_PREVIEW }}
           BUCKET: ${{ vars.DOCUMENTATION_PREVIEW_BUCKET }}
+          ROLE_TO_ASSUME: ${{ vars.AWS_ROLE }}
           SOURCE: html/
           DESTINATION: ${{ steps.acquire-pr-context.outputs.pr-number }}/
 

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ sphinx/_templates/demo_report_help_generated.html
 skore/LICENSE
 skore-hub-project/LICENSE
 skore-local-project/LICENSE
+.aider*


### PR DESCRIPTION
This PR migrates the documentation preview hosting infrastructure from the previous Scaleway rclone-based solution to AWS S3 using OIDC authentication.

Key Changes:

 • New Composite Action: Created .github/actions/sphinx/deploy-aws/action.yml. This action configures  
   AWS credentials via OIDC and performs S3 operations (sync or cp).
 • Workflow Updates:
    • pr-serve-documentation-preview.yml: Switched to use the new AWS deployment action. Added         
      id-token: write permissions required for AWS OIDC authentication.
    • pr-cleanup.yml: Replaced rclone installation and commands with the AWS CLI to remove old preview 
      artifacts from the S3 bucket.
 • Housekeeping: Added .aider* to .gitignore.                                                          

I have configured the following variables have been configured in the repository:

 • AWS_ROLE
 • AWS_REGION