### PR TITLE
docs: Fix Returns references for methods returning `Display`s

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -134,7 +134,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
 
         Returns
         -------
-        MetricsSummaryDisplay
+        :class:`MetricsSummaryDisplay`
             A display containing the statistics for the metrics.
 
         Examples
@@ -1352,7 +1352,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
 
         Returns
         -------
-        RocCurveDisplay
+        :class:`RocCurveDisplay`
             The ROC curve display.
 
         Examples
@@ -1432,7 +1432,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
 
         Returns
         -------
-        PrecisionRecallCurveDisplay
+        :class:`PrecisionRecallCurveDisplay`
             The precision-recall curve display.
 
         Examples
@@ -1520,7 +1520,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
 
         Returns
         -------
-        PredictionErrorDisplay
+        :class:`PredictionErrorDisplay`
             The prediction error display.
 
         Examples
@@ -1597,7 +1597,7 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
 
         Returns
         -------
-        display : :class:`~skore._sklearn._plot.ConfusionMatrixDisplay`
+        :class:`ConfusionMatrixDisplay`
             The confusion matrix display.
 
         Examples

--- a/skore/src/skore/_sklearn/_cross_validation/data_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/data_accessor.py
@@ -95,7 +95,7 @@ class _DataAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
 
         Returns
         -------
-        TableReportDisplay
+        :class:`TableReportDisplay`
             A display object containing the dataset statistics and plots.
 
         Examples

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -135,7 +135,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        MetricsSummaryDisplay
+        :class:`MetricsSummaryDisplay`
             A display containing the statistics for the metrics.
 
         Examples
@@ -1224,7 +1224,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        RocCurveDisplay
+        :class:`RocCurveDisplay`
             The ROC curve display.
 
         Examples
@@ -1292,7 +1292,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        PrecisionRecallCurveDisplay
+        :class:`PrecisionRecallCurveDisplay`
             The precision-recall curve display.
 
         Examples
@@ -1367,7 +1367,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        PredictionErrorDisplay
+        :class:`PredictionErrorDisplay`
             The prediction error display.
 
         Examples
@@ -1437,7 +1437,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        display : :class:`~skore._sklearn._plot.ConfusionMatrixDisplay`
+        :class:`ConfusionMatrixDisplay`
             The confusion matrix display.
 
         Examples

--- a/skore/src/skore/_sklearn/_estimator/data_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/data_accessor.py
@@ -124,7 +124,7 @@ class _DataAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
 
         Returns
         -------
-        TableReportDisplay
+        :class:`TableReportDisplay`
             A display object containing the dataset statistics and plots.
 
         Examples

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -140,7 +140,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        MetricsSummaryDisplay
+        :class:`MetricsSummaryDisplay`
             A display containing the statistics for the metrics.
 
         Examples
@@ -1823,7 +1823,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        RocCurveDisplay
+        :class:`RocCurveDisplay`
             The ROC curve display.
 
         Examples
@@ -1897,7 +1897,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        PrecisionRecallCurveDisplay
+        :class:`PrecisionRecallCurveDisplay`
             The precision-recall curve display.
 
         Examples
@@ -1981,7 +1981,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        PredictionErrorDisplay
+        :class:`PredictionErrorDisplay`
             The prediction error display.
 
         Examples
@@ -2053,7 +2053,7 @@ class _MetricsAccessor(
 
         Returns
         -------
-        display : :class:`~skore._sklearn._plot.ConfusionMatrixDisplay`
+        :class:`ConfusionMatrixDisplay`
             The confusion matrix display.
 
         Examples


### PR DESCRIPTION
I wish sphinx could have warned us that the references didn't work.