### PR TITLE
fix(skore): Cast report to `EstimatorReport` for mypy 

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -461,7 +461,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
                 CrossValidationReport, self.reports_[name]
             ).create_estimator_report(X_test=X_test, y_test=y_test)
 
-        estimator_report = self.reports_[name]
+        estimator_report = cast(EstimatorReport, self.reports_[name])
         X_concat = (
             pd.concat([estimator_report._X_train, estimator_report._X_test])
             if isinstance(estimator_report._X_train, pd.DataFrame)


### PR DESCRIPTION
Solve lint error seen in https://github.com/probabl-ai/skore/pull/2316

Casting should solve the problem and be safe because we have a `if` just above.