### PR TITLE
fix(skore-local-project): Use id to identify report artifact

### DIFF
--- a/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.5/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.2
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -20,13 +20,13 @@ exceptiongroup==1.3.1
     # via pytest
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -55,7 +55,7 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -80,15 +80,15 @@ pandas==2.3.3
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -106,14 +106,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -125,13 +125,13 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -153,13 +153,13 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
@@ -167,11 +167,11 @@ typing-extensions==4.15.0
     # via
     #   exceptiongroup
     #   virtualenv
-tzdata==2025.3
+tzdata==2026.1
     # via pandas
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.5/test-requirements.txt
@@ -151,7 +151,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.2
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -20,13 +20,13 @@ exceptiongroup==1.3.1
     # via pytest
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -55,7 +55,7 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -80,15 +80,15 @@ pandas==2.3.3
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -106,14 +106,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -125,13 +125,13 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -153,13 +153,13 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
@@ -167,11 +167,11 @@ typing-extensions==4.15.0
     # via
     #   exceptiongroup
     #   virtualenv
-tzdata==2025.3
+tzdata==2026.1
     # via pandas
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -151,7 +151,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.5/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,17 +149,17 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via coverage
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.5/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.8/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,17 +149,17 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via coverage
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.11/scikit-learn-1.8/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,15 +149,15 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.8/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,15 +149,15 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.12/scikit-learn-1.8/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,15 +149,15 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,15 +149,15 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,15 +149,15 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.8/test-requirements.txt
@@ -2,11 +2,11 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -18,13 +18,13 @@ distlib==0.4.0
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
@@ -53,11 +53,11 @@ matplotlib==3.10.8
     #   skrub
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -72,21 +72,21 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   seaborn
     #   skore
     #   skrub
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore
 pluggy==1.6.0
     # via
@@ -104,14 +104,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-local-project (skore-local-project/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 pytest-order==1.3.0
     # via skore-local-project (skore-local-project/pyproject.toml)
@@ -123,11 +123,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -149,15 +149,15 @@ six==1.17.0
     # via python-dateutil
 skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore
-skrub==0.7.2
+skrub==0.8.0
     # via skore
 threadpoolctl==3.6.0
     # via scikit-learn
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore-local-project (skore-local-project/pyproject.toml)

--- a/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-local-project/python-3.13/scikit-learn-1.8/test-requirements.txt
@@ -147,7 +147,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.13.1
+skore==0.15.0
     # via skore-local-project (skore-local-project/pyproject.toml)
 skore-local-project==0.0.5
     # via skore

--- a/ci/requirements/skore/python-3.10/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.5/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.2
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -30,19 +30,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==8.38.0
+ipython==8.39.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -80,7 +80,7 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -110,22 +110,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -150,14 +150,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -169,13 +169,13 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -196,7 +196,7 @@ seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -204,7 +204,7 @@ stack-data==0.6.3
     # via ipython
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
@@ -220,15 +220,15 @@ typing-extensions==4.15.0
     #   ipython
     #   optype
     #   virtualenv
-tzdata==2025.3
+tzdata==2026.1
     # via pandas
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.2
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -30,19 +30,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==8.38.0
+ipython==8.39.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -80,7 +80,7 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -110,22 +110,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -150,14 +150,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -169,13 +169,13 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -196,7 +196,7 @@ seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -204,7 +204,7 @@ stack-data==0.6.3
     # via ipython
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
@@ -220,15 +220,15 @@ typing-extensions==4.15.0
     #   ipython
     #   optype
     #   virtualenv
-tzdata==2025.3
+tzdata==2026.1
     # via pandas
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.5/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.10.0
+ipython==9.10.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -205,7 +205,7 @@ stack-data==0.6.3
     # via ipython
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via coverage
 traitlets==5.14.3
     # via
@@ -219,11 +219,11 @@ typing-extensions==4.15.0
     #   optype
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.8/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.10.0
+ipython==9.10.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -205,7 +205,7 @@ stack-data==0.6.3
     # via ipython
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.0
+tomli==2.4.1
     # via coverage
 traitlets==5.14.3
     # via
@@ -219,11 +219,11 @@ typing-extensions==4.15.0
     #   optype
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.12.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -216,11 +216,11 @@ typing-extensions==4.15.0
     #   optype
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.8/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.12.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -216,11 +216,11 @@ typing-extensions==4.15.0
     #   optype
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.12.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -214,11 +214,11 @@ typing-extensions==4.15.0
     # via anywidget
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.12.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -214,11 +214,11 @@ typing-extensions==4.15.0
     # via anywidget
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.12.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -214,11 +214,11 @@ typing-extensions==4.15.0
     # via anywidget
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.8/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.12.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -103,7 +103,7 @@ packaging==26.0
     #   matplotlib
     #   plotly
     #   pytest
-pandas==3.0.1
+pandas==3.0.2
     # via
     #   skore (skore/pyproject.toml)
     #   seaborn
@@ -112,22 +112,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -153,14 +153,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -172,11 +172,11 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -191,13 +191,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -214,11 +214,11 @@ typing-extensions==4.15.0
     # via anywidget
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.8_and_pandas-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.8_and_pandas-2/test-requirements.txt
@@ -1,4 +1,4 @@
-anywidget==0.9.21
+anywidget==0.10.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
@@ -6,13 +6,13 @@ certifi==2026.2.25
     # via requests
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -26,19 +26,19 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-filelock==3.25.1
+filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
-fonttools==4.62.0
+fonttools==4.62.1
     # via matplotlib
-identify==2.6.17
+identify==2.6.18
     # via pre-commit
 idna==3.11
     # via requests
 iniconfig==2.3.0
     # via pytest
-ipython==9.11.0
+ipython==9.12.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -78,11 +78,11 @@ matplotlib-inline==0.2.1
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-narwhals==2.18.0
+narwhals==2.19.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -113,22 +113,22 @@ parso==0.8.6
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.1.1
+pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   skore-local-project
     #   virtualenv
-plotly==6.6.0
+plotly==6.7.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.38.1
+polars==1.39.3
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.38.1
+polars-runtime-32==1.39.3
     # via polars
 pre-commit==4.5.1
     # via skore (skore/pyproject.toml)
@@ -154,14 +154,14 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov
     #   pytest-order
     #   pytest-randomly
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
 pytest-order==1.3.0
     # via skore (skore/pyproject.toml)
@@ -173,13 +173,13 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via virtualenv
 pytz==2026.1.post1
     # via pandas
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.0
+requests==2.33.1
     # via skrub
 rich==14.3.3
     # via
@@ -194,13 +194,13 @@ scipy==1.17.1
     # via
     #   scikit-learn
     #   skrub
-scipy-stubs==1.17.1.1
+scipy-stubs==1.17.1.3
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skore-local-project==0.0.5
+skore-local-project==0.0.6
     # via skore (skore/pyproject.toml)
 skrub==0.8.0
     # via skore (skore/pyproject.toml)
@@ -215,15 +215,15 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via anywidget
-tzdata==2025.3
+tzdata==2026.1
     # via pandas
 urllib3==2.6.3
     # via requests
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 wcwidth==0.6.0
     # via prompt-toolkit
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)

--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -170,23 +170,6 @@ class Project:
         """The workspace of the project."""
         return self.__workspace
 
-    @staticmethod
-    def pickle(report: EstimatorReport | CrossValidationReport) -> tuple[str, bytes]:
-        """
-        Pickle ``report``, return the bytes and the corresponding artifact id.
-
-        Notes
-        -----
-        Artifact identity is derived from the report id, not from the serialized bytes.
-        """
-        artifact_id = str(report.id)
-
-        with io.BytesIO() as stream:
-            joblib.dump(report, stream)
-            pickle_bytes = stream.getvalue()
-
-        return artifact_id, pickle_bytes
-
     @ensure_project_is_not_deleted
     def put(self, key: str, report: EstimatorReport | CrossValidationReport) -> None:
         """
@@ -224,10 +207,12 @@ class Project:
                 f"ort` (found '{type(report)}')"
             )
 
-        artifact_id, pickle_bytes = Project.pickle(report)
+        artifact_id = str(report.id)
 
         if artifact_id not in self.__artifacts_storage:
-            self.__artifacts_storage[artifact_id] = pickle_bytes
+            with io.BytesIO() as stream:
+                joblib.dump(report, stream)
+                self.__artifacts_storage[artifact_id] = stream.getvalue()
 
         self.__metadata_storage[uuid4().hex] = dict(
             Metadata(

--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -173,30 +173,19 @@ class Project:
     @staticmethod
     def pickle(report: EstimatorReport | CrossValidationReport) -> tuple[str, bytes]:
         """
-        Pickle ``report``, return the bytes and the corresponding hash.
+        Pickle ``report``, return the bytes and the corresponding artifact id.
 
         Notes
         -----
-        The report is pickled without its cache, to avoid salting the hash.
+        Artifact identity is derived from the report id, not from the serialized bytes.
         """
-        reports = [report] + getattr(report, "estimator_reports_", [])
-        reports_with_cache = [
-            (report, report._cache) for report in reports if hasattr(report, "_cache")
-        ]
+        artifact_id = str(report.id)
 
-        report.clear_cache()
+        with io.BytesIO() as stream:
+            joblib.dump(report, stream)
+            pickle_bytes = stream.getvalue()
 
-        try:
-            with io.BytesIO() as stream:
-                joblib.dump(report, stream)
-
-                pickle_bytes = stream.getvalue()
-                pickle_hash = joblib.hash(pickle_bytes)
-        finally:
-            for report, cache in reports_with_cache:
-                report._cache = cache  # type: ignore[union-attr]
-
-        return pickle_hash, pickle_bytes
+        return artifact_id, pickle_bytes
 
     @ensure_project_is_not_deleted
     def put(self, key: str, report: EstimatorReport | CrossValidationReport) -> None:
@@ -235,15 +224,15 @@ class Project:
                 f"ort` (found '{type(report)}')"
             )
 
-        pickle_hash, pickle_bytes = Project.pickle(report)
+        artifact_id, pickle_bytes = Project.pickle(report)
 
-        if pickle_hash not in self.__artifacts_storage:
-            self.__artifacts_storage[pickle_hash] = pickle_bytes
+        if artifact_id not in self.__artifacts_storage:
+            self.__artifacts_storage[artifact_id] = pickle_bytes
 
         self.__metadata_storage[uuid4().hex] = dict(
             Metadata(
                 report=report,
-                artifact_id=pickle_hash,
+                artifact_id=artifact_id,
                 project_name=self.name,
                 key=key,
             )

--- a/skore-local-project/tests/unit/test_project.py
+++ b/skore-local-project/tests/unit/test_project.py
@@ -289,20 +289,6 @@ class TestProject:
         assert report.estimator_name_ == regression.estimator_name_
         assert report._ml_task == regression._ml_task
 
-    def test_put_binary_classification_reuses_report_id(
-        self, tmp_path, binary_classification
-    ):
-        project = Project("<project>", workspace=tmp_path)
-        project.put("<key>", binary_classification)
-
-        binary_classification.cache_predictions()
-        project.put("<key>", binary_classification)
-
-        assert list(project._Project__artifacts_storage.keys()) == [
-            str(binary_classification.id)
-        ]
-        assert len(project._Project__metadata_storage) == 2
-
     def test_get_exception(self, tmp_path, regression):
         import re
 

--- a/skore-local-project/tests/unit/test_project.py
+++ b/skore-local-project/tests/unit/test_project.py
@@ -122,75 +122,39 @@ class TestProject:
         assert isinstance(project._Project__metadata_storage, DiskCacheStorage)
         assert isinstance(project._Project__artifacts_storage, DiskCacheStorage)
 
-    def test_pickle_estimator_report(self, regression):
-        regression.clear_cache()
+    def test_put_estimator_report_reuses_artifact_id(self, tmp_path, regression):
+        project = Project("<project>", workspace=tmp_path)
 
-        # Pickle the report once, without any value in the cache
-        assert not regression._cache
-        artifact_id1, pickle1 = Project.pickle(regression)
-        assert not regression._cache
-
-        # Pickle the same report, but with values in the cache
+        project.put("<key-1>", regression)
         regression.cache_predictions()
+        project.put("<key-2>", regression)
 
-        assert regression._cache
-        stored_predictions = getattr(regression, "_predictions", None)
-        if stored_predictions is not None:
-            stored_predictions = stored_predictions.copy()
-        artifact_id2, pickle2 = Project.pickle(regression)
-        assert regression._cache
-        assert getattr(regression, "_predictions", None) == stored_predictions
+        # Ensure only one artifact was persisted:
+        assert len(project._Project__artifacts_storage) == 1
+        # but two reports:
+        assert len(project.summarize()) == 2
 
-        assert artifact_id1 == artifact_id2 == str(regression.id)
-        assert pickle1 != pickle2
+        # Make sure the pickle is not broken:
+        report = project.get(str(regression.id))
+        report.cache_predictions()
 
-        # Make sure that pickles are not broken
-        with BytesIO(pickle1) as stream:
-            report1 = joblib.load(stream)
+    def test_put_cross_validation_report_reuses_artifact_id(
+        self, tmp_path, cv_regression
+    ):
+        project = Project("<project>", workspace=tmp_path)
 
-        with BytesIO(pickle2) as stream:
-            report2 = joblib.load(stream)
-
-        report1.cache_predictions()
-        report2.cache_predictions()
-
-    def test_pickle_cross_validation_report(self, cv_regression):
-        cv_regression.clear_cache()
-        reports = cv_regression.estimator_reports_
-
-        # Pickle the report once, without any value in the cache
-        assert not any(report._cache for report in reports)
-        artifact_id1, pickle1 = Project.pickle(cv_regression)
-        assert not any(report._cache for report in reports)
-
-        # Pickle the same report, but with values in the cache
+        project.put("<key-1>", cv_regression)
         cv_regression.cache_predictions()
+        project.put("<key-2>", cv_regression)
 
-        assert any(report._cache for report in reports)
-        stored_predictions = []
-        for report in reports:
-            predictions = getattr(report, "_predictions", None)
-            stored_predictions.append(
-                None if predictions is None else predictions.copy()
-            )
-        artifact_id2, pickle2 = Project.pickle(cv_regression)
-        assert any(report._cache for report in reports)
-        assert [
-            getattr(report, "_predictions", None) for report in reports
-        ] == stored_predictions
+        # Ensure only one artifact was persisted:
+        assert len(project._Project__artifacts_storage) == 1
+        # but two reports:
+        assert len(project.summarize()) == 2
 
-        assert artifact_id1 == artifact_id2 == str(cv_regression.id)
-        assert pickle1 != pickle2
-
-        # Make sure that pickles are not broken
-        with BytesIO(pickle1) as stream:
-            report1 = joblib.load(stream)
-
-        with BytesIO(pickle2) as stream:
-            report2 = joblib.load(stream)
-
-        report1.cache_predictions()
-        report2.cache_predictions()
+        # Make sure the pickle is not broken:
+        report = project.get(str(cv_regression.id))
+        report.cache_predictions()
 
     def test_init_with_envar(self, monkeypatch, tmp_path):
         monkeypatch.setenv("SKORE_WORKSPACE", str(tmp_path))

--- a/skore-local-project/tests/unit/test_project.py
+++ b/skore-local-project/tests/unit/test_project.py
@@ -123,20 +123,26 @@ class TestProject:
         assert isinstance(project._Project__artifacts_storage, DiskCacheStorage)
 
     def test_pickle_estimator_report(self, regression):
+        regression.clear_cache()
+
         # Pickle the report once, without any value in the cache
         assert not regression._cache
-        hash1, pickle1 = Project.pickle(regression)
+        artifact_id1, pickle1 = Project.pickle(regression)
         assert not regression._cache
 
         # Pickle the same report, but with values in the cache
         regression.cache_predictions()
 
         assert regression._cache
-        hash2, pickle2 = Project.pickle(regression)
+        stored_predictions = getattr(regression, "_predictions", None)
+        if stored_predictions is not None:
+            stored_predictions = stored_predictions.copy()
+        artifact_id2, pickle2 = Project.pickle(regression)
         assert regression._cache
+        assert getattr(regression, "_predictions", None) == stored_predictions
 
-        # Make sure that the two pickles on the report are not affected by the cache
-        assert (hash1, pickle1) == (hash2, pickle2)
+        assert artifact_id1 == artifact_id2 == str(regression.id)
+        assert pickle1 != pickle2
 
         # Make sure that pickles are not broken
         with BytesIO(pickle1) as stream:
@@ -149,22 +155,32 @@ class TestProject:
         report2.cache_predictions()
 
     def test_pickle_cross_validation_report(self, cv_regression):
+        cv_regression.clear_cache()
         reports = cv_regression.estimator_reports_
 
         # Pickle the report once, without any value in the cache
         assert not any(report._cache for report in reports)
-        hash1, pickle1 = Project.pickle(cv_regression)
+        artifact_id1, pickle1 = Project.pickle(cv_regression)
         assert not any(report._cache for report in reports)
 
         # Pickle the same report, but with values in the cache
         cv_regression.cache_predictions()
 
         assert any(report._cache for report in reports)
-        hash2, pickle2 = Project.pickle(cv_regression)
+        stored_predictions = []
+        for report in reports:
+            predictions = getattr(report, "_predictions", None)
+            stored_predictions.append(
+                None if predictions is None else predictions.copy()
+            )
+        artifact_id2, pickle2 = Project.pickle(cv_regression)
         assert any(report._cache for report in reports)
+        assert [
+            getattr(report, "_predictions", None) for report in reports
+        ] == stored_predictions
 
-        # Make sure that the two pickles on the report are not affected by the cache
-        assert (hash1, pickle1) == (hash2, pickle2)
+        assert artifact_id1 == artifact_id2 == str(cv_regression.id)
+        assert pickle1 != pickle2
 
         # Make sure that pickles are not broken
         with BytesIO(pickle1) as stream:
@@ -236,7 +252,7 @@ class TestProject:
             {
                 "project_name": "<project>",
                 "key": "<key>",
-                "artifact_id": next(project._Project__artifacts_storage.keys()),
+                "artifact_id": str(regression.id),
                 "date": nowstr,
                 "learner": "Ridge",
                 "dataset": joblib.hash(regression.y_test),
@@ -276,7 +292,7 @@ class TestProject:
             {
                 "project_name": "<project>",
                 "key": "<key>",
-                "artifact_id": next(project._Project__artifacts_storage.keys()),
+                "artifact_id": str(cv_regression.id),
                 "date": nowstr,
                 "learner": "Ridge",
                 "dataset": joblib.hash(cv_regression.y),
@@ -301,13 +317,27 @@ class TestProject:
         project.put("<key>", regression)
         project.put("<key>", regression)
 
-        report = project.get(next(project._Project__artifacts_storage.keys()))
+        report = project.get(str(regression.id))
 
         assert len(project._Project__artifacts_storage) == 1
         assert len(project._Project__metadata_storage) == 2
         assert isinstance(report, EstimatorReport)
         assert report.estimator_name_ == regression.estimator_name_
         assert report._ml_task == regression._ml_task
+
+    def test_put_binary_classification_reuses_report_id(
+        self, tmp_path, binary_classification
+    ):
+        project = Project("<project>", workspace=tmp_path)
+        project.put("<key>", binary_classification)
+
+        binary_classification.cache_predictions()
+        project.put("<key>", binary_classification)
+
+        assert list(project._Project__artifacts_storage.keys()) == [
+            str(binary_classification.id)
+        ]
+        assert len(project._Project__metadata_storage) == 2
 
     def test_get_exception(self, tmp_path, regression):
         import re
@@ -332,13 +362,11 @@ class TestProject:
         project.put("<key1>", regression)
         project.put("<key2>", cv_regression)
 
-        artifact_ids = list(project._Project__artifacts_storage.keys())
-
         assert len(project._Project__artifacts_storage) == 2
         assert len(project._Project__metadata_storage) == 3
         assert project.summarize() == [
             {
-                "id": artifact_ids[0],
+                "id": str(regression.id),
                 "key": "<key1>",
                 "date": Datetime.nows_isoformat[0],
                 "learner": "Ridge",
@@ -357,7 +385,7 @@ class TestProject:
                 "predict_time_mean": None,
             },
             {
-                "id": artifact_ids[0],
+                "id": str(regression.id),
                 "key": "<key1>",
                 "date": Datetime.nows_isoformat[1],
                 "learner": "Ridge",
@@ -376,7 +404,7 @@ class TestProject:
                 "predict_time_mean": None,
             },
             {
-                "id": artifact_ids[1],
+                "id": str(cv_regression.id),
                 "key": "<key2>",
                 "date": Datetime.nows_isoformat[2],
                 "learner": "Ridge",


### PR DESCRIPTION
Fixes issue #2742 on the `skore-local-project`'s side.

- update lockfiles
- use `report.id` as the persisted artifact identifier in `skore-local-project` / stop deriving local report identity from pickle bytes
- simplify pickling by keeping caches in the serialized payload
