### PR TITLE
chore(skore-hub-project): Call `display.frame(aggregate=None)` in `inspection.py`

### DIFF
--- a/skore-hub-project/src/skore_hub_project/artifact/media/inspection.py
+++ b/skore-hub-project/src/skore_hub_project/artifact/media/inspection.py
@@ -6,7 +6,6 @@ from abc import ABC
 from collections.abc import Callable
 from functools import reduce
 from importlib import metadata
-from inspect import signature
 from typing import ClassVar, Literal, cast
 
 from packaging.version import Version
@@ -31,12 +30,7 @@ class Inspection(Media[Report], ABC):  # noqa: D101
             return None
 
         display = function()
-        # FIXME: in the future, all inspection methods should have an aggregate
-        # parameter and we should be sending unaggregated data to the hub.
-        if "aggregate" in signature(display.frame).parameters:
-            frame = display.frame(aggregate=None)
-        else:
-            frame = display.frame()
+        frame = display.frame(aggregate=None)
 
         return dumps(
             frame.astype(object).where(frame.notna(), "NaN").to_dict(orient="tight")


### PR DESCRIPTION
Remove deprecated code.