### PR TITLE
chore(skore-hub-project): Bump the version of skore-hub-project to build the doc

### DIFF
--- a/ci/requirements/skore/python-3.13/scikit-learn-1.8/sphinx-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.8/sphinx-requirements.txt
@@ -103,8 +103,6 @@ graphql-core==3.2.8
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.3.2
-    # via sqlalchemy
 gunicorn==25.1.0
     # via mlflow
 h11==0.16.0
@@ -390,7 +388,7 @@ six==1.17.0
     # via python-dateutil
 skops==0.13.0
     # via mlflow
-skore-hub-project==0.0.18
+skore-hub-project==0.0.19
     # via skore (skore/pyproject.toml)
 skore-local-project==0.0.5
     # via skore (skore/pyproject.toml)

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -83,7 +83,7 @@ dev = [
   "ipykernel",
 ]
 local = ["skore-local-project>=0.0.4"]
-hub = ["skore-hub-project>=0.0.17"]
+hub = ["skore-hub-project>=0.0.19"]
 mlflow = ["skore-mlflow-project>=0.0.2"]
 
 [project.urls]


### PR DESCRIPTION
Currently, we use `skore-hub-project` 0.18.0 to build the documentation but there is a bug to have a working public project example.

Bumping the minimum requirements then.