### PR TITLE
fix(skore-hub-project): Raise when project name is empty

### DIFF
--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -103,6 +103,12 @@ def slugify_and_warn(string: str, type: Literal["workspace", "name"]) -> str:
             stacklevel=2,
         )
 
+    if slug == "" and type == "name":
+        raise ValueError(
+            "Project name must not be empty. "
+            "This may happen if the given name contains only non-ASCII characters."
+        )
+
     return slug
 
 

--- a/skore-hub-project/tests/unit/project/test_project.py
+++ b/skore-hub-project/tests/unit/project/test_project.py
@@ -131,6 +131,15 @@ class TestProject:
         else:
             assert Project("myworkspace", input).name == output
 
+    def test_name_empty(self):
+        err_msg = "Project name must not be empty."
+        with raises(ValueError, match=err_msg):
+            Project("myworkspace", "")
+
+        warn_msg = "Your project will be created as ''"
+        with warns(UserWarning, match=warn_msg), raises(ValueError, match=err_msg):
+            Project("myworkspace", "あいうえお")
+
     def test_put_exception(self, respx_mock):
         respx_mock.post("projects/myworkspace/myname").mock(Response(200))
 


### PR DESCRIPTION
The project name may have become empty after removing all non-ASCII characters.

Closes #2416