### PR TITLE
docs(skore): Add login to autosummary to generate API doc

### DIFF
--- a/sphinx/reference/project.rst
+++ b/sphinx/reference/project.rst
@@ -9,10 +9,15 @@ Skore project
 These functions and classes are meant for managing a `Project` and its reports.
 
 .. autosummary::
+    :toctree: api/
+    :template: base.rst
+
+    login
+
+.. autosummary::
    :toctree: api/
    :template: class_with_accessors.rst
 
-   login
    Project
 
 .. rubric:: Methods


### PR DESCRIPTION
In the dev version of the documentation, we see that we don't have the API docstring generated for the login function:

<img width="863" height="212" alt="image" src="https://github.com/user-attachments/assets/2965c96f-c944-420a-9b22-716a4991019b" />

This PR add `login` to autosummary to make sure we generate it.