### PR TITLE
ci: Increase the timeout on `pytest` workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -217,13 +217,13 @@ jobs:
 
       - name: Test without coverage
         if: ${{ ! matrix.coverage }}
-        timeout-minutes: 10
+        timeout-minutes: 15
         working-directory: ${{ matrix.package }}/
         run: python -m pytest src/ tests/ --no-cov
 
       - name: Test with coverage
         if: ${{ matrix.coverage }}
-        timeout-minutes: 10
+        timeout-minutes: 15
         working-directory: ${{ matrix.package }}/
         run: |
           mkdir coverage


### PR DESCRIPTION
The duration of the `skore` tests has increased significantly recently, from 2 to 4 minutes to 6 to 7 minutes.
The coverage increases it even more (>10 minutes) and reaches the timeout.

While waiting to investigate and/or optimize the tests, increase the timeout from 10 to 15 minutes.