### PR TITLE
fix: Fix configuration ref in diagnose docs

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -49,7 +49,7 @@ class _BaseReport(ReportHelpMixin):
 
         Checks look for common modeling problems such as overfitting and
         underfitting. Check codes can be muted per-call via `ignore` or globally
-        via :func:`~skore.configuration(ignore_checks=...)` .
+        via :func:`~skore.configuration()` with `ignore_checks=...`.
 
         Parameters
         ----------

--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -37,6 +37,8 @@ ML Assistance
      - Evaluate one or more estimators on the given data.
    * - :func:`compare`
      - Compare pre-existing reports with a :class:`~skore.ComparisonReport`
+   * - :func:`diagnose`
+     - Run checks and return a diagnostic with detected issues.
    * - :func:`train_test_split`
      - Split arrays or matrices into random train and test subsets
    * - :class:`TrainTestSplit`

--- a/sphinx/reference/report/index.rst
+++ b/sphinx/reference/report/index.rst
@@ -17,6 +17,7 @@ These functions and classes build upon scikit-learn's functionality.
 
     evaluate
     compare
+    diagnose
     train_test_split
     TrainTestSplit
 


### PR DESCRIPTION
The reference to `skore.configuration` is broken in the docs of `.diagnose`
<img width="840" height="162" alt="image" src="https://github.com/user-attachments/assets/12fc1bc0-15a4-43ab-80a2-1ba0a3c72e00" />
