### PR TITLE
fix(skore-hub-project): Restore `switch_mpl_backend` for use in conjunction with `plt.ioff()`

### DIFF
--- a/skore-hub-project/src/skore_hub_project/__init__.py
+++ b/skore-hub-project/src/skore_hub_project/__init__.py
@@ -1,6 +1,8 @@
 """Package that provides APIs to communicate between ``skore`` and ``skore hub``."""
 
 from base64 import b64decode, b64encode
+from collections.abc import Iterator
+from contextlib import contextmanager
 from logging import basicConfig, getLogger
 
 from rich.console import Console
@@ -11,6 +13,7 @@ __all__ = [
     "b64_str_to_bytes",
     "bytes_to_b64_str",
     "console",
+    "switch_mpl_backend",
 ]
 
 
@@ -37,3 +40,35 @@ def b64_str_to_bytes(literal: str) -> bytes:
 def bytes_to_b64_str(literal: bytes) -> str:
     """Encode the bytes-like object ``literal`` in a Base64 str."""
     return b64encode(literal).decode("utf-8")
+
+
+@contextmanager
+def switch_mpl_backend(backend: str = "agg") -> Iterator[None]:
+    """
+    Context-manager for switching ``matplotlib.backend``.
+
+    Notes
+    -----
+    The ``agg`` backend is a non-interactive backend that can only write to files.
+    It is used in ``skore-hub-project`` to generate artifacts where we don't need an
+    X display.
+
+    https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend
+    """
+    import importlib
+    import sys
+
+    import matplotlib
+    import matplotlib.pyplot
+
+    original_backend = matplotlib.get_backend()
+    original_pyplot_module = sys.modules.pop("matplotlib.pyplot")
+
+    try:
+        matplotlib.use(backend)
+        importlib.import_module("matplotlib.pyplot")
+        yield
+    finally:
+        sys.modules.pop("matplotlib.pyplot")
+        matplotlib.use(original_backend)
+        sys.modules["matplotlib.pyplot"] = original_pyplot_module

--- a/skore-hub-project/src/skore_hub_project/report/report.py
+++ b/skore-hub-project/src/skore_hub_project/report/report.py
@@ -11,6 +11,7 @@ from matplotlib import pyplot as plt
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
 
+from skore_hub_project import switch_mpl_backend
 from skore_hub_project.artifact.media.media import Media
 from skore_hub_project.artifact.pickle import Pickle
 from skore_hub_project.metric.metric import Metric
@@ -110,6 +111,7 @@ class ReportPayload(BaseModel, ABC, Generic[Report]):
         metrics = [metric_cls(report=self.report) for metric_cls in self.METRICS]
 
         with (
+            switch_mpl_backend(),
             plt.ioff(),
             SkinnedProgress() as progress,
             ThreadPoolExecutor() as pool,
@@ -142,7 +144,7 @@ class ReportPayload(BaseModel, ABC, Generic[Report]):
         """
         payloads = []
 
-        with plt.ioff():
+        with switch_mpl_backend(), plt.ioff():
             for media_cls in self.MEDIAS:
                 payload = media_cls(project=self.project, report=self.report)
 


### PR DESCRIPTION
Partially revert https://github.com/probabl-ai/skore/pull/2439 to fix issue on `tkagg` backend.

```
Exception ignored while calling deallocator <function Image.__del__ at 0x79c6d9c73cc0>:
Traceback (most recent call last):
  File "/home/thomas/.pyenv/versions/3.14.0/lib/python3.14/tkinter/__init__.py", line 4256, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
```
```
Tcl_AsyncDelete: async handler deleted by the wrong thread
[1]    733860 IOT instruction (core dumped)  python -m IPython
```