### PR TITLE
fix: Use cloudpickle instead of joblib to pickle models

### DIFF
--- a/skore-local-project/pyproject.toml
+++ b/skore-local-project/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.10"
 maintainers = [{ name = "skore developers", email = "skore@signal.probabl.ai" }]
 license = "MIT"
 dependencies = [
+  "cloudpickle",
   "diskcache",
   "joblib",
   "platformdirs",
@@ -110,6 +111,7 @@ module = ["skore.*"]
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = [
+  "cloudpickle.*",
   "diskcache.*",
   "joblib.*",
 ]

--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import io
 import os
 from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, ParamSpec, Protocol, TypeVar, cast, runtime_checkable
 from uuid import uuid4
 
-import joblib
+import cloudpickle
 import platformdirs
 
 from .metadata import CrossValidationReportMetadata, EstimatorReportMetadata
@@ -210,9 +209,7 @@ class Project:
         artifact_id = str(report.id)
 
         if artifact_id not in self.__artifacts_storage:
-            with io.BytesIO() as stream:
-                joblib.dump(report, stream)
-                self.__artifacts_storage[artifact_id] = stream.getvalue()
+            self.__artifacts_storage[artifact_id] = cloudpickle.dumps(report)
 
         self.__metadata_storage[uuid4().hex] = dict(
             Metadata(
@@ -227,10 +224,10 @@ class Project:
     def get(self, id: str) -> EstimatorReport | CrossValidationReport:
         """Get a persisted report by its id."""
         if id in self.__artifacts_storage:
-            with io.BytesIO(self.__artifacts_storage[id]) as stream:
-                return cast(
-                    "EstimatorReport | CrossValidationReport", joblib.load(stream)
-                )
+            return cast(
+                "EstimatorReport | CrossValidationReport",
+                cloudpickle.loads(self.__artifacts_storage[id]),
+            )
 
         raise KeyError(id)
 

--- a/skore-local-project/tests/unit/test_project.py
+++ b/skore-local-project/tests/unit/test_project.py
@@ -1,5 +1,4 @@
-from io import BytesIO
-
+import cloudpickle
 import joblib
 from pandas import DataFrame
 from pytest import fixture, raises
@@ -203,8 +202,7 @@ class TestProject:
         # Ensure artifacts are persisted
         assert len(project._Project__artifacts_storage) == 1
 
-        with BytesIO(next(project._Project__artifacts_storage.values())) as stream:
-            artifact = joblib.load(stream)
+        artifact = cloudpickle.loads(next(project._Project__artifacts_storage.values()))
 
         assert isinstance(artifact, EstimatorReport)
         assert artifact.estimator_name_ == "Ridge"
@@ -243,8 +241,7 @@ class TestProject:
         # Ensure artifacts are persisted
         assert len(project._Project__artifacts_storage) == 1
 
-        with BytesIO(next(project._Project__artifacts_storage.values())) as stream:
-            artifact = joblib.load(stream)
+        artifact = cloudpickle.loads(next(project._Project__artifacts_storage.values()))
 
         assert isinstance(artifact, CrossValidationReport)
         assert artifact.estimator_name_ == cv_regression.estimator_name_


### PR DESCRIPTION
Quick fix to ensure that `cloudpickle` would solve the issue.