### PR TITLE
feat(skore): Enable interactive `matplotlib` mode by default

### DIFF
--- a/ci/requirements/skore/python-3.10/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.5/test-requirements.txt
@@ -48,6 +48,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -172,7 +173,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -48,6 +48,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -172,7 +173,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.5/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.8/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.8/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.8/sphinx-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.8/sphinx-requirements.txt
@@ -59,6 +59,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via ipython
 jinja2==3.1.6
@@ -194,7 +195,7 @@ requests==2.32.5
     # via
     #   skrub
     #   sphinx
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.8/test-requirements.txt
@@ -46,6 +46,7 @@ ipywidgets==8.1.8
     # via
     #   skore (skore/pyproject.toml)
     #   anywidget
+    #   rich
 jedi==0.19.2
     # via
     #   skore (skore/pyproject.toml)
@@ -175,7 +176,7 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via skrub
-rich==14.2.0
+rich[jupyter]==14.2.0
     # via
     #   skore (skore/pyproject.toml)
     #   skore-local-project

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -391,7 +391,7 @@ print(f"Time taken to compute the ROC curve: {end - start:.2f} seconds")
 # Let's first start with a basic confusion matrix:
 cm_display = report.metrics.confusion_matrix()
 cm_display.plot()
-plt.show()
+plt.show(block=True)
 
 # %%
 # In binary classification, a confusion matrix depends on the decision threshold used
@@ -407,19 +407,19 @@ print(
 # To visualize the confusion matrix at a different threshold, use the ``threshold_value``
 # parameter. For example, a threshold of 0.3 will classify more samples as positive:
 cm_display.plot(threshold_value=0.3)
-plt.show()
+plt.show(block=True)
 
 # %%
 # We can normalize the confusion matrix to get percentages instead of raw counts.
 # Here we normalize by true labels (rows):
 cm_display.plot(normalize="true")
-plt.show()
+plt.show(block=True)
 
 # %%
 # More plotting options are available via ``heatmap_kwargs``, which are passed to
 # seaborn's heatmap. For example, we can customize the colormap and number format:
 cm_display.set_style(heatmap_kwargs={"cmap": "Greens", "fmt": ".2e"}).plot()
-plt.show()
+plt.show(block=True)
 
 # %%
 # Finally, the confusion matrix can also be exported as a pandas DataFrame for further

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -107,7 +107,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 
 sns.histplot(data=dataset, x=y.name, bins=100)
-plt.show()
+plt.show(block=True)
 
 # %%
 # There seems to be a threshold-effect for high-valued houses: all houses with a price
@@ -574,7 +574,7 @@ X_y_plot.sample(10)
 # %%
 sns.histplot(data=X_y_plot, x="squared_error", hue="split", multiple="dodge", bins=30)
 plt.title("Train and test sets")
-plt.show()
+plt.show(block=True)
 
 # %%
 # Now, in order to assess which features might drive the prediction error, let us look
@@ -1002,7 +1002,7 @@ def plot_permutation_train_test(importances):
     )
     ax.set_xlabel("Decrease of $R^2$ score")
     ax.set_title("Permutation feature importance (Train vs Test)")
-    plt.show()
+    plt.show(block=True)
 
 
 # %%

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "numpy",
   "pandas",
   "plotly",
-  "rich>=14.1",
+  "rich[jupyter]>=14.2",
   "scikit-learn",
   "skore[local]",
   "skrub",

--- a/skore/src/skore/__init__.py
+++ b/skore/src/skore/__init__.py
@@ -4,6 +4,7 @@ from logging import INFO, NullHandler, getLogger
 from warnings import warn
 
 from joblib import __version__ as joblib_version
+from matplotlib import pyplot as plt
 from rich.console import Console
 from rich.theme import Theme
 
@@ -34,7 +35,7 @@ from skore._utils._patch import setup_jupyter_display
 from skore._utils._show_versions import show_versions
 from skore.project import Project
 
-# Configure jupyter display for VS Code compatibility
+plt.ion()
 setup_jupyter_display()
 
 

--- a/skore/tests/unit/utils/test_show_versions.py
+++ b/skore/tests/unit/utils/test_show_versions.py
@@ -33,5 +33,5 @@ def test_show_versions(capfd):
     assert "skore:" in captured.out
     assert "pip:" in captured.out
     assert "numpy:" in captured.out
-    assert "rich:" in captured.out
+    assert "rich[jupyter]:" in captured.out
     assert "scikit-learn:" in captured.out


### PR DESCRIPTION
Partially addresses https://github.com/probabl-ai/skore/issues/2421.

You don't need anymore `%matplotlib` in `IPython`, and `plt.show()` in your script is optional.

---

https://ipython.readthedocs.io/en/stable/interactive/plotting.html#matplotlib-magic
https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.show.html#matplotlib-pyplot-show