### PR TITLE
docs(skore): Update the user guide documentation

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -50,6 +50,10 @@ extensions = [
 ]
 exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 
+# When sphinx-gallery ignores an example (e.g. ``plot_getting_started`` without Hub
+# credentials), the generated ``.rst`` is still emitted and is not in any toctree.
+suppress_warnings = ["toc.not_included"]
+
 # Configuration for generate_accessor_tables extension
 accessor_summary_classes = [
     "skore.EstimatorReport",

--- a/sphinx/reference/report/comparison_report.rst
+++ b/sphinx/reference/report/comparison_report.rst
@@ -1,3 +1,5 @@
+.. _comparison_report:
+
 Comparing multiple reports
 ==========================
 
@@ -34,6 +36,8 @@ way. The functionalities of the report are accessible through accessors.
 
     ComparisonReport.inspection
     ComparisonReport.metrics
+
+.. _comparison_metrics:
 
 Metrics
 -------

--- a/sphinx/reference/report/cross_validation_report.rst
+++ b/sphinx/reference/report/cross_validation_report.rst
@@ -1,3 +1,5 @@
+.. _cross_validation_report:
+
 Report for a cross-validation of an estimator
 =============================================
 

--- a/sphinx/reference/report/estimator_report.rst
+++ b/sphinx/reference/report/estimator_report.rst
@@ -1,3 +1,5 @@
+.. _estimator_report:
+
 Report for a single estimator
 =============================
 

--- a/sphinx/sphinxext/github_link.py
+++ b/sphinx/sphinxext/github_link.py
@@ -7,7 +7,6 @@ import inspect
 import os
 import subprocess
 import sys
-from functools import partial
 from operator import attrgetter
 
 REVISION_CMD = "git rev-parse --short HEAD"
@@ -84,9 +83,11 @@ def make_linkcode_resolve(package, url_fmt):
                                    '{path}#L{lineno}')
     """
     revision = _get_git_revision()
-    return partial(
-        _linkcode_resolve, revision=revision, package=package, url_fmt=url_fmt
-    )
+
+    def linkcode_resolve(domain, info):
+        return _linkcode_resolve(domain, info, package, url_fmt, revision)
+
+    return linkcode_resolve
 
 def setup(app):
     """Configure linkcode_resolve for GitHub links."""

--- a/sphinx/user_guide/displays.rst
+++ b/sphinx/user_guide/displays.rst
@@ -12,11 +12,11 @@ residual plots, summaries of the data—that explain **how well** the model beha
 **why** it looks that way. Doing that by hand means wiring predictions, labels, and
 metrics into matplotlib or seaborn over and over, with slightly different function
 signatures every time, recomputing expensive steps when you tweak a plot, and juggling
-notebook “magic” versus scripts that must call ``show()`` explicitly. When you finally
+notebook "magic" versus scripts that must call ``show()`` explicitly. When you finally
 need the **numbers** behind a chart—for a report, a dashboard, or a statistical
 test—you often end up duplicating logic or scraping axes objects.
 
-Skore’s **display** objects target that gap. A display is a small, dedicated object you
+Skore’s :class:`Display` objects target that gap. A display is a small, dedicated object you
 obtain from a **report** (for example via accessors such as ``report.metrics`` or
 ``report.data``). It already holds the computed quantities needed for a given diagnostic
 view. You are not meant to construct displays from scratch; they are the visualization
@@ -74,7 +74,7 @@ The ``help`` method shows the available attributes and methods for a given displ
     display.help()
 
 You can restyle before plotting—for example the chance level on a ROC curve—then every
-later ``plot`` uses those settings:
+later ``plot`` call will use those settings:
 
 .. plot::
     :context: close-figs

--- a/sphinx/user_guide/displays.rst
+++ b/sphinx/user_guide/displays.rst
@@ -1,14 +1,47 @@
 .. _displays:
 
-=========================================
-Visualization via the `skore` display API
-=========================================
+======================================
+From evaluation results to clear views
+======================================
 
 .. currentmodule:: skore
 
-`skore` provides a family of objects that we call displays. All displays follow the
-common API defined by the :class:`Display` protocol. As a user, you get a display by
-interacting with a reporter. Let's provide an example:
+Once you have fitted a model and scored it, the next step is almost always the same in
+spirit and tedious in practice: you need **figures and tables**—curves, matrices,
+residual plots, summaries of the data—that explain **how well** the model behaves and
+**why** it looks that way. Doing that by hand means wiring predictions, labels, and
+metrics into matplotlib or seaborn over and over, with slightly different function
+signatures every time, recomputing expensive steps when you tweak a plot, and juggling
+notebook “magic” versus scripts that must call ``show()`` explicitly. When you finally
+need the **numbers** behind a chart—for a report, a dashboard, or a statistical
+test—you often end up duplicating logic or scraping axes objects.
+
+Skore’s **display** objects target that gap. A display is a small, dedicated object you
+obtain from a **report** (for example via accessors such as ``report.metrics`` or
+``report.data``). It already holds the computed quantities needed for a given diagnostic
+view. You are not meant to construct displays from scratch; they are the visualization
+layer that sits on top of the same evaluation you used to build the report, so the story
+from metrics to plot stays in one place.
+
+All displays share the same idea of a **stable API**, formalized by the :class:`Display`
+protocol, so learning one display teaches you the others:
+
+- ``plot`` builds a :class:`matplotlib.figure.Figure` from the display’s data and
+  **returns** it. Calling ``plot`` again does not mutate stored results or repeat heavy
+  work unnecessarily; in Jupyter, a bare ``display.plot()`` at the end of a cell can
+  show the figure, while in a script you typically assign the figure and call
+  ``fig.show()`` if needed.
+- ``set_style`` adjusts how subsequent ``plot`` calls render (for example line styles or
+  colors), which helps when you want publication-ready output without rewriting the
+  underlying computation.
+- ``frame`` exposes the underlying data as a :class:`pandas.DataFrame`, so the same view
+  you plotted is also available for filtering, exporting, or custom analysis.
+- ``help`` lists what that display offers in your environment (for example via rich in
+  the terminal or HTML in a notebook), which reduces guesswork when exploring a new
+  chart type.
+
+The example below follows that pattern: evaluate a model, ask the report for a ROC view,
+then plot it.
 
 .. plot::
     :context: close-figs
@@ -29,30 +62,19 @@ interacting with a reporter. Let's provide an example:
     display = report.metrics.roc()
     display.plot()
 
-The :meth:`EstimatorReport.metrics.roc` creates a :class:`RocCurveDisplay` object.
+Here :meth:`EstimatorReport.metrics.roc` returns a :class:`RocCurveDisplay`. Other
+report facets expose other display types (confusion matrices, prediction errors, data
+summaries, and so on); see the report sections in the reference and
+:ref:`example_skore_api` for breadth.
 
-The ``help`` method displays the available attributes and methods of the
-display object interactively:
+The ``help`` method shows the available attributes and methods for a given display:
 
 .. code-block:: python
 
     display.help()
 
-Another available method is ``plot``. It builds a :class:`matplotlib.figure.Figure`
-with the information contained in the display and **returns** that figure. In Jupyter,
-leaving ``display.plot()`` as the last expression shows the figure automatically via its
-representation; in a script, assign ``fig = display.plot(...)`` and call ``fig.show()``
-if needed. Call ``plot`` as many times as you want — it does not modify the display's
-underlying data nor require heavy computation.
-
-.. plot::
-    :context: close-figs
-    :align: center
-
-    display.plot()
-
-The ``plot`` method can be preceded by the ``set_style`` method which accepts parameters to
-tweak the rendering of the display. For instance, customize the appearance of the chance level:
+You can restyle before plotting—for example the chance level on a ROC curve—then every
+later ``plot`` uses those settings:
 
 .. plot::
     :context: close-figs
@@ -63,12 +85,11 @@ tweak the rendering of the display. For instance, customize the appearance of th
     )
     display.plot()
 
-Any subsequent call to ``plot`` uses the style settings set by ``set_style``.
-
-The ``frame`` method retrieves the underlying data used to generate the plot as a
-:class:`pandas.DataFrame`:
+Finally, ``frame`` returns the tabular data backing the figure:
 
 .. code-block:: python
 
     df = display.frame()
     df.head()
+
+For the full list of display classes and report accessors, see the API reference.

--- a/sphinx/user_guide/project.rst
+++ b/sphinx/user_guide/project.rst
@@ -1,28 +1,106 @@
 .. _project:
 
-==============================
-Storing data science artifacts
-==============================
+===================
+Manage your reports
+===================
 
 .. currentmodule:: skore
 
-`skore` provides a :class:`Project` class to store data science artifacts. The storage
-is either local or remote, based on the value passed to the parameter `mode` at
-initialization. When `mode` is set to `hub`, the project is configured to communicate
-with `skore hub`. Refer to the documentation of :class:`Project` for the detailed API
-and take a look on the `example <example-getting-started_>`_.
+When you evaluate models with Skore, you get rich **reports**—structured objects that
+capture metrics, diagnostics, and context. A :class:`Project` is where those reports
+**live** between sessions: a named collection you can grow over time, compare, and load
+back into Python.
 
-Once a project is created, store :class:`EstimatorReport` via the method
-:meth:`Project.put`.
+You pick the storage back end with the ``mode`` argument when you construct the project
+(for example ``mode="local"``, ``mode="hub"``, or ``mode="mlflow"``). The sections below
+first cover **storing** (where data goes and how :meth:`Project.put` behaves), then
+**retrieving** (overview with :meth:`Project.summarize` and single-report access with
+:meth:`Project.get`).
 
-To retrieve the reports stored in the project, use the project summary by calling the
-method :meth:`Project.summarize`. This method returns a summary table with a rich HTML
-representation in interactive Jupyter-like environments.
+Storing reports
+---------------
 
-The summary view allows filtering reports using a parallel coordinates plot. Once the
-reports are filtered, retrieve them by calling the ``reports`` method on the object
-returned by :meth:`Project.summarize`. This method returns a list of
-:class:`EstimatorReport` instances.
+**Storing** combines two ideas: **where** reports are persisted (local disk, Skore Hub,
+or MLflow), and **how** you write them into the project. The three modes differ in
+privacy, collaboration, and integration with other tooling, but the entry point is
+always :meth:`Project.put`.
 
-To retrieve a specific report for which you have its `id`, use the method
-:meth:`Project.get` to retrieve the :class:`EstimatorReport`.
+Regardless of mode, a project may only contain reports for **one ML task** (for example
+all regression or all classification) so comparisons stay meaningful. Skore enforces
+that once you start storing reports.
+
+To save a report, call ``put`` with a string **key** (a name you choose for that run
+within the project) and an :class:`EstimatorReport` or :class:`CrossValidationReport`.
+If you call ``put`` again with the same key, the project keeps **history**, but the
+key’s **current** report becomes the new one.
+
+Local mode: your machine, your copy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Local** mode is the default. Everything stays on disk on the machine where you run
+the code. You **do not start any server**—no tracking server, hub endpoint, or
+background process—and nothing is sent over the network. It suits everyday work,
+teaching, prototypes, and any case where your machine is the source of truth.
+
+Several named projects can share one **workspace** directory; you can set it explicitly
+or rely on a default location for your OS. When you ``put``, Skore writes into that
+local layout; the **key** is simply the human-readable label for the run inside the
+project. See :ref:`example_skore_local_project` for a full script.
+
+Hub mode: shared, remote projects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Hub** mode targets teams that want a **central** place for reports: access control, a
+shared namespace, and storage on **Skore Hub** instead of only on each laptop. Use it
+when others must see the same projects or when hosting and governance matter.
+
+You authenticate (for example via the client login flow) and name the project with a
+**workspace** and **project** as configured in the Skore Hub UI. Each ``put`` sends the
+report to that remote project; the **key** is again your label for the run within the
+project. See the `Hub Skore Project <example-skore-hub-project_>`_ example.
+
+MLflow mode: meet your existing tracking stack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**MLflow** mode fits stacks that already use **MLflow**—shared tracking servers,
+experiment views, or pipelines that expect runs, metrics, and artifacts there. Skore
+**complements** MLflow: your reports show up as runs in an MLflow **experiment** (the
+project ``name`` is the experiment name), next to other logged work.
+
+Here ``put`` has extra meaning: the **key** becomes the **MLflow run name**, and each
+``put`` creates a **new run**, logs metrics and related artifacts, and stores a pickled
+copy of the report so it can be reloaded. You must not already have another MLflow run
+open in the same process when you call ``put``. See :ref:`example_skore_mlflow_project`
+for a runnable setup (including a local MLflow server).
+
+Retrieving reports
+------------------
+
+Summary overview
+^^^^^^^^^^^^^^^^
+
+Call :meth:`Project.summarize` to see **every** report currently in the project at once.
+The return value is a **Summary**: a table of metadata and metrics (one row per report)
+built on :class:`pandas.DataFrame`, so you can sort, slice, and use
+:meth:`pandas.DataFrame.query` like any dataframe.
+
+In Jupyter, with the optional widget extras installed, the summary can also render as an
+interactive view (often with a parallel-coordinates plot) to explore and filter runs.
+Whether you use the widget or the plain table, it is the same object.
+
+After filtering if you wish, call ``.reports()`` on that summary to load the matching
+full :class:`EstimatorReport` or :class:`CrossValidationReport` instances—typical when
+you want to compare several candidates or open a short list of finalists.
+
+Single report by id
+^^^^^^^^^^^^^^^^^^^
+
+When you already know which stored report you need, :meth:`Project.get` loads it by
+**id**. Ids show up in the summary index (and in the MLflow UI for MLflow-backed
+projects). They depend on ``mode``:
+
+- **Local** and **hub**: Skore’s report id for that stored object.
+- **MLflow**: the **MLflow run id** of the run created by ``put``.
+
+If nothing matches, ``get`` raises ``KeyError``. For full signatures and edge cases, see
+:class:`Project` and the `getting started example <example-getting-started_>`_.

--- a/sphinx/user_guide/project.rst
+++ b/sphinx/user_guide/project.rst
@@ -11,7 +11,7 @@ capture metrics, diagnostics, and context. A :class:`Project` is where those rep
 **live** between sessions: a named collection you can grow over time, compare, and load
 back into Python.
 
-You pick the storage back end with the ``mode`` argument when you construct the project
+You pick the storage backend with the ``mode`` argument when you construct the project
 (for example ``mode="local"``, ``mode="hub"``, or ``mode="mlflow"``). The sections below
 first cover **storing** (where data goes and how :meth:`Project.put` behaves), then
 **retrieving** (overview with :meth:`Project.summarize` and single-report access with
@@ -51,7 +51,7 @@ Hub mode: shared, remote projects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Hub** mode targets teams that want a **central** place for reports: access control, a
-shared namespace, and storage on **Skore Hub** instead of only on each laptop. Use it
+shared namespace, and storage on **Skore Hub** instead of only on users' laptops. Use it
 when others must see the same projects or when hosting and governance matter.
 
 You authenticate (for example via the client login flow) and name the project with a
@@ -92,15 +92,15 @@ After filtering if you wish, call ``.reports()`` on that summary to load the mat
 full :class:`EstimatorReport` or :class:`CrossValidationReport` instances—typical when
 you want to compare several candidates or open a short list of finalists.
 
-Single report by id
+Single report by ID
 ^^^^^^^^^^^^^^^^^^^
 
 When you already know which stored report you need, :meth:`Project.get` loads it by
-**id**. Ids show up in the summary index (and in the MLflow UI for MLflow-backed
+**ID**. IDs show up in the summary index (and in the MLflow UI for MLflow-backed
 projects). They depend on ``mode``:
 
-- **Local** and **hub**: Skore’s report id for that stored object.
-- **MLflow**: the **MLflow run id** of the run created by ``put``.
+- **Local** and **hub**: Skore’s report ID for that stored object.
+- **MLflow**: the **MLflow run ID** of the run created by ``put``.
 
 If nothing matches, ``get`` raises ``KeyError``. For full signatures and edge cases, see
 :class:`Project` and the `getting started example <example-getting-started_>`_.

--- a/sphinx/user_guide/reporters.rst
+++ b/sphinx/user_guide/reporters.rst
@@ -1,175 +1,130 @@
 .. _reporters:
 
-====================================
-Structuring data science experiments
-====================================
+=================================
+Evaluation and structured reports
+=================================
 
 .. currentmodule:: skore
 
-When experimenting with data science, many tasks are repetitive across experiments or
-projects. While the data exploration, transformation, and model architecture design
-might require innovation, the evaluation, inspection, and comparison of predictive
-models are usually repetitive. However, these tasks require developing substantial
-amounts of code and storing useful information. In itself, it is a challenge to get it
-right.
+When you experiment with predictive models, a large part of the work is not novel:
+you repeatedly evaluate performance, inspect how the model uses the data, and compare
+candidates. That work still takes a lot of boilerplate and scattered code if you
+assemble it by hand each time.
 
-`skore` provides a set of *reporters* that provide the following features:
+`skore` focuses that workflow behind :func:`~skore.evaluate` and **reports** that expose
+a small, consistent API. A report is a structured object that answers questions about
+**the data** used for evaluation, **how well** the model performs, and **what happens
+inside** the model, without you wiring plots and tables from scratch.
 
-- Provide only methods applicable to the task at hand
-- Cache intermediate results to speed up exploring predictive models
-- Produce data science artifacts with the least amount of code
+Starting point: :func:`~skore.evaluate`
+---------------------------------------
 
-Below, we present the different types of reporters that `skore` provides.
+:func:`~skore.evaluate` is the main entry point to evaluate **one or several**
+scikit-learn–compatible estimators on feature matrix ``X`` and target ``y``.
 
-.. _estimator_report:
+The ``splitter`` argument controls how ``X`` and ``y`` are split for evaluation. For a
+**single train–test split**, pass a **float** (the default is ``0.2``) or a
+:class:`~skore.TrainTestSplit` instance (see :func:`~skore.train_test_split`).
+**Otherwise**, use any **scikit-learn cross-validation splitter** that follows the usual
+scikit-learn cross-validation API.
 
-Reporter for a single estimator
--------------------------------
+Sometimes you only need to **evaluate a model that is already fitted**, without
+refitting it. Pass ``splitter="prefit"`` in that case: ``X`` and ``y`` are treated as
+the test set, and the estimator is not fit again.
 
-:class:`EstimatorReport` is the core reporter in `skore`. It is designed to take a
-scikit-learn compatible estimator and some training and test data. The training data is
-optional if the estimator is already fitted. The parameter `fit` in the constructor
-gives full control over the fitting process. Omitting part of the data reduces the
-number of available methods when inspecting the model. For instance, you cannot inspect
-the metrics of the model on the test data if you do not provide the test data.
+For the full parameter list and return type rules, see the API documentation for
+:func:`~skore.evaluate`.
 
-Data insights
-^^^^^^^^^^^^^
+Three report types, one layout
+------------------------------
 
-:obj:`EstimatorReport.data` is the entry point to get insights on the dataset used to
-train and test the predictive model. It provides a :meth:`EstimatorReport.data.analyze`
-method that returns a :class:`~skore.TableReportDisplay` display. This display makes
-essential analysis of the dataset. The parameter `data_source` specifies which portion
-of the dataset to analyze, whether the train or test data or both. This display is
-particularly useful to see feature distributions and correlation between features as
-well as general statistics of the dataset such as type of data, missing values, etc.
+Depending on ``splitter`` and whether you pass one estimator or a list,
+:func:`~skore.evaluate` returns one of:
 
-Refer to :ref:`estimator_data` for more details regarding the API.
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
 
-Model evaluation
-^^^^^^^^^^^^^^^^
+   * - Return type
+     - Typical use
+   * - :class:`EstimatorReport`
+     - Single train–test split or prefitted estimator.
+   * - :class:`CrossValidationReport`
+     - Cross-validation with more than one split.
+   * - :class:`ComparisonReport`
+     - List of estimators evaluated together.
 
-:obj:`EstimatorReport.metrics` is the entry point that provides methods to evaluate the
-statistical and performance metrics of the predictive model. This accessor provides two
-types of methods:
+All three share the same **accessor** idea where it applies:
 
-1. Methods that return some metrics,
-2. Methods that return a :class:`skore.Display` object.
+- ``.data`` — dataset-oriented analysis (:class:`EstimatorReport`,
+  :class:`CrossValidationReport` only).
+- ``.metrics`` — performance numbers, summaries, and task-specific diagnostics.
+- ``.inspection`` — interpretability and internal structure of the model.
 
-Before diving into the details of these methods, we first discuss the parameters they
-share. `data_source` is a parameter that specifies the data to use to compute the
-metrics. Set it to `train` or `test` to rely on the data provided to the constructor. In
-addition, set `data_source` to `X_y` to pass a new dataset using the parameters `X` and
-`y`. This is useful when you want to compare different models on a new left-out dataset.
+:class:`ComparisonReport` has **no** ``data`` accessor, because compared models may use
+different inputs; use each underlying report in :attr:`~skore.ComparisonReport.reports_`
+if you need per-model data views.
 
-There are individual methods to compute each metric specific to the problem at hand.
-They return usual python objects such as floats, integers, or dictionaries.
+If you already have separate reports (same test target), you can also build a
+:class:`ComparisonReport` with :func:`~skore.compare`.
 
-The second type of methods provided by :obj:`EstimatorReport.metrics` are methods that
-return a :class:`~skore.Display` object. They have a common API as well. They expose
-three methods:
-
-1. `plot` that plots graphically the information contained in the display,
-
-2. `set_style` that sets some graphical settings instead of passing them to the `plot`
-   method at each call,
-
-3. `frame` that returns a `pandas.DataFrame` with the information contained in the
-   display.
-
-We provide the :class:`EstimatorReport.metrics.summarize` method that aggregates metrics
-in a single dataframe, available through a :class:`~skore.Display`. By default, a set of
-metrics is computed based on the type of target variable (e.g. classification or
-regression). Nevertheless, you can specify the metrics you want to compute thanks to the
-`scoring` parameter. We accept different types:
-
-1. A string that corresponds to a scikit-learn scorer name or a built-in `skore`
-   metric name,
-
-2. A callable,
-
-3. A scikit-learn scorer constructed with :func:`sklearn.metrics.make_scorer`.
-
-Refer to the :ref:`displays` section for more details regarding the `skore` display
-API. Refer to the :ref:`estimator_metrics` section for more details on all the
-available metrics in `skore`.
-
-Model interpretability
-^^^^^^^^^^^^^^^^^^^^^^
-
-:obj:`EstimatorReport.inspection` is the entry point to interpret and explain a
-predictive model. This accessor provides methods that return a :class:`skore.Display`
-object. As with other display objects, they expose three methods: `plot`, `set_style`
-and `frame`.
-
-Caching mechanism
-^^^^^^^^^^^^^^^^^
-
-:class:`EstimatorReport` comes together with a caching mechanism that stores
-intermediate information that is expensive to compute, such as predictions. It
-efficiently re-uses this information when recomputing the same metric or a metric
-requiring the same intermediate information.
-
-We expose three methods to interact with the cache:
-
-- :meth:`EstimatorReport.cache_predictions` to cache the predictions of the estimator
-  without awaiting the computation when calling the evaluation metrics.
-- :meth:`EstimatorReport.clear_cache` to clear the cache.
-- :meth:`EstimatorReport.get_predictions` to get the predictions from the cache or
-  compute them if they are not in the cache.
-
-.. note::
-    The current implementation of the caching mechanism happens in-memory. It is
-    therefore not persisted between sessions, apart from loading an
-    :class:`EstimatorReport` from a :class:`Project`. Refer to the following
-    section :ref:`project` for more details.
-
-Refer to the example entitled
-:ref:`sphx_glr_auto_examples_technical_details_plot_cache_mechanism.py` to get a
-detailed view of the caching mechanism.
-
-.. _cross_validation_report:
-
-Cross-validation estimator
+What the accessors are for
 --------------------------
 
-:class:`CrossValidationReport` has a similar API to :class:`EstimatorReport`. The main
-difference is in the initialization. It accepts an estimator, a dataset (i.e. `X` and
-`y`) and a cross-validation strategy. Internally, the dataset is split according to the
-cross-validation strategy and an estimator report is created for each split. Therefore,
-a :class:`CrossValidationReport` is a collection of :class:`EstimatorReport` instances,
-available through the :obj:`CrossValidationReport.estimator_reports_` attribute.
+Data insights (``report.data``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For metrics and displays, the same API is exposed with an extra
-parameter, `aggregate`, to aggregate the metrics across the splits.
+The **data** accessor summarizes the dataset tied to the evaluation: useful views of
+distributions, relationships between features, column types, missing values, and
+similar exploratory signals. On a single train–test report you can often focus on
+train, test, or both; on a cross-validation report, the analysis refers to the full
+``X`` and ``y`` passed to :func:`~skore.evaluate`.
 
-The :class:`CrossValidationReport` also comes with a caching mechanism by leveraging
-the :class:`EstimatorReport` caching mechanism and exposes the same methods.
+See :ref:`estimator_data` for the detailed API on :class:`EstimatorReport` (the
+cross-validation accessor follows the same role on the full dataset).
 
-Refer to the :ref:`cross_validation_metrics` section for more details on the
-metrics available in `skore` for cross-validation.
+Model evaluation (``report.metrics``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _comparison_report:
+The **metrics** accessor covers **statistical** performance (how good the predictions
+are) and **computational** cost (how long fitting and predicting take). You can read
+metrics **individually** or as a **summary table** via
+:meth:`EstimatorReport.metrics.summarize` (and the corresponding accessors on
+:class:`CrossValidationReport` and :class:`ComparisonReport`).
 
-Comparison report
------------------
+When you do not pass an explicit list of metrics, the defaults depend on the **machine
+learning task** that `skore` infers from ``y`` and the estimator:
 
-To compare the performance of different predictive models, `skore` provides the
-:class:`ComparisonReport`.
+- **Classification**: accuracy, precision, and recall. For **binary** classification,
+  ROC AUC is included as well, and if the estimator defines ``predict_proba``, Brier
+  score is added. For **multiclass** classification, if ``predict_proba`` is
+  available, ROC AUC and log loss are added to the defaults.
+- **Regression**: R² (``r2``) and root mean squared error (``rmse``).
 
-:class:`ComparisonReport` takes a list (or a dictionary) of :class:`EstimatorReport` or
-:class:`CrossValidationReport` instances. It then provides methods to compare the
-performance of the different models.
+In all of these cases the default summary also includes **fit time** and **predict
+time**. You can override the choice of metrics via the ``summarize`` API;
+cross-validation and comparison reports support aggregating across folds or models where
+relevant.
 
-In order for the comparison to make sense, the reports must all have the same test
-target. However, they may have different training data or target; this might be the case
-when comparing a new model with the current production model, for example. They may also
-have different testing data (:math:`X_{test}`), which means the compared model pipelines
-do not necessarily need to be the same. The comparison of test targets is done by
-computing a hash of the arrays. Therefore, if the y_test are functionally equal, but
-have different data types, they will be considered as different.
+See :ref:`estimator_metrics` for :class:`EstimatorReport`,
+:ref:`cross_validation_metrics` for :class:`CrossValidationReport`, and
+:ref:`comparison_metrics` for :class:`ComparisonReport`.
 
-The caching mechanism is also available and exposes the same methods.
+Model interpretability (``report.inspection``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Refer to the :ref:`cross_validation_metrics` section for more details on the
-metrics available in `skore` for comparison.
+The **inspection** accessor surfaces model internals and explanations that depend on
+the estimator family: for example coefficients for linear models, or feature
+importance–style summaries for tree-based models. What is available follows the
+estimator you passed to :func:`~skore.evaluate`.
+
+Technical notes
+---------------
+
+For a **walkthrough of the unified API** (the three report types, ``data`` /
+``metrics`` / ``inspection``, and displays), see :ref:`example_skore_api`.
+
+To use **scikit-learn–compatible estimators** from other libraries (e.g. gradient
+boosting packages) or custom classes with a familiar ``fit`` / ``predict`` interface,
+see :ref:`example_sklearn_api`. For ROC-based metrics, the estimator typically needs
+``predict_proba`` when applicable, as noted in that example.

--- a/sphinx/user_guide/reporters.rst
+++ b/sphinx/user_guide/reporters.rst
@@ -1,8 +1,8 @@
 .. _reporters:
 
-================================
+===============================
 Evaluate your predictive models
-================================
+===============================
 
 .. currentmodule:: skore
 
@@ -76,7 +76,7 @@ Data insights (``report.data``)
 
 The **data** accessor summarizes the dataset tied to the evaluation: useful views of
 distributions, relationships between features, column types, missing values, and
-similar exploratory signals. On a single train–test report you can often focus on
+similar exploratory signals. On a single train-test report you can often focus on
 train, test, or both; on a cross-validation report, the analysis refers to the full
 ``X`` and ``y`` passed to :func:`~skore.evaluate`.
 
@@ -125,6 +125,6 @@ For a **walkthrough of the unified API** (the three report types, ``data`` /
 ``metrics`` / ``inspection``, and displays), see :ref:`example_skore_api`.
 
 To use **scikit-learn–compatible estimators** from other libraries (e.g. gradient
-boosting packages) or custom classes with a familiar ``fit`` / ``predict`` interface,
+boosting packages, tabular foundational models) or custom classes with the scikit-learn ``fit`` / ``predict`` interface,
 see :ref:`example_sklearn_api`. For ROC-based metrics, the estimator typically needs
 ``predict_proba`` when applicable, as noted in that example.

--- a/sphinx/user_guide/reporters.rst
+++ b/sphinx/user_guide/reporters.rst
@@ -1,8 +1,8 @@
 .. _reporters:
 
-=================================
-Evaluation and structured reports
-=================================
+================================
+Evaluate your predictive models
+================================
 
 .. currentmodule:: skore
 


### PR DESCRIPTION
closes https://github.com/probabl-ai/skore/issues/1993

Revamp the documentation of the user guide. It is just an update given the recent changes that we have and it does not really change the narrative.

With the work on diagnosis, the user guide will become more interesting I think.