### PR TITLE
chore(skore/inspection): Increase alpha in shaded background

### DIFF
--- a/skore/src/skore/_sklearn/_plot/inspection/utils.py
+++ b/skore/src/skore/_sklearn/_plot/inspection/utils.py
@@ -41,6 +41,6 @@ def _decorate_matplotlib_axis(
                 feature_idx - 0.5,
                 feature_idx + 0.5,
                 color="lightgray",
-                alpha=0.1,
+                alpha=0.4,
                 zorder=0,
             )


### PR DESCRIPTION
Goes from 
<img width="1377" height="586" alt="image" src="https://github.com/user-attachments/assets/0d60bad3-6416-47c3-8eb3-3dd65311d5c8" />
to 
<img width="1377" height="586" alt="image" src="https://github.com/user-attachments/assets/8a8091f9-e2df-49cb-951f-63ad76396af0" />

Allows distinguishing the values accross features in the `feature_importance` displays better.