### PR TITLE
docs(skore): Fix link to pandas documentation in sphinx `conf.py`

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -150,7 +150,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "skrub": ("https://skrub-data.org/stable/", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/stable", None),
+    "pandas": ("http://pandas.pydata.org/docs/", None),
     "polars": ("https://docs.pola.rs/py-polars/html", None),
     "seaborn": ("http://seaborn.pydata.org", None),
     "xgboost": ("https://xgboost.readthedocs.io/en/stable/", None),


### PR DESCRIPTION
It seems pandas doc migrated and that we were using an old URL: https://chatgpt.com/share/69b83cc5-b728-8013-8aba-59b4b5d222e5

All CIs break because of that.

I switched to the new URL: http://pandas.pydata.org/docs/

