### PR TITLE
docs(skore): Embed interactive Project summary plot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,7 +187,6 @@ sphinx/build/
 sphinx/auto_examples/
 sphinx/reference/api/
 sphinx/sg_execution_times.rst
-sphinx/_templates/landing/project_summary_plot.html
 examples/plot_*.png
 sphinx/_templates/demo_report_help_generated.html
 

--- a/sphinx/_scripts/generate_landing_project_summary_plot.py
+++ b/sphinx/_scripts/generate_landing_project_summary_plot.py
@@ -1,30 +1,51 @@
-"""
-Sphinx extension that generates the Plotly HTML fragment embedded on the landing page.
-
-This writes a template snippet to sphinx/_templates/landing/project_summary_plot.html
-    {% include "landing/project_summary_plot.html" %}
-"""
+# Generate the Plotly HTML fragment used by the custom landing page.
+#
+# Output:
+# - sphinx/_templates/landing/project_summary_plot.html
+#
+# Executed during the Sphinx build (builder-inited), then included from the custom
+# landing template via:
+#
+#    {% include "landing/project_summary_plot.html" %}
 
 from __future__ import annotations
 
 from pathlib import Path
+import os
+import sys
 import tempfile
 import uuid
 
 import pandas as pd
 import plotly.io as pio
-import skrub
-import skore
-from skore import CrossValidationReport
 
 from sklearn.datasets import make_regression
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.linear_model import Ridge
 
 
+HERE = Path(__file__).resolve()
+
+# Ensure we import local repo code (skore/src) instead of site-packages.
+# File is: repo_root/sphinx/_scripts/generate_landing_project_summary_plot.py
+REPO_ROOT = HERE.parents[2]
+SKORE_SRC = REPO_ROOT / "skore" / "src"
+sys.path.insert(0, str(SKORE_SRC))
+
+# Now it is safe to import local skore/skrub.
+import skrub  # noqa: E402
+import skore  # noqa: E402
+from skore import CrossValidationReport  # noqa: E402
+
+
+SPHINX_DIR = HERE.parents[1]
+OUT_TEMPLATE = SPHINX_DIR / "_templates" / "landing" / "project_summary_plot.html"
+OUT_TEMPLATE.parent.mkdir(parents=True, exist_ok=True)
+
+
 def _build_project_summary():
-    """Build a small Project + Summary, fast and deterministic."""
     tmp_dir = tempfile.mkdtemp(prefix="skore-docs-landing-")
+    os.chdir(tmp_dir)
 
     X, y = make_regression(n_samples=800, n_features=8, noise=15.0, random_state=0)
     df_num = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
@@ -33,19 +54,14 @@ def _build_project_summary():
     df["division"] = pd.cut(df["f0"], bins=4, labels=["A", "B", "C", "D"]).astype(str)
 
     report_ridge = CrossValidationReport(Ridge(alpha=1.0), df_num, y)
+
     report_hgbdt = CrossValidationReport(
         skrub.tabular_pipeline(HistGradientBoostingRegressor(random_state=0)),
         df,
         y,
     )
 
-    tmp_dir = Path(tempfile.mkdtemp(prefix="skore-docs-landing-"))
-
-    project = skore.Project(
-        name=f"adult_census_survey_{uuid.uuid4().hex[:8]}",
-        workspace=tmp_dir,
-    )
-
+    project = skore.Project(name=f"adult_census_survey_{uuid.uuid4().hex[:8]}")
     project.put("ridge", report_ridge)
     project.put("hgbdt", report_hgbdt)
 
@@ -64,16 +80,18 @@ def _set_checkboxes_by_description(root, descriptions_to_true: set[str]) -> None
     for w in _walk_widgets(root):
         if hasattr(w, "description") and hasattr(w, "value"):
             if str(getattr(w, "description", "")) in descriptions_to_true:
-                w.value = True
+                try:
+                    w.value = True
+                except Exception:
+                    pass
 
 
 def _extract_plotly_figure(summary):
-    """Run the widget headlessly and extract its Plotly FigureWidget."""
-    # Module name is version-dependent; current docs build uses the private module.
+    # Widget module location differs across versions.
     from skore.project._widget import ModelExplorerWidget  # type: ignore
     import skore.project._widget as widget_mod  # type: ignore
 
-    # Avoid printing/displaying FigureWidget during the docs build.
+    # Avoid printing/displaying FigureWidget during Sphinx build.
     widget_mod.display = lambda *args, **kwargs: None
 
     w = ModelExplorerWidget(dataframe=summary)
@@ -100,30 +118,22 @@ def _extract_plotly_figure(summary):
     return fig
 
 
-def _write_plot_snippet(sphinx_dir: Path, fig) -> None:
-    out = sphinx_dir / "_templates" / "landing" / "project_summary_plot.html"
-    out.parent.mkdir(parents=True, exist_ok=True)
-
+def _write_plot_snippet(fig) -> None:
     html = pio.to_html(
         fig,
         full_html=False,
         include_plotlyjs="cdn",
         config={"displayModeBar": False, "responsive": True},
     )
-    out.write_text(html, encoding="utf-8")
+    OUT_TEMPLATE.write_text(html, encoding="utf-8")
+    print(f"[landing] wrote plot snippet to: {OUT_TEMPLATE}")
 
 
-def _on_builder_inited(app) -> None:
-    sphinx_dir = Path(app.confdir)
+def main() -> None:
     summary = _build_project_summary()
     fig = _extract_plotly_figure(summary)
-    _write_plot_snippet(sphinx_dir, fig)
+    _write_plot_snippet(fig)
 
 
-def setup(app):
-    app.connect("builder-inited", _on_builder_inited)
-    return {
-        "version": "0.1",
-        "parallel_read_safe": True,
-        "parallel_write_safe": False,
-    }
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Instead of relying on ipywidget interactivity (#2280), this PR takes an alternative route: the widget is executed at Sphinx build time, the underlying Plotly figure is extracted, and an HTML fragment is generated and embedded directly in the landing template.

This keeps the plot fully interactive (native Plotly), avoids Jupyter/ipywidgets at runtime, and works with static hosting.
<img width="1198" height="535" alt="parallel_coords" src="https://github.com/user-attachments/assets/f86a119f-e024-4aa3-b36c-eb338f77cbc6" />