### PR TITLE
chore: Replace GTM script with our own

### DIFF
--- a/sphinx/_static/js/gtm.js
+++ b/sphinx/_static/js/gtm.js
@@ -1,5 +1,0 @@
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-M9JXX8MX');

--- a/sphinx/_templates/layout.html
+++ b/sphinx/_templates/layout.html
@@ -1,11 +1,4 @@
 {% extends "!layout.html" %}
-
-{% block body_tag %}
-    {{ super() }}
-
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M9JXX8MX"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-
+{% block extrahead %}
+    <script async src="https://b.probabl.ai/pb.min.js"></script>
 {% endblock %}

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -90,8 +90,7 @@ html_static_path = ["_static"]
 
 html_css_files = ["css/custom.css"]
 html_js_files = [
-    "js/sg_plotly_resize.js",
-    "js/gtm.js",
+    "js/sg_plotly_resize.js"
 ]
 
 # sphinx_gallery options


### PR DESCRIPTION
Closes #2593

#### Change description

The hard-coded Google Tag Manager script was replaced with our own script that adds more configuration flexibility (e.g. does not run on `file://` protocol).
