### PR TITLE
UX: more compact CrossValidationReport display

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -526,11 +526,14 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         Used by :meth:`_repr_html_` and by :class:`~skore.ComparisonReport` to embed
         one report's views in the comparison HTML repr.
         """
-        metrics_html = (
-            self.metrics.summarize(data_source="test")
-            .frame(aggregate=("mean", "std"), favorability=False)
-            ._repr_html_()
+        metrics = self.metrics.summarize(data_source="test").frame(
+            aggregate=("mean", "std"), favorability=False
         )
+        # Transform a bit the dataframe to make it more compact
+        columns = [col for _, col in metrics.columns.tolist()]
+        metrics.columns = columns
+        metrics.reset_index(inplace=True)
+        metrics_html = metrics.to_html(None, index=False)
 
         df = self.data._prepare_dataframe_for_display(
             with_y=self.ml_task != "clustering"
@@ -582,6 +585,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             "cross_validation_report.html.j2",
             {
                 "container_id": container_id,
+                "estimator_name": self.estimator_name_,
                 "help_doc_url": help_doc_url,
                 "report_class_name": report_class_name,
                 "metrics_accessor_doc_url": metrics_accessor_doc_url,

--- a/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
@@ -19,7 +19,7 @@
         <summary>
             <span class="report-disclosure-title">Diagnostic</span>
         </summary>
-        <p class="report-inline-note" role="note">
+        <p class="report-inline-note report-inline-right" role="note">
             Investigate more with
             <a
                 href="{{ diagnose_documentation_url }}"
@@ -34,7 +34,7 @@
         <summary>
             <span class="report-disclosure-title">Estimator</span>
         </summary>
-        <p class="report-inline-note" role="note">
+        <p class="report-inline-note report-inline-right" role="note">
             Investigate more with
             <a
                 href="{{ inspection_accessor_doc_url }}"
@@ -49,7 +49,7 @@
         <summary>
             <span class="report-disclosure-title">Data</span>
         </summary>
-        <p class="report-inline-note" role="note">
+        <p class="report-inline-note report-inline-right" role="note">
             Investigate more with
             <a
                 href="{{ data_accessor_doc_url }}"

--- a/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
@@ -1,10 +1,10 @@
 <div class="container">
-    <header class="title">CrossValidationReport</header>
+    <header class="title">CrossValidationReport: {{estimator_name}}</header>
     <details open class="report-disclosure">
         <summary>
             <span class="report-disclosure-title">Results</span>
         </summary>
-        <p class="report-inline-note" role="note">
+        <p class="report-inline-note report-inline-right" role="note">
             Investigate more with
             <a
                 href="{{ metrics_accessor_doc_url }}"

--- a/skore/src/skore/_utils/repr/report.css
+++ b/skore/src/skore/_utils/repr/report.css
@@ -49,7 +49,7 @@
 }
 
 .report-inline-right {
-    float: left;
+    float: right;
     margin-top: -1.6em;
 }
 

--- a/skore/src/skore/_utils/repr/report.css
+++ b/skore/src/skore/_utils/repr/report.css
@@ -12,7 +12,6 @@
 
 .report-hint-note::before {
     content: "Note";
-    display: block;
     font-style: normal;
     font-weight: 600;
     font-size: 9px;
@@ -21,6 +20,7 @@
     color: var(--color-orange);
     opacity: 0.9;
     margin-bottom: 0.35em;
+    margin-right: 1em;
 }
 
 .report-hint-note-link {
@@ -46,6 +46,11 @@
     line-height: 1.4;
     opacity: 0.88;
     white-space: nowrap;
+}
+
+.report-inline-right {
+    text-align: right;
+    margin-top: -1.6em;
 }
 
 .report-disclosure {

--- a/skore/src/skore/_utils/repr/report.css
+++ b/skore/src/skore/_utils/repr/report.css
@@ -57,6 +57,16 @@
     color: var(--color-text);
 }
 
+details.report-disclosure {
+    display: inline-flex;
+    padding-right: 1.5em;
+}
+
+details.report-disclosure:open {
+    display: block;
+    padding-right: 0ex;
+}
+
 .report-disclosure > summary {
     cursor: pointer;
     user-select: none;

--- a/skore/src/skore/_utils/repr/report.css
+++ b/skore/src/skore/_utils/repr/report.css
@@ -49,7 +49,7 @@
 }
 
 .report-inline-right {
-    text-align: right;
+    float: left;
     margin-top: -1.6em;
 }
 


### PR DESCRIPTION
Partially addresses  https://github.com/probabl-ai/skore/issues/2738

Makes a more compact display for the CrossValidationReport:

## Now

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/bf1d43e2-aa8e-49be-a896-ce43668a0b61" />


## Before

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/fcc4b1fd-5343-4833-adc5-3a7662c4032e" />

I implemented this only for the CrossValidationReport. A similar change should be done for the EstimatorReport (and maybe for other objects).

Maybe someone should take over this PR and apply the same recipe to the other objects. I won't have time to work more on it. I've implemented it as a way to show simple changes that could make the UX tighter
