### PR TITLE
docs(skore/RocCurveDisplay): Document `data_source` column

### DIFF
--- a/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
@@ -460,7 +460,7 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
 
             - `estimator`: Name of the estimator (when comparing estimators)
             - `split`: Cross-validation split ID (when doing cross-validation)
-            - `data_source`: Data source used (only when ``data_source="both"``)
+            - `data_source`: Data source used (when `data_source="both"`)
             - `label`: Class label (for multiclass-classification)
             - `threshold`: Decision threshold
             - `fpr`: False Positive Rate


### PR DESCRIPTION
#### Change description

Fixes missing `data_source` column documentation in `RocCurveDisplay` docstrings (`skore/src/skore/_sklearn/_plot/metrics/roc_curve.py`).

Two docstrings were inconsistent with the actual code:

1. **Class-level docstring** — the `roc_curve` parameter listed 6 columns (`estimator`, `split`, `label`, `threshold`, `fpr`, `tpr`) but the DataFrame is built with a `data_source` key in `_compute_data_for_display()`. Added `data_source` between `estimator` and `split` to match the actual dictionary key order.

2. **`frame()` method docstring** — the `Returns` section listed 7 columns but omitted `data_source`, which is conditionally included in the output when `data_source="both"`. Added it with a note clarifying it only appears in that case.

No behavior or API changes — documentation-only fix.

Closes #2569

> **Note for reviewer:** The `roc_auc` parameter in the class docstring is also missing `data_source` (the `roc_auc_records` dict also stores it). This is out of scope for this PR but could be addressed as a follow-up.

#### Contribution checklist

- [ ] Unit tests were added or updated (if necessary)
- [x] Documentation was added or updated (if necessary)
- [ ] The code passes our style conventions (you can check this by running pre-commit on your code with `pre-commit run --all-files`)
- [ ] All the tests pass (please test locally before pushing)
- [ ] The documentation builds and renders properly (if it does, our bot will add a comment linking to a preview of the documentation to review it visually)
- [ ] A new changelog entry was added to CHANGELOG.rst (if necessary; typically, if your change requires updating tests)
- [ ] All the commits in the PR are signed (more information [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
- [x] The pull request title respects the Conventional Commits convention (more information [here](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests))

#### AI usage disclosure

AI tools were involved for:

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding