### PR TITLE
chore: Make update compliant for bash<4

### DIFF
--- a/ci/pip-compile.sh
+++ b/ci/pip-compile.sh
@@ -46,8 +46,7 @@ case $1 in
         esac
 
         for PACKAGE in "${PACKAGES[@]}"; do
-            while IFS= read -r combination || [[ -n "${combination}" ]]; do
-                [[ -z "${combination}" ]] && continue
+            while IFS= read -r combination; do
                 python=$(jq -rc '.python' <<< "${combination}")
                 dependencies=$(jq -rc '.dependencies' <<< "${combination}")
 
@@ -83,9 +82,8 @@ set -eu
     # Move to `TMPDIR` to avoid absolute paths in requirements file
     cd "${TMPDIR}"
 
-    i=0
-    while [ "${i}" -lt "${#COMBINATIONS[@]}" ]; do
-        combination="${COMBINATIONS[i]}"
+    for combination in "${COMBINATIONS[@]}"
+    do
         IFS="|" read -r PACKAGE EXTRA PYTHON DEPENDENCIES <<< "${combination}"
 
         # Escape dependencies to be used in filename, both in Linux and Windows:
@@ -128,6 +126,5 @@ set -eu
            "${@:1}"
 
         let counter++
-        i=$((i + 1))
     done
 )


### PR DESCRIPTION
The current file uses `mapfiles` that is only available for bash 4 while MacOS has only bash 3.2

We can then avoid to use this function.