### PR TITLE
fix(skore): Fix the link to source code in docs

### DIFF
--- a/sphinx/sphinxext/github_link.py
+++ b/sphinx/sphinxext/github_link.py
@@ -92,5 +92,5 @@ def setup(app):
     """Configure linkcode_resolve for GitHub links."""
     app.config["linkcode_resolve"] = make_linkcode_resolve(
         package="skore",
-        url_fmt="https://github.com/probabl-ai/skore/blob/{revision}/skore/{path}#L{lineno}",
+        url_fmt="https://github.com/probabl-ai/skore/blob/{revision}/skore/src/skore/{path}#L{lineno}",
     )


### PR DESCRIPTION
Follow-up to #2442, the link to source in the dev docs is still broken.

It works in the preview.