### PR TITLE
chore(skore): Avoid FutureWarning pandas 2.x

### DIFF
--- a/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
@@ -589,13 +589,15 @@ class ConfusionMatrixDisplay(_ClassifierDisplayMixin, DisplayMixin):
 
         frames = []
         if self.report_type == "comparison-cross-validation":
-            for _, group in self.confusion_matrix.groupby(["split", "estimator"]):
+            for _, group in self.confusion_matrix.groupby(
+                ["split", "estimator"], observed=True
+            ):
                 frames.append(select_threshold_and_format(group))
         elif self.report_type == "cross-validation":
-            for _, group in self.confusion_matrix.groupby(["split"]):
+            for _, group in self.confusion_matrix.groupby(["split"], observed=True):
                 frames.append(select_threshold_and_format(group))
         elif self.report_type == "comparison-estimator":
-            for _, group in self.confusion_matrix.groupby(["estimator"]):
+            for _, group in self.confusion_matrix.groupby(["estimator"], observed=True):
                 frames.append(select_threshold_and_format(group))
         else:
             frames.append(select_threshold_and_format(self.confusion_matrix))


### PR DESCRIPTION
Currently, we raise the following warning in the confusion matrix with Pandas 2.X:

```
/Users/glemaitre/Documents/management/products/2026-03-31-demo-cfm/.pixi/envs/default/li
b/python3.14/site-packages/skore/_sklearn/_plot/metrics/confusion_matrix.py:604: 
FutureWarning: The default of observed=False is deprecated and will be changed to True 
in a future version of pandas. Pass observed=False to retain current behavior or 
observed=True to adopt the future default and silence this warning.
  for _, group in self.confusion_matrix.groupby(["split"]):
```