### PR TITLE
feat(skore-hub-project/client/authentication): Use cookies in Jupyterlite

### DIFF
--- a/skore-hub-project/pyproject.toml
+++ b/skore-hub-project/pyproject.toml
@@ -121,6 +121,8 @@ module = ["skore.*"]
 ignore_missing_imports = true
 module = [
   "joblib.*",
+  "js.*",
+  "pyodide.*",
   "scipy.*",
   "sklearn.*",
 ]

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -1,5 +1,7 @@
 """Client exchanging with ``skore hub``."""
 
+from __future__ import annotations
+
 from contextlib import suppress
 from http import HTTPStatus
 from importlib.metadata import version
@@ -7,7 +9,7 @@ from importlib.util import find_spec
 from json import dumps
 from logging import getLogger
 from time import sleep
-from typing import Any, Final
+from typing import Any, Final, cast
 from urllib.parse import urljoin
 
 from httpx import (
@@ -165,6 +167,52 @@ JUPYTERLITE = find_spec("pyodide") is not None
 class HUBClient(Client):
     """Client exchanging with ``skore hub``."""
 
+    def __init__(
+        self,
+        *,
+        retry: bool = True,
+        retry_total: int | None = 10,
+        retry_backoff_factor: float = 0.25,
+        retry_backoff_max: float = 120,
+        transport: BaseTransport | None = None,
+    ):
+        if JUPYTERLITE and (transport is None):
+            from httpx import Request
+            from js import XMLHttpRequest
+            from pyodide.http.pyxhr import XHRResponse
+
+            class JupyterliteTransport(BaseTransport):
+                def handle_request(self, request: Request) -> Response:
+                    req = XMLHttpRequest.new()
+                    req.open(request.method.upper(), str(request.url), False)
+                    req.withCredentials = True
+
+                    for name, value in request.headers.items():
+                        if name.lower() == "host":
+                            continue
+                        req.setRequestHeader(name, value)
+
+                    req.send(request.content)
+
+                    xhr = XHRResponse(req)
+
+                    return Response(
+                        status_code=xhr.status_code,
+                        headers=xhr.headers,
+                        content=xhr.content,
+                        request=request,
+                    )
+
+            transport = JupyterliteTransport()
+
+        super().__init__(
+            retry=retry,
+            retry_total=retry_total,
+            retry_backoff_factor=retry_backoff_factor,
+            retry_backoff_max=retry_backoff_max,
+            transport=transport,
+        )
+
     def request(
         self,
         method: str,
@@ -195,35 +243,3 @@ class HUBClient(Client):
         url = urljoin(URI(), str(url))
 
         return super().request(method=method, url=url, headers=headers, **kwargs)
-
-
-if JUPYTERLITE:
-    from functools import partial
-
-    from httpx import Request
-    from js import XMLHttpRequest
-    from pyodide.http.pyxhr import XHRResponse
-
-    class __JupyterliteTransport(BaseTransport):
-        def handle_request(self, request: Request) -> Response:
-            req = XMLHttpRequest.new()
-            req.open(request.method.upper(), str(request.url), False)
-            req.withCredentials = True
-
-            for name, value in request.headers.items():
-                if name.lower() == "host":
-                    continue
-                req.setRequestHeader(name, value)
-
-            req.send(request.content)
-
-            xhr = XHRResponse(req)
-
-            return Response(
-                status_code=xhr.status_code,
-                headers=xhr.headers,
-                content=xhr.content,
-                request=request,
-            )
-
-    HUBClient = partial(HUBClient, transport=__JupyterliteTransport())

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -1,10 +1,10 @@
 """Client exchanging with ``skore hub``."""
 
-import importlib.metadata
-import importlib.util
-import json
 from contextlib import suppress
 from http import HTTPStatus
+from importlib.metadata import version
+from importlib.util import find_spec
+from json import dumps
 from logging import getLogger
 from time import sleep
 from typing import Any, Final
@@ -26,34 +26,40 @@ from httpx._types import HeaderTypes
 from skore_hub_project.authentication.uri import URI
 
 logger = getLogger(__name__)
-JUPYTERLITE = importlib.util.find_spec("pyodide") is not None
+JUPYTERLITE = find_spec("pyodide") is not None
 
 
 if JUPYTERLITE:
     from functools import partialmethod
 
-    from httpx import BaseTransport, Response
-    from pyodide.http import pyxhr
+    from httpx import BaseTransport
+    from js import XMLHttpRequest
+    from pyodide.http.pyxhr import XHRResponse
 
     class JupyterliteTransport(BaseTransport):
         def handle_request(self, request):
-            send = getattr(pyxhr, request.method.lower())
-            response = send(
-                request.url,
-                headers=request.headers,
-                data=request.content,
-            )
+            req = XMLHttpRequest.new()
+            req.open(request.method.upper(), str(request.url), False)
+            req.withCredentials = True
+
+            for name, value in request.headers.items():
+                if name.lower() == "host":
+                    continue
+                req.setRequestHeader(name, value)
+
+            req.send(request.content)
+
+            xhr = XHRResponse(req)
 
             return Response(
-                status_code=response.status_code,
-                headers=response.headers,
-                content=response.content,
+                status_code=xhr.status_code,
+                headers=xhr.headers,
+                content=xhr.content,
                 request=request,
             )
 
     HTTPXClient.__init__ = partialmethod(
-        HTTPXClient.__init__,
-        transport=JupyterliteTransport(),
+        HTTPXClient.__init__, transport=JupyterliteTransport()
     )
 
 
@@ -157,7 +163,7 @@ class Client(HTTPXClient):
         )
 
         with suppress(Exception):
-            logger.debug(f"{message}\n{json.dumps(response.json(), indent=4)}")
+            logger.debug(f"{message}\n{dumps(response.json(), indent=4)}")
             message += f": {response.json()['message']}"
 
         raise HTTPStatusError(message, request=response.request, response=response)
@@ -181,7 +187,7 @@ def __semver(version: str) -> str | None:
     return version.replace("rc", "-rc.")
 
 
-PACKAGE_SEMVER = __semver(importlib.metadata.version("skore-hub-project"))
+PACKAGE_SEMVER = __semver(version("skore-hub-project"))
 
 
 class HUBClient(Client):

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -36,7 +36,7 @@ if JUPYTERLITE:
     from js import XMLHttpRequest
     from pyodide.http.pyxhr import XHRResponse
 
-    class JupyterliteTransport(BaseTransport):
+    class __JupyterliteTransport(BaseTransport):
         def handle_request(self, request):
             req = XMLHttpRequest.new()
             req.open(request.method.upper(), str(request.url), False)
@@ -59,7 +59,8 @@ if JUPYTERLITE:
             )
 
     HTTPXClient.__init__ = partialmethod(
-        HTTPXClient.__init__, transport=JupyterliteTransport()
+        HTTPXClient.__init__,
+        transport=__JupyterliteTransport(),
     )
 
 

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -7,7 +7,7 @@ from importlib.util import find_spec
 from json import dumps
 from logging import getLogger
 from time import sleep
-from typing import Any, Final, cast
+from typing import Any, Final
 from urllib.parse import urljoin
 
 from httpx import (
@@ -58,8 +58,7 @@ if JUPYTERLITE:
                 request=request,
             )
 
-    HTTPXClient.__init__ = cast(  # type: ignore[method-assign]
-        Any,
+    HTTPXClient.__init__ = (  # type: ignore[method-assign, assignment]
         partialmethod(HTTPXClient.__init__, transport=__JupyterliteTransport()),
     )
 

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -7,7 +7,7 @@ from importlib.util import find_spec
 from json import dumps
 from logging import getLogger
 from time import sleep
-from typing import Any, Final
+from typing import Any, Final, cast
 from urllib.parse import urljoin
 
 from httpx import (
@@ -33,11 +33,11 @@ if JUPYTERLITE:
     from functools import partialmethod
 
     from httpx import BaseTransport
-    from js import XMLHttpRequest
-    from pyodide.http.pyxhr import XHRResponse
+    from js import XMLHttpRequest  # type: ignore[import-not-found]
+    from pyodide.http.pyxhr import XHRResponse  # type: ignore[import-not-found]
 
     class __JupyterliteTransport(BaseTransport):
-        def handle_request(self, request):
+        def handle_request(self, request):  # type: ignore[no-untyped-def]
             req = XMLHttpRequest.new()
             req.open(request.method.upper(), str(request.url), False)
             req.withCredentials = True
@@ -58,9 +58,9 @@ if JUPYTERLITE:
                 request=request,
             )
 
-    HTTPXClient.__init__ = partialmethod(
-        HTTPXClient.__init__,
-        transport=__JupyterliteTransport(),
+    HTTPXClient.__init__ = cast(  # type: ignore[method-assign]
+        Any,
+        partialmethod(HTTPXClient.__init__, transport=__JupyterliteTransport()),
     )
 
 

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -9,11 +9,12 @@ from importlib.util import find_spec
 from json import dumps
 from logging import getLogger
 from time import sleep
-from typing import Any, Final, cast
+from typing import Any, Final
 from urllib.parse import urljoin
 
 from httpx import (
     URL,
+    BaseTransport,
     Headers,
     HTTPError,
     HTTPStatusError,
@@ -21,7 +22,6 @@ from httpx import (
     RemoteProtocolError,
     Response,
     TimeoutException,
-    BaseTransport,
 )
 from httpx import Client as HTTPXClient
 from httpx._types import HeaderTypes

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -1,6 +1,7 @@
 """Client exchanging with ``skore hub``."""
 
 import importlib.metadata
+import importlib.util
 import json
 from contextlib import suppress
 from http import HTTPStatus
@@ -25,6 +26,35 @@ from httpx._types import HeaderTypes
 from skore_hub_project.authentication.uri import URI
 
 logger = getLogger(__name__)
+JUPYTERLITE = importlib.util.find_spec("pyodide") is not None
+
+
+if JUPYTERLITE:
+    from functools import partialmethod
+
+    from httpx import BaseTransport, Response
+    from pyodide.http import pyxhr
+
+    class JupyterliteTransport(BaseTransport):
+        def handle_request(self, request):
+            send = getattr(pyxhr, request.method.lower())
+            response = send(
+                request.url,
+                headers=request.headers,
+                data=request.content,
+            )
+
+            return Response(
+                status_code=response.status_code,
+                headers=response.headers,
+                content=response.content,
+                request=request,
+            )
+
+    HTTPXClient.__init__ = partialmethod(
+        HTTPXClient.__init__,
+        transport=JupyterliteTransport(),
+    )
 
 
 class Client(HTTPXClient):
@@ -167,16 +197,17 @@ class HUBClient(Client):
         """Execute request with authorization."""
         from skore_hub_project.authentication.login import credentials
 
-        if credentials is None:
+        headers = Headers(headers)
+
+        if credentials is not None:  # User is authenticated via API key or bearer token
+            headers.update(credentials())
+        elif JUPYTERLITE:  # User is authenticated via cookies
+            pass
+        else:  # User is not authenticated
             raise RuntimeError(
                 "You are not logged in. "
                 "Please call the `skore.login()` function at the top of your script."
             )
-
-        headers = Headers(headers)
-
-        # Overload headers with credentials
-        headers.update(credentials())
 
         # Overload headers with package semantic versioning
         if PACKAGE_SEMVER:

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -19,6 +19,7 @@ from httpx import (
     RemoteProtocolError,
     Response,
     TimeoutException,
+    BaseTransport,
 )
 from httpx import Client as HTTPXClient
 from httpx._types import HeaderTypes
@@ -26,41 +27,6 @@ from httpx._types import HeaderTypes
 from skore_hub_project.authentication.uri import URI
 
 logger = getLogger(__name__)
-JUPYTERLITE = find_spec("pyodide") is not None
-
-
-if JUPYTERLITE:
-    from functools import partialmethod
-
-    from httpx import BaseTransport, Request
-    from js import XMLHttpRequest
-    from pyodide.http.pyxhr import XHRResponse
-
-    class __JupyterliteTransport(BaseTransport):
-        def handle_request(self, request: Request) -> Response:
-            req = XMLHttpRequest.new()
-            req.open(request.method.upper(), str(request.url), False)
-            req.withCredentials = True
-
-            for name, value in request.headers.items():
-                if name.lower() == "host":
-                    continue
-                req.setRequestHeader(name, value)
-
-            req.send(request.content)
-
-            xhr = XHRResponse(req)
-
-            return Response(
-                status_code=xhr.status_code,
-                headers=xhr.headers,
-                content=xhr.content,
-                request=request,
-            )
-
-    HTTPXClient.__init__ = (  # type: ignore[method-assign, assignment]
-        partialmethod(HTTPXClient.__init__, transport=__JupyterliteTransport()),
-    )
 
 
 class Client(HTTPXClient):
@@ -111,8 +77,13 @@ class Client(HTTPXClient):
         retry_total: int | None = 10,
         retry_backoff_factor: float = 0.25,
         retry_backoff_max: float = 120,
+        transport: BaseTransport | None = None,
     ):
-        super().__init__(follow_redirects=True, timeout=30)
+        super().__init__(
+            follow_redirects=True,
+            timeout=30,
+            transport=transport,
+        )
 
         self.retry = retry
         self.retry_total = retry_total if retry_total is not None else float("inf")
@@ -188,6 +159,7 @@ def __semver(version: str) -> str | None:
 
 
 PACKAGE_SEMVER = __semver(version("skore-hub-project"))
+JUPYTERLITE = find_spec("pyodide") is not None
 
 
 class HUBClient(Client):
@@ -223,3 +195,35 @@ class HUBClient(Client):
         url = urljoin(URI(), str(url))
 
         return super().request(method=method, url=url, headers=headers, **kwargs)
+
+
+if JUPYTERLITE:
+    from functools import partial
+
+    from httpx import Request
+    from js import XMLHttpRequest
+    from pyodide.http.pyxhr import XHRResponse
+
+    class __JupyterliteTransport(BaseTransport):
+        def handle_request(self, request: Request) -> Response:
+            req = XMLHttpRequest.new()
+            req.open(request.method.upper(), str(request.url), False)
+            req.withCredentials = True
+
+            for name, value in request.headers.items():
+                if name.lower() == "host":
+                    continue
+                req.setRequestHeader(name, value)
+
+            req.send(request.content)
+
+            xhr = XHRResponse(req)
+
+            return Response(
+                status_code=xhr.status_code,
+                headers=xhr.headers,
+                content=xhr.content,
+                request=request,
+            )
+
+    HUBClient = partial(HUBClient, transport=__JupyterliteTransport())

--- a/skore-hub-project/src/skore_hub_project/client/client.py
+++ b/skore-hub-project/src/skore_hub_project/client/client.py
@@ -32,12 +32,12 @@ JUPYTERLITE = find_spec("pyodide") is not None
 if JUPYTERLITE:
     from functools import partialmethod
 
-    from httpx import BaseTransport
-    from js import XMLHttpRequest  # type: ignore[import-not-found]
-    from pyodide.http.pyxhr import XHRResponse  # type: ignore[import-not-found]
+    from httpx import BaseTransport, Request
+    from js import XMLHttpRequest
+    from pyodide.http.pyxhr import XHRResponse
 
     class __JupyterliteTransport(BaseTransport):
-        def handle_request(self, request):  # type: ignore[no-untyped-def]
+        def handle_request(self, request: Request) -> Response:
             req = XMLHttpRequest.new()
             req.open(request.method.upper(), str(request.url), False)
             req.withCredentials = True

--- a/skore-hub-project/tests/unit/client/test_client.py
+++ b/skore-hub-project/tests/unit/client/test_client.py
@@ -230,3 +230,16 @@ class TestHUBClient:
             respx_mock.calls.last.request.headers["X-Skore-Client"]
             == "skore-hub-project/1.0.0"
         )
+
+    def test_jupyterlite(self, monkeypatch):
+        from sys import modules
+        from unittest.mock import Mock
+
+        monkeypatch.setattr("skore_hub_project.client.client.JUPYTERLITE", True)
+        monkeypatch.setitem(modules, "js", Mock())
+        monkeypatch.setitem(modules, "pyodide", Mock())
+        monkeypatch.setitem(modules, "pyodide.http", Mock())
+        monkeypatch.setitem(modules, "pyodide.http.pyxhr", Mock())
+
+        with HUBClient() as client:
+            assert client._transport.__class__.__name__ == "JupyterliteTransport"


### PR DESCRIPTION
Part of https://github.com/probabl-ai/skore-hub/issues/1402.

In Jupyterlite, when no API key or bearer token are available in the session, use browser cookies to authenticate the hub requests.

Note that writing a test is complicated till `pyodide` cannot be installed from PyPi.