### PR TITLE
fix(skore-hub-project): Limit project name length to 64

### DIFF
--- a/skore-hub-project/src/skore_hub_project/project/project.py
+++ b/skore-hub-project/src/skore_hub_project/project/project.py
@@ -104,11 +104,15 @@ def slugify_and_warn(string: str, type: Literal["workspace", "name"]) -> str:
             stacklevel=2,
         )
 
-    if slug == "" and type == "name":
-        raise ValueError(
-            "Project name must not be empty. "
-            "This may happen if the given name contains only non-ASCII characters."
-        )
+    if type == "name":
+        if slug == "":
+            raise ValueError(
+                "Project name must not be empty. "
+                "This may happen if the given name contains only non-ASCII characters."
+            )
+
+        if len(slug) > 64:
+            raise ValueError("Project name must be no more than 64 characters long.")
 
     return slug
 

--- a/skore-hub-project/tests/unit/project/test_project.py
+++ b/skore-hub-project/tests/unit/project/test_project.py
@@ -140,6 +140,11 @@ class TestProject:
         with warns(UserWarning, match=warn_msg), raises(ValueError, match=err_msg):
             Project("myworkspace", "あいうえお")
 
+    def test_name_too_long(self):
+        err_msg = "Project name must be no more than 64 characters long."
+        with raises(ValueError, match=err_msg):
+            Project("myworkspace", "a" * 500)
+
     def test_put_exception(
         self,
         respx_mock,


### PR DESCRIPTION
Closes #2429.

Be advised that in manual tests, the current size limit is 50.