### PR TITLE
fix(skore-hub-project): Call `cache_predictions()` before testing serialization of reports

### DIFF
--- a/skore-hub-project/tests/unit/report/test_cross_validation_report.py
+++ b/skore-hub-project/tests/unit/report/test_cross_validation_report.py
@@ -363,6 +363,7 @@ class TestCrossValidationReportPayload:
     )
     @mark.respx()
     def test_estimators(self, project, payload, upload_mock):
+        payload.report.cache_predictions()
         assert len(payload.estimators) == len(payload.report.estimator_reports_)
 
         for i, estimator in enumerate(payload.estimators):


### PR DESCRIPTION
Related to https://github.com/probabl-ai/skore/issues/2752

When running tests in a "main-main" env, you get a failure that can be easily fixed.

#### Change description

Call `report.cache_predictions()` at the begging of a tests to avoid issues related to the transient state `_can_skip_predict`. The normal path (Project.put) always calls `report.cache_predictions()`, so it's fair to call it in this test too.

#### AI usage: research and understanding
