### PR TITLE
fix: Make diagnostics work with custom metrics

### DIFF
--- a/skore/src/skore/_sklearn/_diagnostic/model_checks.py
+++ b/skore/src/skore/_sklearn/_diagnostic/model_checks.py
@@ -47,6 +47,7 @@ def _get_metrics_data(report: _BaseReport) -> tuple:
         y_test=report.y_test,
         pos_label=report.pos_label,
     )
+    # baseline_report._metric_registry = report._metric_registry
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UndefinedMetricWarning)
         report_data = report.metrics.summarize(data_source="train").data.rename(

--- a/skore/src/skore/_sklearn/_diagnostic/model_checks.py
+++ b/skore/src/skore/_sklearn/_diagnostic/model_checks.py
@@ -47,7 +47,7 @@ def _get_metrics_data(report: _BaseReport) -> tuple:
         y_test=report.y_test,
         pos_label=report.pos_label,
     )
-    # baseline_report._metric_registry = report._metric_registry
+    baseline_report._metric_registry = report._metric_registry
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UndefinedMetricWarning)
         report_data = report.metrics.summarize(data_source="train").data.rename(

--- a/skore/tests/unit/reports/estimator/test_diagnose.py
+++ b/skore/tests/unit/reports/estimator/test_diagnose.py
@@ -1,11 +1,9 @@
 from pathlib import Path
 from urllib.parse import urlparse
 
-import numpy as np
 import pytest
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.linear_model import LinearRegression
-from sklearn.metrics import confusion_matrix, make_scorer
 from sklearn.tree import DecisionTreeRegressor
 
 from skore import Check, EstimatorReport, configuration, evaluate
@@ -240,22 +238,8 @@ def test_check_invalid_protocol(regression_data):
 def test_diagnose_custom_metric(binary_classification_data):
     """Check that diagnose works with custom metrics in the report."""
     X, y = binary_classification_data
-    report = evaluate(DummyClassifier(), X, y)
-
-    def custom_score(y, y_pred, neg_label, pos_label):
-        cm = confusion_matrix(y, y_pred, labels=[neg_label, pos_label])
-        gain_matrix = np.array(
-            [
-                [2, -10],
-                [-1, 2],
-            ]
-        )
-        return np.sum(cm * gain_matrix)
-
-    custom_scorer = make_scorer(
-        custom_score, neg_label=0, pos_label=1, response_method="predict"
-    )
-    report.metrics.add(custom_scorer)
+    report = evaluate(DummyClassifier(), X, y, pos_label=1)
+    report.metrics.add("f1")
     result = report.diagnose()
     assert "SKD002" in result.issues
-    assert "9/9 comparable metrics" in result.issues["SKD002"]["explanation"]
+    assert "7/7 comparable metrics" in result.issues["SKD002"]["explanation"]

--- a/skore/tests/unit/reports/estimator/test_diagnose.py
+++ b/skore/tests/unit/reports/estimator/test_diagnose.py
@@ -238,6 +238,7 @@ def test_check_invalid_protocol(regression_data):
 
 
 def test_diagnose_custom_metric(binary_classification_data):
+    """Check that diagnose works with custom metrics in the report."""
     X, y = binary_classification_data
     report = evaluate(DummyClassifier(), X, y)
 

--- a/skore/tests/unit/reports/estimator/test_diagnose.py
+++ b/skore/tests/unit/reports/estimator/test_diagnose.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from urllib.parse import urlparse
 
+import numpy as np
 import pytest
-from sklearn.dummy import DummyRegressor
+from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.linear_model import LinearRegression
+from sklearn.metrics import confusion_matrix, make_scorer
 from sklearn.tree import DecisionTreeRegressor
 
 from skore import Check, EstimatorReport, configuration, evaluate
@@ -233,3 +235,26 @@ def test_check_invalid_protocol(regression_data):
 
     with pytest.raises(ValueError, match="does not implement the Check protocol."):
         report.add_checks([InvalidCheck()])
+
+
+def test_diagnose_custom_metric(binary_classification_data):
+    X, y = binary_classification_data
+    report = evaluate(DummyClassifier(), X, y)
+
+    def custom_score(y, y_pred, neg_label, pos_label):
+        cm = confusion_matrix(y, y_pred, labels=[neg_label, pos_label])
+        gain_matrix = np.array(
+            [
+                [2, -10],
+                [-1, 2],
+            ]
+        )
+        return np.sum(cm * gain_matrix)
+
+    custom_scorer = make_scorer(
+        custom_score, neg_label=0, pos_label=1, response_method="predict"
+    )
+    report.metrics.add(custom_scorer)
+    result = report.diagnose()
+    assert "SKD002" in result.issues
+    assert "9/9 comparable metrics" in result.issues["SKD002"]["explanation"]


### PR DESCRIPTION
Currently, `.diagnose`, and by extension the report html reprs, crash when a report has a custom metric. This PR introduces a non regression test and a fix.