### PR TITLE
feat(skore): More compact HTML repr for reports

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -499,7 +499,14 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
 
     def _repr_html_(self) -> str:
         """HTML representation with a selector to inspect one compared report."""
-        metrics_html = self.metrics.summarize(data_source="test").frame()._repr_html_()
+        metrics_html = (
+            self.metrics.summarize(data_source="test")
+            .frame()
+            .rename_axis([None, None], axis="columns")
+            .swaplevel(axis="columns")
+            .reset_index()
+            .to_html(index=False)
+        )
 
         comparison_reports = []
         for label, report in self.reports_.items():
@@ -533,6 +540,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
                 "comparison_reports": comparison_reports,
                 "help_doc_url": help_doc_url,
                 "report_class_name": report_class_name,
+                "report_title": "Model comparison",
                 "metrics_accessor_doc_url": metrics_accessor_doc_url,
                 "inspection_accessor_doc_url": inspection_accessor_doc_url,
                 "diagnose_documentation_url": diagnose_documentation_url,

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -499,14 +499,17 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
 
     def _repr_html_(self) -> str:
         """HTML representation with a selector to inspect one compared report."""
-        metrics_html = (
+        metrics_frame = (
             self.metrics.summarize(data_source="test")
             .frame()
-            .rename_axis([None, None], axis="columns")
-            .swaplevel(axis="columns")
-            .reset_index()
-            .to_html(index=False)
+            .rename_axis(
+                None if self._report_type == "comparison-estimator" else [None, None],
+                axis="columns",
+            )
         )
+        if self._report_type == "comparison-cross-validation":
+            metrics_frame = metrics_frame.swaplevel(axis="columns")
+        metrics_html = metrics_frame.reset_index().to_html(index=False)
 
         comparison_reports = []
         for label, report in self.reports_.items():

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -529,7 +529,9 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         metrics_html = (
             self.metrics.summarize(data_source="test")
             .frame(aggregate=("mean", "std"), favorability=False)
-            ._repr_html_()
+            .droplevel(level=0, axis="columns")
+            .reset_index()
+            .to_html(index=False)
         )
 
         df = self.data._prepare_dataframe_for_display(
@@ -584,6 +586,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                 "container_id": container_id,
                 "help_doc_url": help_doc_url,
                 "report_class_name": report_class_name,
+                "report_title": f"Report for {self.estimator_name_}",
                 "metrics_accessor_doc_url": metrics_accessor_doc_url,
                 "inspection_accessor_doc_url": inspection_accessor_doc_url,
                 "data_accessor_doc_url": data_accessor_doc_url,

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -721,7 +721,8 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                     data_source="train" if data_source == "train" else "test"
                 )
                 .frame()
-                ._repr_html_()
+                .reset_index()
+                .to_html(index=False)
             )
         try:
             estimator_html = self.estimator_._repr_html_()
@@ -768,6 +769,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 "container_id": container_id,
                 "help_doc_url": help_doc_url,
                 "report_class_name": report_class_name,
+                "report_title": f"Report for {self.estimator_name_}",
                 "metrics_accessor_doc_url": metrics_accessor_doc_url,
                 "inspection_accessor_doc_url": inspection_accessor_doc_url,
                 "data_accessor_doc_url": data_accessor_doc_url,

--- a/skore/src/skore/_utils/repr/_report_tabset_chrome.html.j2
+++ b/skore/src/skore/_utils/repr/_report_tabset_chrome.html.j2
@@ -1,0 +1,35 @@
+{# Shared tab chrome: radio inputs, tab labels, and per-tab help tooltips.
+   Expects: container_id, report_tabs (see parent templates), report_class_name. #}
+{% for tab in report_tabs %}
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-{{ loop.index0 }}" class="report-tab-input"{% if loop.first %} checked{% endif %}>
+{% endfor %}
+        <div class="report-tablist-row">
+            <div class="report-tablist" role="tablist">
+{% for tab in report_tabs %}
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-{{ loop.index0 }}" role="presentation">{{ tab.label }}</label>
+                </div>
+{% endfor %}
+            </div>
+            <div class="report-tablist-help">
+                <button type="button" class="report-tab-help report-tab-help-global" aria-label="Help for the selected tab">
+                    ?
+{% for tab in report_tabs %}
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-{{ loop.index0 }}">
+{% if tab.help_variant == "comparison_data" %}
+                        Explore the data for each compared report via that report's
+                        <code>.data</code> accessor.
+{% else %}
+                        Investigate more with
+                        <a
+                            href="{{ tab.help_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.{{ tab.accessor_name }}</a>.
+{% endif %}
+                    </span>
+{% endfor %}
+                </button>
+            </div>
+        </div>

--- a/skore/src/skore/_utils/repr/comparison_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/comparison_report-content.html.j2
@@ -1,102 +1,119 @@
 <div class="container">
-    <header class="title">ComparisonReport</header>
-    <details open class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Results</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ metrics_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.metrics</a>.
-        </p>
-        <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Diagnostic</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ diagnose_documentation_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.diagnose</a>.
-        </p>
-        <div class="report-section report-diagnostic">
-            <div class="comparison-report-select-row">
-                <label for="{{ container_id }}-report-select-diagnostic">Selected report</label>
-                <select
-                    id="{{ container_id }}-report-select-diagnostic"
-                    class="skore-comparison-report-select"
-                    aria-label="Select which report's diagnostic to show"
-                >
-                    {% for row in comparison_reports %}
-                    <option value="{{ loop.index0 }}">{{ row.label }}</option>
-                    {% endfor %}
-                </select>
+    <header class="title">{{ report_title | e }}</header>
+    <div class="report-tabset">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-0" class="report-tab-input" checked>
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-1" class="report-tab-input">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-2" class="report-tab-input">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-3" class="report-tab-input">
+        <div class="report-tablist-row">
+            <div class="report-tablist" role="tablist">
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-0" role="presentation">Results</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-1" role="presentation">Diagnostic</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-2" role="presentation">Estimator</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-3" role="presentation">Data</label>
+                </div>
             </div>
-            <slot name="diagnostic"></slot>
-        </div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Estimator</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ inspection_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.inspection</a>.
-        </p>
-        <div class="report-section report-estimator">
-            <div class="comparison-report-select-row">
-                <label for="{{ container_id }}-report-select-estimator">Selected report</label>
-                <select
-                    id="{{ container_id }}-report-select-estimator"
-                    class="skore-comparison-report-select"
-                    aria-label="Select which report's estimator to show"
-                >
-                    {% for row in comparison_reports %}
-                    <option value="{{ loop.index0 }}">{{ row.label }}</option>
-                    {% endfor %}
-                </select>
+            <div class="report-tablist-help">
+                <button type="button" class="report-tab-help report-tab-help-global" aria-label="Help for the selected tab">
+                    ?
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-0">
+                        Investigate more with
+                        <a
+                            href="{{ metrics_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.metrics</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-1">
+                        Investigate more with
+                        <a
+                            href="{{ diagnose_documentation_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.diagnose</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-2">
+                        Investigate more with
+                        <a
+                            href="{{ inspection_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.inspection</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-3">
+                        Explore the data for each compared report via that report's
+                        <code>.data</code> accessor.
+                    </span>
+                </button>
             </div>
-            <slot name="estimator-display"></slot>
         </div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Data</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Explore the data for each compared report via that report's
-            <code>.data</code> accessor.
-        </p>
-        <div class="report-section report-data">
-            <div class="comparison-report-select-row">
-                <label for="{{ container_id }}-report-select-data">Selected report</label>
-                <select
-                    id="{{ container_id }}-report-select-data"
-                    class="skore-comparison-report-select"
-                    aria-label="Select which report's data view to show"
-                >
-                    {% for row in comparison_reports %}
-                    <option value="{{ loop.index0 }}">{{ row.label }}</option>
-                    {% endfor %}
-                </select>
+        <div class="report-tab-panels">
+            <div class="report-tab-panel">
+                <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>
             </div>
-            <slot name="table-report"></slot>
+            <div class="report-tab-panel">
+                <div class="report-section report-diagnostic">
+                    <div class="comparison-report-select-row">
+                        <label for="{{ container_id }}-report-select-diagnostic">Selected report</label>
+                        <select
+                            id="{{ container_id }}-report-select-diagnostic"
+                            class="skore-comparison-report-select"
+                            aria-label="Select which report's diagnostic to show"
+                        >
+                            {% for row in comparison_reports %}
+                            <option value="{{ loop.index0 }}">{{ row.label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <slot name="diagnostic"></slot>
+                </div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-estimator">
+                    <div class="comparison-report-select-row">
+                        <label for="{{ container_id }}-report-select-estimator">Selected report</label>
+                        <select
+                            id="{{ container_id }}-report-select-estimator"
+                            class="skore-comparison-report-select"
+                            aria-label="Select which report's estimator to show"
+                        >
+                            {% for row in comparison_reports %}
+                            <option value="{{ loop.index0 }}">{{ row.label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <slot name="estimator-display"></slot>
+                </div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-data">
+                    <div class="comparison-report-select-row">
+                        <label for="{{ container_id }}-report-select-data">Selected report</label>
+                        <select
+                            id="{{ container_id }}-report-select-data"
+                            class="skore-comparison-report-select"
+                            aria-label="Select which report's data view to show"
+                        >
+                            {% for row in comparison_reports %}
+                            <option value="{{ loop.index0 }}">{{ row.label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <slot name="table-report"></slot>
+                </div>
+            </div>
         </div>
-    </details>
+    </div>
     <p class="report-hint-note" role="note">
         Use
         <a

--- a/skore/src/skore/_utils/repr/comparison_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/comparison_report-content.html.j2
@@ -1,62 +1,13 @@
+{% set report_tabs = [
+    {"label": "Results", "help_variant": "accessor", "help_url": metrics_accessor_doc_url, "accessor_name": "metrics"},
+    {"label": "Diagnostic", "help_variant": "accessor", "help_url": diagnose_documentation_url, "accessor_name": "diagnose"},
+    {"label": "Estimator", "help_variant": "accessor", "help_url": inspection_accessor_doc_url, "accessor_name": "inspection"},
+    {"label": "Data", "help_variant": "comparison_data"},
+] %}
 <div class="container">
     <header class="title">{{ report_title | e }}</header>
     <div class="report-tabset">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-0" class="report-tab-input" checked>
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-1" class="report-tab-input">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-2" class="report-tab-input">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-3" class="report-tab-input">
-        <div class="report-tablist-row">
-            <div class="report-tablist" role="tablist">
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-0" role="presentation">Results</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-1" role="presentation">Diagnostic</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-2" role="presentation">Estimator</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-3" role="presentation">Data</label>
-                </div>
-            </div>
-            <div class="report-tablist-help">
-                <button type="button" class="report-tab-help report-tab-help-global" aria-label="Help for the selected tab">
-                    ?
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-0">
-                        Investigate more with
-                        <a
-                            href="{{ metrics_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.metrics</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-1">
-                        Investigate more with
-                        <a
-                            href="{{ diagnose_documentation_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.diagnose</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-2">
-                        Investigate more with
-                        <a
-                            href="{{ inspection_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.inspection</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-3">
-                        Explore the data for each compared report via that report's
-                        <code>.data</code> accessor.
-                    </span>
-                </button>
-            </div>
-        </div>
+        {% include "_report_tabset_chrome.html.j2" %}
         <div class="report-tab-panels">
             <div class="report-tab-panel">
                 <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>

--- a/skore/src/skore/_utils/repr/comparison_report.js
+++ b/skore/src/skore/_utils/repr/comparison_report.js
@@ -23,7 +23,7 @@ function skoreInitComparisonReport(containerId) {
         applyThemeToReportContainer(root, containerId + "-wrapper");
     }
 
-    shadowRoot.querySelectorAll(".report-disclosure .tooltip-text a").forEach((a) => {
+    shadowRoot.querySelectorAll(".report-tabset .tooltip-text a").forEach((a) => {
         a.addEventListener("click", (e) => {
             e.stopPropagation();
         });

--- a/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
@@ -1,65 +1,82 @@
 <div class="container">
-    <header class="title">CrossValidationReport</header>
-    <details open class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Results</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ metrics_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.metrics</a>.
-        </p>
-        <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Diagnostic</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ diagnose_documentation_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.diagnose</a>.
-        </p>
-        <div class="report-section report-diagnostic"><slot name="diagnostic"></slot></div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Estimator</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ inspection_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.inspection</a>.
-        </p>
-        <div class="report-section report-estimator"><slot name="estimator-display"></slot></div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Data</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ data_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.data</a>.
-        </p>
-        <div class="report-section report-data"><slot name="table-report"></slot></div>
-    </details>
+    <header class="title">{{ report_title | e }}</header>
+    <div class="report-tabset">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-0" class="report-tab-input" checked>
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-1" class="report-tab-input">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-2" class="report-tab-input">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-3" class="report-tab-input">
+        <div class="report-tablist-row">
+            <div class="report-tablist" role="tablist">
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-0" role="presentation">Results</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-1" role="presentation">Diagnostic</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-2" role="presentation">Estimator</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-3" role="presentation">Data</label>
+                </div>
+            </div>
+            <div class="report-tablist-help">
+                <button type="button" class="report-tab-help report-tab-help-global" aria-label="Help for the selected tab">
+                    ?
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-0">
+                        Investigate more with
+                        <a
+                            href="{{ metrics_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.metrics</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-1">
+                        Investigate more with
+                        <a
+                            href="{{ diagnose_documentation_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.diagnose</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-2">
+                        Investigate more with
+                        <a
+                            href="{{ inspection_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.inspection</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-3">
+                        Investigate more with
+                        <a
+                            href="{{ data_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.data</a>.
+                    </span>
+                </button>
+            </div>
+        </div>
+        <div class="report-tab-panels">
+            <div class="report-tab-panel">
+                <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-diagnostic"><slot name="diagnostic"></slot></div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-estimator"><slot name="estimator-display"></slot></div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-data"><slot name="table-report"></slot></div>
+            </div>
+        </div>
+    </div>
     <p class="report-hint-note" role="note">
         Use
         <a

--- a/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/cross_validation_report-content.html.j2
@@ -1,67 +1,13 @@
+{% set report_tabs = [
+    {"label": "Results", "help_variant": "accessor", "help_url": metrics_accessor_doc_url, "accessor_name": "metrics"},
+    {"label": "Diagnostic", "help_variant": "accessor", "help_url": diagnose_documentation_url, "accessor_name": "diagnose"},
+    {"label": "Estimator", "help_variant": "accessor", "help_url": inspection_accessor_doc_url, "accessor_name": "inspection"},
+    {"label": "Data", "help_variant": "accessor", "help_url": data_accessor_doc_url, "accessor_name": "data"},
+] %}
 <div class="container">
     <header class="title">{{ report_title | e }}</header>
     <div class="report-tabset">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-0" class="report-tab-input" checked>
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-1" class="report-tab-input">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-2" class="report-tab-input">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-3" class="report-tab-input">
-        <div class="report-tablist-row">
-            <div class="report-tablist" role="tablist">
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-0" role="presentation">Results</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-1" role="presentation">Diagnostic</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-2" role="presentation">Estimator</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-3" role="presentation">Data</label>
-                </div>
-            </div>
-            <div class="report-tablist-help">
-                <button type="button" class="report-tab-help report-tab-help-global" aria-label="Help for the selected tab">
-                    ?
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-0">
-                        Investigate more with
-                        <a
-                            href="{{ metrics_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.metrics</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-1">
-                        Investigate more with
-                        <a
-                            href="{{ diagnose_documentation_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.diagnose</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-2">
-                        Investigate more with
-                        <a
-                            href="{{ inspection_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.inspection</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-3">
-                        Investigate more with
-                        <a
-                            href="{{ data_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.data</a>.
-                    </span>
-                </button>
-            </div>
-        </div>
+        {% include "_report_tabset_chrome.html.j2" %}
         <div class="report-tab-panels">
             <div class="report-tab-panel">
                 <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>

--- a/skore/src/skore/_utils/repr/estimator_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/estimator_report-content.html.j2
@@ -1,67 +1,13 @@
+{% set report_tabs = [
+    {"label": "Results", "help_variant": "accessor", "help_url": metrics_accessor_doc_url, "accessor_name": "metrics"},
+    {"label": "Diagnostic", "help_variant": "accessor", "help_url": diagnose_documentation_url, "accessor_name": "diagnose"},
+    {"label": "Estimator", "help_variant": "accessor", "help_url": inspection_accessor_doc_url, "accessor_name": "inspection"},
+    {"label": "Data", "help_variant": "accessor", "help_url": data_accessor_doc_url, "accessor_name": "data"},
+] %}
 <div class="container">
     <header class="title">{{ report_title | e }}</header>
     <div class="report-tabset">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-0" class="report-tab-input" checked>
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-1" class="report-tab-input">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-2" class="report-tab-input">
-        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-3" class="report-tab-input">
-        <div class="report-tablist-row">
-            <div class="report-tablist" role="tablist">
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-0" role="presentation">Results</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-1" role="presentation">Diagnostic</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-2" role="presentation">Estimator</label>
-                </div>
-                <div class="report-tab-item">
-                    <label class="report-tab-label" for="{{ container_id }}-report-tab-3" role="presentation">Data</label>
-                </div>
-            </div>
-            <div class="report-tablist-help">
-                <button type="button" class="report-tab-help report-tab-help-global" aria-label="Help for the selected tab">
-                    ?
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-0">
-                        Investigate more with
-                        <a
-                            href="{{ metrics_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.metrics</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-1">
-                        Investigate more with
-                        <a
-                            href="{{ diagnose_documentation_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.diagnose</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-2">
-                        Investigate more with
-                        <a
-                            href="{{ inspection_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.inspection</a>.
-                    </span>
-                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-3">
-                        Investigate more with
-                        <a
-                            href="{{ data_accessor_doc_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="report-hint-note-link"
-                        >{{ report_class_name }}.data</a>.
-                    </span>
-                </button>
-            </div>
-        </div>
+        {% include "_report_tabset_chrome.html.j2" %}
         <div class="report-tab-panels">
             <div class="report-tab-panel">
                 <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>

--- a/skore/src/skore/_utils/repr/estimator_report-content.html.j2
+++ b/skore/src/skore/_utils/repr/estimator_report-content.html.j2
@@ -1,65 +1,82 @@
 <div class="container">
-    <header class="title">EstimatorReport</header>
-    <details open class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Results</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ metrics_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.metrics</a>.
-        </p>
-        <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Diagnostic</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ diagnose_documentation_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.diagnose</a>.
-        </p>
-        <div class="report-section report-diagnostic"><slot name="diagnostic"></slot></div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Estimator</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ inspection_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.inspection</a>.
-        </p>
-        <div class="report-section report-estimator"><slot name="estimator-display"></slot></div>
-    </details>
-    <details class="report-disclosure">
-        <summary>
-            <span class="report-disclosure-title">Data</span>
-        </summary>
-        <p class="report-inline-note" role="note">
-            Investigate more with
-            <a
-                href="{{ data_accessor_doc_url }}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="report-hint-note-link"
-            >{{ report_class_name }}.data</a>.
-        </p>
-        <div class="report-section report-data"><slot name="table-report"></slot></div>
-    </details>
+    <header class="title">{{ report_title | e }}</header>
+    <div class="report-tabset">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-0" class="report-tab-input" checked>
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-1" class="report-tab-input">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-2" class="report-tab-input">
+        <input type="radio" name="{{ container_id }}-report-tab" id="{{ container_id }}-report-tab-3" class="report-tab-input">
+        <div class="report-tablist-row">
+            <div class="report-tablist" role="tablist">
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-0" role="presentation">Results</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-1" role="presentation">Diagnostic</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-2" role="presentation">Estimator</label>
+                </div>
+                <div class="report-tab-item">
+                    <label class="report-tab-label" for="{{ container_id }}-report-tab-3" role="presentation">Data</label>
+                </div>
+            </div>
+            <div class="report-tablist-help">
+                <button type="button" class="report-tab-help report-tab-help-global" aria-label="Help for the selected tab">
+                    ?
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-0">
+                        Investigate more with
+                        <a
+                            href="{{ metrics_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.metrics</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-1">
+                        Investigate more with
+                        <a
+                            href="{{ diagnose_documentation_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.diagnose</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-2">
+                        Investigate more with
+                        <a
+                            href="{{ inspection_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.inspection</a>.
+                    </span>
+                    <span class="tooltip-text report-tab-help-tip report-tab-help-tip-3">
+                        Investigate more with
+                        <a
+                            href="{{ data_accessor_doc_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="report-hint-note-link"
+                        >{{ report_class_name }}.data</a>.
+                    </span>
+                </button>
+            </div>
+        </div>
+        <div class="report-tab-panels">
+            <div class="report-tab-panel">
+                <div class="report-section report-metrics">{{ metrics_summary | safe }}</div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-diagnostic"><slot name="diagnostic"></slot></div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-estimator"><slot name="estimator-display"></slot></div>
+            </div>
+            <div class="report-tab-panel">
+                <div class="report-section report-data"><slot name="table-report"></slot></div>
+            </div>
+        </div>
+    </div>
     <p class="report-hint-note" role="note">
         Use
         <a

--- a/skore/src/skore/_utils/repr/estimator_report.js
+++ b/skore/src/skore/_utils/repr/estimator_report.js
@@ -18,7 +18,7 @@ function skoreInitEstimatorReport(containerId) {
         applyThemeToReportContainer(root, containerId + "-wrapper");
     }
 
-    shadowRoot.querySelectorAll(".report-disclosure .tooltip-text a").forEach((a) => {
+    shadowRoot.querySelectorAll(".report-tabset .tooltip-text a").forEach((a) => {
         a.addEventListener("click", (e) => {
             e.stopPropagation();
         });

--- a/skore/src/skore/_utils/repr/report.css
+++ b/skore/src/skore/_utils/repr/report.css
@@ -37,33 +37,178 @@
     border-radius: 2px;
 }
 
-.report-inline-note {
-    margin: 0.5em 0 0;
+.report-tabset {
+    position: relative;
     color: var(--color-text);
-    font-size: 11px;
+}
+
+.report-tab-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.report-tablist-row {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    width: 100%;
+    box-sizing: border-box;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-text) 25%, transparent);
+}
+
+.report-tablist {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.15em;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    margin: 0;
+    padding: 0;
+    border-bottom: none;
+}
+
+.report-tablist-help {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    align-self: center;
+    padding: 0 0.15em 0 0.65em;
+    margin: 0.15em 0;
+    border-left: 1px solid color-mix(in srgb, var(--color-text) 22%, transparent);
+}
+
+.report-tab-item {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.report-tab-help {
+    position: relative;
+    box-sizing: border-box;
+    flex-shrink: 0;
+    margin: 0;
+    padding: 0;
+    width: 1.35em;
+    height: 1.35em;
+    min-width: 1.35em;
+    min-height: 1.35em;
+    border: 1px solid color-mix(in srgb, var(--color-blue) 50%, transparent);
+    border-radius: 50%;
+    font-family: inherit;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-blue);
+    background-color: var(--color-background);
+    cursor: help;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.report-tab-help:hover {
+    background-color: var(--color-blue-hover);
+}
+
+.report-tab-help:focus-visible {
+    outline: 2px solid var(--color-blue);
+    outline-offset: 2px;
+}
+
+/* Single global "?": show only the tooltip for the checked tab */
+.report-tab-help-global:hover .report-tab-help-tip,
+.report-tab-help-global:focus-within .report-tab-help-tip {
+    visibility: hidden;
+    opacity: 0;
+}
+
+.report-tabset:has(> .report-tab-input:nth-child(1):checked) .report-tab-help-global:hover .report-tab-help-tip-0,
+.report-tabset:has(> .report-tab-input:nth-child(1):checked) .report-tab-help-global:focus-within .report-tab-help-tip-0,
+.report-tabset:has(> .report-tab-input:nth-child(2):checked) .report-tab-help-global:hover .report-tab-help-tip-1,
+.report-tabset:has(> .report-tab-input:nth-child(2):checked) .report-tab-help-global:focus-within .report-tab-help-tip-1,
+.report-tabset:has(> .report-tab-input:nth-child(3):checked) .report-tab-help-global:hover .report-tab-help-tip-2,
+.report-tabset:has(> .report-tab-input:nth-child(3):checked) .report-tab-help-global:focus-within .report-tab-help-tip-2,
+.report-tabset:has(> .report-tab-input:nth-child(4):checked) .report-tab-help-global:hover .report-tab-help-tip-3,
+.report-tabset:has(> .report-tab-input:nth-child(4):checked) .report-tab-help-global:focus-within .report-tab-help-tip-3 {
+    visibility: visible;
+    opacity: 1;
+}
+
+.report-tab-help-global .report-tab-help-tip {
     font-style: italic;
     font-weight: 400;
-    line-height: 1.4;
-    opacity: 0.88;
-    white-space: nowrap;
+    opacity: 0.95;
+    max-width: min(280px, 90vw);
+    width: max-content;
+    top: 50%;
+    left: auto;
+    right: 100%;
+    margin-left: 0;
+    margin-right: 8px;
+    transform: translateY(-50%);
 }
 
-.report-disclosure {
-    color: var(--color-text);
+.report-tab-help-global .report-tab-help-tip::before {
+    right: auto;
+    left: 100%;
+    border-right-color: transparent;
+    border-left-color: var(--color-orange);
 }
 
-.report-disclosure > summary {
+.report-tab-label {
     cursor: pointer;
     user-select: none;
     color: var(--color-blue);
     font-weight: bold;
     line-height: 1.5em;
-    display: flex;
-    align-items: center;
-    gap: 0.45em;
-    list-style: none;
-    padding: 0.2em 0.15em;
+    padding: 0.35em 0.65em;
     margin: 0;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    flex-shrink: 0;
+    border-radius: 4px 4px 0 0;
+}
+
+.report-tab-label:hover {
+    background-color: var(--color-blue-hover);
+}
+
+.report-tabset:has(> .report-tab-input:nth-child(1):checked) .report-tablist .report-tab-item:nth-child(1) .report-tab-label,
+.report-tabset:has(> .report-tab-input:nth-child(2):checked) .report-tablist .report-tab-item:nth-child(2) .report-tab-label,
+.report-tabset:has(> .report-tab-input:nth-child(3):checked) .report-tablist .report-tab-item:nth-child(3) .report-tab-label,
+.report-tabset:has(> .report-tab-input:nth-child(4):checked) .report-tablist .report-tab-item:nth-child(4) .report-tab-label {
+    border-bottom-color: var(--color-blue);
+}
+
+.report-tab-panels {
+    margin-top: 0.35em;
+}
+
+.report-tab-panels .report-tab-panel {
+    display: none;
+}
+
+.report-tabset:has(> .report-tab-input:nth-child(1):checked) .report-tab-panels .report-tab-panel:nth-child(1),
+.report-tabset:has(> .report-tab-input:nth-child(2):checked) .report-tab-panels .report-tab-panel:nth-child(2),
+.report-tabset:has(> .report-tab-input:nth-child(3):checked) .report-tab-panels .report-tab-panel:nth-child(3),
+.report-tabset:has(> .report-tab-input:nth-child(4):checked) .report-tab-panels .report-tab-panel:nth-child(4) {
+    display: block;
+}
+
+.report-tab-panel .report-section {
+    overflow-x: auto;
+    max-width: 100%;
 }
 
 .report-disclosure-title {
@@ -118,36 +263,6 @@
 
 .report-tooltip-accessor-link:hover {
     text-decoration-thickness: 2px;
-}
-
-.report-disclosure > summary::-webkit-details-marker {
-    display: none;
-}
-
-.report-disclosure > summary::before {
-    content: "";
-    display: block;
-    width: 0.45em;
-    height: 0.45em;
-    flex-shrink: 0;
-    border-right: 2px solid var(--color-blue);
-    border-bottom: 2px solid var(--color-blue);
-    transform: rotate(-45deg);
-    transition: transform 0.12s ease;
-}
-
-.report-disclosure[open] > summary::before {
-    transform: rotate(45deg);
-}
-
-.report-disclosure > summary:hover {
-    background-color: var(--color-blue-hover);
-    border-radius: 4px;
-}
-
-.report-disclosure > .report-section {
-    overflow-x: auto;
-    max-width: 100%;
 }
 
 .report-metrics table.dataframe {

--- a/skore/tests/conftest.py
+++ b/skore/tests/conftest.py
@@ -539,6 +539,52 @@ def comparison_cross_validation_reports_regression(
 
 
 @pytest.fixture
+def estimator_reports_multioutput_regression(regression_multioutput_train_test_split):
+    X_train, X_test, y_train, y_test = regression_multioutput_train_test_split
+
+    estimator_report_1 = EstimatorReport(
+        DummyRegressor(),
+        X_train=X_train,
+        y_train=y_train,
+        X_test=X_test,
+        y_test=y_test,
+    )
+    estimator_report_2 = EstimatorReport(
+        DummyRegressor(),
+        X_train=X_train,
+        y_train=y_train,
+        X_test=X_test,
+        y_test=y_test,
+    )
+
+    return estimator_report_1, estimator_report_2
+
+
+@pytest.fixture
+def comparison_estimator_reports_multioutput_regression(
+    estimator_reports_multioutput_regression,
+):
+    estimator_report_1, estimator_report_2 = estimator_reports_multioutput_regression
+    return ComparisonReport([estimator_report_1, estimator_report_2])
+
+
+@pytest.fixture
+def cross_validation_reports_multioutput_regression(regression_multioutput_data):
+    X, y = regression_multioutput_data
+    cv_report_1 = CrossValidationReport(DummyRegressor(), X, y, splitter=2)
+    cv_report_2 = CrossValidationReport(DummyRegressor(), X, y, splitter=2)
+    return cv_report_1, cv_report_2
+
+
+@pytest.fixture
+def comparison_cross_validation_reports_multioutput_regression(
+    cross_validation_reports_multioutput_regression,
+):
+    cv_report_1, cv_report_2 = cross_validation_reports_multioutput_regression
+    return ComparisonReport([cv_report_1, cv_report_2])
+
+
+@pytest.fixture
 def linear_regression_comparison_report(linear_regression_with_train_test):
     """Fixture providing a ComparisonReport with two linear regression estimators."""
     estimator, X_train, X_test, y_train, y_test = linear_regression_with_train_test

--- a/skore/tests/unit/reports/comparison/test_report.py
+++ b/skore/tests/unit/reports/comparison/test_report.py
@@ -287,14 +287,22 @@ def test_create_estimator_report_invalid_name(
     [
         "comparison_estimator_reports_binary_classification",
         "comparison_cross_validation_reports_binary_classification",
+        "comparison_estimator_reports_multiclass_classification",
+        "comparison_cross_validation_reports_multiclass_classification",
+        "comparison_estimator_reports_regression",
+        "comparison_cross_validation_reports_regression",
+        "comparison_estimator_reports_multioutput_regression",
+        "comparison_cross_validation_reports_multioutput_regression",
     ],
 )
 def test_report_repr_html(comparison_fixture, request):
     report = request.getfixturevalue(comparison_fixture)
+    sub_report = next(iter(report.reports_.values()))
+    expected_estimator_name = sub_report.estimator_.__class__.__name__
     html_out = report._repr_html_()
     assert "skore-comparison-report-" in html_out
     assert "Model comparison" in html_out
-    assert "DummyClassifier" in html_out
+    assert expected_estimator_name in html_out
     assert "skoreInitComparisonReport" in html_out
     assert "report-hint-note" in html_out
     assert "docs.skore.probabl.ai" in html_out

--- a/skore/tests/unit/reports/comparison/test_report.py
+++ b/skore/tests/unit/reports/comparison/test_report.py
@@ -293,11 +293,11 @@ def test_report_repr_html(comparison_fixture, request):
     report = request.getfixturevalue(comparison_fixture)
     html_out = report._repr_html_()
     assert "skore-comparison-report-" in html_out
-    assert "ComparisonReport" in html_out
+    assert "Model comparison" in html_out
     assert "DummyClassifier" in html_out
     assert "skoreInitComparisonReport" in html_out
     assert "report-hint-note" in html_out
     assert "docs.skore.probabl.ai" in html_out
-    assert "report-disclosure-title" in html_out
+    assert "report-tabset" in html_out
     assert "ComparisonReport.metrics" in html_out
     assert "skore-comparison-report-select" in html_out

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -5,7 +5,7 @@ import skrub
 from sklearn.base import clone
 from sklearn.cluster import KMeans
 from sklearn.datasets import make_classification
-from sklearn.dummy import DummyClassifier
+from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LinearRegression, LogisticRegression
@@ -238,26 +238,60 @@ def test_create_estimator_report(container_types, forest_binary_classification_d
     assert est_report_with_test.pos_label == cv_report.pos_label
 
 
-@pytest.mark.parametrize("splitter", [2, 3])
-@pytest.mark.parametrize("bad_estimator", [False, True])
-def test_report_repr_html(splitter, bad_estimator):
-    X, y = make_classification(n_classes=2, random_state=42)
+class _DummyClassifierBadRepr(DummyClassifier):
+    def _repr_html_(self):
+        raise TypeError("error")
 
-    class DummyClassifierBadRepr(DummyClassifier):
-        def _repr_html_(self):
-            raise TypeError("error")
 
-    estimator = DummyClassifierBadRepr() if bad_estimator else DummyClassifier()
-    report = CrossValidationReport(estimator, X, y, splitter=splitter)
-    html_out = report._repr_html_()
+def _assert_cross_validation_report_repr_html(
+    html_out: str, expected_estimator_name: str
+) -> None:
     assert "skore-cross-validation-report-" in html_out
-    assert "DummyClassifier" in html_out
+    assert expected_estimator_name in html_out
     assert "skoreInitEstimatorReport" in html_out
     assert "report-hint-note" in html_out
     assert "docs.skore.probabl.ai" in html_out
     assert "report-tabset" in html_out
     assert "Report for" in html_out
     assert "CrossValidationReport.metrics" in html_out
+
+
+def test_report_repr_html_binary_classification():
+    X, y = make_classification(n_classes=2, random_state=42)
+    estimator = DummyClassifier()
+    report = CrossValidationReport(estimator, X, y, splitter=2)
+    _assert_cross_validation_report_repr_html(report._repr_html_(), "DummyClassifier")
+
+
+def test_report_repr_html_multiclass_classification(multiclass_classification_data):
+    X, y = multiclass_classification_data
+    estimator = DummyClassifier(strategy="uniform", random_state=0)
+    report = CrossValidationReport(estimator, X, y, splitter=2)
+    _assert_cross_validation_report_repr_html(report._repr_html_(), "DummyClassifier")
+
+
+def test_report_repr_html_regression(regression_data):
+    X, y = regression_data
+    estimator = DummyRegressor()
+    report = CrossValidationReport(estimator, X, y, splitter=2)
+    _assert_cross_validation_report_repr_html(report._repr_html_(), "DummyRegressor")
+
+
+def test_report_repr_html_multioutput_regression(regression_multioutput_data):
+    X, y = regression_multioutput_data
+    estimator = DummyRegressor()
+    report = CrossValidationReport(estimator, X, y, splitter=2)
+    _assert_cross_validation_report_repr_html(report._repr_html_(), "DummyRegressor")
+
+
+@pytest.mark.parametrize("splitter", [2, 3])
+def test_report_repr_html_sklearn_estimator_bad_html_repr(splitter):
+    """HTML repr must still work when the underlying estimator rejects
+    ``_repr_html_``."""
+    X, y = make_classification(n_classes=2, random_state=42)
+    estimator = _DummyClassifierBadRepr()
+    report = CrossValidationReport(estimator, X, y, splitter=splitter)
+    _assert_cross_validation_report_repr_html(report._repr_html_(), "DummyClassifier")
 
 
 def test_report_with_data_op():

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -255,7 +255,8 @@ def test_report_repr_html(splitter, bad_estimator):
     assert "skoreInitEstimatorReport" in html_out
     assert "report-hint-note" in html_out
     assert "docs.skore.probabl.ai" in html_out
-    assert "report-disclosure-title" in html_out
+    assert "report-tabset" in html_out
+    assert "Report for" in html_out
     assert "CrossValidationReport.metrics" in html_out
 
 

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -377,7 +377,8 @@ def test_report_repr_html(with_train, bad_estimator):
     assert "skoreInitEstimatorReport" in html_out
     assert "report-hint-note" in html_out
     assert "docs.skore.probabl.ai" in html_out
-    assert "report-disclosure-title" in html_out
+    assert "report-tabset" in html_out
+    assert "Report for" in html_out
     assert "EstimatorReport.metrics" in html_out
 
 

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -8,7 +8,7 @@ import pytest
 import skrub
 from sklearn.cluster import KMeans
 from sklearn.datasets import make_classification, make_regression
-from sklearn.dummy import DummyClassifier
+from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import FixedThresholdClassifier, train_test_split
@@ -354,32 +354,95 @@ def test_has_no_deep_copy():
         )
 
 
-@pytest.mark.parametrize("with_train", [False, True])
-@pytest.mark.parametrize("bad_estimator", [False, True])
-def test_report_repr_html(with_train, bad_estimator):
-    X, y = make_classification(n_classes=2, random_state=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+class _DummyClassifierBadRepr(DummyClassifier):
+    def _repr_html_(self):
+        raise TypeError("error")
 
-    class DummyClassifierBadRepr(DummyClassifier):
-        def _repr_html_(self):
-            raise TypeError("error")
 
-    estimator = DummyClassifierBadRepr() if bad_estimator else DummyClassifier()
-    estimator.fit(X_train, y_train)
-    kwargs = {}
-    if with_train:
-        kwargs.update(X_train=X_train, y_train=y_train)
-    kwargs.update(X_test=X_test, y_test=y_test)
-    report = EstimatorReport(estimator, fit=False, **kwargs)
-    html_out = report._repr_html_()
+def _assert_estimator_report_repr_html(
+    html_out: str, expected_estimator_name: str
+) -> None:
     assert "skore-estimator-report-" in html_out
-    assert "DummyClassifier" in html_out
+    assert expected_estimator_name in html_out
     assert "skoreInitEstimatorReport" in html_out
     assert "report-hint-note" in html_out
     assert "docs.skore.probabl.ai" in html_out
     assert "report-tabset" in html_out
     assert "Report for" in html_out
     assert "EstimatorReport.metrics" in html_out
+
+
+@pytest.mark.parametrize("with_train", [False, True])
+def test_report_repr_html_binary_classification(with_train):
+    X, y = make_classification(n_classes=2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    estimator = DummyClassifier()
+    estimator.fit(X_train, y_train)
+    kwargs = {}
+    if with_train:
+        kwargs.update(X_train=X_train, y_train=y_train)
+    kwargs.update(X_test=X_test, y_test=y_test)
+    report = EstimatorReport(estimator, fit=False, **kwargs)
+    _assert_estimator_report_repr_html(report._repr_html_(), "DummyClassifier")
+
+
+@pytest.mark.parametrize("with_train", [False, True])
+def test_report_repr_html_multiclass_classification(
+    with_train, multiclass_classification_train_test_split
+):
+    X_train, X_test, y_train, y_test = multiclass_classification_train_test_split
+    estimator = DummyClassifier(strategy="uniform", random_state=0)
+    estimator.fit(X_train, y_train)
+    kwargs = {}
+    if with_train:
+        kwargs.update(X_train=X_train, y_train=y_train)
+    kwargs.update(X_test=X_test, y_test=y_test)
+    report = EstimatorReport(estimator, fit=False, **kwargs)
+    _assert_estimator_report_repr_html(report._repr_html_(), "DummyClassifier")
+
+
+@pytest.mark.parametrize("with_train", [False, True])
+def test_report_repr_html_regression(with_train, regression_train_test_split):
+    X_train, X_test, y_train, y_test = regression_train_test_split
+    estimator = DummyRegressor()
+    estimator.fit(X_train, y_train)
+    kwargs = {}
+    if with_train:
+        kwargs.update(X_train=X_train, y_train=y_train)
+    kwargs.update(X_test=X_test, y_test=y_test)
+    report = EstimatorReport(estimator, fit=False, **kwargs)
+    _assert_estimator_report_repr_html(report._repr_html_(), "DummyRegressor")
+
+
+@pytest.mark.parametrize("with_train", [False, True])
+def test_report_repr_html_multioutput_regression(
+    with_train, regression_multioutput_train_test_split
+):
+    X_train, X_test, y_train, y_test = regression_multioutput_train_test_split
+    estimator = DummyRegressor()
+    estimator.fit(X_train, y_train)
+    kwargs = {}
+    if with_train:
+        kwargs.update(X_train=X_train, y_train=y_train)
+    kwargs.update(X_test=X_test, y_test=y_test)
+    report = EstimatorReport(estimator, fit=False, **kwargs)
+    _assert_estimator_report_repr_html(report._repr_html_(), "DummyRegressor")
+
+
+@pytest.mark.parametrize("with_train", [False, True])
+def test_report_repr_html_sklearn_estimator_bad_html_repr(with_train):
+    """HTML repr must still work when the underlying estimator rejects
+    ``_repr_html_``."""
+    X, y = make_classification(n_classes=2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    estimator = _DummyClassifierBadRepr()
+    estimator.fit(X_train, y_train)
+    kwargs = {}
+    if with_train:
+        kwargs.update(X_train=X_train, y_train=y_train)
+    kwargs.update(X_test=X_test, y_test=y_test)
+    report = EstimatorReport(estimator, fit=False, **kwargs)
+    _assert_estimator_report_repr_html(report._repr_html_(), "DummyClassifier")
 
 
 def test_report_get_data_and_y_true_error():


### PR DESCRIPTION
closes #2738 
closes #2739 

Implement a tab selection instead of details/summary. Due to this change, I also moved the help with a single menu on the right of the tabs.

In addition, I reuse the tweaks from #2739 to reduce the amount of information in the header of the metrics table and use it directly as a title of the repr.

I added different tests to make sure that with different number of classes and output, constructing the HTML repr does not fail.

### Estimator

<img width="820" height="406" alt="image" src="https://github.com/user-attachments/assets/c0d85f4e-9b97-4190-be5b-13ac34da1cd9" />

### Cross-validation

<img width="830" height="418" alt="image" src="https://github.com/user-attachments/assets/68cdcb31-9945-4100-873a-de4bc06bdd17" />

### Comparison of estimator

<img width="574" height="284" alt="image" src="https://github.com/user-attachments/assets/2f53c3db-cc70-47b0-9c80-e1ba876fe04c" />

### Comparison of cross-validation

<img width="818" height="438" alt="image" src="https://github.com/user-attachments/assets/70cc7667-1939-42d6-868a-62dc6520b29a" />
