### PR TITLE
refactor(skore): Remove _verbose_name in favor of using registered named from accessor

### DIFF
--- a/skore/src/skore/_externals/_pandas_accessors.py
+++ b/skore/src/skore/_externals/_pandas_accessors.py
@@ -47,6 +47,7 @@ def _register_accessor(name, cls):
                 f"attribute with the same name."
             )
         setattr(cls, name, Accessor(name, accessor))
+        accessor._accessor_name = name
         cls._accessors.add(name)
         return accessor
 

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -36,8 +36,6 @@ class _BaseAccessor(AccessorHelpMixin, Generic[ParentT]):
     ``AccessorHelpMixin`` to provide a dedicated ``help()`` and rich/HTML help tree.
     """
 
-    _verbose_name: str = "accessor"
-
     def __init__(self, parent: ParentT) -> None:
         self._parent = parent
 
@@ -264,8 +262,6 @@ class _BaseMetricsAccessor:
     ####################################################################################
     # Methods related to the help tree
     ####################################################################################
-
-    _verbose_name: str = "metrics"
 
     def _get_favorability_text(self, name: str) -> str | None:
         """Get favorability text for a method, or None if not applicable."""

--- a/skore/src/skore/_sklearn/_comparison/inspection_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/inspection_accessor.py
@@ -21,8 +21,6 @@ class _InspectionAccessor(_BaseAccessor["ComparisonReport"], DirNamesMixin):
     You can access this accessor using the `inspection` attribute.
     """
 
-    _verbose_name: str = "feature_importance"
-
     def __init__(self, parent: ComparisonReport) -> None:
         super().__init__(parent)
 

--- a/skore/src/skore/_sklearn/_cross_validation/data_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/data_accessor.py
@@ -16,8 +16,6 @@ class _DataAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
     It provides methods to create plots and to visualise the dataset.
     """
 
-    _verbose_name: str = "data"
-
     def __init__(self, parent: CrossValidationReport) -> None:
         super().__init__(parent)
 

--- a/skore/src/skore/_sklearn/_cross_validation/inspection_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/inspection_accessor.py
@@ -19,8 +19,6 @@ class _InspectionAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
     You can access this accessor using the `inspection` attribute.
     """
 
-    _verbose_name: str = "feature_importance"
-
     def __init__(self, parent: CrossValidationReport) -> None:
         super().__init__(parent)
 

--- a/skore/src/skore/_sklearn/_estimator/data_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/data_accessor.py
@@ -16,8 +16,6 @@ class _DataAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
     It provides methods to create plots and to visualise the datasets.
     """
 
-    _verbose_name: str = "data"
-
     def __init__(self, parent: EstimatorReport) -> None:
         super().__init__(parent)
 

--- a/skore/src/skore/_sklearn/_estimator/inspection_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/inspection_accessor.py
@@ -36,8 +36,6 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
     You can access this accessor using the `inspection` attribute.
     """
 
-    _verbose_name: str = "feature_importance"
-
     def __init__(self, parent: EstimatorReport) -> None:
         super().__init__(parent)
 

--- a/skore/src/skore/_utils/_testing.py
+++ b/skore/src/skore/_utils/_testing.py
@@ -125,7 +125,7 @@ class MockReport(_BaseReport):
 class MockAccessor(_BaseAccessor):
     """Minimal accessor for testing."""
 
-    _verbose_name = "mock_accessor"
+    _accessor_name = "mock_accessor"  # registering an accessor will set this attribute
 
     def __init__(self, parent):
         super().__init__(parent)

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib.metadata import version
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import quote
 
 from skore._externals._sklearn_compat import parse_version
@@ -473,11 +473,12 @@ class _AccessorHelpDataMixin(_BaseHelpDataMixin):
     It defines ``_build_help_data`` by looking at methods of an accessor.
     """
 
-    _verbose_name: str
     _parent: Any
+    _accessor_name: ClassVar[str]  # set by _register_accessor on concrete classes
 
     def _build_help_data(self) -> AccessorHelpData:
         """Build data structure for Jinja2/Rich rendering for accessors."""
+        accessor_name = self.__class__._accessor_name
         root_node = self._parent.__class__.__name__
         methods = [
             self._build_method_data(
@@ -485,14 +486,14 @@ class _AccessorHelpDataMixin(_BaseHelpDataMixin):
                 method=method,
                 obj=self,
                 parent_obj=self._parent,
-                accessor_name=self._verbose_name,
+                accessor_name=accessor_name,
             )
             for name, method in get_public_methods(self)
         ]
         return AccessorHelpData(
             title=self._get_help_title(),
             root_node=root_node,
-            accessor_name=self._verbose_name,
+            accessor_name=accessor_name,
             accessor_branch_id=str(uuid.uuid4()),
             methods=methods,
         )

--- a/skore/tests/unit/utils/test_testing.py
+++ b/skore/tests/unit/utils/test_testing.py
@@ -90,12 +90,12 @@ def test_mock_report_accessor_config():
     assert MockReport._ACCESSOR_CONFIG == {}
 
 
-def test_mock_accessor_init_and_verbose_name(mock_estimator):
-    """MockAccessor stores parent, has _verbose_name."""
+def test_mock_accessor_init_and_accessor_name(mock_estimator):
+    """MockAccessor stores parent, has _accessor_name."""
     report = MockReport(mock_estimator)
     accessor = MockAccessor(parent=report)
     assert accessor._parent is report
-    assert MockAccessor._verbose_name == "mock_accessor"
+    assert MockAccessor._accessor_name == "mock_accessor"
 
 
 def test_mock_accessor_get_help_tree_title():


### PR DESCRIPTION
revisiting #2471 

This solving the issue to have twice the same source of information. Here, we create the accessor name when registering and use it every where.

If the name is not defined then something will break with an `AttributeError` for sure and thus we don't need extra tests.