### PR TITLE
fix: Revert diagnose in api ref

### DIFF
--- a/sphinx/reference/index.rst
+++ b/sphinx/reference/index.rst
@@ -37,8 +37,6 @@ ML Assistance
      - Evaluate one or more estimators on the given data.
    * - :func:`compare`
      - Compare pre-existing reports with a :class:`~skore.ComparisonReport`
-   * - :func:`diagnose`
-     - Run checks and return a diagnostic with detected issues.
    * - :func:`train_test_split`
      - Split arrays or matrices into random train and test subsets
    * - :class:`TrainTestSplit`

--- a/sphinx/reference/report/index.rst
+++ b/sphinx/reference/report/index.rst
@@ -17,7 +17,6 @@ These functions and classes build upon scikit-learn's functionality.
 
     evaluate
     compare
-    diagnose
     train_test_split
     TrainTestSplit
 


### PR DESCRIPTION
Revert part of #2775.

I wanted to add `.diagnose` somewhere in the main API page of our documentation but since it is under no accessor but still is a report method, not a global method, it currently does not really have an obvious place to be put in.