### PR TITLE
docs(skore): Add documentation for `configuration`

### DIFF
--- a/skore/src/skore/_config.py
+++ b/skore/src/skore/_config.py
@@ -14,6 +14,42 @@ class LocalConfiguration(Local):
 
 
 class Configuration:
+    """Configuration for `skore` behavior.
+
+    You can read and set options via attribute access. In parallel processing (e.g.
+    ``joblib.Parallel``), each thread receives its own copy of the configuration;
+    changing attributes inside a worker thread only affects that thread and does not
+    modify the global configuration in the main thread.
+
+    Attributes
+    ----------
+    show_progress : bool
+        Whether to show progress bars for long-running operations.
+        Default is ``True`` (or ``False`` when joblib < 1.4).
+
+    plot_backend : str
+        Backend used for rendering plots (e.g. ``"matplotlib"``).
+        Default is ``"matplotlib"``.
+
+    Examples
+    --------
+    **Global configuration** using the ``configuration`` instance from skore:
+
+    >>> # xdoctest: +SKIP
+    >>> from skore import configuration
+    >>> configuration.show_progress = False
+    >>> configuration.plot_backend = "matplotlib"
+
+    **Temporary overrides** using the context manager (previous values are
+    restored on exit):
+
+    >>> # xdoctest: +SKIP
+    >>> with configuration(show_progress=False):
+    ...     report.fit(X, y)
+    >>> with configuration(plot_backend="plotly"):
+    ...     report.plot()
+    """
+
     def __init__(self):
         self.local = LocalConfiguration()
 

--- a/sphinx/_templates/base.rst
+++ b/sphinx/_templates/base.rst
@@ -27,6 +27,12 @@
    :add-heading: Gallery examples
    :heading-level: -
 
+{%- elif objtype in ("data", "attribute") -%}
+
+.. currentmodule:: {{ module }}
+
+.. autodata:: {{ objname }}
+
 {%- else -%}
 
 .. currentmodule:: {{ module }}

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -85,6 +85,8 @@ Utilities
 .. list-table::
    :widths: 30 70
 
+   * - :obj:`configuration`
+     - Global configuration for `skore` also usable as a context manager
    * - :func:`show_versions`
      - Print version information for skore and its dependencies
 

--- a/sphinx/reference/utils.rst
+++ b/sphinx/reference/utils.rst
@@ -1,3 +1,5 @@
+.. _reference_utils:
+
 Utilities
 ---------
 


### PR DESCRIPTION
Sphinx documentation to be listed as an object.