### PR TITLE
fix(skore-local-project): Fix mypy linting

### DIFF
--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -179,7 +179,6 @@ class Project:
         -----
         The report is pickled without its cache, to avoid salting the hash.
         """
-        # test
         reports = [report] + getattr(report, "estimator_reports_", [])
         reports_with_cache = [
             (report, report._cache) for report in reports if hasattr(report, "_cache")
@@ -195,7 +194,7 @@ class Project:
                 pickle_hash = joblib.hash(pickle_bytes)
         finally:
             for report, cache in reports_with_cache:
-                report._cache = cache
+                report._cache = cache  # type: ignore[union-attr]
 
         return pickle_hash, pickle_bytes
 


### PR DESCRIPTION
I don't know why, but `mypy` started failing in `skore-local-project` (after the release I think?).

#### Change description

Dirty fix: `# type: ignore[union-attr]`

We'll do something better after the cache refactor and the get_state/from_state PR.
