### PR TITLE
fix(skore/progress-bar): Disable progress-bar on demand

### DIFF
--- a/skore/src/skore/_utils/_progress_bar.py
+++ b/skore/src/skore/_utils/_progress_bar.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-from functools import partial
 from operator import length_hint
 from typing import Any, TypeVar
 
@@ -13,29 +12,29 @@ from rich.progress import (
 from skore._config import get_config
 
 T = TypeVar("T")
-SkinnedProgress = partial(
-    Progress,
-    SpinnerColumn(),
-    TextColumn("[bold cyan]{task.description}"),
-    BarColumn(
-        complete_style="dark_orange",
-        finished_style="dark_orange",
-        pulse_style="orange1",
-    ),
-    TextColumn("[orange1]{task.percentage:>3.0f}%"),
-    expand=False,
-    transient=True,
-    disable=(not get_config()["show_progress"]),
-)
 
 
 class ProgressBar:
     """Simplified progress bar based on ``rich.Progress``."""
 
     def __init__(self, description: str, total: float | None):
+        progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold cyan]{task.description}"),
+            BarColumn(
+                complete_style="dark_orange",
+                finished_style="dark_orange",
+                pulse_style="orange1",
+            ),
+            TextColumn("[orange1]{task.percentage:>3.0f}%"),
+            expand=False,
+            transient=True,
+            disable=(not get_config()["show_progress"]),
+        )
+
         self._description = description
         self._total = total
-        self._progress = SkinnedProgress()
+        self._progress = progress
         self._task = self._progress.add_task(description, total=total)
 
     def __enter__(self):

--- a/skore/tests/unit/utils/test_progress_bar.py
+++ b/skore/tests/unit/utils/test_progress_bar.py
@@ -3,6 +3,7 @@ from time import sleep
 
 from pytest import raises
 
+from skore import config_context, get_config
 from skore._utils._progress_bar import ProgressBar, track
 
 
@@ -155,3 +156,17 @@ def test_track(monkeypatch):
     assert progress._progress.live._started is False
     assert progress._progress.finished
     assert progress._progress.tasks[0].finished
+
+
+def test_disable_progress_bar():
+    with ProgressBar(description="progress1", total=0) as progress1:
+        assert get_config()["show_progress"] is True
+        assert progress1._progress.disable is False
+
+        with (
+            config_context(show_progress=False),
+            ProgressBar(description="progress2", total=0) as progress2,
+        ):
+            assert get_config()["show_progress"] is False
+            assert progress1._progress.disable is False
+            assert progress2._progress.disable is True


### PR DESCRIPTION
By using `SkinnedProgress` as a static partial, we defined the value of `disable` during import and it could no longer be changed.