### PR TITLE
fix(skore-hub-project/splitting_strategy): Use `_safe_indexing` with `report.y`

### DIFF
--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.5/test-requirements.txt
@@ -118,6 +118,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -118,6 +118,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.5/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.8/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.8/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.8/test-requirements.txt
@@ -115,6 +115,7 @@ packaging==25.0
     #   pytest
 pandas==2.3.3
     # via
+    #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub

--- a/skore-hub-project/pyproject.toml
+++ b/skore-hub-project/pyproject.toml
@@ -19,13 +19,14 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+  "pandas",
   "pandas-stubs",
   "pre-commit",
+  "pytest",
   "pytest-cov",
   "pytest-order",
   "pytest-randomly",
   "pytest-xdist",
-  "pytest",
   "respx",
   "skore",
   "xdoctest",

--- a/skore-hub-project/src/skore_hub_project/report/cross_validation_report.py
+++ b/skore-hub-project/src/skore_hub_project/report/cross_validation_report.py
@@ -205,11 +205,15 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
         of 200 buckets, and averaging the number of samples belonging to the test-set in
         each of these buckets. @TODO: find a better representation of the distribution.
         """
+        from skore._externals._sklearn_compat import (  # type: ignore[attr-defined]
+            _safe_indexing,
+        )
+
         splits = []
 
         for train_indices, test_indices in self.report.split_indices:
-            train_y = self.report.y[train_indices]
-            test_y = self.report.y[test_indices]
+            train_y = _safe_indexing(self.report.y, train_indices)
+            test_y = _safe_indexing(self.report.y, test_indices)
             train_target_distribution: list[float] = []
             test_target_distribution: list[float] = []
 

--- a/skore-hub-project/tests/unit/report/test_cross_validation_report.py
+++ b/skore-hub-project/tests/unit/report/test_cross_validation_report.py
@@ -1,13 +1,14 @@
 from io import BytesIO
 
 from joblib import dump, hash
+from pandas import Series
 from pydantic import ValidationError
 from pytest import fixture, mark, raises
 from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import KFold, RepeatedKFold
-from skore import CrossValidationReport, EstimatorReport
+from skore import CrossValidationReport, EstimatorReport, train_test_split
 
 from skore_hub_project.artifact.media import (
     ConfusionMatrixDataFrameTest,
@@ -110,7 +111,7 @@ class TestCrossValidationReportPayload:
         assert payload.dataset_size == 10
 
     @mark.respx(assert_all_called=False)
-    def test_splits(self, payload):
+    def test_splitting_strategy(self, payload):
         assert payload.splitting_strategy == {
             "repeat_count": 1,
             "seed": "None",
@@ -146,7 +147,7 @@ class TestCrossValidationReportPayload:
         }
 
     @mark.respx(assert_all_called=False)
-    def test_splits_with_repetitions(self, project):
+    def test_splitting_strategy_with_repetitions(self, project):
         X, y = make_classification(random_state=42, n_samples=10)
         payload = CrossValidationReportPayload(
             project=project,
@@ -219,7 +220,7 @@ class TestCrossValidationReportPayload:
         }
 
     @mark.respx(assert_all_called=False)
-    def test_splits_for_regression(self, project):
+    def test_splitting_strategy_for_regression(self, project):
         X, y = make_regression(random_state=42, n_samples=10)
         payload = CrossValidationReportPayload(
             project=project,
@@ -243,6 +244,60 @@ class TestCrossValidationReportPayload:
             assert len(test_target_distribution) == 100
             assert all(isinstance(value, float) for value in train_target_distribution)
             assert all(isinstance(value, float) for value in test_target_distribution)
+
+    @mark.respx(assert_all_called=False)
+    def test_splitting_strategy_with_y_series_and_index(self, project):
+        X, y = make_classification(random_state=42, n_samples=10)
+        X_experiment, _, y_experiment, _ = train_test_split(
+            X, Series(y), random_state=42
+        )
+
+        payload = CrossValidationReportPayload(
+            project=project,
+            report=CrossValidationReport(
+                RandomForestClassifier(random_state=42),
+                X_experiment,
+                y_experiment,
+                splitter=2,
+            ),
+            key="<key>",
+        )
+
+        assert 5 not in y_experiment.index
+        assert 5 in payload.report.split_indices[0][0]
+        assert payload.splitting_strategy == {
+            "repeat_count": 1,
+            "seed": "None",
+            "splits": [
+                {
+                    "test": {
+                        "target_distribution": [1, 3],
+                        "groups": None,
+                        "sample_count": 4,
+                    },
+                    "train": {
+                        "target_distribution": [1, 2],
+                        "groups": None,
+                        "sample_count": 3,
+                    },
+                    "train_test_distribution": [1, 1, 1, 1, 0, 0, 0],
+                },
+                {
+                    "test": {
+                        "target_distribution": [1, 2],
+                        "groups": None,
+                        "sample_count": 3,
+                    },
+                    "train": {
+                        "target_distribution": [1, 3],
+                        "groups": None,
+                        "sample_count": 4,
+                    },
+                    "train_test_distribution": [0, 0, 0, 0, 1, 1, 1],
+                },
+            ],
+            "strategy_name": "StratifiedKFold",
+        }
 
     @mark.respx(assert_all_called=False)
     def test_class_names(self, payload):


### PR DESCRIPTION
Needed for https://github.com/probabl-ai/skore/pull/2524/: fix `splitting_strategy` when `report.y` is an indexed `pandas.Series`.
