### PR TITLE
fix(skore): Ensure figure-level legend is included when saving PredictionErrorDisplay plot

### DIFF
--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -297,7 +297,7 @@ class PredictionErrorDisplay(DisplayMixin):
 
         labels.append("Perfect predictions")
 
-        self.ax_[len(self.ax_)//2].legend(
+        self.ax_[len(self.ax_) // 2].legend(
             handles,
             labels,
             loc="upper center",
@@ -305,8 +305,10 @@ class PredictionErrorDisplay(DisplayMixin):
             ncol=1,
             frameon=True,
         )
+
         if len(self.ax_) == 1:
             self.ax_ = self.ax_[0]
+
         w, h = self.figure_.get_size_inches()
         self.figure_.set_size_inches(w, h + 0.25 * len(labels))
         self.figure_.tight_layout()

--- a/skore/tests/unit/displays/prediction_error/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_cross_validation.py
@@ -11,7 +11,7 @@ def test_legend(pyplot, task, legend_prefix, request):
     figure, _ = request.getfixturevalue(
         f"comparison_cross_validation_reports_{task}_figure_axes"
     )
-    legend = figure.axes[len(figure.axes)//2].get_legend()
+    legend = figure.axes[len(figure.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == 3
@@ -29,7 +29,8 @@ def test_legend_actual_vs_predicted(pyplot, task, legend_prefix, request):
     report = request.getfixturevalue(f"comparison_cross_validation_reports_{task}")
     display = report.metrics.prediction_error()
     display.plot(kind="actual_vs_predicted")
-    legend_texts = [t.get_text() for t in display.figure_.axes[len(display.figure_.axes)//2].get_legend().get_texts()]
+    legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
+    legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == 3
     assert legend_texts[0] == f"{legend_prefix} #0"
     assert legend_texts[1] == f"{legend_prefix} #1"

--- a/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
@@ -10,7 +10,7 @@ def test_legend(pyplot, task, n_legend_entries, request):
     figure, _ = request.getfixturevalue(
         f"comparison_estimator_reports_{task}_figure_axes"
     )
-    legend = figure.axes[len(figure.axes)//2].get_legend()
+    legend = figure.axes[len(figure.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == n_legend_entries
@@ -29,7 +29,8 @@ def test_legend_actual_vs_predicted(pyplot, task, n_legend_entries, request):
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.metrics.prediction_error()
     display.plot(kind="actual_vs_predicted")
-    legend_texts = [t.get_text() for t in display.figure_.axes[len(display.figure_.axes)//2].get_legend().get_texts()]
+    legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
+    legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == n_legend_entries
     if task == "multioutput_regression":
         assert legend_texts[0] == "Output #0"
@@ -94,7 +95,8 @@ def test_subplot_by_data_source(pyplot, task, request):
     else:
         display.plot(subplot_by="data_source")
         assert len(display.ax_) == 2
-        legend_texts = [t.get_text() for t in display.figure_.axes[len(display.figure_.axes)//2].get_legend().get_texts()]
+        legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
+        legend_texts = [t.get_text() for t in legend.get_texts()]
         assert len(legend_texts) == 3
         assert legend_texts[0] == "DummyRegressor_1"
         assert legend_texts[1] == "DummyRegressor_2"
@@ -107,7 +109,7 @@ def test_source_both(pyplot, task, request):
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.metrics.prediction_error(data_source="both")
     display.plot()
-    legend = display.figure_.axes[len(display.figure_.axes)//2].get_legend()
+    legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == 3 if task == "regression" else 7

--- a/skore/tests/unit/displays/prediction_error/test_cross_validation.py
+++ b/skore/tests/unit/displays/prediction_error/test_cross_validation.py
@@ -9,7 +9,7 @@ import pytest
 def test_legend(pyplot, task, legend_prefix, request):
     """Check the legend of the prediction error plot with cross-validation."""
     figure, _ = request.getfixturevalue(f"cross_validation_reports_{task}_figure_axes")
-    legend = figure.axes[len(figure.axes)//2].get_legend()
+    legend = figure.axes[len(figure.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == 3
@@ -27,7 +27,8 @@ def test_legend_actual_vs_predicted(pyplot, task, legend_prefix, request):
     report = request.getfixturevalue(f"cross_validation_reports_{task}")[0]
     display = report.metrics.prediction_error()
     display.plot(kind="actual_vs_predicted")
-    legend_texts = [t.get_text() for t in display.figure_.axes[len(display.figure_.axes)//2].get_legend().get_texts()]
+    legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
+    legend_texts = [t.get_text() for t in legend.get_texts()]
 
     assert len(legend_texts) == 3
     assert legend_texts[0] == f"{legend_prefix} #0"

--- a/skore/tests/unit/displays/prediction_error/test_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_estimator.py
@@ -11,7 +11,7 @@ from skore import EstimatorReport
 def test_legend(pyplot, task, n_legend_entries, request):
     """Check the legend of the prediction error plot."""
     figure, _ = request.getfixturevalue(f"estimator_reports_{task}_figure_axes")
-    legend = figure.axes[len(figure.axes)//2].get_legend()
+    legend = figure.axes[len(figure.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == n_legend_entries
@@ -30,7 +30,8 @@ def test_legend_actual_vs_predicted(pyplot, task, n_legend_entries, request):
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     display = report.metrics.prediction_error()
     display.plot(kind="actual_vs_predicted")
-    legend_texts = [t.get_text() for t in display.figure_.axes[len(display.figure_.axes)//2].get_legend().get_texts()]
+    legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
+    legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == n_legend_entries
     if task == "multioutput_regression":
         assert legend_texts[0] == "Output #0"
@@ -91,7 +92,8 @@ def test_subplot_by_data_source(pyplot, task, request):
     display.plot(subplot_by="data_source")
     assert isinstance(display.ax_[0], mpl.axes.Axes)
     assert len(display.ax_) == 2
-    legend_texts = [t.get_text() for t in display.figure_.axes[len(display.figure_.axes)//2].get_legend().get_texts()]
+    legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
+    legend_texts = [t.get_text() for t in legend.get_texts()]
     assert len(legend_texts) == 1 if task == "regression" else 2
     assert legend_texts[-1] == "Perfect predictions"
     if task == "multioutput_regression":
@@ -105,7 +107,7 @@ def test_source_both(pyplot, task, request):
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     display = report.metrics.prediction_error(data_source="both")
     display.plot()
-    legend = display.figure_.axes[len(display.figure_.axes)//2].get_legend()
+    legend = display.figure_.axes[len(display.figure_.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
     assert legend_texts[-1] == "Perfect predictions"


### PR DESCRIPTION
Fixes #2505

## Problem
`PredictionErrorDisplay.plot()` creates a figure-level legend via `self.figure_.legend()` with `bbox_to_anchor=(0.5, 0)`, placing it below the figure boundary. matplotlib's `savefig` excludes figure-level legends from boundary calculation by default, causing the legend to be clipped in saved output.

Confirmed via inspecting the legend's bounding box after `plot()`:
```python
print(display.figure_.legends[0].get_window_extent())
# Bbox(x0=211.875, y0=-67.0, x1=392.125, y1=0.0)
```
`y1=0.0` confirms the legend sits exactly at the bottom edge — below the figure boundary.

Note: `tight_layout(rect=...)` and `subplots_adjust` were both investigated but neither accounts for figure-level legends — the bounding box remained at `y0=-67, y1=0` in both cases.

## Fix
Move the legend from figure level to axis level via `ax_[len(ax_)//2].legend()`, so it is included in `tight_layout` computation. Increase figure height by `1.2 inches` to make room for the legend below the plot. This avoids patching `savefig` and prevents pickling issues.


## Testing
Verified across:
- Basic save: `plt.savefig("file.png")`
- `kind="actual_vs_predicted"`
- Single data source
- High DPI: `dpi=300`
- PDF output
- Multiple estimators comparison
- Small figure size

## Before / After
<img width="604" height="500" alt="image" src="https://github.com/user-attachments/assets/3dd1767d-65e9-4d58-8674-66bc85736112" />
<img width="556" height="577" alt="image" src="https://github.com/user-attachments/assets/537b3209-130b-40fa-8f3a-4e942b44ada7" />
