### PR TITLE
fix(skore-hub-project): Add average precision and roc auc to binary classification performance

### DIFF
--- a/skore-hub-project/src/skore_hub_project/artifact/media/performance.py
+++ b/skore-hub-project/src/skore_hub_project/artifact/media/performance.py
@@ -64,7 +64,15 @@ class PerformanceDataFrame(Media[Report], ABC):  # noqa: D101
             else function(data_source=self.data_source)
         )
 
-        # pass optional parameters to the frame method
+        frame = display.frame(**self.get_frame_kwargs(display))
+
+        return dumps(
+            frame.astype(object).where(frame.notna(), "NaN").to_dict(orient="tight")
+        )
+
+    @staticmethod
+    def get_frame_kwargs(display: Display) -> dict[str, str | bool]:
+        """Get the kwargs to pass to the frame method."""
         params = signature(display.frame).parameters
         kwargs: dict[str, str | bool] = {}
         if "threshold_value" in params:
@@ -74,11 +82,7 @@ class PerformanceDataFrame(Media[Report], ABC):  # noqa: D101
         if "with_roc_auc" in params:
             kwargs["with_roc_auc"] = True
 
-        frame = display.frame(**kwargs)
-
-        return dumps(
-            frame.astype(object).where(frame.notna(), "NaN").to_dict(orient="tight")
-        )
+        return kwargs
 
 
 class PrecisionRecallSVG(PerformanceSVG[Report], ABC):  # noqa: D101

--- a/skore-hub-project/tests/unit/artifact/media/test_performance.py
+++ b/skore-hub-project/tests/unit/artifact/media/test_performance.py
@@ -1,4 +1,3 @@
-from inspect import signature
 from io import BytesIO
 
 from matplotlib import pyplot as plt
@@ -23,6 +22,7 @@ from skore_hub_project.artifact.media import (
     RocSVGTest,
     RocSVGTrain,
 )
+from skore_hub_project.artifact.media.performance import PerformanceDataFrame
 from skore_hub_project.artifact.serializer import Serializer
 from skore_hub_project.json import dumps
 
@@ -39,10 +39,7 @@ def serialize_svg(display) -> bytes:
 
 
 def serialize_dataframe(display) -> bytes:
-    if "threshold_value" in signature(display.frame).parameters:
-        frame = display.frame(threshold_value="all")
-    else:
-        frame = display.frame()
+    frame = display.frame(**PerformanceDataFrame.get_frame_kwargs(display))
 
     return dumps(
         frame.astype(object).where(frame.notna(), "NaN").to_dict(orient="tight")


### PR DESCRIPTION
Two optional parameters were not passed when computing performance related data frames.
