### PR TITLE
fix(skore-hub-project): Compute confusion matrix with all thresholds

### DIFF
--- a/skore-hub-project/src/skore_hub_project/artifact/media/performance.py
+++ b/skore-hub-project/src/skore_hub_project/artifact/media/performance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Callable
 from functools import reduce
+from inspect import signature
 from io import BytesIO
 from typing import ClassVar, Literal, cast
 
@@ -63,7 +64,10 @@ class PerformanceDataFrame(Media[Report], ABC):  # noqa: D101
             else function(data_source=self.data_source)
         )
 
-        frame = display.frame()
+        if "threshold_value" in signature(display.frame).parameters:
+            frame = display.frame(threshold_value="all")
+        else:
+            frame = display.frame()
 
         return dumps(
             frame.astype(object).where(frame.notna(), "NaN").to_dict(orient="tight")

--- a/skore-hub-project/tests/unit/artifact/media/test_performance.py
+++ b/skore-hub-project/tests/unit/artifact/media/test_performance.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from io import BytesIO
 
 from matplotlib import pyplot as plt
@@ -38,7 +39,11 @@ def serialize_svg(display) -> bytes:
 
 
 def serialize_dataframe(display) -> bytes:
-    frame = display.frame()
+    if "threshold_value" in signature(display.frame).parameters:
+        frame = display.frame(threshold_value="all")
+    else:
+        frame = display.frame()
+
     return dumps(
         frame.astype(object).where(frame.notna(), "NaN").to_dict(orient="tight")
     )


### PR DESCRIPTION
`skore-hub-project` now computes all thresholds.