### PR TITLE
chore(skore): Hide the cv progress bar when splitter does a single split in evaluate

### DIFF
--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -147,6 +147,8 @@ def evaluate(
 
     if isinstance(splitter, float):
         splitter = TrainTestSplit(test_size=splitter)
+
+    if hasattr(splitter, "get_n_splits") and splitter.get_n_splits(X, y) == 1:
         with configuration(show_progress=False):
             report = CrossValidationReport(
                 estimator,
@@ -159,7 +161,7 @@ def evaluate(
             )
         return report.estimator_reports_[0]
 
-    report = CrossValidationReport(
+    return CrossValidationReport(
         estimator,
         X,
         y,
@@ -168,8 +170,3 @@ def evaluate(
         splitter=splitter,
         n_jobs=n_jobs,
     )
-
-    # In case the splitter only produces one split, return the single estimator report
-    if len(report.estimator_reports_) == 1:
-        return report.estimator_reports_[0]
-    return report

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -146,12 +146,12 @@ def evaluate(
         )
 
     if isinstance(splitter, float):
-        # It's easier to make a 1-split CrossValidationReport
-        # and extract an EstimatorReport from it,
-        # than to make an EstimatorReport from scratch
         splitter = TrainTestSplit(test_size=splitter)
 
     if hasattr(splitter, "get_n_splits") and splitter.get_n_splits(X, y) == 1:
+        # It's easier to make a 1-split CrossValidationReport
+        # and extract an EstimatorReport from it,
+        # than to make an EstimatorReport from scratch
         with configuration(show_progress=False):
             report = CrossValidationReport(
                 estimator,

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 
 from sklearn.base import BaseEstimator
 
+from skore import configuration
 from skore._sklearn._comparison.report import ComparisonReport
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._estimator.report import EstimatorReport
@@ -146,6 +147,17 @@ def evaluate(
 
     if isinstance(splitter, float):
         splitter = TrainTestSplit(test_size=splitter)
+        with configuration(show_progress=False):
+            report = CrossValidationReport(
+                estimator,
+                X,
+                y,
+                data=data,
+                pos_label=pos_label,
+                splitter=splitter,
+                n_jobs=n_jobs,
+            )
+        return report.estimator_reports_[0]
 
     report = CrossValidationReport(
         estimator,
@@ -156,6 +168,8 @@ def evaluate(
         splitter=splitter,
         n_jobs=n_jobs,
     )
+
+    # In case the splitter only produces one split, return the single estimator report
     if len(report.estimator_reports_) == 1:
         return report.estimator_reports_[0]
     return report


### PR DESCRIPTION
More general version of what was done in #2811 : hide the cv bar progress when the splitter only performs a single train/test split, not only for `splitter: float`. E.g. it also hides the progress bar for a custom instance of `skore.TrainTestSplit`