### PR TITLE
fix(skore): Inspect cache before checking score_func in metrics

### DIFF
--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -148,9 +148,6 @@ class Metric:
         **kwargs
             Additional keyword arguments passed to ``score_func``.
         """
-        if self.score_func is None:
-            raise ValueError(f"Metric {self.name!r} has no score_func.")
-
         _, y_true = report._get_data_and_y_true(data_source=data_source)
 
         # Merge default kwargs with call-time kwargs
@@ -160,6 +157,9 @@ class Metric:
         score = report._cache.get(cache_key)
         if score is not None:
             return score
+
+        if self.score_func is None:
+            raise ValueError(f"Metric {self.name!r} has no score_func.")
 
         assert self.response_method is not None
 

--- a/skore/tests/unit/reports/estimator/metrics/test_add.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_add.py
@@ -642,7 +642,7 @@ class TestSerialization:
         """Test that if added metric is a lambda, it is lost when pickling."""
         report = binary_classification_report
 
-        scorer = make_scorer(lambda y_true, y_pred: (y_true - y_pred).abs().mean())
+        scorer = make_scorer(lambda y_true, y_pred: np.abs(y_true - y_pred).mean())
         report.metrics.add(scorer)
         assert report._metric_registry["<lambda>"].score_func is not None
 
@@ -652,6 +652,11 @@ class TestSerialization:
         err_msg = "Metric '<lambda>' has no score_func."
         with pytest.raises(ValueError, match=err_msg):
             report2.metrics.summarize()
+
+        # if we cache beforehand, then it works:
+        report.metrics.summarize()
+        report3 = pickle.loads(pickle.dumps(report))
+        report3.metrics.summarize()
 
 
 class TestMetricNew:


### PR DESCRIPTION
(not really a fix, but don't know how to call it)

#### Change description

The goal is to make this flow possible:

```Python
scorer = make_scorer(lambda y_true, y_pred: np.abs(y_true - y_pred).mean())
report.metrics.add(scorer)
report.metrics.summarize()

report3 = pickle.loads(pickle.dumps(report))
report3.metrics.summarize()  # currently raises, while all the results needed are in cache
```

For that, we just need to swap the cache check and the `if self.score_func is None` check.

#### Contribution checklist

- [x] Unit tests were added or updated 
- [ ] All the tests pass (please test locally before pushing)
- [ ] The documentation builds and renders properly (if it does, our bot will add a comment linking
to a preview of the documentation to review it visually)

#### AI usage: no