### PR TITLE
chore(ci): Update `pytest` and `pygments` in lockfiles

### DIFF
--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.5/test-requirements.txt
@@ -164,7 +164,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.10/scikit-learn-1.7/test-requirements.txt
@@ -164,7 +164,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.5/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.8/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.8/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.7/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.8/test-requirements.txt
@@ -162,7 +162,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-hub-project (skore-hub-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.10/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.10/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
@@ -242,7 +242,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.10/scikit-learn-1.7_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.10/scikit-learn-1.7_and_mlflow-3/test-requirements.txt
@@ -242,7 +242,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.11/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.11/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.11/scikit-learn-1.8_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.11/scikit-learn-1.8_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.12/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.12/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.12/scikit-learn-1.8_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.12/scikit-learn-1.8_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.5_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.6_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.6_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.7_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.7_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-2.20/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-2.20/test-requirements.txt
@@ -199,7 +199,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-2/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-2/test-requirements.txt
@@ -212,7 +212,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-3.0/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-3.0/test-requirements.txt
@@ -209,7 +209,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore-mlflow-project/python-3.13/scikit-learn-1.8_and_mlflow-3/test-requirements.txt
@@ -238,7 +238,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   skore-mlflow-project (skore-mlflow-project/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.8/sphinx-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.8/sphinx-requirements.txt
@@ -311,7 +311,7 @@ pydata-sphinx-theme==0.16.1
     # via skore (skore/pyproject.toml)
 pydot==4.0.1
     # via skrub
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   accessible-pygments
     #   ipython
@@ -325,7 +325,7 @@ pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.2
+pytest==9.0.3
     # via pytest-timeout
 pytest-timeout==2.4.0
     # via kaleido


### PR DESCRIPTION
Fixing dependabot alerts for CVE-2025-71176 and CVE-2026-4539.