### PR TITLE
feat(skore/EstimatorReport)!: Move arguments from `.summarize()` to `.frame()`

### DIFF
--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -156,7 +156,7 @@ data_display.plot(kind="corr")
 
 # %%
 hgbt_split_1 = hgbt_model_report.estimator_reports_[0]
-hgbt_split_1.metrics.summarize(favorability=True).frame()
+hgbt_split_1.metrics.summarize().frame(favorability=True)
 
 # %%
 # The favorability of each metric indicates whether the metric is better

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -169,7 +169,9 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                 results.index = results.index.str.replace(
                     r"\((.*)\)$", r"\1", regex=True
                 )
-        return MetricsSummaryDisplay(results)
+        return MetricsSummaryDisplay(
+            data=results, report_type=self._parent._report_type
+        )
 
     def _compute_metric_scores(
         self,
@@ -199,15 +201,32 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                 )
             )
 
-            kwargs = dict(
-                data_source=data_source,
-                **metric_kwargs,
-            )
+            kwargs = dict(data_source=data_source, **metric_kwargs)
             if is_cv_report:
                 kwargs["aggregate"] = None
 
+            # FIXME(#1837)
+            # "favorability" and "flat_index" are passed to `.frame()` for
+            # EstimatorReports while they are passed to `.summarize()` for
+            # CrossValidationReports
+            frame_kwargs = {}
+            if not is_cv_report:
+                for key in ("favorability", "flat_index"):
+                    if key in kwargs:
+                        frame_kwargs[key] = kwargs.pop(key)
+
+            if "favorability" in kwargs:
+                favorability = kwargs["favorability"]
+            elif "favorability" in frame_kwargs:
+                favorability = frame_kwargs["favorability"]
+            else:
+                favorability = False
+            favorability = cast(bool, favorability)
+
             individual_results = [
-                result.frame() if report_metric_name == "summarize" else result
+                result.frame(**frame_kwargs)
+                if report_metric_name == "summarize"
+                else result
                 for result in track(
                     parallel(
                         joblib.delayed(getattr(report.metrics, report_metric_name))(
@@ -224,14 +243,14 @@ class _MetricsAccessor(_BaseMetricsAccessor, _BaseAccessor, DirNamesMixin):
                 results = _combine_estimator_results(
                     individual_results,
                     estimator_names=self._parent.reports_.keys(),
-                    favorability=metric_kwargs.get("favorability", False),
+                    favorability=favorability,
                     data_source=data_source,
                 )
             else:  # "CrossValidationReport"
                 results = _combine_cross_validation_results(
                     individual_results,
                     estimator_names=self._parent.reports_.keys(),
-                    favorability=metric_kwargs.get("favorability", False),
+                    favorability=favorability,
                     aggregate=aggregate,
                 )
 

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -168,7 +168,7 @@ class _MetricsAccessor(
                 results.index = results.index.str.replace(
                     r"\((.*)\)$", r"\1", regex=True
                 )
-        return MetricsSummaryDisplay(summarize_data=results)
+        return MetricsSummaryDisplay(data=results, report_type="cross-validation")
 
     def _compute_metric_scores(
         self,
@@ -196,8 +196,15 @@ class _MetricsAccessor(
                 )
             )
 
+            frame_kwargs = {}
+            for key in ("favorability", "flat_index"):
+                if key in metric_kwargs:
+                    frame_kwargs[key] = metric_kwargs.pop(key)
+
             results = [
-                result.frame() if report_metric_name == "summarize" else result
+                result.frame(**frame_kwargs)
+                if report_metric_name == "summarize"
+                else result
                 for result in track(
                     parallel(
                         delayed(getattr(report.metrics, report_metric_name))(
@@ -220,7 +227,7 @@ class _MetricsAccessor(
             # Pop the favorability column if it exists, to:
             # - not use it in the aggregate operation
             # - later to only report a single column and not by split columns
-            if metric_kwargs.get("favorability", False):
+            if frame_kwargs.get("favorability", False):
                 favorability = results.pop("Favorability").iloc[:, 0]
             else:
                 favorability = None

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -247,7 +247,7 @@ class _MetricsAccessor(
                         f"Please use a valid metric from the "
                         f"list of supported metrics: "
                         f"{list(self._score_or_loss_info.keys())} "
-                        "or a valid scikit-learn scoring string."
+                        "or a valid scikit-learn metric string."
                     ) from err
                 if metric_kwargs is not None:
                     raise ValueError(

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -470,6 +470,7 @@ class _MetricsAccessor(
             scores["label"] = pd.Series(scores["label"], dtype=pd.BooleanDtype())
         elif any(isinstance(label, int) for label in scores["label"]):
             scores["label"] = pd.Series(scores["label"], dtype=pd.Int64Dtype())
+
         if any(isinstance(output, int) for output in scores["output"]):
             scores["output"] = pd.Series(scores["output"], dtype=pd.Int64Dtype())
 

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -189,9 +189,9 @@ class _MetricsAccessor(
             pos_label = self._parent.pos_label
 
         # Handle dictionary metrics
-        metric_verbose_names: list[str | None] | None = None
+        metric_names: list[str | None] | None = None
         if isinstance(metric, dict):
-            metric_verbose_names = list(metric.keys())
+            metric_names = list(metric.keys())
             metrics = list(metric.values())
         elif metric is not None and not isinstance(metric, list):
             metrics = [metric]
@@ -212,13 +212,11 @@ class _MetricsAccessor(
                 metrics = ["r2", "rmse"]
             metrics += ["fit_time", "predict_time"]
 
-        if metric_verbose_names is None:
-            metric_verbose_names = [None] * len(metrics)
+        if metric_names is None:
+            metric_names = [None] * len(metrics)
 
         rows = []
-        for metric_verbose_name, metric_ in zip(
-            metric_verbose_names, metrics, strict=True
-        ):
+        for metric_name, metric_ in zip(metric_names, metrics, strict=True):
             if isinstance(metric_, str) and metric_ not in self._score_or_loss_info:
                 try:
                     metric_ = sklearn.metrics.get_scorer(metric_)
@@ -262,13 +260,9 @@ class _MetricsAccessor(
                     elif pos_label is not None:
                         metrics_kwargs["pos_label"] = pos_label
 
-                metric_name = metric_._score_func.__name__
                 metric_favorability = "(↗︎)" if metric_._sign == 1 else "(↘︎)"
-
-                if metric_verbose_name is None:
-                    metric_verbose_name = metric_._score_func.__name__.replace(
-                        "_", " "
-                    ).title()
+                if metric_name is None:
+                    metric_name = metric_._score_func.__name__.replace("_", " ").title()
 
             elif isinstance(metric_, str) or callable(metric_):
                 if isinstance(metric_, str):
@@ -279,11 +273,8 @@ class _MetricsAccessor(
                         else metric_,
                     )
                     metrics_kwargs = {}
-                    metric_name = metric_
-                    if metric_verbose_name is None:
-                        metric_verbose_name = (
-                            f"{self._score_or_loss_info[metric_]['name']}"
-                        )
+                    if metric_name is None:
+                        metric_name = self._score_or_loss_info[metric_]["name"]
                     metric_favorability = self._score_or_loss_info[metric_]["icon"]
                 else:
                     # Handle callable metrics
@@ -315,9 +306,8 @@ class _MetricsAccessor(
                             for param in metric_callable_params
                             if param in metric_kwargs
                         }
-                    metric_name = metric_.__name__
-                    if metric_verbose_name is None:
-                        metric_verbose_name = metric_.__name__.replace("_", " ").title()
+                    if metric_name is None:
+                        metric_name = metric_.__name__.replace("_", " ").title()
                     metric_favorability = ""
 
                 metrics_params = inspect.signature(metric_fn).parameters
@@ -336,7 +326,6 @@ class _MetricsAccessor(
 
             row = {
                 "metric": metric_name,
-                "verbose_name": metric_verbose_name,
                 "estimator_name": self._parent.estimator_name_,
                 "data_source": data_source,
                 "favorability": metric_favorability,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -280,6 +280,7 @@ class _MetricsAccessor(
                         else metric_,
                     )
                     metrics_kwargs = {}
+                    metric_name = metric_
                     if metric_verbose_name is None:
                         metric_verbose_name = (
                             f"{self._score_or_loss_info[metric_]['name']}"

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -464,10 +464,15 @@ class _MetricsAccessor(
                 scores["score"].append(score)
                 scores["favorability"].append(metric_favorability)
 
-        if any(isinstance(label, int) for label in scores["label"]):
-            scores["label"] = pd.Series(scores["label"], dtype=pd.Int64Dtype()).astype(
-                "object"
-            )
+        # Prevent ints from being converted to float (which is pandas' default behaviour
+        # when there are `None` in the columns)
+        if any(isinstance(label, bool) for label in scores["label"]):
+            scores["label"] = pd.Series(scores["label"], dtype=pd.BooleanDtype())
+        elif any(isinstance(label, int) for label in scores["label"]):
+            scores["label"] = pd.Series(scores["label"], dtype=pd.Int64Dtype())
+        if any(isinstance(output, int) for output in scores["output"]):
+            scores["output"] = pd.Series(scores["output"], dtype=pd.Int64Dtype())
+
         return MetricsSummaryDisplay(data=pd.DataFrame(scores), report_type="estimator")
 
     def _compute_metric_scores(

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -198,7 +198,8 @@ class _MetricsAccessor(
         elif isinstance(metric, list):
             metrics = metric
 
-        if metric is None:
+        # Treat empty list same as None - use defaults
+        if metric is None or (isinstance(metric, list) and len(metric) == 0):
             # Equivalent to _get_scorers_to_add
             if self._parent._ml_task == "binary-classification":
                 metrics = ["accuracy", "precision", "recall", "roc_auc"]

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -190,7 +190,7 @@ class _MetricsAccessor(
             pos_label = self._parent.pos_label
 
         # Handle dictionary metrics
-        metric_verbose_names = None
+        metric_verbose_names: list[str | None] | None = None
         if isinstance(metric, dict):
             metric_verbose_names = list(metric.keys())
             metrics = list(metric.values())
@@ -214,7 +214,7 @@ class _MetricsAccessor(
             metrics += ["fit_time", "predict_time"]
 
         if metric_verbose_names is None:
-            metric_verbose_names = [None] * len(metrics)  # type: ignore
+            metric_verbose_names = [None] * len(metrics)
 
         scores = defaultdict(list)
         for metric_verbose_name, metric_ in zip(

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -1,5 +1,4 @@
 import inspect
-from collections import defaultdict
 from collections.abc import Callable
 from functools import partial
 from typing import Any, Literal, cast
@@ -216,7 +215,7 @@ class _MetricsAccessor(
         if metric_verbose_names is None:
             metric_verbose_names = [None] * len(metrics)
 
-        scores = defaultdict(list)
+        rows = []
         for metric_verbose_name, metric_ in zip(
             metric_verbose_names, metrics, strict=True
         ):
@@ -335,146 +334,56 @@ class _MetricsAccessor(
 
             score = metric_fn(data_source=data_source, **metrics_kwargs)
 
-            if self._parent._ml_task == "binary-classification":
+            row = {
+                "metric": metric_name,
+                "verbose_name": metric_verbose_name,
+                "estimator_name": self._parent.estimator_name_,
+                "data_source": data_source,
+                "favorability": metric_favorability,
+                "label": None,
+                "average": None,
+                "output": None,
+                "score": score,
+            }
+
+            if (
+                self._parent._ml_task == "binary-classification"
+                and metrics_kwargs.get("average") == "binary"
+            ):
+                rows.append({**row, "label": pos_label})
+            elif self._parent._ml_task in (
+                "binary-classification",
+                "multiclass-classification",
+            ):
                 if isinstance(score, dict):
-                    classes = list(score.keys())
-                    for label in classes:
-                        scores["metric"].append(metric_name)
-                        scores["verbose_name"].append(metric_verbose_name)
-                        scores["estimator_name"].append(self._parent.estimator_name_)
-                        scores["data_source"].append(data_source)
-                        scores["label"].append(label)
-                        scores["average"].append(None)
-                        scores["output"].append(None)
-                        scores["score"].append(score[label])
-                        scores["favorability"].append(metric_favorability)
-                elif "average" in metrics_kwargs:
-                    if metrics_kwargs["average"] == "binary":
-                        scores["metric"].append(metric_name)
-                        scores["verbose_name"].append(metric_verbose_name)
-                        scores["estimator_name"].append(self._parent.estimator_name_)
-                        scores["data_source"].append(data_source)
-                        scores["average"].append(None)
-                        scores["label"].append(pos_label)
-                        scores["output"].append(None)
-                    elif metrics_kwargs["average"] is not None:
-                        scores["metric"].append(metric_name)
-                        scores["verbose_name"].append(metric_verbose_name)
-                        scores["estimator_name"].append(self._parent.estimator_name_)
-                        scores["data_source"].append(data_source)
-                        scores["label"].append(None)
-                        scores["average"].append(metrics_kwargs["average"])
-                        scores["output"].append(None)
-                    else:
-                        scores["metric"].append(metric_name)
-                        scores["verbose_name"].append(metric_verbose_name)
-                        scores["estimator_name"].append(self._parent.estimator_name_)
-                        scores["data_source"].append(data_source)
-                        scores["label"].append(None)
-                        scores["average"].append(None)
-                        scores["output"].append(None)
-                    scores["score"].append(score)
-                    scores["favorability"].append(metric_favorability)
+                    for label in score:
+                        rows.append({**row, "label": label, "score": score[label]})  # noqa: PERF401
                 else:
-                    scores["metric"].append(metric_name)
-                    scores["verbose_name"].append(metric_verbose_name)
-                    scores["estimator_name"].append(self._parent.estimator_name_)
-                    scores["data_source"].append(data_source)
-                    scores["label"].append(None)
-                    scores["average"].append(None)
-                    scores["output"].append(None)
-                    scores["score"].append(score)
-                    scores["favorability"].append(metric_favorability)
-            elif self._parent._ml_task == "multiclass-classification":
-                if isinstance(score, dict):
-                    classes = list(score.keys())
-                    for label in classes:
-                        scores["metric"].append(metric_name)
-                        scores["verbose_name"].append(metric_verbose_name)
-                        scores["estimator_name"].append(self._parent.estimator_name_)
-                        scores["data_source"].append(data_source)
-                        scores["label"].append(label)
-                        scores["average"].append(None)
-                        scores["output"].append(None)
-                        scores["score"].append(score[label])
-                        scores["favorability"].append(metric_favorability)
-                elif (
-                    "average" in metrics_kwargs
-                    and metrics_kwargs["average"] is not None
-                ):
-                    scores["metric"].append(metric_name)
-                    scores["verbose_name"].append(metric_verbose_name)
-                    scores["estimator_name"].append(self._parent.estimator_name_)
-                    scores["data_source"].append(data_source)
-                    scores["label"].append(None)
-                    scores["average"].append(metrics_kwargs["average"])
-                    scores["output"].append(None)
-                    scores["score"].append(score)
-                    scores["favorability"].append(metric_favorability)
-                else:
-                    scores["metric"].append(metric_name)
-                    scores["verbose_name"].append(metric_verbose_name)
-                    scores["estimator_name"].append(self._parent.estimator_name_)
-                    scores["data_source"].append(data_source)
-                    scores["label"].append(None)
-                    scores["average"].append(None)
-                    scores["output"].append(None)
-                    scores["score"].append(score)
-                    scores["favorability"].append(metric_favorability)
-            elif self._parent._ml_task == "regression":
-                scores["metric"].append(metric_name)
-                scores["verbose_name"].append(metric_verbose_name)
-                scores["estimator_name"].append(self._parent.estimator_name_)
-                scores["data_source"].append(data_source)
-                scores["label"].append(None)
-                scores["average"].append(None)
-                scores["output"].append(None)
-                scores["score"].append(score)
-                scores["favorability"].append(metric_favorability)
+                    rows.append({**row, "average": metrics_kwargs.get("average")})
             elif self._parent._ml_task == "multioutput-regression":
                 if isinstance(score, list):
                     for output_idx, output_score in enumerate(score):
-                        scores["metric"].append(metric_name)
-                        scores["verbose_name"].append(metric_verbose_name)
-                        scores["estimator_name"].append(self._parent.estimator_name_)
-                        scores["data_source"].append(data_source)
-                        scores["label"].append(None)
-                        scores["average"].append(None)
-                        scores["output"].append(output_idx)
-                        scores["score"].append(output_score)
-                        scores["favorability"].append(metric_favorability)
+                        rows.append(
+                            {**row, "output": output_idx, "score": output_score}
+                        )
                 else:
-                    scores["metric"].append(metric_name)
-                    scores["verbose_name"].append(metric_verbose_name)
-                    scores["estimator_name"].append(self._parent.estimator_name_)
-                    scores["data_source"].append(data_source)
-                    scores["label"].append(None)
-                    scores["average"].append(metrics_kwargs.get("multioutput"))
-                    scores["output"].append(None)
-                    scores["score"].append(score)
-                    scores["favorability"].append(metric_favorability)
-            else:  # unknown task - try our best
-                scores["metric"].append(metric_name)
-                scores["verbose_name"].append(metric_verbose_name)
-                scores["estimator_name"].append(self._parent.estimator_name_)
-                scores["data_source"].append(data_source)
-                scores["label"].append(None)
-                scores["average"].append(None)
-                scores["output"].append(None)
-                scores["score"].append(score)
-                scores["favorability"].append(metric_favorability)
+                    rows.append({**row, "average": metrics_kwargs.get("multioutput")})
+            else:
+                rows.append(row)
 
-        # Prevent ints from being converted to float (which is pandas' default behaviour
-        # when there are `None` in the columns)
-        if any(isinstance(label, bool) for label in scores["label"]):
-            scores["label"] = pd.Series(scores["label"], dtype=pd.BooleanDtype())
-        elif any(isinstance(label, int) for label in scores["label"]):
-            scores["label"] = pd.Series(scores["label"], dtype=pd.Int64Dtype())
+        data = pd.DataFrame(rows)
 
-        if any(isinstance(output, int) for output in scores["output"]):
-            scores["output"] = pd.Series(scores["output"], dtype=pd.Int64Dtype())
+        # Preserve original types from being converted to float
+        # (which is pandas' default behaviour when there are `None` in the columns)
+        if any(isinstance(row["label"], bool) for row in rows):
+            data["label"] = data["label"].astype(pd.BooleanDtype())
+        elif any(isinstance(row["label"], int) for row in rows):
+            data["label"] = data["label"].astype(pd.Int64Dtype())
 
-        return MetricsSummaryDisplay(data=pd.DataFrame(scores), report_type="estimator")
+        if any(isinstance(row["output"], int) for row in rows):
+            data["output"] = data["output"].astype(pd.Int64Dtype())
+
+        return MetricsSummaryDisplay(data=data, report_type="estimator")
 
     def _compute_metric_scores(
         self,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -5,8 +5,8 @@ from typing import Any, Literal, cast
 
 import numpy as np
 import pandas as pd
+import sklearn
 from numpy.typing import ArrayLike, NDArray
-from sklearn import metrics as sklearn_metrics
 from sklearn.metrics._scorer import _BaseScorer
 from sklearn.utils.metaestimators import available_if
 
@@ -240,7 +240,7 @@ class _MetricsAccessor(
         for metric_name, metric_ in zip(metric_names, metrics, strict=False):
             if isinstance(metric_, str) and metric_ not in self._score_or_loss_info:
                 try:
-                    metric_ = sklearn_metrics.get_scorer(metric_)
+                    metric_ = sklearn.metrics.get_scorer(metric_)
                 except ValueError as err:
                     raise ValueError(
                         f"Invalid metric: {metric_!r}. "
@@ -640,7 +640,7 @@ class _MetricsAccessor(
         0.95...
         """
         score = self._compute_metric_scores(
-            sklearn_metrics.accuracy_score,
+            sklearn.metrics.accuracy_score,
             data_source=data_source,
             response_method="predict",
         )
@@ -728,7 +728,7 @@ class _MetricsAccessor(
             average = "binary"
 
         result = self._compute_metric_scores(
-            sklearn_metrics.precision_score,
+            sklearn.metrics.precision_score,
             data_source=data_source,
             response_method="predict",
             pos_label=pos_label,
@@ -823,7 +823,7 @@ class _MetricsAccessor(
             average = "binary"
 
         result = self._compute_metric_scores(
-            sklearn_metrics.recall_score,
+            sklearn.metrics.recall_score,
             data_source=data_source,
             response_method="predict",
             pos_label=pos_label,
@@ -881,7 +881,7 @@ class _MetricsAccessor(
         # `pos_label`. Since we get the predictions with `get_response_method`, we
         # can pass any `pos_label`, they will lead to the same result.
         result = self._compute_metric_scores(
-            sklearn_metrics.brier_score_loss,
+            sklearn.metrics.brier_score_loss,
             data_source=data_source,
             response_method="predict_proba",
             pos_label=self._parent._estimator.classes_[-1],
@@ -965,7 +965,7 @@ class _MetricsAccessor(
         0.99...
         """
         result = self._compute_metric_scores(
-            sklearn_metrics.roc_auc_score,
+            sklearn.metrics.roc_auc_score,
             data_source=data_source,
             response_method=["predict_proba", "decision_function"],
             average=average,
@@ -1022,7 +1022,7 @@ class _MetricsAccessor(
         0.10...
         """
         result = self._compute_metric_scores(
-            sklearn_metrics.log_loss,
+            sklearn.metrics.log_loss,
             data_source=data_source,
             response_method="predict_proba",
         )
@@ -1080,7 +1080,7 @@ class _MetricsAccessor(
         0.35...
         """
         result = self._compute_metric_scores(
-            sklearn_metrics.r2_score,
+            sklearn.metrics.r2_score,
             data_source=data_source,
             response_method="predict",
             multioutput=multioutput,
@@ -1144,7 +1144,7 @@ class _MetricsAccessor(
         56.5...
         """
         result = self._compute_metric_scores(
-            sklearn_metrics.root_mean_squared_error,
+            sklearn.metrics.root_mean_squared_error,
             data_source=data_source,
             response_method="predict",
             multioutput=multioutput,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -1,12 +1,13 @@
 import inspect
-from collections.abc import Callable, Iterable
+from collections import defaultdict
+from collections.abc import Callable
 from functools import partial
 from typing import Any, Literal, cast
 
 import numpy as np
 import pandas as pd
 import sklearn
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 from sklearn.metrics._scorer import _BaseScorer
 from sklearn.utils.metaestimators import available_if
 
@@ -40,7 +41,6 @@ from skore._utils._accessor import (
     _get_ys_for_single_report,
 )
 from skore._utils._cache_key import deep_key_sanitize
-from skore._utils._index import flatten_multi_index
 
 
 class _MetricsAccessor(
@@ -67,8 +67,6 @@ class _MetricsAccessor(
         metric_kwargs: dict[str, Any] | None = None,
         response_method: str | list[str] | None = None,
         pos_label: PositiveLabel | None = _DEFAULT,
-        favorability: bool = False,
-        flat_index: bool = False,
     ) -> MetricsSummaryDisplay:
         """Report a set of metrics for our estimator.
 
@@ -118,14 +116,6 @@ class _MetricsAccessor(
             class is set to the one provided when creating the report. If `None`,
             the metric is computed considering each class as a positive class.
 
-        favorability : bool, default=False
-            Whether or not to add an indicator of the favorability of the metric as
-            an extra column in the returned DataFrame.
-
-        flat_index : bool, default=False
-            Whether to flatten the multi-index columns. Flat index will always be lower
-            case, do not include spaces and remove the hash symbol to ease indexing.
-
         Returns
         -------
         :class:`MetricsSummaryDisplay`
@@ -142,7 +132,7 @@ class _MetricsAccessor(
         ...
         >>> classifier = LogisticRegression(max_iter=10_000)
         >>> report = EstimatorReport(classifier, **split_data, pos_label=1)
-        >>> report.metrics.summarize(favorability=True).frame()
+        >>> report.metrics.summarize().frame(favorability=True)
                     LogisticRegression Favorability
         Metric
         Accuracy               0.95...         (↗︎)
@@ -153,15 +143,13 @@ class _MetricsAccessor(
         >>> # Using scikit-learn metrics
         >>> report.metrics.summarize(
         ...     metric=["f1"],
-        ...     favorability=True,
-        ... ).frame()
+        ... ).frame(favorability=True)
                                   LogisticRegression Favorability
         Metric   Label / Average
         F1 Score               1             0.96...          (↗︎)
         >>> report.metrics.summarize(
-        ...    favorability=True,
         ...    data_source="both"
-        ... ).frame().drop(["Fit time (s)", "Predict time (s)"])
+        ... ).frame(favorability=True).drop(["Fit time (s)", "Predict time (s)"])
                      LogisticRegression (train)  LogisticRegression (test)  Favorability
         Metric
         Accuracy                        0.96...                     0.95...          (↗︎)
@@ -172,8 +160,7 @@ class _MetricsAccessor(
         >>> # Using scikit-learn metrics
         >>> report.metrics.summarize(
         ...     metric=["f1"],
-        ...     favorability=True,
-        ... ).frame()
+        ... ).frame(favorability=True)
                                   LogisticRegression Favorability
         Metric   Label / Average
         F1 Score               1             0.96...          (↗︎)
@@ -184,8 +171,6 @@ class _MetricsAccessor(
                 metric=metric,
                 metric_kwargs=metric_kwargs,
                 pos_label=pos_label,
-                favorability=False,
-                flat_index=flat_index,
                 response_method=response_method,
             )
             test_summary = self.summarize(
@@ -193,25 +178,21 @@ class _MetricsAccessor(
                 metric=metric,
                 metric_kwargs=metric_kwargs,
                 pos_label=pos_label,
-                favorability=favorability,
-                flat_index=flat_index,
                 response_method=response_method,
             )
-            # Add suffix to the dataframes to distinguish train and test.
-            train_df = train_summary.frame().add_suffix(" (train)")
-            test_df = test_summary.frame().add_suffix(" (test)")
-            combined = pd.concat([train_df, test_df], axis=1).rename(
-                columns={"Favorability (test)": "Favorability"}
+
+            combined = pd.concat(
+                [train_summary.data, test_summary.data], ignore_index=True
             )
-            return MetricsSummaryDisplay(summarize_data=combined)
+            return MetricsSummaryDisplay(data=combined, report_type="estimator")
 
         if pos_label is _DEFAULT:
             pos_label = self._parent.pos_label
 
         # Handle dictionary metrics
-        metric_names = None
+        metric_verbose_names = None
         if isinstance(metric, dict):
-            metric_names = list(metric.keys())
+            metric_verbose_names = list(metric.keys())
             metrics = list(metric.values())
         elif metric is not None and not isinstance(metric, list):
             metrics = [metric]
@@ -232,12 +213,13 @@ class _MetricsAccessor(
                 metrics = ["r2", "rmse"]
             metrics += ["fit_time", "predict_time"]
 
-        if metric_names is None:
-            metric_names = [None] * len(metrics)  # type: ignore
+        if metric_verbose_names is None:
+            metric_verbose_names = [None] * len(metrics)  # type: ignore
 
-        scores = []
-        favorability_indicator = []
-        for metric_name, metric_ in zip(metric_names, metrics, strict=False):
+        scores = defaultdict(list)
+        for metric_verbose_name, metric_ in zip(
+            metric_verbose_names, metrics, strict=True
+        ):
             if isinstance(metric_, str) and metric_ not in self._score_or_loss_info:
                 try:
                     metric_ = sklearn.metrics.get_scorer(metric_)
@@ -280,10 +262,15 @@ class _MetricsAccessor(
                             )
                     elif pos_label is not None:
                         metrics_kwargs["pos_label"] = pos_label
-                if metric_name is None:
-                    metric_name = metric_._score_func.__name__.replace("_", " ").title()
+
+                metric_name = metric_._score_func.__name__
                 metric_favorability = "(↗︎)" if metric_._sign == 1 else "(↘︎)"
-                favorability_indicator.append(metric_favorability)
+
+                if metric_verbose_name is None:
+                    metric_verbose_name = metric_._score_func.__name__.replace(
+                        "_", " "
+                    ).title()
+
             elif isinstance(metric_, str) or callable(metric_):
                 if isinstance(metric_, str):
                     metric_fn = getattr(
@@ -293,8 +280,10 @@ class _MetricsAccessor(
                         else metric_,
                     )
                     metrics_kwargs = {}
-                    if metric_name is None:
-                        metric_name = f"{self._score_or_loss_info[metric_]['name']}"
+                    if metric_verbose_name is None:
+                        metric_verbose_name = (
+                            f"{self._score_or_loss_info[metric_]['name']}"
+                        )
                     metric_favorability = self._score_or_loss_info[metric_]["icon"]
                 else:
                     # Handle callable metrics
@@ -326,10 +315,10 @@ class _MetricsAccessor(
                             for param in metric_callable_params
                             if param in metric_kwargs
                         }
-                    if metric_name is None:
-                        metric_name = metric_.__name__
+                    metric_name = metric_.__name__
+                    if metric_verbose_name is None:
+                        metric_verbose_name = metric_.__name__.replace("_", " ").title()
                     metric_favorability = ""
-                    favorability_indicator.append(metric_favorability)
 
                 metrics_params = inspect.signature(metric_fn).parameters
                 if metric_kwargs is not None:
@@ -345,102 +334,140 @@ class _MetricsAccessor(
 
             score = metric_fn(data_source=data_source, **metrics_kwargs)
 
-            index: pd.Index | pd.MultiIndex | list[str] | None
-            score_array: NDArray
             if self._parent._ml_task == "binary-classification":
                 if isinstance(score, dict):
                     classes = list(score.keys())
-                    index = pd.MultiIndex.from_arrays(
-                        [[metric_name] * len(classes), classes],
-                        names=["Metric", "Label / Average"],
-                    )
-                    score_array = np.hstack([score[c] for c in classes]).reshape(-1, 1)
+                    for label in classes:
+                        scores["metric"].append(metric_name)
+                        scores["verbose_name"].append(metric_verbose_name)
+                        scores["estimator_name"].append(self._parent.estimator_name_)
+                        scores["data_source"].append(data_source)
+                        scores["label"].append(label)
+                        scores["average"].append(None)
+                        scores["output"].append(None)
+                        scores["score"].append(score[label])
+                        scores["favorability"].append(metric_favorability)
                 elif "average" in metrics_kwargs:
                     if metrics_kwargs["average"] == "binary":
-                        index = pd.MultiIndex.from_arrays(
-                            [[metric_name], [pos_label]],
-                            names=["Metric", "Label / Average"],
-                        )
+                        scores["metric"].append(metric_name)
+                        scores["verbose_name"].append(metric_verbose_name)
+                        scores["estimator_name"].append(self._parent.estimator_name_)
+                        scores["data_source"].append(data_source)
+                        scores["average"].append(None)
+                        scores["label"].append(pos_label)
+                        scores["output"].append(None)
                     elif metrics_kwargs["average"] is not None:
-                        index = pd.MultiIndex.from_arrays(
-                            [[metric_name], [metrics_kwargs["average"]]],
-                            names=["Metric", "Label / Average"],
-                        )
+                        scores["metric"].append(metric_name)
+                        scores["verbose_name"].append(metric_verbose_name)
+                        scores["estimator_name"].append(self._parent.estimator_name_)
+                        scores["data_source"].append(data_source)
+                        scores["label"].append(None)
+                        scores["average"].append(metrics_kwargs["average"])
+                        scores["output"].append(None)
                     else:
-                        index = pd.Index([metric_name], name="Metric")
-                    score_array = np.array(score).reshape(-1, 1)
+                        scores["metric"].append(metric_name)
+                        scores["verbose_name"].append(metric_verbose_name)
+                        scores["estimator_name"].append(self._parent.estimator_name_)
+                        scores["data_source"].append(data_source)
+                        scores["label"].append(None)
+                        scores["average"].append(None)
+                        scores["output"].append(None)
+                    scores["score"].append(score)
+                    scores["favorability"].append(metric_favorability)
                 else:
-                    index = pd.Index([metric_name], name="Metric")
-                    score_array = np.array(score).reshape(-1, 1)
+                    scores["metric"].append(metric_name)
+                    scores["verbose_name"].append(metric_verbose_name)
+                    scores["estimator_name"].append(self._parent.estimator_name_)
+                    scores["data_source"].append(data_source)
+                    scores["label"].append(None)
+                    scores["average"].append(None)
+                    scores["output"].append(None)
+                    scores["score"].append(score)
+                    scores["favorability"].append(metric_favorability)
             elif self._parent._ml_task == "multiclass-classification":
                 if isinstance(score, dict):
                     classes = list(score.keys())
-                    index = pd.MultiIndex.from_arrays(
-                        [[metric_name] * len(classes), classes],
-                        names=["Metric", "Label / Average"],
-                    )
-                    score_array = np.hstack([score[c] for c in classes]).reshape(-1, 1)
+                    for label in classes:
+                        scores["metric"].append(metric_name)
+                        scores["verbose_name"].append(metric_verbose_name)
+                        scores["estimator_name"].append(self._parent.estimator_name_)
+                        scores["data_source"].append(data_source)
+                        scores["label"].append(label)
+                        scores["average"].append(None)
+                        scores["output"].append(None)
+                        scores["score"].append(score[label])
+                        scores["favorability"].append(metric_favorability)
                 elif (
                     "average" in metrics_kwargs
                     and metrics_kwargs["average"] is not None
                 ):
-                    index = pd.MultiIndex.from_arrays(
-                        [[metric_name], [metrics_kwargs["average"]]],
-                        names=["Metric", "Label / Average"],
-                    )
-                    score_array = np.array(score).reshape(-1, 1)
+                    scores["metric"].append(metric_name)
+                    scores["verbose_name"].append(metric_verbose_name)
+                    scores["estimator_name"].append(self._parent.estimator_name_)
+                    scores["data_source"].append(data_source)
+                    scores["label"].append(None)
+                    scores["average"].append(metrics_kwargs["average"])
+                    scores["output"].append(None)
+                    scores["score"].append(score)
+                    scores["favorability"].append(metric_favorability)
                 else:
-                    index = pd.Index([metric_name], name="Metric")
-                    score_array = np.array(score).reshape(-1, 1)
-            elif self._parent._ml_task in ("regression", "multioutput-regression"):
+                    scores["metric"].append(metric_name)
+                    scores["verbose_name"].append(metric_verbose_name)
+                    scores["estimator_name"].append(self._parent.estimator_name_)
+                    scores["data_source"].append(data_source)
+                    scores["label"].append(None)
+                    scores["average"].append(None)
+                    scores["output"].append(None)
+                    scores["score"].append(score)
+                    scores["favorability"].append(metric_favorability)
+            elif self._parent._ml_task == "regression":
+                scores["metric"].append(metric_name)
+                scores["verbose_name"].append(metric_verbose_name)
+                scores["estimator_name"].append(self._parent.estimator_name_)
+                scores["data_source"].append(data_source)
+                scores["label"].append(None)
+                scores["average"].append(None)
+                scores["output"].append(None)
+                scores["score"].append(score)
+                scores["favorability"].append(metric_favorability)
+            elif self._parent._ml_task == "multioutput-regression":
                 if isinstance(score, list):
-                    index = pd.MultiIndex.from_arrays(
-                        [[metric_name] * len(score), list(range(len(score)))],
-                        names=["Metric", "Output"],
-                    )
-                    score_array = np.array(score).reshape(-1, 1)
+                    for output_idx, output_score in enumerate(score):
+                        scores["metric"].append(metric_name)
+                        scores["verbose_name"].append(metric_verbose_name)
+                        scores["estimator_name"].append(self._parent.estimator_name_)
+                        scores["data_source"].append(data_source)
+                        scores["label"].append(None)
+                        scores["average"].append(None)
+                        scores["output"].append(output_idx)
+                        scores["score"].append(output_score)
+                        scores["favorability"].append(metric_favorability)
                 else:
-                    index = pd.Index([metric_name], name="Metric")
-                    score_array = np.array(score).reshape(-1, 1)
+                    scores["metric"].append(metric_name)
+                    scores["verbose_name"].append(metric_verbose_name)
+                    scores["estimator_name"].append(self._parent.estimator_name_)
+                    scores["data_source"].append(data_source)
+                    scores["label"].append(None)
+                    scores["average"].append(metrics_kwargs.get("multioutput"))
+                    scores["output"].append(None)
+                    scores["score"].append(score)
+                    scores["favorability"].append(metric_favorability)
             else:  # unknown task - try our best
-                index = None if isinstance(score, Iterable) else [metric_name]
+                scores["metric"].append(metric_name)
+                scores["verbose_name"].append(metric_verbose_name)
+                scores["estimator_name"].append(self._parent.estimator_name_)
+                scores["data_source"].append(data_source)
+                scores["label"].append(None)
+                scores["average"].append(None)
+                scores["output"].append(None)
+                scores["score"].append(score)
+                scores["favorability"].append(metric_favorability)
 
-            score_df = pd.DataFrame(
-                score_array, index=index, columns=[self._parent.estimator_name_]
+        if any(isinstance(label, int) for label in scores["label"]):
+            scores["label"] = pd.Series(scores["label"], dtype=pd.Int64Dtype()).astype(
+                "object"
             )
-            if favorability:
-                score_df["Favorability"] = metric_favorability
-
-            scores.append(score_df)
-
-        if any(
-            isinstance(df, pd.DataFrame) and isinstance(df.index, pd.MultiIndex)
-            for df in scores
-        ):
-            # Convert single-level dataframes to multi-level
-            for i, df in enumerate(scores):
-                if not isinstance(df.index, pd.MultiIndex):
-                    if "regression" in self._parent._ml_task:
-                        name_index = ["Metric", "Output"]
-                    else:
-                        name_index = ["Metric", "Label / Average"]
-
-                    scores[i].index = pd.MultiIndex.from_tuples(
-                        [(idx, "") for idx in df.index],
-                        names=name_index,
-                    )
-
-        results = pd.concat(scores, axis=0)
-        if flat_index:
-            if isinstance(results.columns, pd.MultiIndex):
-                results.columns = flatten_multi_index(results.columns)
-            if isinstance(results.index, pd.MultiIndex):
-                results.index = flatten_multi_index(results.index)
-            if isinstance(results.index, pd.Index):
-                results.index = results.index.str.replace(
-                    r"\((.*)\)$", r"\1", regex=True
-                )
-        return MetricsSummaryDisplay(summarize_data=results)
+        return MetricsSummaryDisplay(data=pd.DataFrame(scores), report_type="estimator")
 
     def _compute_metric_scores(
         self,

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -1,4 +1,8 @@
+import pandas as pd
+
 from skore._sklearn._plot.base import DisplayMixin
+from skore._sklearn.types import ReportType
+from skore._utils._index import flatten_multi_index, rename_columns_and_index
 
 
 class MetricsSummaryDisplay(DisplayMixin):
@@ -6,20 +10,117 @@ class MetricsSummaryDisplay(DisplayMixin):
 
     An instance of this class will be created by `Report.metrics.summarize()`.
     This class should not be instantiated directly.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        The data to display.
+
+    report_type : {"estimator", "comparison-estimator", "cross-validation", \
+            "comparison-cross-validation"}
+        The type of report.
     """
 
-    def __init__(self, summarize_data):
-        self.summarize_data = summarize_data
+    _possible_index_columns: set[str] = {
+        "metric",
+        "verbose_name",
+        "label",
+        "output",
+        "average",
+    }
 
-    def frame(self):
+    def __init__(
+        self,
+        data: pd.DataFrame,
+        report_type: ReportType,
+    ):
+        self.data = data
+        self.report_type = report_type
+
+    def frame(
+        self,
+        *,
+        favorability: bool = False,
+        flat_index: bool = False,
+    ):
         """Return the summarize as a dataframe.
+
+        Parameters
+        ----------
+        favorability : bool, default=False
+            Whether or not to add an indicator of the favorability of the metric as
+            an extra column in the returned DataFrame.
+
+        flat_index : bool, default=False
+            Whether to return a flat index or a multi-index.
 
         Returns
         -------
         frame : pandas.DataFrame
             The report metrics as a dataframe.
         """
-        return self.summarize_data
+        df = self.data.copy()
+
+        if self.report_type == "estimator":
+            df = df.dropna(axis="columns", how="all")
+
+            # TODO: Is "metric" ever needed?
+            df = df.drop(columns="metric")
+
+            for col in ("label", "output", "average"):
+                if col in df:
+                    df[col] = df[col].fillna("")
+
+            estimator_name = df.pop("estimator_name")[0]
+            index = df.columns.intersection(self._possible_index_columns).tolist()
+            df = df.set_index(index)
+
+            if not favorability:
+                df = df.drop(columns="favorability")
+
+            if flat_index:
+                if isinstance(df.columns, pd.MultiIndex):
+                    df.columns = flatten_multi_index(df.columns)
+                if isinstance(df.index, pd.MultiIndex):
+                    df.index = flatten_multi_index(df.index)
+                if isinstance(df.index, pd.Index):
+                    df.index = df.index.str.replace(r"\((.*)\)$", r"\1", regex=True)
+
+            df = rename_columns_and_index(
+                df,
+                {
+                    "metric": "Metric",
+                    "verbose_name": "Metric",
+                    "label": "Label / Average",
+                    "output": "Output",
+                    "average": "Average",
+                    "favorability": "Favorability",
+                    "score": estimator_name,
+                },
+            )
+
+            if df["data_source"].nunique() == 1:
+                df = df.drop(columns="data_source")
+            else:
+                # Show metrics one column per data source
+                df_pivoted = df.reset_index().pivot_table(
+                    index=df.index.names,
+                    columns="data_source",
+                    values=estimator_name,
+                    sort=False,
+                )
+                df_pivoted.columns = [
+                    f"{estimator_name} ({col})" for col in df_pivoted.columns
+                ]
+
+                if favorability:
+                    df_pivoted["Favorability"] = df[df["data_source"] == "test"][
+                        "Favorability"
+                    ]
+
+                df = df_pivoted.copy()
+
+        return df
 
     @DisplayMixin.style_plot
     def plot(self):

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -102,9 +102,8 @@ class MetricsSummaryDisplay(DisplayMixin):
         if self.report_type == "estimator":
             df = df.dropna(axis="columns", how="all")
 
-            for col in ("label", "output", "average"):
-                if col in df:
-                    df[col] = df[col].astype("str").fillna("")
+            for col in df.columns.intersection(["label", "output", "average"]):
+                df[col] = df[col].astype(str).replace("<NA>", "").fillna("")
 
             estimator_name = df.pop("estimator_name")[0]
             index = df.columns.intersection(self._possible_index_columns).tolist()

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -115,6 +115,12 @@ class MetricsSummaryDisplay(DisplayMixin):
 
             if not favorability:
                 df = df.drop(columns="favorability")
+            else:
+                # Put favorability at the end
+                df = df[
+                    [col for col in df.columns if col != "favorability"]
+                    + ["favorability"]
+                ]
 
             df = MetricsSummaryDisplay._rename_columns_and_index(
                 df,

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -21,14 +21,6 @@ class MetricsSummaryDisplay(DisplayMixin):
         The type of report.
     """
 
-    _possible_index_columns: set[str] = {
-        "metric",
-        "verbose_name",
-        "label",
-        "output",
-        "average",
-    }
-
     def __init__(
         self,
         data: pd.DataFrame,
@@ -106,7 +98,9 @@ class MetricsSummaryDisplay(DisplayMixin):
                 df[col] = df[col].astype(str).replace("<NA>", "").fillna("")
 
             estimator_name = df.pop("estimator_name")[0]
-            index = df.columns.intersection(self._possible_index_columns).tolist()
+            index = df.columns.intersection(
+                ["metric", "verbose_name", "label", "output", "average"]
+            ).to_list()
             df = df.set_index(index)
 
             if not favorability:

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -95,7 +95,7 @@ class MetricsSummaryDisplay(DisplayMixin):
             df = df.dropna(axis="columns", how="all")
 
             for col in df.columns.intersection(["label", "output", "average"]):
-                df[col] = df[col].astype(str).replace("<NA>", "").fillna("")
+                df[col] = df[col].astype("str").replace("<NA>", "").fillna("")
 
             estimator_name = df.pop("estimator_name")[0]
             index = df.columns.intersection(

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -78,14 +78,6 @@ class MetricsSummaryDisplay(DisplayMixin):
             if not favorability:
                 df = df.drop(columns="favorability")
 
-            if flat_index:
-                if isinstance(df.columns, pd.MultiIndex):
-                    df.columns = flatten_multi_index(df.columns)
-                if isinstance(df.index, pd.MultiIndex):
-                    df.index = flatten_multi_index(df.index)
-                if isinstance(df.index, pd.Index):
-                    df.index = df.index.str.replace(r"\((.*)\)$", r"\1", regex=True)
-
             df = rename_columns_and_index(
                 df,
                 {
@@ -119,6 +111,15 @@ class MetricsSummaryDisplay(DisplayMixin):
                     ]
 
                 df = df_pivoted.copy()
+
+            # Apply flat_index transformation after pivot (if needed)
+            if flat_index:
+                if isinstance(df.columns, pd.MultiIndex):
+                    df.columns = flatten_multi_index(df.columns)
+                if isinstance(df.index, pd.MultiIndex):
+                    df.index = flatten_multi_index(df.index)
+                if isinstance(df.index, pd.Index):
+                    df.index = df.index.str.replace(r"\((.*)\)$", r"\1", regex=True)
 
         return df
 

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -69,7 +69,7 @@ class MetricsSummaryDisplay(DisplayMixin):
 
             for col in ("label", "output", "average"):
                 if col in df:
-                    df[col] = df[col].fillna("")
+                    df[col] = df[col].astype("str").fillna("")
 
             estimator_name = df.pop("estimator_name")[0]
             index = df.columns.intersection(self._possible_index_columns).tolist()

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -102,9 +102,6 @@ class MetricsSummaryDisplay(DisplayMixin):
         if self.report_type == "estimator":
             df = df.dropna(axis="columns", how="all")
 
-            # TODO: Is "metric" ever needed?
-            df = df.drop(columns="metric")
-
             for col in ("label", "output", "average"):
                 if col in df:
                     df[col] = df[col].astype("str").fillna("")

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -29,44 +29,6 @@ class MetricsSummaryDisplay(DisplayMixin):
         self.data = data
         self.report_type = report_type
 
-    @staticmethod
-    def _rename_columns_and_index(
-        df: pd.DataFrame, mapping: dict[str, str]
-    ) -> pd.DataFrame:
-        """Rename names of columns and index names.
-
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> frame = pd.DataFrame(
-                [1, 2, 3],
-                index=pd.MultiIndex.from_tuples(
-                    [(0, ''), (1, ''), (2, '')],
-                    names=['a', 'b'],
-                ),
-                columns=["c"],
-            )
-        >>> frame
-             c
-        a b
-        0    1
-        1    2
-        2    3
-        >>> MetricsSummaryDisplay._rename_columns_and_index(
-        ...     frame, {"a": "d", "b": "e", "c": "f"}
-        ... )
-             f
-        d e
-        0    1
-        1    2
-        2    3
-        """
-        df_ = df.rename(columns=mapping)
-        df_.index = df_.index.set_names(
-            [mapping.get(name, name) for name in df_.index.names]
-        )
-        return df_
-
     def frame(
         self,
         *,
@@ -112,17 +74,19 @@ class MetricsSummaryDisplay(DisplayMixin):
                     + ["favorability"]
                 ]
 
-            df = MetricsSummaryDisplay._rename_columns_and_index(
-                df,
-                {
-                    "metric": "Metric",
-                    "verbose_name": "Metric",
-                    "label": "Label / Average",
-                    "output": "Output",
-                    "average": "Average",
-                    "favorability": "Favorability",
-                    "score": estimator_name,
-                },
+            # Rename columns as well as index names
+            new_columns = {
+                "metric": "Metric",
+                "verbose_name": "Metric",
+                "label": "Label / Average",
+                "output": "Output",
+                "average": "Average",
+                "favorability": "Favorability",
+                "score": estimator_name,
+            }
+            df = df.rename(columns=new_columns)
+            df.index = df.index.set_names(
+                [new_columns.get(name, name) for name in df.index.names]
             )
 
             if df["data_source"].nunique() == 1:

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from skore._sklearn._plot.base import DisplayMixin
 from skore._sklearn.types import ReportType
-from skore._utils._index import flatten_multi_index, rename_columns_and_index
+from skore._utils._index import flatten_multi_index
 
 
 class MetricsSummaryDisplay(DisplayMixin):
@@ -36,6 +36,44 @@ class MetricsSummaryDisplay(DisplayMixin):
     ):
         self.data = data
         self.report_type = report_type
+
+    @staticmethod
+    def _rename_columns_and_index(
+        df: pd.DataFrame, mapping: dict[str, str]
+    ) -> pd.DataFrame:
+        """Rename names of columns and index names.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> frame = pd.DataFrame(
+                [1, 2, 3],
+                index=pd.MultiIndex.from_tuples(
+                    [(0, ''), (1, ''), (2, '')],
+                    names=['a', 'b'],
+                ),
+                columns=["c"],
+            )
+        >>> frame
+             c
+        a b
+        0    1
+        1    2
+        2    3
+        >>> MetricsSummaryDisplay._rename_columns_and_index(
+        ...     frame, {"a": "d", "b": "e", "c": "f"}
+        ... )
+             f
+        d e
+        0    1
+        1    2
+        2    3
+        """
+        df_ = df.rename(columns=mapping)
+        df_.index = df_.index.set_names(
+            [mapping.get(name, name) for name in df_.index.names]
+        )
+        return df_
 
     def frame(
         self,
@@ -78,7 +116,7 @@ class MetricsSummaryDisplay(DisplayMixin):
             if not favorability:
                 df = df.drop(columns="favorability")
 
-            df = rename_columns_and_index(
+            df = MetricsSummaryDisplay._rename_columns_and_index(
                 df,
                 {
                     "metric": "Metric",

--- a/skore/src/skore/_utils/_index.py
+++ b/skore/src/skore/_utils/_index.py
@@ -1,41 +1,87 @@
 import pandas as pd
 
 
-def flatten_multi_index(index: pd.MultiIndex) -> pd.Index:
+def flatten_multi_index(
+    index: pd.MultiIndex | pd.Index, join_str: str = "_"
+) -> pd.Index:
     """Flatten a pandas MultiIndex into a single-level Index.
 
     Flatten a pandas `MultiIndex` into a single-level Index by joining the levels
-    with underscores. Empty strings are skipped when joining. Spaces are replaced by
-    an underscore and "#" are skipped.
+    with the specified string. Empty strings are skipped when joining. Spaces within
+    level values are replaced with the join string, and "#" characters are removed
+    from the final result.
 
     Parameters
     ----------
     index : pandas.MultiIndex
         The `MultiIndex` to flatten.
 
+    join_str : str, default="_"
+        The string to use for joining the levels.
+
     Returns
     -------
     pandas.Index
-        A flattened `Index` with non-empty levels joined by underscores.
+        A flattened `Index` with non-empty levels joined by the specified
+        `join_str`. Any spaces within level values are also replaced with
+        `join_str`.
 
     Examples
     --------
     >>> import pandas as pd
     >>> mi = pd.MultiIndex.from_tuples(
-    ...     [('a', ''), ('b', '2')], names=['letter', 'number']
+    ...     [('a', ''), ('b', '2'), ('c d', 'e f')], names=['letter', 'number']
     ... )
-    >>> flatten_multi_index(mi)
-    Index(['a', 'b_2'], dtype=...)
+    >>> flatten_multi_index(mi)  # default join_str="_"
+    Index(['a', 'b_2', 'c_d_e_f'], dtype=...)
+    >>> flatten_multi_index(mi, join_str=" ")
+    Index(['a', 'b 2', 'c d e f'], dtype=...)
+    >>> flatten_multi_index(mi, join_str="-")
+    Index(['a', 'b-2', 'c-d-e-f'], dtype=...)
     """
     if not isinstance(index, pd.MultiIndex):
-        raise ValueError("`index` must be a MultiIndex.")
+        return index
 
     return pd.Index(
         [
-            "_".join(filter(bool, map(str, values)))
-            .replace(" ", "_")
+            join_str.join(filter(bool, map(str, values)))
+            .replace(" ", join_str)
             .replace("#", "")
             .lower()
             for values in index
         ]
     )
+
+
+def rename_columns_and_index(df: pd.DataFrame, mapping: dict[str, str]) -> pd.DataFrame:
+    """Rename names of columns and index names.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> frame = pd.DataFrame(
+            [1, 2, 3],
+            index=pd.MultiIndex.from_tuples(
+                [(0, ''), (1, ''), (2, '')],
+                names=['a', 'b'],
+            ),
+            columns=["c"],
+        )
+    >>> frame
+         c
+    a b
+    0    1
+    1    2
+    2    3
+    >>> rename_columns_and_index(frame, {"a": "d", "b": "e", "c": "f"})
+         f
+    d e
+    0    1
+    1    2
+    2    3
+    """
+    df_ = df.rename(columns=mapping)
+    df_.index = df_.index.set_names(
+        [mapping.get(name, name) for name in df_.index.names]
+    )
+    return df_

--- a/skore/src/skore/_utils/_index.py
+++ b/skore/src/skore/_utils/_index.py
@@ -51,37 +51,3 @@ def flatten_multi_index(
             for values in index
         ]
     )
-
-
-def rename_columns_and_index(df: pd.DataFrame, mapping: dict[str, str]) -> pd.DataFrame:
-    """Rename names of columns and index names.
-
-    Examples
-    --------
-    >>> import pandas as pd
-    >>> frame = pd.DataFrame(
-            [1, 2, 3],
-            index=pd.MultiIndex.from_tuples(
-                [(0, ''), (1, ''), (2, '')],
-                names=['a', 'b'],
-            ),
-            columns=["c"],
-        )
-    >>> frame
-         c
-    a b
-    0    1
-    1    2
-    2    3
-    >>> rename_columns_and_index(frame, {"a": "d", "b": "e", "c": "f"})
-         f
-    d e
-    0    1
-    1    2
-    2    3
-    """
-    df_ = df.rename(columns=mapping)
-    df_.index = df_.index.set_names(
-        [mapping.get(name, name) for name in df_.index.names]
-    )
-    return df_

--- a/skore/tests/unit/displays/metrics_summary/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_comparison_estimator.py
@@ -20,10 +20,10 @@ def test_data_source_both(
     expected_index = pd.MultiIndex.from_tuples(
         [
             ("Accuracy", ""),
-            ("Precision", 0),
-            ("Precision", 1),
-            ("Recall", 0),
-            ("Recall", 1),
+            ("Precision", "0"),
+            ("Precision", "1"),
+            ("Recall", "0"),
+            ("Recall", "1"),
             ("ROC AUC", ""),
             ("Brier score", ""),
             ("Fit time (s)", ""),

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -1,46 +1,18 @@
-"""Tests for MetricsSummaryDisplay.frame() method with bare DataFrames.
-
-These tests focus on testing the display/formatting logic of MetricsSummaryDisplay
-without depending on EstimatorReport or summarize().
-"""
+"""Tests for MetricsSummaryDisplay.frame() method."""
 
 import pandas as pd
+from sklearn.model_selection import train_test_split
 
-from skore._sklearn._plot.metrics.metrics_summary_display import MetricsSummaryDisplay
+from skore import EstimatorReport
 
 
-def test_frame_favorability_binary_classification():
-    data = pd.DataFrame(
-        {
-            "metric": [
-                "accuracy",
-                "precision",
-                "precision",
-                "recall",
-                "recall",
-                "roc_auc",
-                "brier_score",
-            ],
-            "verbose_name": [
-                "Accuracy",
-                "Precision",
-                "Precision",
-                "Recall",
-                "Recall",
-                "ROC AUC",
-                "Brier score",
-            ],
-            "label": ["", "0", "1", "0", "1", "", ""],
-            "estimator_name": ["RandomForestClassifier"] * 7,
-            "score": [0.95, 0.92, 0.97, 0.89, 0.98, 0.96, 0.08],
-            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)", "(↘︎)"],
-            "data_source": ["test"] * 7,
-            "average": [None] * 7,
-            "output": [None] * 7,
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+def test_favorability_binary(forest_binary_classification_with_test):
+    """
+    Test that favorability column is correctly displayed for binary classification.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize()
 
     result_no_fav = display.frame(favorability=False)
     assert result_no_fav.columns.to_list() == ["RandomForestClassifier"]
@@ -53,22 +25,11 @@ def test_frame_favorability_binary_classification():
     assert set(result_with_fav["Favorability"]) == {"(↗︎)", "(↘︎)"}
 
 
-def test_frame_favorability_regression():
+def test_favorability_regression(linear_regression_with_test):
     """Test that favorability column is correctly displayed for regression metrics."""
-    data = pd.DataFrame(
-        {
-            "metric": ["r2", "rmse"],
-            "verbose_name": ["R²", "RMSE"],
-            "estimator_name": ["LinearRegression", "LinearRegression"],
-            "score": [0.85, 0.15],
-            "favorability": ["(↗︎)", "(↘︎)"],
-            "data_source": ["test", "test"],
-            "average": [None] * 2,
-            "output": [None] * 2,
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize()
 
     result_no_fav = display.frame(favorability=False)
     assert result_no_fav.columns.to_list() == ["LinearRegression"]
@@ -78,23 +39,11 @@ def test_frame_favorability_regression():
     assert set(result_with_fav["Favorability"]) == {"(↗︎)", "(↘︎)"}
 
 
-def test_frame_flat_index_multiclass():
+def test_flat_index_multiclass(forest_multiclass_classification_with_test):
     """Test flat_index parameter with multiclass classification data."""
-    data = pd.DataFrame(
-        {
-            "metric": ["precision"] * 3 + ["recall"] * 3,
-            "verbose_name": ["Precision"] * 3 + ["Recall"] * 3,
-            "label": ["0", "1", "2"] * 2,
-            "estimator_name": ["RandomForestClassifier"] * 6,
-            "score": [0.92, 0.87, 0.91, 0.88, 0.85, 0.90],
-            "favorability": ["(↗︎)"] * 6,
-            "data_source": ["test"] * 6,
-            "average": [None] * 6,
-            "output": [None] * 6,
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    estimator, X_test, y_test = forest_multiclass_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize()
 
     result_multi = display.frame(favorability=False, flat_index=False)
     assert isinstance(result_multi.index, pd.MultiIndex)
@@ -103,62 +52,79 @@ def test_frame_flat_index_multiclass():
     result_flat = display.frame(favorability=False, flat_index=True)
     assert isinstance(result_flat.index, pd.Index)
     assert result_flat.index.to_list() == [
+        "accuracy",
         "precision_0",
         "precision_1",
         "precision_2",
         "recall_0",
         "recall_1",
         "recall_2",
+        "roc_auc_0",
+        "roc_auc_1",
+        "roc_auc_2",
+        "log_loss",
+        "fit_time_s",
+        "predict_time_s",
     ]
 
 
-def test_frame_flat_index_with_favorability():
-    """Test that flat_index and favorability work together."""
-    data = pd.DataFrame(
-        {
-            "metric": ["precision", "precision", "recall", "recall"],
-            "verbose_name": ["Precision", "Precision", "Recall", "Recall"],
-            "label": ["0", "1", "0", "1"],
-            "estimator_name": ["LogisticRegression"] * 4,
-            "score": [0.85, 0.90, 0.88, 0.92],
-            "favorability": ["(↗︎)"] * 4,
-            "data_source": ["test"] * 4,
-            "average": [None] * 4,
-            "output": [None] * 4,
-        }
-    )
+def test_flat_index_multioutput(linear_regression_multioutput_with_test):
+    """Test flat_index with multioutput regression data."""
+    estimator, X_test, y_test = linear_regression_multioutput_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize(metric_kwargs={"multioutput": "raw_values"})
 
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    result_multi = display.frame(favorability=False, flat_index=False)
+    assert isinstance(result_multi.index, pd.MultiIndex)
+    assert result_multi.index.names == ["Metric", "Output"]
+    assert result_multi.shape == (6, 1)
+    assert result_multi.loc[("R²", "0"), "LinearRegression"] == 1
+    assert result_multi.loc[("R²", "1"), "LinearRegression"] == 1
+
+    result_flat = display.frame(favorability=False, flat_index=True)
+    assert isinstance(result_flat.index, pd.Index)
+    # Note: "R²" is lowercased
+    assert result_flat.index.to_list() == [
+        "r²_0",
+        "r²_1",
+        "rmse_0",
+        "rmse_1",
+        "fit_time_s",
+        "predict_time_s",
+    ]
+
+
+def test_flat_index_with_favorability(forest_binary_classification_with_test):
+    """Test that flat_index and favorability work together."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize()
 
     result = display.frame(favorability=True, flat_index=True)
-    assert result.columns.to_list() == ["LogisticRegression", "Favorability"]
+    assert result.columns.to_list() == ["RandomForestClassifier", "Favorability"]
 
     assert isinstance(result.index, pd.Index)
     assert result.index.to_list() == [
+        "accuracy",
         "precision_0",
         "precision_1",
         "recall_0",
         "recall_1",
+        "roc_auc",
+        "brier_score",
+        "fit_time_s",
+        "predict_time_s",
     ]
 
 
-def test_frame_data_source_both_with_favorability():
+def test_data_source_both_favorability(forest_binary_classification_data):
     """Test favorability with data_source='both' (train and test)."""
-    data = pd.DataFrame(
-        {
-            "metric": ["accuracy", "accuracy", "roc_auc", "roc_auc"],
-            "verbose_name": ["Accuracy", "Accuracy", "ROC AUC", "ROC AUC"],
-            "label": [None] * 4,
-            "estimator_name": ["RandomForestClassifier"] * 4,
-            "score": [0.98, 0.95, 0.99, 0.96],
-            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)"],
-            "data_source": ["train", "test", "train", "test"],
-            "average": [None] * 4,
-            "output": [None] * 4,
-        }
+    estimator, X, y = forest_binary_classification_data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    display = report.metrics.summarize(data_source="both")
 
     result_no_fav = display.frame(favorability=False)
     assert result_no_fav.columns.to_list() == [
@@ -172,147 +138,3 @@ def test_frame_data_source_both_with_favorability():
         "RandomForestClassifier (test)",
         "Favorability",
     ]
-
-
-def test_frame_multioutput_with_flat_index():
-    """Test flat_index with multioutput regression data."""
-    data = pd.DataFrame(
-        {
-            "metric": ["r2", "r2", "r2", "rmse", "rmse", "rmse"],
-            "verbose_name": ["R²", "R²", "R²", "RMSE", "RMSE", "RMSE"],
-            "output": ["0", "1", "2", "0", "1", "2"],
-            "estimator_name": ["LinearRegression"] * 6,
-            "score": [0.85, 0.78, 0.92, 0.12, 0.18, 0.09],
-            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)", "(↘︎)", "(↘︎)", "(↘︎)"],
-            "data_source": ["test"] * 6,
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
-
-    result_multi = display.frame(favorability=False, flat_index=False)
-    assert isinstance(result_multi.index, pd.MultiIndex)
-    assert result_multi.index.names == ["Metric", "Output"]
-
-    result_flat = display.frame(favorability=False, flat_index=True)
-    assert isinstance(result_flat.index, pd.Index)
-    # Note: "R²" is lowercased
-    assert result_flat.index.to_list() == [
-        "r²_0",
-        "r²_1",
-        "r²_2",
-        "rmse_0",
-        "rmse_1",
-        "rmse_2",
-    ]
-
-
-def test_frame_multioutput_multiindex():
-    """Test that multioutput data creates proper MultiIndex."""
-    data = pd.DataFrame(
-        {
-            "metric": ["r2", "r2", "rmse", "rmse"],
-            "verbose_name": ["R²", "R²", "RMSE", "RMSE"],
-            "output": ["0", "1", "0", "1"],
-            "estimator_name": ["LinearRegression"] * 4,
-            "score": [0.85, 0.78, 0.12, 0.18],
-            "favorability": ["(↗︎)", "(↗︎)", "(↘︎)", "(↘︎)"],
-            "data_source": ["test"] * 4,
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
-    result = display.frame(favorability=False)
-
-    assert isinstance(result.index, pd.MultiIndex)
-    assert result.index.names == ["Metric", "Output"]
-    assert result.shape == (4, 1)
-    assert result.loc[("R²", "0"), "LinearRegression"] == 0.85
-    assert result.loc[("R²", "1"), "LinearRegression"] == 0.78
-
-
-def test_frame_single_data_source_dropped():
-    """Test that data_source column is dropped when there's only one source."""
-    data = pd.DataFrame(
-        {
-            "metric": ["accuracy", "precision"],
-            "verbose_name": ["Accuracy", "Precision"],
-            "estimator_name": ["LogisticRegression"] * 2,
-            "score": [0.95, 0.92],
-            "favorability": ["(↗︎)", "(↗︎)"],
-            "data_source": ["test", "test"],
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
-    result = display.frame(favorability=False)
-
-    assert "data_source" not in result.columns
-
-
-def test_frame_multiple_data_sources_pivoted():
-    """Test that multiple data sources create separate columns."""
-    data = pd.DataFrame(
-        {
-            "metric": ["accuracy", "accuracy"],
-            "verbose_name": ["Accuracy", "Accuracy"],
-            "estimator_name": ["LogisticRegression"] * 2,
-            "score": [0.98, 0.95],
-            "favorability": ["(↗︎)", "(↗︎)"],
-            "data_source": ["train", "test"],
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
-    result = display.frame(favorability=False)
-
-    assert result.columns.to_list() == [
-        "LogisticRegression (train)",
-        "LogisticRegression (test)",
-    ]
-    assert result.loc["Accuracy", "LogisticRegression (train)"] == 0.98
-    assert result.loc["Accuracy", "LogisticRegression (test)"] == 0.95
-
-
-def test_frame_empty_label_values():
-    """Test that empty label values are handled correctly."""
-    data = pd.DataFrame(
-        {
-            "metric": ["accuracy", "precision", "precision"],
-            "verbose_name": ["Accuracy", "Precision", "Precision"],
-            "label": ["", "0", "1"],
-            "estimator_name": ["RandomForestClassifier"] * 3,
-            "score": [0.95, 0.92, 0.97],
-            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)"],
-            "data_source": ["test"] * 3,
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
-    result = display.frame(favorability=False)
-
-    # Empty string labels should be preserved in the MultiIndex
-    assert isinstance(result.index, pd.MultiIndex)
-    assert ("Accuracy", "") in result.index
-    assert ("Precision", "0") in result.index
-    assert ("Precision", "1") in result.index
-
-
-def test_frame_preserves_score_values():
-    """Test that score values are preserved correctly in the output."""
-    expected_scores = [0.95, 0.92, 0.87, 0.91]
-    data = pd.DataFrame(
-        {
-            "metric": ["accuracy", "precision", "recall", "f1"],
-            "verbose_name": ["Accuracy", "Precision", "Recall", "F1"],
-            "estimator_name": ["SVC"] * 4,
-            "score": expected_scores,
-            "favorability": ["(↗︎)"] * 4,
-            "data_source": ["test"] * 4,
-        }
-    )
-
-    display = MetricsSummaryDisplay(data=data, report_type="estimator")
-    result = display.frame(favorability=False)
-
-    assert result["SVC"].tolist() == expected_scores

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -138,3 +138,30 @@ def test_data_source_both_favorability(forest_binary_classification_data):
         "RandomForestClassifier (test)",
         "Favorability",
     ]
+
+
+def test_data_source_both_flat_index(forest_binary_classification_data):
+    """Test flat_index with data_source='both' (train and test)."""
+    estimator, X, y = forest_binary_classification_data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+    display = report.metrics.summarize(data_source="both")
+
+    result = display.frame(flat_index=True)
+    assert result.columns.to_list() == [
+        "RandomForestClassifier (train)",
+        "RandomForestClassifier (test)",
+    ]
+    assert result.index.to_list() == [
+        "accuracy",
+        "precision_0",
+        "precision_1",
+        "recall_0",
+        "recall_1",
+        "roc_auc",
+        "brier_score",
+        "fit_time_s",
+        "predict_time_s",
+    ]

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -1,571 +1,318 @@
-import re
+"""Tests for MetricsSummaryDisplay.frame() method with bare DataFrames.
 
-import numpy as np
+These tests focus on testing the display/formatting logic of MetricsSummaryDisplay
+without depending on EstimatorReport or summarize().
+"""
+
 import pandas as pd
-import pytest
-from sklearn.base import clone
-from sklearn.datasets import make_classification
-from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import (
-    accuracy_score,
-    f1_score,
-    get_scorer,
-    make_scorer,
-    median_absolute_error,
-    precision_score,
-    r2_score,
-    recall_score,
-)
 
-from skore import EstimatorReport
+from skore._sklearn._plot.metrics.metrics_summary_display import MetricsSummaryDisplay
 
 
-def _normalize_metric_name(column):
-    """Helper to normalize the metric name present in a pandas index that could be
-    a multi-index or single-index."""
-    # if we have a multi-index, then the metric name is on level 0
-    s = column[0] if isinstance(column, tuple) else column
-    # Remove spaces and underscores and (s) suffix
-    s = s.lower().replace(" (s)", "")
-    return re.sub(r"[^a-zA-Z]", "", s)
-
-
-def _check_results_summarize(result, expected_metrics, expected_nb_stats):
-    assert isinstance(result, pd.DataFrame)
-    assert len(result.index) == expected_nb_stats
-
-    normalized_expected = {
-        _normalize_metric_name(metric) for metric in expected_metrics
-    }
-    for column in result.index:
-        normalized_column = _normalize_metric_name(column)
-        matches = [
-            metric for metric in normalized_expected if metric == normalized_column
-        ]
-        assert len(matches) == 1, (
-            f"No match found for column '{column}' in expected metrics: "
-            f" {expected_metrics}"
-        )
-
-
-@pytest.mark.parametrize("pos_label, nb_stats", [(None, 2), (1, 1)])
-@pytest.mark.parametrize("data_source", ["test"])
-def test_binary_classification(
-    forest_binary_classification_with_test,
-    svc_binary_classification_with_test,
-    pos_label,
-    nb_stats,
-    data_source,
-):
-    """Check the behaviour of the `MetricsSummaryDisplay` method with binary
-    classification. We test both with an SVC that does not support `predict_proba` and a
-    RandomForestClassifier that does.
-    """
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(
-        pos_label=pos_label,
-        data_source=data_source,
-    ).frame()
-    assert "Favorability" not in result.columns
-    expected_metrics = (
-        "accuracy",
-        "precision",
-        "recall",
-        "roc_auc",
-        "brier_score",
-        "fit_time",
-        "predict_time",
-    )
-    # depending on `pos_label`, we report a stats for each class or not for
-    # precision and recall
-    expected_nb_stats = 2 * nb_stats + 5
-    _check_results_summarize(result, expected_metrics, expected_nb_stats)
-
-    # Repeat the same experiment where we the target labels are not [0, 1] but
-    # ["neg", "pos"]. We check that we don't get any error.
-    target_names = np.array(["neg", "pos"], dtype=object)
-    pos_label_name = target_names[pos_label] if pos_label is not None else pos_label
-    y_test = target_names[y_test]
-    estimator = clone(estimator).fit(X_test, y_test)
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(
-        pos_label=pos_label_name,
-        data_source=data_source,
-    ).frame()
-    expected_metrics = (
-        "accuracy",
-        "precision",
-        "recall",
-        "roc_auc",
-        "brier_score",
-        "fit_time",
-        "predict_time",
-    )
-    # depending on `pos_label`, we report a stats for each class or not for
-    # precision and recall
-    expected_nb_stats = 2 * nb_stats + 5
-    _check_results_summarize(result, expected_metrics, expected_nb_stats)
-
-    estimator, X_test, y_test = svc_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(
-        pos_label=pos_label,
-        data_source=data_source,
-    ).frame()
-    expected_metrics = (
-        "accuracy",
-        "precision",
-        "recall",
-        "roc_auc",
-        "fit_time",
-        "predict_time",
-    )
-    # depending on `pos_label`, we report a stats for each class or not for
-    # precision and recall
-    expected_nb_stats = 2 * nb_stats + 4
-    _check_results_summarize(result, expected_metrics, expected_nb_stats)
-
-
-@pytest.mark.parametrize("data_source", ["test"])
-def test_multiclass_classification(
-    forest_multiclass_classification_with_test,
-    svc_multiclass_classification_with_test,
-    data_source,
-):
-    """Check the behaviour of the `MetricsSummaryDisplay` method with multiclass
-    classification.
-    """
-    estimator, X_test, y_test = forest_multiclass_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(data_source=data_source).frame()
-    assert "Favorability" not in result.columns
-    expected_metrics = (
-        "accuracy",
-        "precision",
-        "recall",
-        "roc_auc",
-        "log_loss",
-        "fit_time",
-        "predict_time",
-    )
-    # since we are not averaging by default, we report 3 statistics for
-    # precision, recall and roc_auc
-    expected_nb_stats = 3 * 3 + 4
-    _check_results_summarize(result, expected_metrics, expected_nb_stats)
-
-    estimator, X_test, y_test = svc_multiclass_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(data_source=data_source).frame()
-    expected_metrics = ("accuracy", "precision", "recall", "fit_time", "predict_time")
-    # since we are not averaging by default, we report 3 statistics for
-    # precision and recall
-    expected_nb_stats = 3 * 2 + 3
-    _check_results_summarize(result, expected_metrics, expected_nb_stats)
-
-
-@pytest.mark.parametrize("data_source", ["test"])
-def test_regression(linear_regression_with_test, data_source):
-    """Check the behaviour of the `MetricsSummaryDisplay` method with regression."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(data_source=data_source).frame()
-    assert "Favorability" not in result.columns
-    expected_metrics = ("r2", "rmse", "fit_time", "predict_time")
-    _check_results_summarize(result, expected_metrics, len(expected_metrics))
-
-
-def test_metric_kwargs(
-    linear_regression_multioutput_with_test, forest_multiclass_classification_with_test
-):
-    """Check the behaviour of the `MetricsSummaryDisplay` method with metric kwargs."""
-    estimator, X_test, y_test = linear_regression_multioutput_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, "summarize")
-    result = report.metrics.summarize(
-        metric_kwargs={"multioutput": "raw_values"}
-    ).frame()
-    assert result.shape == (6, 1)
-    assert isinstance(result.index, pd.MultiIndex)
-    assert result.index.names == ["Metric", "Output"]
-
-    estimator, X_test, y_test = forest_multiclass_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, "summarize")
-    result = report.metrics.summarize(metric_kwargs={"average": None}).frame()
-    assert result.shape == (13, 1)
-    assert isinstance(result.index, pd.MultiIndex)
-    assert result.index.names == ["Metric", "Label / Average"]
-
-
-@pytest.mark.parametrize(
-    "fixture_name, metric_dict, expected_columns",
-    [
-        (
-            "linear_regression_with_test",
-            {
-                "R2": "r2",
-                "RMSE": "rmse",
-                "FIT_TIME": "fit_time",
-                "PREDICT_TIME": "predict_time",
-            },
-            ["R2", "RMSE", "FIT_TIME", "PREDICT_TIME"],
-        ),
-        (
-            "forest_multiclass_classification_with_test",
-            {
-                "Accuracy": "accuracy",
-                "Precision": "precision",
-                "Recall": "recall",
-                "ROC AUC": "roc_auc",
-                "Log Loss": "log_loss",
-                "Fit Time": "fit_time",
-                "Predict Time": "predict_time",
-            },
-            [
+def test_frame_favorability_binary_classification():
+    data = pd.DataFrame(
+        {
+            "metric": [
+                "accuracy",
+                "precision",
+                "precision",
+                "recall",
+                "recall",
+                "roc_auc",
+                "brier_score",
+            ],
+            "verbose_name": [
                 "Accuracy",
                 "Precision",
                 "Precision",
-                "Precision",
-                "Recall",
                 "Recall",
                 "Recall",
                 "ROC AUC",
-                "ROC AUC",
-                "ROC AUC",
-                "Log Loss",
-                "Fit Time",
-                "Predict Time",
+                "Brier score",
             ],
-        ),
-    ],
-)
-def test_overwrite_metric_names_with_dict(
-    request, fixture_name, metric_dict, expected_columns
-):
-    """Test that we can overwrite the metric names using dict metric."""
-    estimator, X_test, y_test = request.getfixturevalue(fixture_name)
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(metric=metric_dict).frame()
-    assert result.shape == (len(expected_columns), 1)
-
-    # Get level 0 names if MultiIndex, otherwise get column names
-    result_index = (
-        result.index.get_level_values(0).tolist()
-        if isinstance(result.index, pd.MultiIndex)
-        else result.index.tolist()
-    )
-    assert result_index == expected_columns
-
-
-def test_favorability(
-    forest_binary_classification_with_test,
-):
-    """Check that the behaviour of `favorability` is correct."""
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize().frame(favorability=True)
-    assert "Favorability" in result.columns
-    favorability = result["Favorability"]
-    assert favorability["Accuracy"].tolist() == ["(↗︎)"]
-    assert favorability["Precision"].tolist() == ["(↗︎)", "(↗︎)"]
-    assert favorability["Recall"].tolist() == ["(↗︎)", "(↗︎)"]
-    assert favorability["ROC AUC"].tolist() == ["(↗︎)"]
-    assert favorability["Brier score"].tolist() == ["(↘︎)"]
-
-
-@pytest.mark.parametrize(
-    "metric, metric_kwargs",
-    [
-        ("accuracy", None),
-        ("neg_log_loss", None),
-        (accuracy_score, {"response_method": "predict"}),
-        (get_scorer("accuracy"), None),
-    ],
-)
-def test_metric_single_list_equivalence(
-    forest_binary_classification_with_test, metric, metric_kwargs
-):
-    """Check that passing a single string, callable, scorer is equivalent to passing a
-    list with a single element."""
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result_single = report.metrics.summarize(
-        metric=metric, metric_kwargs=metric_kwargs
-    ).frame()
-    result_list = report.metrics.summarize(
-        metric=[metric], metric_kwargs=metric_kwargs
-    ).frame()
-    assert result_single.equals(result_list)
-
-
-def test_metric_custom_metric(linear_regression_with_test):
-    """Check that we can pass a custom metric with specific kwargs into
-    `MetricsSummaryDisplay`."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    weights = np.ones_like(y_test) * 2
-
-    def custom_metric(y_true, y_pred, some_weights):
-        return np.mean((y_true - y_pred) * some_weights)
-
-    result = report.metrics.summarize(
-        metric=["r2", custom_metric],
-        metric_kwargs={"some_weights": weights, "response_method": "predict"},
-    ).frame()
-    assert result.shape == (2, 1)
-    np.testing.assert_allclose(
-        result.to_numpy(),
-        [
-            [r2_score(y_test, estimator.predict(X_test))],
-            [custom_metric(y_test, estimator.predict(X_test), weights)],
-        ],
+            "label": ["", "0", "1", "0", "1", "", ""],
+            "estimator_name": ["RandomForestClassifier"] * 7,
+            "score": [0.95, 0.92, 0.97, 0.89, 0.98, 0.96, 0.08],
+            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)", "(↘︎)"],
+            "data_source": ["test"] * 7,
+            "average": [None] * 7,
+            "output": [None] * 7,
+        }
     )
 
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
 
-def test_scorer(linear_regression_with_test):
-    """Check that we can pass scikit-learn scorer with different parameters to
-    the `MetricsSummaryDisplay` method."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    weights = np.ones_like(y_test) * 2
+    result_no_fav = display.frame(favorability=False)
+    assert result_no_fav.columns.to_list() == ["RandomForestClassifier"]
 
-    def custom_metric(y_true, y_pred, some_weights):
-        return np.mean((y_true - y_pred) * some_weights)
+    result_with_fav = display.frame(favorability=True)
+    assert result_with_fav.columns.to_list() == [
+        "RandomForestClassifier",
+        "Favorability",
+    ]
+    assert set(result_with_fav["Favorability"]) == {"(↗︎)", "(↘︎)"}
 
-    median_absolute_error_scorer = make_scorer(
-        median_absolute_error, response_method="predict"
-    )
-    custom_metric_scorer = make_scorer(
-        custom_metric, response_method="predict", some_weights=weights
-    )
-    result = report.metrics.summarize(
-        metric=[r2_score, median_absolute_error_scorer, custom_metric_scorer],
-        metric_kwargs={"response_method": "predict"},  # only dispatched to r2_score
-    ).frame()
-    assert result.shape == (3, 1)
-    np.testing.assert_allclose(
-        result.to_numpy(),
-        [
-            [r2_score(y_test, estimator.predict(X_test))],
-            [median_absolute_error(y_test, estimator.predict(X_test))],
-            [custom_metric(y_test, estimator.predict(X_test), weights)],
-        ],
+
+def test_frame_favorability_regression():
+    """Test that favorability column is correctly displayed for regression metrics."""
+    data = pd.DataFrame(
+        {
+            "metric": ["r2", "rmse"],
+            "verbose_name": ["R²", "RMSE"],
+            "estimator_name": ["LinearRegression", "LinearRegression"],
+            "score": [0.85, 0.15],
+            "favorability": ["(↗︎)", "(↘︎)"],
+            "data_source": ["test", "test"],
+            "average": [None] * 2,
+            "output": [None] * 2,
+        }
     )
 
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
 
-@pytest.mark.parametrize(
-    "scorer, pos_label",
-    [
-        (
-            make_scorer(
-                f1_score, response_method="predict", average="macro", pos_label=1
-            ),
-            1,
-        ),
-        (
-            make_scorer(
-                f1_score, response_method="predict", average="macro", pos_label=1
-            ),
-            None,
-        ),
-        (make_scorer(f1_score, response_method="predict", average="macro"), 1),
-    ],
-)
-def test_scorer_binary_classification(
-    forest_binary_classification_with_test, scorer, pos_label
-):
-    """Check that we can pass scikit-learn scorer with different parameters to
-    the `MetricsSummaryDisplay` method.
+    result_no_fav = display.frame(favorability=False)
+    assert result_no_fav.columns.to_list() == ["LinearRegression"]
 
-    We also check that we can pass `pos_label` whether to the scorer or to the
-    `MetricsSummaryDisplay` method or consistently to both.
-    """
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    result_with_fav = display.frame(favorability=True)
+    assert result_with_fav.columns.to_list() == ["LinearRegression", "Favorability"]
+    assert set(result_with_fav["Favorability"]) == {"(↗︎)", "(↘︎)"}
 
-    result = report.metrics.summarize(
-        metric=["accuracy", accuracy_score, scorer],
-        metric_kwargs={"response_method": "predict"},
-    ).frame()
-    assert result.shape == (3, 1)
-    np.testing.assert_allclose(
-        result.to_numpy(),
-        [
-            [accuracy_score(y_test, estimator.predict(X_test))],
-            [accuracy_score(y_test, estimator.predict(X_test))],
-            [
-                f1_score(
-                    y_test,
-                    estimator.predict(X_test),
-                    average="macro",
-                    pos_label=pos_label,
-                )
-            ],
-        ],
+
+def test_frame_flat_index_multiclass():
+    """Test flat_index parameter with multiclass classification data."""
+    data = pd.DataFrame(
+        {
+            "metric": ["precision"] * 3 + ["recall"] * 3,
+            "verbose_name": ["Precision"] * 3 + ["Recall"] * 3,
+            "label": ["0", "1", "2"] * 2,
+            "estimator_name": ["RandomForestClassifier"] * 6,
+            "score": [0.92, 0.87, 0.91, 0.88, 0.85, 0.90],
+            "favorability": ["(↗︎)"] * 6,
+            "data_source": ["test"] * 6,
+            "average": [None] * 6,
+            "output": [None] * 6,
+        }
     )
 
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
 
-def test_scorer_pos_label_error(
-    forest_binary_classification_with_test,
-):
-    """Check that we raise an error when pos_label is passed both in the scorer and
-    globally conducting to a mismatch."""
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    result_multi = display.frame(favorability=False, flat_index=False)
+    assert isinstance(result_multi.index, pd.MultiIndex)
+    assert result_multi.index.names == ["Metric", "Label / Average"]
 
-    f1_scorer = make_scorer(
-        f1_score, response_method="predict", average="macro", pos_label=1
-    )
-    err_msg = re.escape(
-        "`pos_label` is passed both in the scorer and to the `summarize` method."
-    )
-    with pytest.raises(ValueError, match=err_msg):
-        report.metrics.summarize(metric=[f1_scorer], pos_label=0).frame()
-
-
-def test_invalid_metric_type(linear_regression_with_test):
-    """Check that we raise the expected error message if an invalid metric is passed."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-
-    err_msg = re.escape("Invalid type of metric: <class 'int'> for 1")
-    with pytest.raises(ValueError, match=err_msg):
-        report.metrics.summarize(metric=[1]).frame()
+    result_flat = display.frame(favorability=False, flat_index=True)
+    assert isinstance(result_flat.index, pd.Index)
+    assert result_flat.index.to_list() == [
+        "precision_0",
+        "precision_1",
+        "precision_2",
+        "recall_0",
+        "recall_1",
+        "recall_2",
+    ]
 
 
-def test_neg_metric_strings(forest_binary_classification_with_test):
-    """Check that scikit-learn metrics with 'neg_' prefix are handled correctly."""
-    classifier, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
-
-    result = report.metrics.summarize(metric=["neg_log_loss"]).frame()
-    assert "Log Loss" in result.index
-    assert result.loc["Log Loss", "RandomForestClassifier"] == pytest.approx(
-        report.metrics.log_loss()
+def test_frame_flat_index_with_favorability():
+    """Test that flat_index and favorability work together."""
+    data = pd.DataFrame(
+        {
+            "metric": ["precision", "precision", "recall", "recall"],
+            "verbose_name": ["Precision", "Precision", "Recall", "Recall"],
+            "label": ["0", "1", "0", "1"],
+            "estimator_name": ["LogisticRegression"] * 4,
+            "score": [0.85, 0.90, 0.88, 0.92],
+            "favorability": ["(↗︎)"] * 4,
+            "data_source": ["test"] * 4,
+            "average": [None] * 4,
+            "output": [None] * 4,
+        }
     )
 
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
 
-def test_sklearn_metric_strings(forest_binary_classification_with_test):
-    """Check that scikit-learn metric strings can be passed to summarize."""
-    classifier, X_test, y_test = forest_binary_classification_with_test
-    class_report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
+    result = display.frame(favorability=True, flat_index=True)
+    assert result.columns.to_list() == ["LogisticRegression", "Favorability"]
 
-    result = class_report.metrics.summarize(metric=["neg_log_loss"]).frame()
-    assert "Log Loss" in result.index.get_level_values(0)
-
-    result_multi = class_report.metrics.summarize(
-        metric=["accuracy", "neg_log_loss", "roc_auc"]
-    ).frame(favorability=True)
-    assert "Accuracy" in result_multi.index.get_level_values(0)
-    assert "Log Loss" in result_multi.index.get_level_values(0)
-    assert "ROC AUC" in result_multi.index.get_level_values(0)
-
-    favorability = result_multi.loc["Accuracy"]["Favorability"]
-    assert favorability == "(↗︎)"
-    favorability = result_multi.loc["Log Loss"]["Favorability"]
-    assert favorability == "(↘︎)"
+    assert isinstance(result.index, pd.Index)
+    assert result.index.to_list() == [
+        "precision_0",
+        "precision_1",
+        "recall_0",
+        "recall_1",
+    ]
 
 
-def test_sklearn_metric_strings_regression(
-    linear_regression_with_test,
-):
-    """Test scikit-learn regression metric strings in `MetricsSummaryDisplay`."""
-    regressor, X_test, y_test = linear_regression_with_test
-    reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
-
-    reg_result = reg_report.metrics.summarize(
-        metric=["neg_mean_squared_error", "neg_mean_absolute_error", "r2"],
-    ).frame(favorability=True)
-
-    assert "Mean Squared Error" in reg_result.index.get_level_values(0)
-    assert "Mean Absolute Error" in reg_result.index.get_level_values(0)
-    assert "R²" in reg_result.index.get_level_values(0)
-
-    assert reg_result.loc["Mean Squared Error"]["Favorability"] == "(↘︎)"
-    assert reg_result.loc["R²"]["Favorability"] == "(↗︎)"
-
-
-def test_metric_strings_regression(linear_regression_with_test):
-    """Test skore regression metric strings in `MetricsSummaryDisplay`."""
-    regressor, X_test, y_test = linear_regression_with_test
-    reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
-
-    reg_result = reg_report.metrics.summarize(
-        metric=["rmse", "r2"],
-    ).frame(favorability=True)
-
-    assert "RMSE" in reg_result.index.get_level_values(0)
-    assert "R²" in reg_result.index.get_level_values(0)
-
-    assert reg_result.loc["RMSE"]["Favorability"] == "(↘︎)"
-    assert reg_result.loc["R²"]["Favorability"] == "(↗︎)"
-
-
-def test_scorer_names_pos_label(
-    forest_binary_classification_with_test,
-):
-    """Check that `pos_label` is dispatched with scikit-learn scorer names."""
-    classifier, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
-
-    result = report.metrics.summarize(metric=["f1"], pos_label=0).frame()
-    assert result.index[0] == ("F1 Score", 0)
-
-    f1_scorer = make_scorer(
-        f1_score, response_method="predict", average="binary", pos_label=0
-    )
-    assert result.loc[("F1 Score", 0), "RandomForestClassifier"] == pytest.approx(
-        f1_scorer(classifier, X_test, y_test)
+def test_frame_data_source_both_with_favorability():
+    """Test favorability with data_source='both' (train and test)."""
+    data = pd.DataFrame(
+        {
+            "metric": ["accuracy", "accuracy", "roc_auc", "roc_auc"],
+            "verbose_name": ["Accuracy", "Accuracy", "ROC AUC", "ROC AUC"],
+            "label": [None] * 4,
+            "estimator_name": ["RandomForestClassifier"] * 4,
+            "score": [0.98, 0.95, 0.99, 0.96],
+            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)", "(↗︎)"],
+            "data_source": ["train", "test", "train", "test"],
+            "average": [None] * 4,
+            "output": [None] * 4,
+        }
     )
 
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
 
-def test_sklearn_scorer_names_metric_kwargs(
-    forest_binary_classification_with_test,
-):
-    """Check that `metric_kwargs` is not supported when `metric` is a scikit-learn
-    scorer name.
-    """
-    classifier, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
+    result_no_fav = display.frame(favorability=False)
+    assert result_no_fav.columns.to_list() == [
+        "RandomForestClassifier (train)",
+        "RandomForestClassifier (test)",
+    ]
 
-    err_msg = (
-        "The `metric_kwargs` parameter is not supported when `metric` is a "
-        "scikit-learn scorer name."
-    )
-    with pytest.raises(ValueError, match=err_msg):
-        report.metrics.summarize(
-            metric=["f1"], metric_kwargs={"average": "macro"}
-        ).frame()
+    result_with_fav = display.frame(favorability=True)
+    assert result_with_fav.columns.to_list() == [
+        "RandomForestClassifier (train)",
+        "RandomForestClassifier (test)",
+        "Favorability",
+    ]
 
 
-@pytest.mark.parametrize(
-    "metric, metric_fn", [("precision", precision_score), ("recall", recall_score)]
-)
-def test_pos_label_overwrite(metric, metric_fn):
-    """Check that `pos_label` can be overwritten in `summarize`"""
-    X, y = make_classification(
-        n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
-    )
-    labels = np.array(["A", "B"], dtype=object)
-    y = labels[y]
-    classifier = LogisticRegression().fit(X, y)
-
-    report = EstimatorReport(classifier, X_test=X, y_test=y)
-    result = report.metrics.summarize(metric=metric).frame().reset_index()
-    assert result["Label / Average"].to_list() == ["A", "B"]
-
-    report = EstimatorReport(classifier, X_test=X, y_test=y, pos_label="B")
-    result = report.metrics.summarize(metric=metric).frame().reset_index()
-    assert "Label / Average" not in result.columns
-    assert result[report.estimator_name_].item() == pytest.approx(
-        metric_fn(y, classifier.predict(X), pos_label="B")
+def test_frame_multioutput_with_flat_index():
+    """Test flat_index with multioutput regression data."""
+    data = pd.DataFrame(
+        {
+            "metric": ["r2", "r2", "r2", "rmse", "rmse", "rmse"],
+            "verbose_name": ["R²", "R²", "R²", "RMSE", "RMSE", "RMSE"],
+            "output": ["0", "1", "2", "0", "1", "2"],
+            "estimator_name": ["LinearRegression"] * 6,
+            "score": [0.85, 0.78, 0.92, 0.12, 0.18, 0.09],
+            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)", "(↘︎)", "(↘︎)", "(↘︎)"],
+            "data_source": ["test"] * 6,
+        }
     )
 
-    result = (
-        report.metrics.summarize(metric=metric, pos_label="A").frame().reset_index()
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+
+    result_multi = display.frame(favorability=False, flat_index=False)
+    assert isinstance(result_multi.index, pd.MultiIndex)
+    assert result_multi.index.names == ["Metric", "Output"]
+
+    result_flat = display.frame(favorability=False, flat_index=True)
+    assert isinstance(result_flat.index, pd.Index)
+    # Note: "R²" is lowercased
+    assert result_flat.index.to_list() == [
+        "r²_0",
+        "r²_1",
+        "r²_2",
+        "rmse_0",
+        "rmse_1",
+        "rmse_2",
+    ]
+
+
+def test_frame_multioutput_multiindex():
+    """Test that multioutput data creates proper MultiIndex."""
+    data = pd.DataFrame(
+        {
+            "metric": ["r2", "r2", "rmse", "rmse"],
+            "verbose_name": ["R²", "R²", "RMSE", "RMSE"],
+            "output": ["0", "1", "0", "1"],
+            "estimator_name": ["LinearRegression"] * 4,
+            "score": [0.85, 0.78, 0.12, 0.18],
+            "favorability": ["(↗︎)", "(↗︎)", "(↘︎)", "(↘︎)"],
+            "data_source": ["test"] * 4,
+        }
     )
-    assert "Label / Average" not in result.columns
-    assert result[report.estimator_name_].item() == pytest.approx(
-        metric_fn(y, classifier.predict(X), pos_label="A")
+
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    result = display.frame(favorability=False)
+
+    assert isinstance(result.index, pd.MultiIndex)
+    assert result.index.names == ["Metric", "Output"]
+    assert result.shape == (4, 1)
+    assert result.loc[("R²", "0"), "LinearRegression"] == 0.85
+    assert result.loc[("R²", "1"), "LinearRegression"] == 0.78
+
+
+def test_frame_single_data_source_dropped():
+    """Test that data_source column is dropped when there's only one source."""
+    data = pd.DataFrame(
+        {
+            "metric": ["accuracy", "precision"],
+            "verbose_name": ["Accuracy", "Precision"],
+            "estimator_name": ["LogisticRegression"] * 2,
+            "score": [0.95, 0.92],
+            "favorability": ["(↗︎)", "(↗︎)"],
+            "data_source": ["test", "test"],
+        }
     )
+
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    result = display.frame(favorability=False)
+
+    assert "data_source" not in result.columns
+
+
+def test_frame_multiple_data_sources_pivoted():
+    """Test that multiple data sources create separate columns."""
+    data = pd.DataFrame(
+        {
+            "metric": ["accuracy", "accuracy"],
+            "verbose_name": ["Accuracy", "Accuracy"],
+            "estimator_name": ["LogisticRegression"] * 2,
+            "score": [0.98, 0.95],
+            "favorability": ["(↗︎)", "(↗︎)"],
+            "data_source": ["train", "test"],
+        }
+    )
+
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    result = display.frame(favorability=False)
+
+    assert result.columns.to_list() == [
+        "LogisticRegression (train)",
+        "LogisticRegression (test)",
+    ]
+    assert result.loc["Accuracy", "LogisticRegression (train)"] == 0.98
+    assert result.loc["Accuracy", "LogisticRegression (test)"] == 0.95
+
+
+def test_frame_empty_label_values():
+    """Test that empty label values are handled correctly."""
+    data = pd.DataFrame(
+        {
+            "metric": ["accuracy", "precision", "precision"],
+            "verbose_name": ["Accuracy", "Precision", "Precision"],
+            "label": ["", "0", "1"],
+            "estimator_name": ["RandomForestClassifier"] * 3,
+            "score": [0.95, 0.92, 0.97],
+            "favorability": ["(↗︎)", "(↗︎)", "(↗︎)"],
+            "data_source": ["test"] * 3,
+        }
+    )
+
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    result = display.frame(favorability=False)
+
+    # Empty string labels should be preserved in the MultiIndex
+    assert isinstance(result.index, pd.MultiIndex)
+    assert ("Accuracy", "") in result.index
+    assert ("Precision", "0") in result.index
+    assert ("Precision", "1") in result.index
+
+
+def test_frame_preserves_score_values():
+    """Test that score values are preserved correctly in the output."""
+    expected_scores = [0.95, 0.92, 0.87, 0.91]
+    data = pd.DataFrame(
+        {
+            "metric": ["accuracy", "precision", "recall", "f1"],
+            "verbose_name": ["Accuracy", "Precision", "Recall", "F1"],
+            "estimator_name": ["SVC"] * 4,
+            "score": expected_scores,
+            "favorability": ["(↗︎)"] * 4,
+            "data_source": ["test"] * 4,
+        }
+    )
+
+    display = MetricsSummaryDisplay(data=data, report_type="estimator")
+    result = display.frame(favorability=False)
+
+    assert result["SVC"].tolist() == expected_scores

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -264,7 +264,7 @@ def test_favorability(
     """Check that the behaviour of `favorability` is correct."""
     estimator, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(favorability=True).frame()
+    result = report.metrics.summarize().frame(favorability=True)
     assert "Favorability" in result.columns
     favorability = result["Favorability"]
     assert favorability["Accuracy"].tolist() == ["(↗︎)"]
@@ -455,8 +455,8 @@ def test_sklearn_metric_strings(forest_binary_classification_with_test):
     assert "Log Loss" in result.index.get_level_values(0)
 
     result_multi = class_report.metrics.summarize(
-        metric=["accuracy", "neg_log_loss", "roc_auc"], favorability=True
-    ).frame()
+        metric=["accuracy", "neg_log_loss", "roc_auc"]
+    ).frame(favorability=True)
     assert "Accuracy" in result_multi.index.get_level_values(0)
     assert "Log Loss" in result_multi.index.get_level_values(0)
     assert "ROC AUC" in result_multi.index.get_level_values(0)
@@ -476,8 +476,7 @@ def test_sklearn_metric_strings_regression(
 
     reg_result = reg_report.metrics.summarize(
         metric=["neg_mean_squared_error", "neg_mean_absolute_error", "r2"],
-        favorability=True,
-    ).frame()
+    ).frame(favorability=True)
 
     assert "Mean Squared Error" in reg_result.index.get_level_values(0)
     assert "Mean Absolute Error" in reg_result.index.get_level_values(0)
@@ -493,8 +492,8 @@ def test_metric_strings_regression(linear_regression_with_test):
     reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
 
     reg_result = reg_report.metrics.summarize(
-        metric=["rmse", "r2"], favorability=True
-    ).frame()
+        metric=["rmse", "r2"],
+    ).frame(favorability=True)
 
     assert "RMSE" in reg_result.index.get_level_values(0)
     assert "R²" in reg_result.index.get_level_values(0)
@@ -511,8 +510,8 @@ def test_scorer_names_pos_label(
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
 
     result = report.metrics.summarize(metric=["f1"], pos_label=0).frame()
-    assert "F1 Score" in result.index.get_level_values(0)
-    assert 0 in result.index.get_level_values(1)
+    assert result.index[0] == ("F1 Score", 0)
+
     f1_scorer = make_scorer(
         f1_score, response_method="predict", average="binary", pos_label=0
     )

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -240,10 +240,10 @@ def test_metric_kwargs(
         ),
     ],
 )
-def test_overwrite_scoring_names_with_dict(
+def test_overwrite_metric_names_with_dict(
     request, fixture_name, metric_dict, expected_columns
 ):
-    """Test that we can overwrite the scoring names using dict metric."""
+    """Test that we can overwrite the metric names using dict metric."""
     estimator, X_test, y_test = request.getfixturevalue(fixture_name)
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     result = report.metrics.summarize(metric=metric_dict).frame()
@@ -266,12 +266,12 @@ def test_favorability(
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     result = report.metrics.summarize(favorability=True).frame()
     assert "Favorability" in result.columns
-    indicator = result["Favorability"]
-    assert indicator["Accuracy"].tolist() == ["(↗︎)"]
-    assert indicator["Precision"].tolist() == ["(↗︎)", "(↗︎)"]
-    assert indicator["Recall"].tolist() == ["(↗︎)", "(↗︎)"]
-    assert indicator["ROC AUC"].tolist() == ["(↗︎)"]
-    assert indicator["Brier score"].tolist() == ["(↘︎)"]
+    favorability = result["Favorability"]
+    assert favorability["Accuracy"].tolist() == ["(↗︎)"]
+    assert favorability["Precision"].tolist() == ["(↗︎)", "(↗︎)"]
+    assert favorability["Recall"].tolist() == ["(↗︎)", "(↗︎)"]
+    assert favorability["ROC AUC"].tolist() == ["(↗︎)"]
+    assert favorability["Brier score"].tolist() == ["(↘︎)"]
 
 
 @pytest.mark.parametrize(
@@ -434,9 +434,7 @@ def test_invalid_metric_type(linear_regression_with_test):
         report.metrics.summarize(metric=[1]).frame()
 
 
-def test_neg_metric_strings(
-    forest_binary_classification_with_test,
-):
+def test_neg_metric_strings(forest_binary_classification_with_test):
     """Check that scikit-learn metrics with 'neg_' prefix are handled correctly."""
     classifier, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
@@ -448,10 +446,8 @@ def test_neg_metric_strings(
     )
 
 
-def test_sklearn_scoring_strings(
-    forest_binary_classification_with_test,
-):
-    """Test that scikit-learn metric strings can be passed to summarize."""
+def test_sklearn_metric_strings(forest_binary_classification_with_test):
+    """Check that scikit-learn metric strings can be passed to summarize."""
     classifier, X_test, y_test = forest_binary_classification_with_test
     class_report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
 
@@ -471,7 +467,7 @@ def test_sklearn_scoring_strings(
     assert favorability == "(↘︎)"
 
 
-def test_sklearn_scoring_strings_regression(
+def test_sklearn_metric_strings_regression(
     linear_regression_with_test,
 ):
     """Test scikit-learn regression metric strings in `MetricsSummaryDisplay`."""

--- a/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
@@ -67,7 +67,7 @@ def case_accuracy(comparison_cross_validation_reports_binary_classification):
 @pytest.fixture
 def case_precision(comparison_cross_validation_reports_binary_classification):
     expected_index = pd.MultiIndex.from_tuples(
-        [("Precision", 0), ("Precision", 1)], names=["Metric", "Label / Average"]
+        [("Precision", "0"), ("Precision", "1")], names=["Metric", "Label / Average"]
     )
     return (
         comparison_cross_validation_reports_binary_classification,
@@ -80,7 +80,7 @@ def case_precision(comparison_cross_validation_reports_binary_classification):
 @pytest.fixture
 def case_recall(comparison_cross_validation_reports_binary_classification):
     expected_index = pd.MultiIndex.from_tuples(
-        [("Recall", 0), ("Recall", 1)], names=["Metric", "Label / Average"]
+        [("Recall", "0"), ("Recall", "1")], names=["Metric", "Label / Average"]
     )
     return (
         comparison_cross_validation_reports_binary_classification,

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -6,7 +6,6 @@ from sklearn.base import clone
 from skore import ComparisonReport, EstimatorReport
 
 
-@pytest.mark.parametrize("data_source", ["test"])
 @pytest.mark.parametrize(
     "metric_name, expected",
     [
@@ -91,24 +90,20 @@ from skore import ComparisonReport, EstimatorReport
     ],
 )
 def test_binary_classification(
-    metric_name,
-    expected,
-    data_source,
-    comparison_estimator_reports_binary_classification,
+    metric_name, expected, comparison_estimator_reports_binary_classification
 ):
     """Check the metrics work."""
     report = comparison_estimator_reports_binary_classification
 
     # ensure metric is valid
-    result = getattr(report.metrics, metric_name)(data_source=data_source)
-    pd.testing.assert_frame_equal(result, expected)
+    result = getattr(report.metrics, metric_name)()
+    pd.testing.assert_frame_equal(result, expected, check_index_type=False)
 
     # ensure metric is valid even from the cache
-    result = getattr(report.metrics, metric_name)(data_source=data_source)
-    pd.testing.assert_frame_equal(result, expected)
+    result = getattr(report.metrics, metric_name)()
+    pd.testing.assert_frame_equal(result, expected, check_index_type=False)
 
 
-@pytest.mark.parametrize("data_source", ["test"])
 @pytest.mark.parametrize(
     "metric_name, expected",
     [
@@ -136,18 +131,16 @@ def test_binary_classification(
         ),
     ],
 )
-def test_regression(
-    metric_name, expected, data_source, comparison_estimator_reports_regression
-):
+def test_regression(metric_name, expected, comparison_estimator_reports_regression):
     """Check the metrics work."""
     comp = comparison_estimator_reports_regression
     # ensure metric is valid
     result = getattr(comp.metrics, metric_name)()
-    pd.testing.assert_frame_equal(result, expected)
+    pd.testing.assert_frame_equal(result, expected, check_index_type=False)
 
     # ensure metric is valid even from the cache
     result = getattr(comp.metrics, metric_name)()
-    pd.testing.assert_frame_equal(result, expected)
+    pd.testing.assert_frame_equal(result, expected, check_index_type=False)
 
 
 def test_timings(comparison_estimator_reports_binary_classification):

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -32,7 +32,7 @@ from skore import ComparisonReport, EstimatorReport
                     name="Estimator",
                 ),
                 index=pd.MultiIndex.from_tuples(
-                    [("Precision", 0), ("Precision", 1)],
+                    [("Precision", "0"), ("Precision", "1")],
                     names=["Metric", "Label / Average"],
                 ),
             ),
@@ -49,7 +49,7 @@ from skore import ComparisonReport, EstimatorReport
                     name="Estimator",
                 ),
                 index=pd.MultiIndex.from_tuples(
-                    [("Recall", 0), ("Recall", 1)],
+                    [("Recall", "0"), ("Recall", "1")],
                     names=["Metric", "Label / Average"],
                 ),
             ),

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -97,11 +97,11 @@ def test_binary_classification(
 
     # ensure metric is valid
     result = getattr(report.metrics, metric_name)()
-    pd.testing.assert_frame_equal(result, expected, check_index_type=False)
+    pd.testing.assert_frame_equal(result, expected)
 
     # ensure metric is valid even from the cache
     result = getattr(report.metrics, metric_name)()
-    pd.testing.assert_frame_equal(result, expected, check_index_type=False)
+    pd.testing.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -326,34 +326,6 @@ def test_custom_metric_compatible_estimator(
     assert result == pytest.approx(1)
 
 
-def test_get_X_y_error():
-    """Check that we raise the proper error in `get_X_y_and_use_cache`."""
-    X, y = make_classification(n_classes=2, random_state=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-
-    estimator = LogisticRegression().fit(X_train, y_train)
-    report = EstimatorReport(estimator)
-
-    err_msg = re.escape(
-        "Invalid data source: unknown. Possible values are: test, train."
-    )
-    with pytest.raises(ValueError, match=err_msg):
-        report.metrics.log_loss(data_source="unknown")
-
-    for data_source in ("train", "test"):
-        err_msg = re.escape(
-            f"No {data_source} data (i.e. X_{data_source} and y_{data_source}) were "
-            f"provided when creating the report. Please provide the {data_source} "
-            "data when creating the report."
-        )
-        with pytest.raises(ValueError, match=err_msg):
-            report.metrics.log_loss(data_source=data_source)
-
-    report = EstimatorReport(
-        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
-    )
-
-
 @pytest.mark.parametrize("prefit_estimator", [True, False])
 def test_has_side_effects(prefit_estimator):
     """Re-fitting the estimator outside the EstimatorReport
@@ -433,7 +405,7 @@ def test_average_return_float(forest_binary_classification_with_test):
     "metric, metric_fn", [("precision", precision_score), ("recall", recall_score)]
 )
 def test_precision_recall_pos_label_overwrite(metric, metric_fn):
-    """Check that `pos_label` can be overwritten in `summarize`"""
+    """Check that `pos_label` can be overwritten."""
     X, y = make_classification(
         n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
     )

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -1,16 +1,12 @@
-import re
 from numbers import Real
 
 import joblib
 import numpy as np
-import pandas as pd
 import pytest
-from pandas.testing import assert_series_equal
 from sklearn.base import BaseEstimator
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import (
-    get_scorer,
     make_scorer,
     precision_score,
     recall_score,
@@ -19,104 +15,6 @@ from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
 
 from skore import EstimatorReport
-
-
-@pytest.mark.parametrize("metric", ["accuracy", "brier_score", "roc_auc", "log_loss"])
-def test_summarize_binary_classification(
-    forest_binary_classification_with_test, metric
-):
-    """Check the behaviour of the metrics methods available for binary
-    classification.
-    """
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, metric)
-    result = getattr(report.metrics, metric)()
-    assert isinstance(result, float)
-    # check that we hit the cache
-    result_with_cache = getattr(report.metrics, metric)()
-    assert result == pytest.approx(result_with_cache)
-
-    # check that something was written to the cache
-    assert report._cache != {}
-    report.clear_cache()
-
-
-@pytest.mark.parametrize("metric", ["precision", "recall"])
-def test_summarize_binary_classification_pr(
-    forest_binary_classification_with_test, metric
-):
-    """Check the behaviour of the precision and recall metrics available for binary
-    classification.
-    """
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, metric)
-    result = getattr(report.metrics, metric)()
-    assert isinstance(result, dict)
-    # check that we hit the cache
-    result_with_cache = getattr(report.metrics, metric)()
-    assert result == result_with_cache
-
-    # check that something was written to the cache
-    assert report._cache != {}
-    report.clear_cache()
-
-
-@pytest.mark.parametrize("metric", ["r2", "rmse"])
-def test_summarize_regression(linear_regression_with_test, metric):
-    """Check the behaviour of the metrics methods available for regression."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, metric)
-    result = getattr(report.metrics, metric)()
-    assert isinstance(result, float)
-    # check that we hit the cache
-    result_with_cache = getattr(report.metrics, metric)()
-    assert result == pytest.approx(result_with_cache)
-
-    # check that something was written to the cache
-    assert report._cache != {}
-    report.clear_cache()
-
-
-def test_summarize_data_source_both(forest_binary_classification_data):
-    """Check the behaviour of `summarize` with `data_source="both"`."""
-    estimator, X, y = forest_binary_classification_data
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-
-    report = EstimatorReport(
-        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
-    )
-
-    result_train = report.metrics.summarize(data_source="train").frame()
-    result_test = report.metrics.summarize(data_source="test").frame()
-    result_both = report.metrics.summarize(data_source="both").frame()
-
-    assert result_both.columns.tolist() == [
-        "RandomForestClassifier (train)",
-        "RandomForestClassifier (test)",
-    ]
-    assert_series_equal(
-        result_both["RandomForestClassifier (train)"],
-        result_train["RandomForestClassifier"],
-        check_names=False,
-    )
-    assert_series_equal(
-        result_both["RandomForestClassifier (test)"],
-        result_test["RandomForestClassifier"],
-        check_names=False,
-    )
-
-    # By default,
-    result_both = report.metrics.summarize(
-        data_source="both", favorability=True
-    ).frame()
-    assert result_both.columns.tolist() == [
-        "RandomForestClassifier (train)",
-        "RandomForestClassifier (test)",
-        "Favorability",
-    ]
 
 
 def deep_contain(value, test_value):
@@ -252,16 +150,6 @@ def test_custom_metric_scorer(linear_regression_with_test):
     assert result == pytest.approx(
         custom_metric(y_test, estimator.predict(X_test), threshold)
     )
-
-
-@pytest.mark.parametrize("metric", ["public_metric", "_private_metric"])
-def test_summarize_error_metric_strings(linear_regression_with_test, metric):
-    """Check that we raise an error if a metric string is not a valid metric."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    err_msg = re.escape(f"Invalid metric: {metric!r}.")
-    with pytest.raises(ValueError, match=err_msg):
-        report.metrics.summarize(metric=[metric])
 
 
 def test_custom_function_kwargs_numpy_array(
@@ -444,50 +332,3 @@ def test_roc_multiclass_requires_predict_proba(
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
     assert hasattr(report.metrics, "roc_auc")
     report.metrics.roc_auc()
-
-
-def test_summarize_metric_dict(forest_binary_classification_with_test):
-    """Test that metric can be passed as a dictionary with custom names."""
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-
-    # Test with dictionary metric
-    metric_dict = {
-        "Custom Accuracy": "accuracy",
-        "Custom Precision": "precision",
-        "Custom R2": get_scorer("neg_mean_absolute_error"),
-    }
-
-    result = report.metrics.summarize(metric=metric_dict).frame()
-
-    # Check that custom names are used
-    assert "Custom Accuracy" in result.index
-    assert "Custom Precision" in result.index
-    assert "Custom R2" in result.index
-
-    # Verify the result structure
-    assert isinstance(result, pd.DataFrame)
-    assert len(result.index) >= 3  # At least our 3 custom metrics
-
-
-def test_summarize_metric_dict_with_callables(linear_regression_with_test):
-    """Test that metric dict works with callable functions."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-
-    def custom_metric(y_true, y_pred):
-        return np.mean(np.abs(y_true - y_pred))
-
-    metric_dict = {"R Squared": "r2", "Custom MAE": custom_metric}
-
-    result = report.metrics.summarize(
-        metric=metric_dict, metric_kwargs={"response_method": "predict"}
-    ).frame()
-
-    # Check that custom names are used
-    assert "R Squared" in result.index
-    assert "Custom MAE" in result.index
-
-    # Verify the result structure
-    assert isinstance(result, pd.DataFrame)
-    assert len(result.index) == 2

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -256,7 +256,7 @@ def test_custom_metric_scorer(linear_regression_with_test):
 
 @pytest.mark.parametrize("metric", ["public_metric", "_private_metric"])
 def test_summarize_error_metric_strings(linear_regression_with_test, metric):
-    """Check that we raise an error if a scoring string is not a valid metric."""
+    """Check that we raise an error if a metric string is not a valid metric."""
     estimator, X_test, y_test = linear_regression_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     err_msg = re.escape(f"Invalid metric: {metric!r}.")
@@ -497,11 +497,11 @@ def test_roc_multiclass_requires_predict_proba(
 
 
 def test_summarize_metric_dict(forest_binary_classification_with_test):
-    """Test that scoring can be passed as a dictionary with custom names."""
+    """Test that metric can be passed as a dictionary with custom names."""
     estimator, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
-    # Test with dictionary scoring
+    # Test with dictionary metric
     metric_dict = {
         "Custom Accuracy": "accuracy",
         "Custom Precision": "precision",
@@ -521,7 +521,7 @@ def test_summarize_metric_dict(forest_binary_classification_with_test):
 
 
 def test_summarize_metric_dict_with_callables(linear_regression_with_test):
-    """Test that scoring dict works with callable functions."""
+    """Test that metric dict works with callable functions."""
     estimator, X_test, y_test = linear_regression_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -379,28 +379,6 @@ def test_has_side_effects(prefit_estimator):
     np.testing.assert_array_equal(predictions_before, predictions_after)
 
 
-def test_has_no_deep_copy():
-    """Check that we raise a warning if the deep copy failed with a fitted
-    estimator."""
-    X, y = make_classification(n_classes=2, random_state=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-
-    estimator = LogisticRegression()
-    # Make it so deepcopy does not work
-    estimator.__reduce_ex__ = None
-    estimator.__reduce__ = None
-
-    with pytest.warns(UserWarning, match="Deepcopy failed"):
-        EstimatorReport(
-            estimator,
-            fit=False,
-            X_train=X_train,
-            X_test=X_test,
-            y_train=y_train,
-            y_test=y_test,
-        )
-
-
 @pytest.mark.parametrize("metric", ["brier_score", "log_loss"])
 def test_brier_log_loss_requires_probabilities(metric):
     """Check that the Brier score and the Log loss is not defined for estimator

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -3,73 +3,274 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_series_equal
-from sklearn.metrics import get_scorer
+from pandas.testing import assert_frame_equal, assert_series_equal
+from sklearn.base import clone
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    get_scorer,
+    make_scorer,
+    median_absolute_error,
+    precision_score,
+    r2_score,
+    recall_score,
+)
 from sklearn.model_selection import train_test_split
 
-from skore import EstimatorReport
+from skore import EstimatorReport, MetricsSummaryDisplay
+from skore._utils._testing import check_cache_changed, check_cache_unchanged
 
 
-@pytest.mark.parametrize("metric", ["public_metric", "_private_metric"])
-def test_error_metric_strings(linear_regression_with_test, metric):
-    """Check that we raise an error if a metric string is not a valid metric."""
+def check_display_structure(
+    display,
+    *,
+    expected_metrics,
+    expected_verbose_names=None,
+    expected_estimator_name=None,
+    expected_data_source="test",
+):
+    """
+    Helper function to check the structure of a MetricsSummaryDisplay.data DataFrame.
+
+    Parameters
+    ----------
+    display : MetricsSummaryDisplay
+        The display object to check.
+    expected_metrics : set, optional
+        Expected set of metric names.
+    expected_verbose_names : set, optional
+        Expected set of verbose names.
+    expected_estimator_name : str, optional
+        Expected estimator name.
+    expected_data_source : str, default="test"
+        Expected data source value.
+    """
+    assert isinstance(display.data, pd.DataFrame)
+    data = display.data
+
+    assert set(data.columns) == {
+        "metric",
+        "verbose_name",
+        "estimator_name",
+        "data_source",
+        "label",
+        "average",
+        "output",
+        "score",
+        "favorability",
+    }
+    assert set(data["metric"]) == expected_metrics
+    if expected_verbose_names is not None:
+        assert set(data["verbose_name"]) == expected_verbose_names
+    assert set(data["estimator_name"]) == {expected_estimator_name}
+    assert set(data["data_source"]) == {expected_data_source}
+    assert data["average"].isna().all()
+    assert pd.api.types.is_numeric_dtype(data["score"])
+    assert set(data["favorability"]) == {"(↗︎)", "(↘︎)"}
+
+
+# Tests for the happy path, with different ML tasks
+
+
+def test_binary_classification_forest(forest_binary_classification_with_test):
+    """
+    Check the behaviour of summarize() with binary classification using
+    RandomForestClassifier.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize()
+
+    check_display_structure(
+        display,
+        expected_metrics={
+            "accuracy",
+            "precision",
+            "recall",
+            "roc_auc",
+            "brier_score",
+            "fit_time",
+            "predict_time",
+        },
+        expected_estimator_name="RandomForestClassifier",
+    )
+
+    # Precision and recall should have 2 rows (one per class in binary classification)
+    assert len(display.data[display.data["metric"] == "precision"]) == 2
+    assert len(display.data[display.data["metric"] == "recall"]) == 2
+    # Labels should be 0 and 1 for precision
+    precision_labels = set(display.data[display.data["metric"] == "precision"]["label"])
+    assert precision_labels == {0, 1}
+
+    # Output column should be all NaN for non-multioutput
+    assert display.data["output"].isna().all()
+
+
+def test_binary_classification_forest_pos_label(forest_binary_classification_with_test):
+    """
+    Check the behaviour of summarize() with binary classification using
+    RandomForestClassifier with pos_label specified.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize(pos_label=1)
+
+    check_display_structure(
+        display,
+        expected_metrics={
+            "accuracy",
+            "precision",
+            "recall",
+            "roc_auc",
+            "brier_score",
+            "fit_time",
+            "predict_time",
+        },
+        expected_estimator_name="RandomForestClassifier",
+    )
+
+    assert len(display.data[display.data["metric"] == "precision"]) == 1
+    assert len(display.data[display.data["metric"] == "recall"]) == 1
+    # Label is None for precision/recall when pos_label is specified
+    assert display.data["label"].isna().all()
+    assert display.data["output"].isna().all()
+
+
+def test_binary_classification_svc(svc_binary_classification_with_test):
+    """
+    Check the behaviour of summarize() with binary classification using SVC
+    (no predict_proba).
+    """
+    estimator, X_test, y_test = svc_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize(pos_label=1)
+
+    assert isinstance(display.data, pd.DataFrame)
+    # No Brier score
+    check_display_structure(
+        display,
+        expected_metrics={
+            "accuracy",
+            "precision",
+            "recall",
+            "roc_auc",
+            "fit_time",
+            "predict_time",
+        },
+        expected_estimator_name="SVC",
+    )
+
+
+def test_multiclass_classification_forest(forest_multiclass_classification_with_test):
+    """
+    Check the behaviour of summarize() with multiclass classification using
+    RandomForestClassifier.
+    """
+    estimator, X_test, y_test = forest_multiclass_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize()
+
+    check_display_structure(
+        display,
+        expected_metrics={
+            "accuracy",
+            "log_loss",
+            "precision",
+            "recall",
+            "roc_auc",
+            "predict_time",
+            "fit_time",
+        },
+        expected_estimator_name="RandomForestClassifier",
+    )
+
+    assert display.data["output"].isna().all()
+    data = display.data.set_index("metric")
+    assert len(data.loc["precision"]) == 3
+    assert len(data.loc["recall"]) == 3
+    assert set(data.loc["precision", "label"]) == {0, 1, 2}
+
+
+def test_multiclass_classification_svc(svc_multiclass_classification_with_test):
+    """Check the behaviour of summarize() with multiclass classification using SVC."""
+    estimator, X_test, y_test = svc_multiclass_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize()
+
+    check_display_structure(
+        display,
+        expected_metrics={
+            "accuracy",
+            "precision",
+            "recall",
+            "fit_time",
+            "predict_time",
+        },
+        expected_estimator_name="SVC",
+    )
+
+    assert display.data["output"].isna().all()
+    data = display.data.set_index("metric")
+    assert len(data.loc["precision"]) == 3
+    assert len(data.loc["recall"]) == 3
+    assert set(data.loc["precision", "label"]) == {0, 1, 2}
+
+
+def test_regression(linear_regression_with_test):
+    """Check the behaviour of summarize() with regression."""
     estimator, X_test, y_test = linear_regression_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    err_msg = re.escape(f"Invalid metric: {metric!r}.")
-    with pytest.raises(ValueError, match=err_msg):
-        report.metrics.summarize(metric=[metric])
+    display = report.metrics.summarize()
+
+    check_display_structure(
+        display,
+        expected_metrics={"r2", "rmse", "fit_time", "predict_time"},
+        expected_verbose_names={"R²", "RMSE", "Fit time (s)", "Predict time (s)"},
+        expected_estimator_name="LinearRegression",
+    )
+
+    assert display.data["label"].isna().all()
+    assert display.data["output"].isna().all()
 
 
-@pytest.mark.parametrize("metric", ["accuracy", "brier_score", "roc_auc", "log_loss"])
-def test_binary_classification(forest_binary_classification_with_test, metric):
+def test_multioutput_regression(linear_regression_multioutput_with_test):
+    """Check the behaviour of summarize() with multioutput regression."""
+    estimator, X_test, y_test = linear_regression_multioutput_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize(metric_kwargs={"multioutput": "raw_values"})
+
+    check_display_structure(
+        display,
+        expected_metrics={"r2", "rmse", "fit_time", "predict_time"},
+        expected_verbose_names={"R²", "RMSE", "Fit time (s)", "Predict time (s)"},
+        expected_estimator_name="LinearRegression",
+    )
+
+    assert display.data["label"].isna().all()
+    data = display.data.set_index("metric")
+    assert len(data.loc["r2", "output"]) == 2
+    assert len(data.loc["rmse", "output"]) == 2
+    assert set(data.loc["r2", "output"]) == {0, 1}
+
+
+def test_cache(forest_binary_classification_with_test):
     """Check the behaviour of the metrics methods available for binary
     classification.
     """
     estimator, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, metric)
-    result = getattr(report.metrics, metric)()
-    assert isinstance(result, float)
-    # check that we hit the cache
-    result_with_cache = getattr(report.metrics, metric)()
-    assert result == pytest.approx(result_with_cache)
 
-    # check that something was written to the cache
-    assert report._cache != {}
+    with check_cache_changed(report._cache):
+        result = report.metrics.summarize()
+    assert isinstance(result, MetricsSummaryDisplay)
 
+    with check_cache_unchanged(report._cache):
+        result_from_cache = report.metrics.summarize()
+    assert_frame_equal(result.data, result_from_cache.data)
 
-@pytest.mark.parametrize("metric", ["precision", "recall"])
-def test_binary_classification_pr(forest_binary_classification_with_test, metric):
-    """Check the behaviour of the precision and recall metrics available for binary
-    classification.
-    """
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, metric)
-    result = getattr(report.metrics, metric)()
-    assert isinstance(result, dict)
-    # check that we hit the cache
-    result_with_cache = getattr(report.metrics, metric)()
-    assert result == result_with_cache
-
-    # check that something was written to the cache
-    assert report._cache != {}
-
-
-@pytest.mark.parametrize("metric", ["r2", "rmse"])
-def test_regression(linear_regression_with_test, metric):
-    """Check the behaviour of the metrics methods available for regression."""
-    estimator, X_test, y_test = linear_regression_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    assert hasattr(report.metrics, metric)
-    result = getattr(report.metrics, metric)()
-    assert isinstance(result, float)
-    # check that we hit the cache
-    result_with_cache = getattr(report.metrics, metric)()
-    assert result == pytest.approx(result_with_cache)
-
-    # check that something was written to the cache
-    assert report._cache != {}
+    report.clear_cache()
 
 
 def test_data_source_both(forest_binary_classification_data):
@@ -81,31 +282,56 @@ def test_data_source_both(forest_binary_classification_data):
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
     )
 
-    result_train = report.metrics.summarize(data_source="train").frame()
-    result_test = report.metrics.summarize(data_source="test").frame()
-    result_both = report.metrics.summarize(data_source="both").frame()
+    display_train = report.metrics.summarize(data_source="train")
+    display_test = report.metrics.summarize(data_source="test")
+    display_both = report.metrics.summarize(data_source="both")
 
-    assert result_both.columns.tolist() == [
-        "RandomForestClassifier (train)",
-        "RandomForestClassifier (test)",
-    ]
+    assert set(display_both.data["data_source"]) == {"train", "test"}
+
+    train_data = display_both.data[display_both.data["data_source"] == "train"]
     assert_series_equal(
-        result_both["RandomForestClassifier (train)"],
-        result_train["RandomForestClassifier"],
-        check_names=False,
-    )
-    assert_series_equal(
-        result_both["RandomForestClassifier (test)"],
-        result_test["RandomForestClassifier"],
-        check_names=False,
+        train_data["score"], display_train.data["score"], check_index=False
     )
 
-    result_both = report.metrics.summarize(data_source="both").frame(favorability=True)
-    assert result_both.columns.tolist() == [
-        "RandomForestClassifier (train)",
-        "RandomForestClassifier (test)",
-        "Favorability",
-    ]
+    test_data = display_both.data[display_both.data["data_source"] == "test"]
+    assert_series_equal(
+        test_data["score"], display_test.data["score"], check_index=False
+    )
+
+
+# Tests about passing `metric`
+
+
+def test_invalid_metric_type(linear_regression_with_test):
+    """Check that we raise the expected error message if an invalid metric is passed."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    err_msg = re.escape("Invalid type of metric: <class 'int'> for 1")
+    with pytest.raises(ValueError, match=err_msg):
+        report.metrics.summarize(metric=[1])
+
+
+@pytest.mark.parametrize("metric", ["public_metric", "_private_metric"])
+def test_error_metric_strings(linear_regression_with_test, metric):
+    """Check that we raise an error if a metric string is not a valid metric."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    err_msg = re.escape(f"Invalid metric: {metric!r}.")
+    with pytest.raises(ValueError, match=err_msg):
+        report.metrics.summarize(metric=[metric])
+
+
+def test_metric_strings_regression(linear_regression_with_test):
+    """Test skore regression metric strings in summarize()."""
+    regressor, X_test, y_test = linear_regression_with_test
+    reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
+
+    display = reg_report.metrics.summarize(metric=["rmse", "r2"])
+
+    assert isinstance(display.data, pd.DataFrame)
+    assert set(display.data["verbose_name"]) == {"RMSE", "R²"}
 
 
 def test_metric_dict(forest_binary_classification_with_test):
@@ -113,23 +339,18 @@ def test_metric_dict(forest_binary_classification_with_test):
     estimator, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
-    # Test with dictionary metric
     metric_dict = {
         "Custom Accuracy": "accuracy",
         "Custom Precision": "precision",
         "Custom R2": get_scorer("neg_mean_absolute_error"),
     }
 
-    result = report.metrics.summarize(metric=metric_dict).frame()
+    display = report.metrics.summarize(metric=metric_dict)
+    assert isinstance(display.data, pd.DataFrame)
 
-    # Check that custom names are used
-    assert "Custom Accuracy" in result.index
-    assert "Custom Precision" in result.index
-    assert "Custom R2" in result.index
-
-    # Verify the result structure
-    assert isinstance(result, pd.DataFrame)
-    assert len(result.index) >= 3  # At least our 3 custom metrics
+    # Precision will have 2 rows (one per class)
+    assert len(display.data) == 4
+    assert set(display.data["verbose_name"]) == set(metric_dict)
 
 
 def test_metric_dict_with_callables(linear_regression_with_test):
@@ -142,14 +363,330 @@ def test_metric_dict_with_callables(linear_regression_with_test):
 
     metric_dict = {"R Squared": "r2", "Custom MAE": custom_metric}
 
-    result = report.metrics.summarize(
+    display = report.metrics.summarize(
         metric=metric_dict, metric_kwargs={"response_method": "predict"}
-    ).frame()
+    )
+    assert isinstance(display.data, pd.DataFrame)
+    assert len(display.data) == 2
+    assert set(display.data["verbose_name"]) == set(metric_dict)
 
-    # Check that custom names are used
-    assert "R Squared" in result.index
-    assert "Custom MAE" in result.index
 
-    # Verify the result structure
-    assert isinstance(result, pd.DataFrame)
-    assert len(result.index) == 2
+def test_metric_dict_overwrite_metric_names(forest_multiclass_classification_with_test):
+    """Test that we can overwrite the metric names using dict metric."""
+    estimator, X_test, y_test = forest_multiclass_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    metric_dict = {"ROC AUC": "_roc_auc", "Fit Time": "_fit_time"}
+
+    display = report.metrics.summarize(metric=metric_dict)
+    assert isinstance(display.data, pd.DataFrame)
+    assert set(display.data["verbose_name"]) == set(metric_dict)
+
+
+@pytest.mark.parametrize(
+    "metric, metric_kwargs",
+    [
+        ("accuracy", None),
+        ("neg_log_loss", None),
+        (accuracy_score, {"response_method": "predict"}),
+        (get_scorer("accuracy"), None),
+    ],
+)
+def test_metric_single_list_equivalence(
+    forest_binary_classification_with_test, metric, metric_kwargs
+):
+    """Check that passing a single string, callable, scorer is equivalent to passing a
+    list with a single element."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display_single = report.metrics.summarize(
+        metric=metric, metric_kwargs=metric_kwargs
+    )
+    display_list = report.metrics.summarize(
+        metric=[metric], metric_kwargs=metric_kwargs
+    )
+    pd.testing.assert_frame_equal(display_single.data, display_list.data)
+
+
+def test_custom_metric(linear_regression_with_test):
+    """Check that we can pass a custom metric with specific kwargs to summarize()."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    weights = np.ones_like(y_test) * 2
+
+    def custom_metric(y_true, y_pred, some_weights):
+        return np.mean((y_true - y_pred) * some_weights)
+
+    display = report.metrics.summarize(
+        metric=["r2", custom_metric],
+        metric_kwargs={"some_weights": weights, "response_method": "predict"},
+    )
+    assert isinstance(display.data, pd.DataFrame)
+    assert set(display.data["metric"]) == {"r2", "custom_metric"}
+
+    scores = display.data.set_index("metric")["score"]
+    assert scores["r2"] == pytest.approx(r2_score(y_test, estimator.predict(X_test)))
+    assert scores["custom_metric"] == pytest.approx(
+        custom_metric(y_test, estimator.predict(X_test), weights)
+    )
+
+
+def test_scorer(linear_regression_with_test):
+    """
+    Check that we can pass scikit-learn scorer with different parameters to summarize().
+    """
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    weights = np.ones_like(y_test) * 2
+
+    def custom_metric(y_true, y_pred, some_weights):
+        return np.mean((y_true - y_pred) * some_weights)
+
+    custom_metric_scorer = make_scorer(
+        custom_metric, response_method="predict", some_weights=weights
+    )
+
+    median_absolute_error_scorer = make_scorer(
+        median_absolute_error, response_method="predict"
+    )
+
+    display = report.metrics.summarize(
+        metric=[r2_score, median_absolute_error_scorer, custom_metric_scorer],
+        metric_kwargs={"response_method": "predict"},
+    )
+    assert isinstance(display.data, pd.DataFrame)
+    assert len(display.data) == 3
+
+    scores = display.data["score"].values
+    expected_scores = [
+        r2_score(y_test, estimator.predict(X_test)),
+        median_absolute_error(y_test, estimator.predict(X_test)),
+        custom_metric(y_test, estimator.predict(X_test), weights),
+    ]
+    np.testing.assert_allclose(scores, expected_scores)
+
+
+@pytest.mark.parametrize(
+    "scorer, pos_label",
+    [
+        (
+            make_scorer(
+                f1_score, response_method="predict", average="macro", pos_label=1
+            ),
+            1,
+        ),
+        (
+            make_scorer(
+                f1_score, response_method="predict", average="macro", pos_label=1
+            ),
+            None,
+        ),
+        (make_scorer(f1_score, response_method="predict", average="macro"), 1),
+    ],
+)
+def test_scorer_binary_classification(
+    forest_binary_classification_with_test, scorer, pos_label
+):
+    """Check that we can pass scikit-learn scorer with different parameters to
+    summarize()."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    display = report.metrics.summarize(
+        metric=["accuracy", accuracy_score, scorer],
+        metric_kwargs={"response_method": "predict"},
+    )
+    assert isinstance(display.data, pd.DataFrame)
+    assert len(display.data) == 3
+
+    expected_scores = [
+        accuracy_score(y_test, estimator.predict(X_test)),
+        accuracy_score(y_test, estimator.predict(X_test)),
+        f1_score(
+            y_test, estimator.predict(X_test), average="macro", pos_label=pos_label
+        ),
+    ]
+    np.testing.assert_allclose(display.data["score"].values, expected_scores)
+
+
+def test_neg_metric_strings(forest_binary_classification_with_test):
+    """Check that scikit-learn metrics with 'neg_' prefix are handled correctly."""
+    classifier, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
+
+    display = report.metrics.summarize(metric=["neg_log_loss"])
+    assert isinstance(display.data, pd.DataFrame)
+
+    # Note: neg_log_loss was converted to log_loss
+    assert "log_loss" in set(display.data["metric"])
+    assert "Log Loss" in set(display.data["verbose_name"])
+
+    score = display.data.set_index("metric").loc["log_loss", "score"]
+    assert score == pytest.approx(report.metrics.log_loss())
+
+
+def test_sklearn_metric_strings(forest_binary_classification_with_test):
+    """Check that multiple scikit-learn metric strings can be passed to summarize."""
+    classifier, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
+
+    display = report.metrics.summarize(metric=["accuracy", "log_loss", "roc_auc"])
+    assert set(display.data["metric"]) == {"accuracy", "log_loss", "roc_auc"}
+    assert set(display.data["verbose_name"]) == {"Accuracy", "Log loss", "ROC AUC"}
+
+
+def test_sklearn_metric_strings_regression(
+    linear_regression_with_test,
+):
+    """Test scikit-learn regression metric strings in summarize()."""
+    regressor, X_test, y_test = linear_regression_with_test
+    reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
+
+    display = reg_report.metrics.summarize(
+        metric=["neg_mean_squared_error", "neg_mean_absolute_error", "r2"],
+    )
+
+    assert isinstance(display.data, pd.DataFrame)
+    assert set(display.data["verbose_name"]) == {
+        "Mean Squared Error",
+        "Mean Absolute Error",
+        "R²",
+    }
+
+
+# Tests about passing `metric_kwargs`
+
+
+def test_metric_kwargs_average(forest_multiclass_classification_with_test):
+    """Check the behaviour of summarize() when `average` is passed in metric_kwargs."""
+    estimator, X_test, y_test = forest_multiclass_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize(metric_kwargs={"average": None})
+
+    assert isinstance(display.data, pd.DataFrame)
+    assert len(display.data) > 4
+
+
+def test_metric_kwargs_multioutput(linear_regression_multioutput_with_test):
+    """Check the behaviour of summarize() when `multioutput` is passed in
+    metric_kwargs."""
+    estimator, X_test, y_test = linear_regression_multioutput_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    assert hasattr(report.metrics, "summarize")
+    display = report.metrics.summarize(metric_kwargs={"multioutput": "raw_values"})
+
+    assert isinstance(display.data, pd.DataFrame)
+    assert "output" in display.data.columns
+    assert len(display.data[display.data["metric"] == "r2"]) >= 2
+
+
+def test_sklearn_scorer_names_metric_kwargs(forest_binary_classification_with_test):
+    """Check that `metric_kwargs` is not supported when `metric` is a scikit-learn
+    scorer name.
+    """
+    classifier, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
+
+    err_msg = (
+        "The `metric_kwargs` parameter is not supported when `metric` is a "
+        "scikit-learn scorer name."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        report.metrics.summarize(metric=["f1"], metric_kwargs={"average": "macro"})
+
+
+# Tests about passing `pos_label`
+
+
+def test_pos_label_scorer_error(forest_binary_classification_with_test):
+    """Check that we raise an error when pos_label is passed both in the scorer and
+    in summarize()."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    f1_scorer = make_scorer(
+        f1_score, response_method="predict", average="macro", pos_label=1
+    )
+    err_msg = re.escape(
+        "`pos_label` is passed both in the scorer and to the `summarize` method."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        report.metrics.summarize(metric=[f1_scorer], pos_label=0)
+
+
+@pytest.mark.parametrize("pos_label", [None, 1])
+def test_pos_label_strings(forest_binary_classification_with_test, pos_label):
+    """
+    Check the behaviour of summarize() with binary classification using string labels.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+
+    target_names = np.array(["neg", "pos"], dtype=object)
+    pos_label_string = target_names[pos_label] if pos_label is not None else pos_label
+    y_test = target_names[y_test]
+
+    estimator = clone(estimator).fit(X_test, y_test)
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    display = report.metrics.summarize(pos_label=pos_label_string)
+    assert isinstance(display.data, pd.DataFrame)
+    assert set(display.data["metric"]) == {
+        "accuracy",
+        "precision",
+        "recall",
+        "roc_auc",
+        "brier_score",
+        "fit_time",
+        "predict_time",
+    }
+
+
+def test_pos_label_scorer_names(
+    forest_binary_classification_with_test,
+):
+    """Check that `pos_label` is dispatched with scikit-learn scorer names."""
+    classifier, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
+
+    display = report.metrics.summarize(metric=["f1"], pos_label=0)
+    assert isinstance(display.data, pd.DataFrame)
+    assert set(display.data["label"]) == {0}
+
+    f1_scorer = make_scorer(
+        f1_score, response_method="predict", average="binary", pos_label=0
+    )
+    score = display.data["score"].to_list()[0]
+    assert score == pytest.approx(f1_scorer(classifier, X_test, y_test))
+
+
+@pytest.mark.parametrize(
+    "metric, metric_fn", [("precision", precision_score), ("recall", recall_score)]
+)
+def test_pos_label_overwrite(metric, metric_fn):
+    """Check that `pos_label` can be overwritten in `summarize`"""
+    X, y = make_classification(
+        n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
+    )
+    labels = np.array(["A", "B"], dtype=object)
+    y = labels[y]
+    classifier = LogisticRegression().fit(X, y)
+
+    # Test without pos_label - should have multiple rows (one per class)
+    report = EstimatorReport(classifier, X_test=X, y_test=y)
+    display = report.metrics.summarize(metric=metric)
+    assert isinstance(display.data, pd.DataFrame)
+    assert len(display.data) == 2  # One row per class
+    assert set(display.data["label"]) == {"A", "B"}
+
+    # Test with pos_label="B" - should have single row
+    report = EstimatorReport(classifier, X_test=X, y_test=y, pos_label="B")
+    display = report.metrics.summarize(metric=metric)
+    assert len(display.data) == 1
+    score_B = display.data["score"].values[0]
+    assert score_B == pytest.approx(metric_fn(y, classifier.predict(X), pos_label="B"))
+
+    # Test with pos_label="A" override - should have single row
+    display = report.metrics.summarize(metric=metric, pos_label="A")
+    assert len(display.data) == 1
+    score_A = display.data["score"].values[0]
+    assert score_A == pytest.approx(metric_fn(y, classifier.predict(X), pos_label="A"))

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -431,6 +431,38 @@ def test_custom_metric(linear_regression_with_test):
     )
 
 
+def test_custom_metric_average_none(forest_binary_classification_with_test):
+    """
+    Test binary classification with custom metric returning single value and
+    average is None.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    def custom_f1(y_true, y_pred, average=None):
+        return f1_score(y_true, y_pred, average="binary")
+
+    display = report.metrics.summarize(
+        metric=custom_f1, response_method="predict", metric_kwargs={"average": None}
+    )
+
+    assert len(display.data) == 1
+    assert display.data["average"].isna().all()
+    assert display.data["label"].isna().all()
+
+
+def test_custom_metric_no_response_method(forest_binary_classification_with_test):
+    """Test that ValueError is raised when callable metric lacks response_method."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    def custom_metric(y_true, y_pred):
+        return 0.5
+
+    with pytest.raises(ValueError, match="response_method is required"):
+        report.metrics.summarize(metric=custom_metric)
+
+
 def test_scorer(linear_regression_with_test):
     """
     Check that we can pass scikit-learn scorer with different parameters to summarize().
@@ -509,6 +541,21 @@ def test_scorer_binary_classification(
     np.testing.assert_allclose(display.data["score"].values, expected_scores)
 
 
+def test_scorer_with_average(
+    forest_multiclass_classification_with_test,
+):
+    """Test multiclass classification with average parameter."""
+    estimator, X_test, y_test = forest_multiclass_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    scorer = make_scorer(f1_score, average="macro")
+    display = report.metrics.summarize(metric=[scorer])
+
+    assert len(display.data) == 1
+    assert display.data["average"].values[0] == "macro"
+    assert display.data["label"].isna().all()
+
+
 def test_neg_metric_strings(forest_binary_classification_with_test):
     """Check that scikit-learn metrics with 'neg_' prefix are handled correctly."""
     classifier, X_test, y_test = forest_binary_classification_with_test
@@ -535,9 +582,7 @@ def test_sklearn_metric_strings(forest_binary_classification_with_test):
     assert set(display.data["verbose_name"]) == {"Accuracy", "Log loss", "ROC AUC"}
 
 
-def test_sklearn_metric_strings_regression(
-    linear_regression_with_test,
-):
+def test_sklearn_metric_strings_regression(linear_regression_with_test):
     """Test scikit-learn regression metric strings in summarize()."""
     regressor, X_test, y_test = linear_regression_with_test
     reg_report = EstimatorReport(regressor, X_test=X_test, y_test=y_test)
@@ -552,6 +597,29 @@ def test_sklearn_metric_strings_regression(
         "Mean Absolute Error",
         "R²",
     }
+
+
+def test_unknown_ml_task(forest_binary_classification_with_test):
+    """Test summarize with unknown ML task."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    report._ml_task = "unknown-task"
+
+    # If ML task is not recognized then none of the default metrics will
+    # work
+    def custom_metric(y_true, y_pred):
+        return 0.8
+
+    display = report.metrics.summarize(
+        metric=[custom_metric], response_method="predict"
+    )
+
+    assert len(display.data) == 1
+    assert display.data["score"].values[0] == 0.8
+    assert display.data["label"].isna().all()
+    assert display.data["average"].isna().all()
+    assert display.data["output"].isna().all()
 
 
 # Tests about passing `metric_kwargs`
@@ -578,6 +646,23 @@ def test_metric_kwargs_multioutput(linear_regression_multioutput_with_test):
     assert isinstance(display.data, pd.DataFrame)
     assert "output" in display.data.columns
     assert len(display.data[display.data["metric"] == "r2"]) >= 2
+
+
+def test_metric_kwargs_none(
+    forest_binary_classification_with_test,
+):
+    """Test callable metric when metric_kwargs is None."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    def custom_metric(y_true, y_pred):
+        return 0.75
+
+    display = report.metrics.summarize(metric=custom_metric, response_method="predict")
+
+    assert isinstance(display.data, pd.DataFrame)
+    assert len(display.data) == 1
+    assert display.data["score"].values[0] == 0.75
 
 
 def test_sklearn_scorer_names_metric_kwargs(forest_binary_classification_with_test):

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -3,7 +3,8 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal, assert_series_equal
+from numpy.testing import assert_array_equal
+from pandas.testing import assert_frame_equal
 from sklearn.base import clone
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
@@ -249,14 +250,10 @@ def test_data_source_both(forest_binary_classification_data):
     assert set(display_both.data["data_source"]) == {"train", "test"}
 
     train_data = display_both.data[display_both.data["data_source"] == "train"]
-    assert_series_equal(
-        train_data["score"], display_train.data["score"], check_index=False
-    )
+    assert_array_equal(train_data["score"], display_train.data["score"])
 
     test_data = display_both.data[display_both.data["data_source"] == "test"]
-    assert_series_equal(
-        test_data["score"], display_test.data["score"], check_index=False
-    )
+    assert_array_equal(test_data["score"], display_test.data["score"])
 
 
 # Tests about passing `metric`

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -269,6 +269,17 @@ def test_invalid_metric_type(linear_regression_with_test):
         report.metrics.summarize(metric=[1])
 
 
+def test_empty_metric_list_uses_defaults(linear_regression_with_test):
+    """Check that empty metric list falls back to default metrics."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    assert_frame_equal(
+        report.metrics.summarize(metric=[]).data,
+        report.metrics.summarize(metric=None).data,
+    )
+
+
 @pytest.mark.parametrize("metric", ["public_metric", "_private_metric"])
 def test_error_metric_strings(linear_regression_with_test, metric):
     """Check that we raise an error if a metric string is not a valid metric."""

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -1,0 +1,158 @@
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_series_equal
+from sklearn.metrics import get_scorer
+from sklearn.model_selection import train_test_split
+
+from skore import EstimatorReport
+
+
+@pytest.mark.parametrize("metric", ["public_metric", "_private_metric"])
+def test_error_metric_strings(linear_regression_with_test, metric):
+    """Check that we raise an error if a metric string is not a valid metric."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    err_msg = re.escape(f"Invalid metric: {metric!r}.")
+    with pytest.raises(ValueError, match=err_msg):
+        report.metrics.summarize(metric=[metric])
+
+
+@pytest.mark.parametrize("metric", ["accuracy", "brier_score", "roc_auc", "log_loss"])
+def test_binary_classification(forest_binary_classification_with_test, metric):
+    """Check the behaviour of the metrics methods available for binary
+    classification.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    assert hasattr(report.metrics, metric)
+    result = getattr(report.metrics, metric)()
+    assert isinstance(result, float)
+    # check that we hit the cache
+    result_with_cache = getattr(report.metrics, metric)()
+    assert result == pytest.approx(result_with_cache)
+
+    # check that something was written to the cache
+    assert report._cache != {}
+
+
+@pytest.mark.parametrize("metric", ["precision", "recall"])
+def test_binary_classification_pr(forest_binary_classification_with_test, metric):
+    """Check the behaviour of the precision and recall metrics available for binary
+    classification.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    assert hasattr(report.metrics, metric)
+    result = getattr(report.metrics, metric)()
+    assert isinstance(result, dict)
+    # check that we hit the cache
+    result_with_cache = getattr(report.metrics, metric)()
+    assert result == result_with_cache
+
+    # check that something was written to the cache
+    assert report._cache != {}
+
+
+@pytest.mark.parametrize("metric", ["r2", "rmse"])
+def test_regression(linear_regression_with_test, metric):
+    """Check the behaviour of the metrics methods available for regression."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    assert hasattr(report.metrics, metric)
+    result = getattr(report.metrics, metric)()
+    assert isinstance(result, float)
+    # check that we hit the cache
+    result_with_cache = getattr(report.metrics, metric)()
+    assert result == pytest.approx(result_with_cache)
+
+    # check that something was written to the cache
+    assert report._cache != {}
+
+
+def test_data_source_both(forest_binary_classification_data):
+    """Check the behaviour of `summarize` with `data_source="both"`."""
+    estimator, X, y = forest_binary_classification_data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+
+    result_train = report.metrics.summarize(data_source="train").frame()
+    result_test = report.metrics.summarize(data_source="test").frame()
+    result_both = report.metrics.summarize(data_source="both").frame()
+
+    assert result_both.columns.tolist() == [
+        "RandomForestClassifier (train)",
+        "RandomForestClassifier (test)",
+    ]
+    assert_series_equal(
+        result_both["RandomForestClassifier (train)"],
+        result_train["RandomForestClassifier"],
+        check_names=False,
+    )
+    assert_series_equal(
+        result_both["RandomForestClassifier (test)"],
+        result_test["RandomForestClassifier"],
+        check_names=False,
+    )
+
+    # By default,
+    result_both = report.metrics.summarize(
+        data_source="both", favorability=True
+    ).frame()
+    assert result_both.columns.tolist() == [
+        "RandomForestClassifier (train)",
+        "RandomForestClassifier (test)",
+        "Favorability",
+    ]
+
+
+def test_metric_dict(forest_binary_classification_with_test):
+    """Test that metric can be passed as a dictionary with custom names."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    # Test with dictionary metric
+    metric_dict = {
+        "Custom Accuracy": "accuracy",
+        "Custom Precision": "precision",
+        "Custom R2": get_scorer("neg_mean_absolute_error"),
+    }
+
+    result = report.metrics.summarize(metric=metric_dict).frame()
+
+    # Check that custom names are used
+    assert "Custom Accuracy" in result.index
+    assert "Custom Precision" in result.index
+    assert "Custom R2" in result.index
+
+    # Verify the result structure
+    assert isinstance(result, pd.DataFrame)
+    assert len(result.index) >= 3  # At least our 3 custom metrics
+
+
+def test_metric_dict_with_callables(linear_regression_with_test):
+    """Test that metric dict works with callable functions."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    def custom_metric(y_true, y_pred):
+        return np.mean(np.abs(y_true - y_pred))
+
+    metric_dict = {"R Squared": "r2", "Custom MAE": custom_metric}
+
+    result = report.metrics.summarize(
+        metric=metric_dict, metric_kwargs={"response_method": "predict"}
+    ).frame()
+
+    # Check that custom names are used
+    assert "R Squared" in result.index
+    assert "Custom MAE" in result.index
+
+    # Verify the result structure
+    assert isinstance(result, pd.DataFrame)
+    assert len(result.index) == 2

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -108,36 +108,6 @@ def test_binary_classification_forest(forest_binary_classification_with_test):
     assert display.data["output"].isna().all()
 
 
-def test_binary_classification_forest_pos_label(forest_binary_classification_with_test):
-    """
-    Check the behaviour of summarize() with binary classification using
-    RandomForestClassifier with pos_label specified.
-    """
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    display = report.metrics.summarize(pos_label=1)
-
-    check_display_structure(
-        display,
-        expected_metrics={
-            "accuracy",
-            "precision",
-            "recall",
-            "roc_auc",
-            "brier_score",
-            "fit_time",
-            "predict_time",
-        },
-        expected_estimator_name="RandomForestClassifier",
-    )
-
-    assert len(display.data[display.data["metric"] == "precision"]) == 1
-    assert len(display.data[display.data["metric"] == "recall"]) == 1
-    # Label is None for precision/recall when pos_label is specified
-    assert display.data["label"].isna().all()
-    assert display.data["output"].isna().all()
-
-
 def test_binary_classification_svc(svc_binary_classification_with_test):
     """
     Check the behaviour of summarize() with binary classification using SVC
@@ -376,7 +346,7 @@ def test_metric_dict_overwrite_metric_names(forest_multiclass_classification_wit
     estimator, X_test, y_test = forest_multiclass_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
-    metric_dict = {"ROC AUC": "_roc_auc", "Fit Time": "_fit_time"}
+    metric_dict = {"ROC AUC": "roc_auc", "Fit Time": "fit_time"}
 
     display = report.metrics.summarize(metric=metric_dict)
     assert isinstance(display.data, pd.DataFrame)
@@ -681,6 +651,33 @@ def test_sklearn_scorer_names_metric_kwargs(forest_binary_classification_with_te
 
 
 # Tests about passing `pos_label`
+
+
+def test_pos_label(forest_binary_classification_with_test):
+    """Check that `pos_label` can be passed."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    display = report.metrics.summarize(pos_label=1)
+
+    check_display_structure(
+        display,
+        expected_metrics={
+            "accuracy",
+            "precision",
+            "recall",
+            "roc_auc",
+            "brier_score",
+            "fit_time",
+            "predict_time",
+        },
+        expected_estimator_name="RandomForestClassifier",
+    )
+
+    assert len(display.data[display.data["metric"] == "precision"]) == 1
+    assert len(display.data[display.data["metric"] == "recall"]) == 1
+    # Label is None for precision/recall when pos_label is specified
+    assert display.data["label"].isna().all()
+    assert display.data["output"].isna().all()
 
 
 def test_pos_label_scorer_error(forest_binary_classification_with_test):

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -73,7 +73,7 @@ def test_regression(linear_regression_with_test, metric):
 
 
 def test_data_source_both(forest_binary_classification_data):
-    """Check the behaviour of `summarize` with `data_source="both"`."""
+    """Check the behaviour with `data_source="both"`."""
     estimator, X, y = forest_binary_classification_data
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
 
@@ -100,10 +100,7 @@ def test_data_source_both(forest_binary_classification_data):
         check_names=False,
     )
 
-    # By default,
-    result_both = report.metrics.summarize(
-        data_source="both", favorability=True
-    ).frame()
+    result_both = report.metrics.summarize(data_source="both").frame(favorability=True)
     assert result_both.columns.tolist() == [
         "RandomForestClassifier (train)",
         "RandomForestClassifier (test)",

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -684,21 +684,19 @@ def test_pos_label_scorer_error(forest_binary_classification_with_test):
         report.metrics.summarize(metric=[f1_scorer], pos_label=0)
 
 
-@pytest.mark.parametrize("pos_label", [None, 1])
-def test_pos_label_strings(forest_binary_classification_with_test, pos_label):
+def test_pos_label_strings(forest_binary_classification_with_test):
     """
     Check the behaviour of summarize() with binary classification using string labels.
     """
     estimator, X_test, y_test = forest_binary_classification_with_test
 
     target_names = np.array(["neg", "pos"], dtype=object)
-    pos_label_string = target_names[pos_label] if pos_label is not None else pos_label
     y_test = target_names[y_test]
 
     estimator = clone(estimator).fit(X_test, y_test)
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
 
-    display = report.metrics.summarize(pos_label=pos_label_string)
+    display = report.metrics.summarize()
     assert isinstance(display.data, pd.DataFrame)
     assert set(display.data["metric"]) == {
         "Accuracy",
@@ -709,6 +707,39 @@ def test_pos_label_strings(forest_binary_classification_with_test, pos_label):
         "Fit time (s)",
         "Predict time (s)",
     }
+
+    labels = display.data.set_index("metric").loc["Precision", "label"]
+    assert set(labels) == {"neg", "pos"}
+
+
+def test_pos_label_bool(forest_binary_classification_with_test):
+    """
+    Check the behaviour of summarize() with binary classification using boolean labels.
+    """
+    estimator, X_test, y_test = forest_binary_classification_with_test
+
+    target_names = np.array([False, True], dtype=bool)
+    y_test = target_names[y_test]
+
+    estimator = clone(estimator).fit(X_test, y_test)
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    display = report.metrics.summarize()
+    assert isinstance(display.data, pd.DataFrame)
+    assert set(display.data["metric"]) == {
+        "Accuracy",
+        "Precision",
+        "Recall",
+        "ROC AUC",
+        "Brier score",
+        "Fit time (s)",
+        "Predict time (s)",
+    }
+
+    labels = display.data.set_index("metric").loc["Precision", "label"]
+    # Use `is` to avoid casting
+    assert any(label is np.False_ for label in labels)
+    assert any(label is np.True_ for label in labels)
 
 
 def test_pos_label_scorer_names(

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -27,7 +27,6 @@ def check_display_structure(
     display,
     *,
     expected_metrics,
-    expected_verbose_names=None,
     expected_estimator_name=None,
     expected_data_source="test",
 ):
@@ -40,8 +39,6 @@ def check_display_structure(
         The display object to check.
     expected_metrics : set, optional
         Expected set of metric names.
-    expected_verbose_names : set, optional
-        Expected set of verbose names.
     expected_estimator_name : str, optional
         Expected estimator name.
     expected_data_source : str, default="test"
@@ -52,7 +49,6 @@ def check_display_structure(
 
     assert set(data.columns) == {
         "metric",
-        "verbose_name",
         "estimator_name",
         "data_source",
         "label",
@@ -62,8 +58,6 @@ def check_display_structure(
         "favorability",
     }
     assert set(data["metric"]) == expected_metrics
-    if expected_verbose_names is not None:
-        assert set(data["verbose_name"]) == expected_verbose_names
     assert set(data["estimator_name"]) == {expected_estimator_name}
     assert set(data["data_source"]) == {expected_data_source}
     assert data["average"].isna().all()
@@ -86,22 +80,22 @@ def test_binary_classification_forest(forest_binary_classification_with_test):
     check_display_structure(
         display,
         expected_metrics={
-            "accuracy",
-            "precision",
-            "recall",
-            "roc_auc",
-            "brier_score",
-            "fit_time",
-            "predict_time",
+            "Accuracy",
+            "Precision",
+            "Recall",
+            "ROC AUC",
+            "Brier score",
+            "Fit time (s)",
+            "Predict time (s)",
         },
         expected_estimator_name="RandomForestClassifier",
     )
 
     # Precision and recall should have 2 rows (one per class in binary classification)
-    assert len(display.data[display.data["metric"] == "precision"]) == 2
-    assert len(display.data[display.data["metric"] == "recall"]) == 2
+    assert len(display.data[display.data["metric"] == "Precision"]) == 2
+    assert len(display.data[display.data["metric"] == "Recall"]) == 2
     # Labels should be 0 and 1 for precision
-    precision_labels = set(display.data[display.data["metric"] == "precision"]["label"])
+    precision_labels = set(display.data[display.data["metric"] == "Precision"]["label"])
     assert precision_labels == {0, 1}
 
     # Output column should be all NaN for non-multioutput
@@ -122,12 +116,12 @@ def test_binary_classification_svc(svc_binary_classification_with_test):
     check_display_structure(
         display,
         expected_metrics={
-            "accuracy",
-            "precision",
-            "recall",
-            "roc_auc",
-            "fit_time",
-            "predict_time",
+            "Accuracy",
+            "Precision",
+            "Recall",
+            "ROC AUC",
+            "Fit time (s)",
+            "Predict time (s)",
         },
         expected_estimator_name="SVC",
     )
@@ -145,22 +139,22 @@ def test_multiclass_classification_forest(forest_multiclass_classification_with_
     check_display_structure(
         display,
         expected_metrics={
-            "accuracy",
-            "log_loss",
-            "precision",
-            "recall",
-            "roc_auc",
-            "predict_time",
-            "fit_time",
+            "Accuracy",
+            "Log loss",
+            "Precision",
+            "Recall",
+            "ROC AUC",
+            "Predict time (s)",
+            "Fit time (s)",
         },
         expected_estimator_name="RandomForestClassifier",
     )
 
     assert display.data["output"].isna().all()
     data = display.data.set_index("metric")
-    assert len(data.loc["precision"]) == 3
-    assert len(data.loc["recall"]) == 3
-    assert set(data.loc["precision", "label"]) == {0, 1, 2}
+    assert len(data.loc["Precision"]) == 3
+    assert len(data.loc["Recall"]) == 3
+    assert set(data.loc["Precision", "label"]) == {0, 1, 2}
 
 
 def test_multiclass_classification_svc(svc_multiclass_classification_with_test):
@@ -172,20 +166,20 @@ def test_multiclass_classification_svc(svc_multiclass_classification_with_test):
     check_display_structure(
         display,
         expected_metrics={
-            "accuracy",
-            "precision",
-            "recall",
-            "fit_time",
-            "predict_time",
+            "Accuracy",
+            "Precision",
+            "Recall",
+            "Fit time (s)",
+            "Predict time (s)",
         },
         expected_estimator_name="SVC",
     )
 
     assert display.data["output"].isna().all()
     data = display.data.set_index("metric")
-    assert len(data.loc["precision"]) == 3
-    assert len(data.loc["recall"]) == 3
-    assert set(data.loc["precision", "label"]) == {0, 1, 2}
+    assert len(data.loc["Precision"]) == 3
+    assert len(data.loc["Recall"]) == 3
+    assert set(data.loc["Precision", "label"]) == {0, 1, 2}
 
 
 def test_regression(linear_regression_with_test):
@@ -196,8 +190,7 @@ def test_regression(linear_regression_with_test):
 
     check_display_structure(
         display,
-        expected_metrics={"r2", "rmse", "fit_time", "predict_time"},
-        expected_verbose_names={"R²", "RMSE", "Fit time (s)", "Predict time (s)"},
+        expected_metrics={"R²", "RMSE", "Fit time (s)", "Predict time (s)"},
         expected_estimator_name="LinearRegression",
     )
 
@@ -213,16 +206,15 @@ def test_multioutput_regression(linear_regression_multioutput_with_test):
 
     check_display_structure(
         display,
-        expected_metrics={"r2", "rmse", "fit_time", "predict_time"},
-        expected_verbose_names={"R²", "RMSE", "Fit time (s)", "Predict time (s)"},
+        expected_metrics={"R²", "RMSE", "Fit time (s)", "Predict time (s)"},
         expected_estimator_name="LinearRegression",
     )
 
     assert display.data["label"].isna().all()
     data = display.data.set_index("metric")
-    assert len(data.loc["r2", "output"]) == 2
-    assert len(data.loc["rmse", "output"]) == 2
-    assert set(data.loc["r2", "output"]) == {0, 1}
+    assert len(data.loc["R²", "output"]) == 2
+    assert len(data.loc["RMSE", "output"]) == 2
+    assert set(data.loc["R²", "output"]) == {0, 1}
 
 
 def test_cache(forest_binary_classification_with_test):
@@ -239,8 +231,6 @@ def test_cache(forest_binary_classification_with_test):
     with check_cache_unchanged(report._cache):
         result_from_cache = report.metrics.summarize()
     assert_frame_equal(result.data, result_from_cache.data)
-
-    report.clear_cache()
 
 
 def test_data_source_both(forest_binary_classification_data):
@@ -301,7 +291,7 @@ def test_metric_strings_regression(linear_regression_with_test):
     display = reg_report.metrics.summarize(metric=["rmse", "r2"])
 
     assert isinstance(display.data, pd.DataFrame)
-    assert set(display.data["verbose_name"]) == {"RMSE", "R²"}
+    assert set(display.data["metric"]) == {"RMSE", "R²"}
 
 
 def test_metric_dict(forest_binary_classification_with_test):
@@ -320,7 +310,7 @@ def test_metric_dict(forest_binary_classification_with_test):
 
     # Precision will have 2 rows (one per class)
     assert len(display.data) == 4
-    assert set(display.data["verbose_name"]) == set(metric_dict)
+    assert set(display.data["metric"]) == set(metric_dict)
 
 
 def test_metric_dict_with_callables(linear_regression_with_test):
@@ -338,7 +328,7 @@ def test_metric_dict_with_callables(linear_regression_with_test):
     )
     assert isinstance(display.data, pd.DataFrame)
     assert len(display.data) == 2
-    assert set(display.data["verbose_name"]) == set(metric_dict)
+    assert set(display.data["metric"]) == set(metric_dict)
 
 
 def test_metric_dict_overwrite_metric_names(forest_multiclass_classification_with_test):
@@ -350,7 +340,7 @@ def test_metric_dict_overwrite_metric_names(forest_multiclass_classification_wit
 
     display = report.metrics.summarize(metric=metric_dict)
     assert isinstance(display.data, pd.DataFrame)
-    assert set(display.data["verbose_name"]) == set(metric_dict)
+    assert set(display.data["metric"]) == set(metric_dict)
 
 
 @pytest.mark.parametrize(
@@ -392,11 +382,11 @@ def test_custom_metric(linear_regression_with_test):
         metric_kwargs={"some_weights": weights, "response_method": "predict"},
     )
     assert isinstance(display.data, pd.DataFrame)
-    assert set(display.data["metric"]) == {"r2", "custom_metric"}
+    assert set(display.data["metric"]) == {"R²", "Custom Metric"}
 
     scores = display.data.set_index("metric")["score"]
-    assert scores["r2"] == pytest.approx(r2_score(y_test, estimator.predict(X_test)))
-    assert scores["custom_metric"] == pytest.approx(
+    assert scores["R²"] == pytest.approx(r2_score(y_test, estimator.predict(X_test)))
+    assert scores["Custom Metric"] == pytest.approx(
         custom_metric(y_test, estimator.predict(X_test), weights)
     )
 
@@ -535,10 +525,9 @@ def test_neg_metric_strings(forest_binary_classification_with_test):
     assert isinstance(display.data, pd.DataFrame)
 
     # Note: neg_log_loss was converted to log_loss
-    assert "log_loss" in set(display.data["metric"])
-    assert "Log Loss" in set(display.data["verbose_name"])
+    assert "Log Loss" in set(display.data["metric"])
 
-    score = display.data.set_index("metric").loc["log_loss", "score"]
+    score = display.data.set_index("metric").loc["Log Loss", "score"]
     assert score == pytest.approx(report.metrics.log_loss())
 
 
@@ -548,8 +537,7 @@ def test_sklearn_metric_strings(forest_binary_classification_with_test):
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
 
     display = report.metrics.summarize(metric=["accuracy", "log_loss", "roc_auc"])
-    assert set(display.data["metric"]) == {"accuracy", "log_loss", "roc_auc"}
-    assert set(display.data["verbose_name"]) == {"Accuracy", "Log loss", "ROC AUC"}
+    assert set(display.data["metric"]) == {"Accuracy", "Log loss", "ROC AUC"}
 
 
 def test_sklearn_metric_strings_regression(linear_regression_with_test):
@@ -562,7 +550,7 @@ def test_sklearn_metric_strings_regression(linear_regression_with_test):
     )
 
     assert isinstance(display.data, pd.DataFrame)
-    assert set(display.data["verbose_name"]) == {
+    assert set(display.data["metric"]) == {
         "Mean Squared Error",
         "Mean Absolute Error",
         "R²",
@@ -615,7 +603,7 @@ def test_metric_kwargs_multioutput(linear_regression_multioutput_with_test):
 
     assert isinstance(display.data, pd.DataFrame)
     assert "output" in display.data.columns
-    assert len(display.data[display.data["metric"] == "r2"]) >= 2
+    assert len(display.data[display.data["metric"] == "R²"]) >= 2
 
 
 def test_metric_kwargs_none(
@@ -662,19 +650,19 @@ def test_pos_label(forest_binary_classification_with_test):
     check_display_structure(
         display,
         expected_metrics={
-            "accuracy",
-            "precision",
-            "recall",
-            "roc_auc",
-            "brier_score",
-            "fit_time",
-            "predict_time",
+            "Accuracy",
+            "Precision",
+            "Recall",
+            "ROC AUC",
+            "Brier score",
+            "Fit time (s)",
+            "Predict time (s)",
         },
         expected_estimator_name="RandomForestClassifier",
     )
 
-    assert len(display.data[display.data["metric"] == "precision"]) == 1
-    assert len(display.data[display.data["metric"] == "recall"]) == 1
+    assert len(display.data[display.data["metric"] == "Precision"]) == 1
+    assert len(display.data[display.data["metric"] == "Recall"]) == 1
     # Label is None for precision/recall when pos_label is specified
     assert display.data["label"].isna().all()
     assert display.data["output"].isna().all()
@@ -713,13 +701,13 @@ def test_pos_label_strings(forest_binary_classification_with_test, pos_label):
     display = report.metrics.summarize(pos_label=pos_label_string)
     assert isinstance(display.data, pd.DataFrame)
     assert set(display.data["metric"]) == {
-        "accuracy",
-        "precision",
-        "recall",
-        "roc_auc",
-        "brier_score",
-        "fit_time",
-        "predict_time",
+        "Accuracy",
+        "Precision",
+        "Recall",
+        "ROC AUC",
+        "Brier score",
+        "Fit time (s)",
+        "Predict time (s)",
     }
 
 

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -208,7 +208,7 @@ def test_flat_index(forest_binary_classification_with_test):
     """
     estimator, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    result = report.metrics.summarize(flat_index=True).frame()
+    result = report.metrics.summarize().frame(flat_index=True)
     assert result.shape == (9, 1)
     assert isinstance(result.index, pd.Index)
     assert result.index.tolist() == [

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -309,3 +309,25 @@ def test_clustering():
         "classification or regression model instead.",
     ):
         EstimatorReport(KMeans())
+
+
+def test_has_no_deep_copy():
+    """Check that we raise a warning if the deep copy failed with a fitted
+    estimator."""
+    X, y = make_classification(n_classes=2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+
+    estimator = LogisticRegression()
+    # Make it so deepcopy does not work
+    estimator.__reduce_ex__ = None
+    estimator.__reduce__ = None
+
+    with pytest.warns(UserWarning, match="Deepcopy failed"):
+        EstimatorReport(
+            estimator,
+            fit=False,
+            X_train=X_train,
+            X_test=X_test,
+            y_train=y_train,
+            y_test=y_test,
+        )

--- a/skore/tests/unit/utils/test_index.py
+++ b/skore/tests/unit/utils/test_index.py
@@ -57,8 +57,15 @@ def test_flatten_multi_index(input_tuples, names, expected_values):
     pd.testing.assert_index_equal(result, expected)
 
 
-def test_flatten_multi_index_invalid_input():
-    """Test that non-MultiIndex input raises ValueError."""
+def test_flatten_multi_index_non_multi_index_input():
+    """Test that non-MultiIndex input is returned as-is."""
     simple_index = pd.Index(["a", "b"])
-    with pytest.raises(ValueError, match="`index` must be a MultiIndex."):
-        flatten_multi_index(simple_index)
+    result = flatten_multi_index(simple_index)
+    pd.testing.assert_index_equal(result, simple_index)
+
+
+def test_flatten_multi_index_non_multi_index_with_join_str():
+    """Test that non-MultiIndex input is returned as-is regardless of join_str."""
+    simple_index = pd.Index(["a", "b"])
+    result = flatten_multi_index(simple_index, join_str="-")
+    pd.testing.assert_index_equal(result, simple_index)

--- a/skore/tests/unit/utils/test_index.py
+++ b/skore/tests/unit/utils/test_index.py
@@ -57,14 +57,7 @@ def test_flatten_multi_index(input_tuples, names, expected_values):
     pd.testing.assert_index_equal(result, expected)
 
 
-def test_flatten_multi_index_non_multi_index_input():
-    """Test that non-MultiIndex input is returned as-is."""
-    simple_index = pd.Index(["a", "b"])
-    result = flatten_multi_index(simple_index)
-    pd.testing.assert_index_equal(result, simple_index)
-
-
-def test_flatten_multi_index_non_multi_index_with_join_str():
+def test_flatten_multi_index_non_multi_index():
     """Test that non-MultiIndex input is returned as-is regardless of join_str."""
     simple_index = pd.Index(["a", "b"])
     result = flatten_multi_index(simple_index, join_str="-")


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

If this is your first contribution, take a look at our contribution guidelines:
https://docs.skore.probabl.ai/dev/contributing.html
-->
#### Change description
<!--
Please describe what your contribution changes for skore.

Here is some inspiration for what to write here:
- Are you adding a new feature? Fixing a bug?
- Can you give an example of your change in action, e.g. a snippet of code or a plot?
- Is your change likely to break users' code?
- Are there any other details the reviewer should be aware of, such as API design choices, performance characteristics or edge cases?

Please reference issues/PRs when possible, e.g. "Fixes #1234", "Closes #3456", "See also #7890".
More information [here](https://github.com/blog/1506-closing-issues-via-pull-requests).
-->


`EstimatorReport.metrics.summarize()` no longer accepts arguments `flat_index` or `favorability`. These have been moved to `MetricsSummaryDisplay.frame()`.
This moves the responsibility of displaying things from `EstimatorReport._MetricsAccessor` to `MetricsSummaryDisplay`. 

```python
# Before
report.metrics.summarize(flat_index=True, favorability=True).frame()

# After
report.metrics.summarize().frame(flat_index=True, favorability=True)
```

This is a breaking change.

The rest of the PR consists in various refactorings, in particular the tests have been updated to reflect the change in responsibility:
- Tests of `summarize()` were extracted from `tests/unit/reports/estimator/metrics/test_numeric.py` to a new file, `tests/unit/reports/estimator/metrics/test_summarize.py`.
- `test_summarize.py` now tests that `summarize()` behaves well, and that the output of `summarize()` has a well-formed DataFrame. `.frame()` is never called.
- `displays/metrics_summary/test_estimator.py` has been rewritten to specifically test `.frame()` arguments.

A number of commits are included that could be pulled out into a separate PR if needed.

Closes #2533 
Supersedes #1839 in part

#### Contribution checklist
<!--
Below are some of the criteria that the review will include.
Feel free to use it as a checklist to ensure that your contribution is high-quality.
-->

- [x] Unit tests were added or updated (if necessary)
- [x] Documentation was added or updated (if necessary)

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure you understand our [automated contributions policy](https://docs.skore.probabl.ai/dev/contributing.html#automated-contributions-policy)
-->
AI tools were involved for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

In particular I used Claude to increase coverage.
<!-- Any other comments can go here. Thanks again for contributing! -->

