### PR TITLE
fix(skore): Include metric registry in state

### DIFF
--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -300,6 +300,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 "test_data": self._test_data,
             },
             "predictions": predictions,
+            "metric_registry": self._metric_registry,
             # ---------- OPTIONAL STATE ------------
             # this part is less structured and not crucial for reconstructing a report
             # so we won't try ensuring backward compatibility.
@@ -337,7 +338,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 for (data_source, name), val in state["predictions"].items()
             }
         )
-        report._metric_registry = MetricRegistry(report)
+        report._metric_registry = state["metric_registry"]
 
         return report
 

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -536,9 +536,11 @@ def test_from_state_bypasses_init_and_restores_state(
         estimator,
         X_test=X_test,
         y_test=y_test,
+        pos_label=1,
     )
     expected_accuracy = report.metrics.accuracy()
     report.cache_predictions()
+    report.metrics.add("f1", name="F1")
     state = report.get_state()
 
     def _unexpected_init(self, *args, **kwargs):
@@ -557,8 +559,10 @@ def test_from_state_bypasses_init_and_restores_state(
     assert restored._cache == report._cache
     assert restored.metrics.accuracy() == expected_accuracy
 
-    # check new metrics can be computed:
-    report.metrics.roc_auc()
+    # check new metrics can be computed, including custom metrics:
+    restored.metrics.roc_auc()
+    df = restored.metrics.summarize().frame()
+    assert "F1" in df.index
 
 
 def test_from_state_rejects_unknown_version(logistic_binary_classification_with_test):


### PR DESCRIPTION
Without this fix, you loose the custom metrics you've added after a round-trip through `get_state`/`from_state`
