### PR TITLE
fix(skore-hub-project): Raise earlier an error when pos_label not provided before serialization

### DIFF
--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -25,6 +25,7 @@ from unicodedata import normalize
 import joblib
 import orjson
 from httpx import HTTPStatusError
+from sklearn.utils.validation import _check_pos_label_consistency
 
 from skore_hub_project.client.client import Client, HUBClient
 from skore_hub_project.protocol import CrossValidationReport, EstimatorReport
@@ -230,29 +231,38 @@ class Project:
         """
         from ..report import CrossValidationReportPayload, EstimatorReportPayload
 
-        if report.ml_task == "binary-classification" and report.pos_label is None:
-            raise ValueError(
-                "For binary classification, you need to specify the positive label "
-                "to serialize the expected metrics and displays. You can set it using "
-                "`report.pos_label = <positive_label>`."
-            )
-
         if not isinstance(key, str):
             raise TypeError(f"Key must be a string (found '{type(key)}')")
+
+        if not isinstance(report, EstimatorReport | CrossValidationReport):
+            raise TypeError(
+                f"Report must be a `skore.EstimatorReport` or "
+                f"`skore.CrossValidationReport` (found '{type(report)}')"
+            )
+
+        if report.ml_task == "binary-classification":
+            # check that pos_label is either specified or can be inferred from the data
+            if isinstance(report, EstimatorReport):
+                target = report.estimator_.classes_
+            else:  # CrossValidationReport
+                target = report.estimator_reports_[0].estimator_.classes_
+
+            try:
+                _check_pos_label_consistency(report.pos_label, target)
+            except ValueError as exc:
+                raise ValueError(
+                    "For binary classification, the positive label must be specified. "
+                    "You can set it using `report.pos_label = <positive_label>`."
+                ) from exc
 
         payload: EstimatorReportPayload | CrossValidationReportPayload
 
         if isinstance(report, EstimatorReport):
             payload = EstimatorReportPayload(project=self, key=key, report=report)
             endpoint = "estimator-reports"
-        elif isinstance(report, CrossValidationReport):
+        else:  # CrossValidationReport
             payload = CrossValidationReportPayload(project=self, key=key, report=report)
             endpoint = "cross-validation-reports"
-        else:
-            raise TypeError(
-                f"Report must be a `skore.EstimatorReport` or "
-                f"`skore.CrossValidationReport` (found '{type(report)}')"
-            )
 
         payload_dict = payload.model_dump()
         payload_json_bytes = orjson.dumps(payload_dict, option=orjson.OPT_NON_STR_KEYS)

--- a/skore-hub-project/src/skore_hub_project/protocol.py
+++ b/skore-hub-project/src/skore_hub_project/protocol.py
@@ -32,12 +32,14 @@ class EstimatorReport(Protocol):
     data: Any
     ml_task: str
     estimator: Any
+    estimator_: Any
     estimator_name_: str
     X_train: Any
     y_train: Any
     X_test: Any
     y_test: Any
     fit: Any
+    fit_time_: Any
     pos_label: Any
 
 
@@ -54,9 +56,11 @@ class CrossValidationReport(Protocol):
     estimator_reports_: Any
     ml_task: str
     estimator: Any
+    estimator_: Any
     estimator_name_: str
     X: Any
     y: Any
     splitter: Any
     split_indices: Any
     pos_label: Any
+    n_jobs: Any

--- a/skore-hub-project/tests/conftest.py
+++ b/skore-hub-project/tests/conftest.py
@@ -4,6 +4,7 @@ from importlib import reload
 from unittest.mock import Mock
 from urllib.parse import urljoin
 
+import numpy as np
 from httpx import Client, Response
 from pytest import fixture
 from sklearn.datasets import make_classification, make_regression
@@ -110,6 +111,60 @@ def small_cv_binary_classification() -> CrossValidationReport:
     return CrossValidationReport(
         RandomForestClassifier(random_state=42), X, y, splitter=2
     )
+
+
+def _make_binary_estimator_report_string_labels(*, pos_label=None):
+    """Binary classification with string y labels ('negative', 'positive')."""
+    X, y = make_classification(random_state=42)
+    labels = np.array(["negative", "positive"])
+    y = labels[y]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    report = EstimatorReport(
+        RandomForestClassifier(random_state=42),
+        X_train=X_train,
+        X_test=X_test,
+        y_train=y_train,
+        y_test=y_test,
+        pos_label=pos_label
+    )
+    return report
+
+
+def _make_cv_binary_report_string_labels(*, pos_label=None):
+    """Cross-validation binary classification with string y labels."""
+    X, y = make_classification(random_state=42, n_samples=50)
+    labels = np.array(["negative", "positive"])
+    y = labels[y]
+    report = CrossValidationReport(
+        RandomForestClassifier(random_state=42), X, y, splitter=2, pos_label=pos_label
+    )
+    return report
+
+
+@fixture(scope="module")
+def binary_classification_string_labels() -> EstimatorReport:
+    """Binary classification with string labels, pos_label not set."""
+    return _make_binary_estimator_report_string_labels()
+
+
+@fixture(scope="module")
+def binary_classification_string_labels_with_pos_label() -> EstimatorReport:
+    """Binary classification with string labels and pos_label='positive'."""
+    return _make_binary_estimator_report_string_labels(pos_label="positive")
+
+
+@fixture(scope="module")
+def cv_binary_classification_string_labels() -> CrossValidationReport:
+    """CV binary classification with string labels, pos_label not set."""
+    return _make_cv_binary_report_string_labels()
+
+
+@fixture(scope="module")
+def cv_binary_classification_string_labels_with_pos_label() -> CrossValidationReport:
+    """CV binary classification with string labels and pos_label='positive'."""
+    return _make_cv_binary_report_string_labels(pos_label="positive")
 
 
 @fixture

--- a/skore-hub-project/tests/unit/project/test_project.py
+++ b/skore-hub-project/tests/unit/project/test_project.py
@@ -140,7 +140,12 @@ class TestProject:
         with warns(UserWarning, match=warn_msg), raises(ValueError, match=err_msg):
             Project("myworkspace", "あいうえお")
 
-    def test_put_exception(self, respx_mock):
+    def test_put_exception(
+        self,
+        respx_mock,
+        binary_classification_string_labels,
+        cv_binary_classification_string_labels,
+    ):
         respx_mock.post("projects/myworkspace/myname").mock(Response(200))
 
         with raises(TypeError, match="Key must be a string"):
@@ -151,6 +156,19 @@ class TestProject:
             match="must be a `skore.EstimatorReport` or `skore.CrossValidationReport`",
         ):
             Project("myworkspace", "myname").put("<key>", "<value>")
+
+        pos_label_msg = (
+            "For binary classification, the positive label must be specified. "
+            "You can set it using `report.pos_label = <positive_label>`."
+        )
+        with raises(ValueError, match=pos_label_msg):
+            Project("myworkspace", "myname").put(
+                "<key>", binary_classification_string_labels
+            )
+        with raises(ValueError, match=pos_label_msg):
+            Project("myworkspace", "myname").put(
+                "<key>", cv_binary_classification_string_labels
+            )
 
     def test_put_estimator_report(self, monkeypatch, binary_classification, respx_mock):
         respx_mock.post("projects/myworkspace/myname").mock(Response(200))
@@ -210,6 +228,62 @@ class TestProject:
         )
 
         # Compare content with the desired output
+        assert content == desired
+
+    def test_put_estimator_report_string_labels_with_pos_label(
+        self, binary_classification_string_labels_with_pos_label, respx_mock
+    ):
+        """Put with binary string labels and pos_label set works."""
+        respx_mock.post("projects/myworkspace/myname").mock(Response(200))
+        respx_mock.post("projects/myworkspace/myname/artifacts").mock(
+            Response(200, json=[])
+        )
+        respx_mock.post("projects/myworkspace/myname/estimator-reports").mock(
+            Response(200)
+        )
+
+        project = Project("myworkspace", "myname")
+        report = binary_classification_string_labels_with_pos_label
+        project.put("<key>", report)
+
+        content = loads(respx_mock.calls.last.request.content.decode())
+        desired = loads(
+            dumps(
+                EstimatorReportPayload(
+                    project=project, key="<key>", report=report
+                ).model_dump()
+            )
+        )
+        assert content == desired
+
+    @mark.filterwarnings(
+        "ignore:Precision is ill-defined.*:sklearn.exceptions.UndefinedMetricWarning",
+        "ignore:The default of observed=False is deprecated.*:FutureWarning:seaborn",
+    )
+    def test_put_cross_validation_report_string_labels_with_pos_label(
+        self, cv_binary_classification_string_labels_with_pos_label, respx_mock
+    ):
+        """Put with CV binary string labels and pos_label set works."""
+        respx_mock.post("projects/myworkspace/myname").mock(Response(200))
+        respx_mock.post("projects/myworkspace/myname/artifacts").mock(
+            Response(200, json=[])
+        )
+        respx_mock.post("projects/myworkspace/myname/cross-validation-reports").mock(
+            Response(200)
+        )
+
+        project = Project("myworkspace", "myname")
+        report = cv_binary_classification_string_labels_with_pos_label
+        project.put("<key>", report)
+
+        content = loads(respx_mock.calls.last.request.content.decode())
+        desired = loads(
+            dumps(
+                CrossValidationReportPayload(
+                    project=project, key="<key>", report=report
+                ).model_dump()
+            )
+        )
         assert content == desired
 
     def test_get_estimator_report(self, respx_mock, regression):


### PR DESCRIPTION
closes #2417 
requires https://github.com/probabl-ai/skore/pull/2438

Force to raise an earlier when `pos_label` is not set at the level of the report when trying to serialize. Provide a way to make the proper change.