### PR TITLE
docs(skore): Add skore.login to API documentation

### DIFF
--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -22,6 +22,9 @@ Project Management
 
    * - :class:`Project`
      - Main class for managing a skore project and its reports
+   * - :func:`login`
+     - Login to remote backend (e.g. Skore Hub) to later use the project management
+       features.
 
 
 ML Assistance


### PR DESCRIPTION
closes #2640 

Add the function `skore.login` to the API reference page.