### PR TITLE
fix(skore): Eager id to avoid mutation (which breaks checksum in `skore-hub-project`)

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from io import StringIO
 from typing import Generic, Literal, TypeVar
 from uuid import uuid4
@@ -26,9 +25,8 @@ class _BaseReport(ReportHelpMixin):
         "comparison-cross-validation",
     ]
 
-    @cached_property
-    def id(self) -> int:
-        return uuid4().int
+    def __init__(self) -> None:
+        self.id = uuid4().int
 
     @property
     def _hash(self) -> int:

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -250,6 +250,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         - all estimators have non-empty X_test and y_test,
         - all estimators have the same X_test and y_test.
         """
+        super().__init__()
         self.reports_, self._report_type, self._pos_label = (
             ComparisonReport._validate_reports(reports)
         )

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -152,6 +152,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         splitter: int | SKLearnCrossValidator | Generator | None = None,
         n_jobs: int | None = None,
     ) -> None:
+        super().__init__()
         if is_clusterer(estimator):
             raise ValueError(
                 "Clustering models are not supported yet. Please use a"

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -174,6 +174,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         y_test: ArrayLike,
         pos_label: PositiveLabel | None = None,
     ) -> None:
+        super().__init__()
         self._fit = fit
 
         if is_clusterer(estimator):


### PR DESCRIPTION
#### Change description

Define `self.id` at init instead of a cached property. The cached property breaks the checksum stability in `skore-hub-project` (try running tests on "main-main", you'll see). 

#### AI usage disclosure

Research and understanding
