### PR TITLE
fix(skore/tests): Make tests pass with `pandas>=3`

### DIFF
--- a/skore/src/skore/_utils/_index.py
+++ b/skore/src/skore/_utils/_index.py
@@ -25,7 +25,7 @@ def flatten_multi_index(index: pd.MultiIndex) -> pd.Index:
     ...     [('a', ''), ('b', '2')], names=['letter', 'number']
     ... )
     >>> flatten_multi_index(mi)
-    Index(['a', 'b_2'], dtype='object')
+    Index(['a', 'b_2'], dtype=...)
     """
     if not isinstance(index, pd.MultiIndex):
         raise ValueError("`index` must be a MultiIndex.")

--- a/skore/tests/unit/displays/table_report/test_common.py
+++ b/skore/tests/unit/displays/table_report/test_common.py
@@ -40,7 +40,7 @@ def display(request):
     return report.data.analyze()
 
 
-@pytest.mark.parametrize("dtype", ["category", "object"])
+@pytest.mark.parametrize("dtype", ["category", "str"])
 @pytest.mark.parametrize("other_label", ["other", "xxx"])
 def test_truncate_top_k_categories(dtype, other_label):
     """Check the behaviour of `_truncate_top_k_categories` when `col` is a categorical

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -19,7 +19,7 @@ from skore import ComparisonReport, EstimatorReport
                     ["DummyClassifier_1", "DummyClassifier_2"],
                     name="Estimator",
                 ),
-                index=pd.Index(["Accuracy"], dtype="object", name="Metric"),
+                index=pd.Index(["Accuracy"], name="Metric"),
             ),
         ),
         (
@@ -64,7 +64,7 @@ from skore import ComparisonReport, EstimatorReport
                     ["DummyClassifier_1", "DummyClassifier_2"],
                     name="Estimator",
                 ),
-                index=pd.Index(["Brier score"], dtype="object", name="Metric"),
+                index=pd.Index(["Brier score"], name="Metric"),
             ),
         ),
         (
@@ -75,7 +75,7 @@ from skore import ComparisonReport, EstimatorReport
                     ["DummyClassifier_1", "DummyClassifier_2"],
                     name="Estimator",
                 ),
-                index=pd.Index(["ROC AUC"], dtype="object", name="Metric"),
+                index=pd.Index(["ROC AUC"], name="Metric"),
             ),
         ),
         (
@@ -86,7 +86,7 @@ from skore import ComparisonReport, EstimatorReport
                     ["DummyClassifier_1", "DummyClassifier_2"],
                     name="Estimator",
                 ),
-                index=pd.Index(["Log loss"], dtype="object", name="Metric"),
+                index=pd.Index(["Log loss"], name="Metric"),
             ),
         ),
     ],
@@ -133,7 +133,7 @@ def test_binary_classification(
                     ["DummyRegressor_1", "DummyRegressor_2"],
                     name="Estimator",
                 ),
-                index=pd.Index(["RMSE"], dtype="object", name="Metric"),
+                index=pd.Index(["RMSE"], name="Metric"),
             ),
         ),
         (
@@ -144,7 +144,7 @@ def test_binary_classification(
                     ["DummyRegressor_1", "DummyRegressor_2"],
                     name="Estimator",
                 ),
-                index=pd.Index(["R²"], dtype="object", name="Metric"),
+                index=pd.Index(["R²"], name="Metric"),
             ),
         ),
     ],


### PR DESCRIPTION
Fixes #2457 

Given that the only test failures are solved by changing the tests, I would say that we don't need pandas3-specific testing. We can reevaluate this if bug reports start coming in.