### PR TITLE
Revert "fix(skore): Close plots to avoid triggering a user-facing warning"

### DIFF
--- a/skore/src/skore/_sklearn/_plot/base.py
+++ b/skore/src/skore/_sklearn/_plot/base.py
@@ -191,8 +191,7 @@ class StyleDisplayMixin:
         1. Applies default style settings
         2. Runs `plot_func` under `plt.ioff()` so figures are not shown until returned
         3. Calls `Figure.tight_layout()` on the returned figure when applicable
-        4. Deregisters pyplot-managed figures created during the display call
-        5. Restores the original style settings
+        4. Restores the original style settings
 
         Parameters
         ----------
@@ -211,21 +210,14 @@ class StyleDisplayMixin:
             # `plt.style.context` has a side effect with the interactive mode.
             # See https://github.com/matplotlib/matplotlib/issues/25041
             original_params = {key: plt.rcParams[key] for key in DEFAULT_STYLE}
-            figures_before = set(plt.get_fignums())
             plt.rcParams.update(DEFAULT_STYLE)
             result: Any = None
             try:
                 with plt.ioff():
                     result = plot_func(self, *args, **kwargs)
+            finally:
                 if isinstance(result, Figure):
                     result.tight_layout()
-            finally:
-                # Seaborn figure-level helpers go through pyplot and keep figures
-                # registered until they are explicitly closed. Deregister all figures
-                # created during this display call while keeping the returned Figure
-                # object usable by the caller.
-                for figure_num in set(plt.get_fignums()) - figures_before:
-                    plt.close(figure_num)
                 plt.rcParams.update(original_params)
             return result
 

--- a/skore/tests/unit/displays/test_common.py
+++ b/skore/tests/unit/displays/test_common.py
@@ -29,18 +29,3 @@ def test_display_protocol(pyplot, capsys, plot_func, estimator, dataset):
     display = getattr(report.metrics, plot_func)()
 
     assert isinstance(display, Display)
-
-
-def test_repeated_display_plot_calls_do_not_keep_figures_open(
-    pyplot, estimator_reports_binary_classification
-):
-    """Repeated plotting should not accumulate pyplot-managed figures."""
-
-    report = estimator_reports_binary_classification[0]
-    display = report.metrics.precision_recall()
-    figures_before = set(pyplot.get_fignums())
-
-    for _ in range(25):
-        display.plot()
-
-    assert set(pyplot.get_fignums()) == figures_before


### PR DESCRIPTION
Reverts probabl-ai/skore#2778

I don't think that we should automatically close figure on the behalf of the user. Here, the side effect is that it is breaking the generation of the documentation because we close the figure before to save them probably.
