### PR TITLE
docs(skore): Add link to the API key account page

### DIFF
--- a/skore/src/skore/_login.py
+++ b/skore/src/skore/_login.py
@@ -27,7 +27,8 @@ def login(*, mode: Literal["local", "hub"] = "hub", **kwargs):
     projects remotely.
 
     In this mode, you must be already registered to the ``Skore Hub``. Also, we
-    recommend that you set up an API key via [url](coming soon) and use it to log in.
+    recommend that you set up an API key via https://skore.probabl.ai/account
+    and use it to log in.
 
     .. rubric:: Local mode
 


### PR DESCRIPTION
Follow-up from https://github.com/probabl-ai/skore/issues/2333 for the `skore.Project`.

Since the Skore Hub has a page to setup API keys, this PR update the documentation of `skore.Project`.
