### PR TITLE
fix(skore): Do not start matplotlib GUI in non-main thread

### DIFF
--- a/skore/src/skore/_sklearn/_plot/base.py
+++ b/skore/src/skore/_sklearn/_plot/base.py
@@ -1,3 +1,4 @@
+import threading
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, Literal, Protocol, runtime_checkable
@@ -213,7 +214,14 @@ class StyleDisplayMixin:
             try:
                 result = plot_func(self, *args, **kwargs)
             finally:
-                plt.tight_layout()
+                try:
+                    if threading.current_thread() is threading.main_thread():
+                        # Only call `tight_layout` when we are inside the main thread
+                        # since that otherwise we are surely serializing figures instead
+                        # do not display them.
+                        plt.tight_layout()
+                except Exception:
+                    pass
                 plt.rcParams.update(original_params)
             return result
 


### PR DESCRIPTION
related #2409 

When putting in parallel, we trigger Matplotlib GUI outside of the main thread which seems to be tricky.

Here, `plt.tight_layout` is triggering such behaviour.

However, it does not address all the problem detected in #2409. Indeed, because we are using seaborn that call `plt.figure`, then the Matplotlib GUI is called from outside skore. The solution, would be to switch to a non-interactive backend.

But we end-up in the same issue pointed out by @thomass-dev. I assume that putting object in parallel will have exactly the same problem. So while using `plt.ioff` to deactivate the interactive mode allowing to not break matplotlib in a notebook, this solution does not solve really the problem of the backend.

So we might finally need to find a way to switch the plotting backend even once `matplotlib` has been imported because we don't have the hand on what `seaborn` is doing.