### PR TITLE
chore(skore): Add report_type in state metadata

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -173,7 +173,9 @@ class _BaseReport(ReportHelpMixin):
             "id": uuid4().int,
             "skore-version": version("skore"),
             "creation-date": datetime.now(timezone.utc).isoformat(),
-            "report_type": self._report_type,
+            # comparison reports don't have a _report_type yet at init time
+            # but they don't have a `get_state` anyway:
+            "report_type": getattr(self, "_report_type", "comparison"),
         }
         self._checks_registry: list[Check] = list(_BUILTIN_CHECKS)
 

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -173,6 +173,7 @@ class _BaseReport(ReportHelpMixin):
             "id": uuid4().int,
             "skore-version": version("skore"),
             "creation-date": datetime.now(timezone.utc).isoformat(),
+            "report_type": self._report_type,
         }
         self._checks_registry: list[Check] = list(_BUILTIN_CHECKS)
 

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -295,6 +295,10 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             # in the future, we could support some BW compatibility instead of crashing
             raise ValueError(f"Unexpected state version: {version!r}")
 
+        report_type = state["metadata"]["report_type"]
+        if report_type != cls._report_type:
+            raise ValueError(f"Unexpected report_type in state: {report_type}")
+
         report = cls.__new__(cls)
 
         report._metadata = state["metadata"]

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -316,6 +316,10 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
             # in the future, we could support some BW compatibility instead of crashing
             raise ValueError(f"Unexpected state version: {version!r}")
 
+        report_type = state["metadata"]["report_type"]
+        if report_type != cls._report_type:
+            raise ValueError(f"Unexpected report_type in state: {report_type}")
+
         report = cls.__new__(cls)
 
         report._metadata = state["metadata"]

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -540,6 +540,7 @@ def test_from_state_bypasses_init_and_restores_state(
     expected_accuracy = report.metrics.accuracy()
     report.cache_predictions()
     state = report.get_state()
+    assert state["metadata"]["report_type"] == report._report_type
 
     def _unexpected_init(self, *args, **kwargs):
         raise AssertionError("__init__ should not be called by from_state")


### PR DESCRIPTION
Everything is in the title ^^

**Motivation:** Needed/useful when you have a `state` and you need to pick between `EstimatorReport.from_state` and `CrossValidationReport.from_state` to deserialize it :sweat_smile: 