### PR TITLE
feat(skore): Allow to set pos_label after creating report

### DIFF
--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -224,13 +224,6 @@ class Project:
         """
         from ..report import CrossValidationReportPayload, EstimatorReportPayload
 
-        if report.ml_task == "binary-classification" and report.pos_label is None:
-            raise ValueError(
-                "For binary classification, you need to specify the positive label "
-                "to serialize the expected metrics and displays. You can set it using "
-                "`report.pos_label = <positive_label>`."
-            )
-
         if not isinstance(key, str):
             raise TypeError(f"Key must be a string (found '{type(key)}')")
 

--- a/skore-hub-project/src/skore_hub_project/protocol.py
+++ b/skore-hub-project/src/skore_hub_project/protocol.py
@@ -38,7 +38,6 @@ class EstimatorReport(Protocol):
     X_test: Any
     y_test: Any
     fit: Any
-    pos_label: Any
 
 
 @runtime_checkable
@@ -59,4 +58,3 @@ class CrossValidationReport(Protocol):
     y: Any
     splitter: Any
     split_indices: Any
-    pos_label: Any


### PR DESCRIPTION
Partially address #2417 

To offer a solution to user to change `pos_label`, we should be less restrictive and allow changing `pos_label` after instantiation. Since we do it with the `EstimatorReport`, it is pretty straightforward. We only need to invalidate the cache and set hashes to be consistent with the way we handle it in `EstimatorReport`.

Potentially, I think that we could have a better handling of the cache by not removing everything.