### PR TITLE
docs(skore): Fix a wrong find/replace for feature_importance

### DIFF
--- a/skore/src/skore/_sklearn/_estimator/inspection_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/inspection_accessor.py
@@ -90,7 +90,7 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
 
         This method is available for estimators that expose a `feature_importances_`
         attribute. See for example
-        :attr:`sklearn.ensemble.GradientBoostingClassifier.inspections_`.
+        :attr:`sklearn.ensemble.GradientBoostingClassifier.feature_importances_`.
         In particular, note that the MDI is computed at fit time, i.e. using the
         training data.
 


### PR DESCRIPTION
closes #2441 

I make a search for `inspections_` because we might have introduce a regression when replacing `feature_importance` by `inspection`. But the attribute `feature_importances_` from scikit-learn would have as well been replaced.

I only found one occurrence.