### PR TITLE
docs(skore): Do not show matplotlib Figure repr in example

### DIFF
--- a/examples/getting_started/plot_getting_started.py
+++ b/examples/getting_started/plot_getting_started.py
@@ -180,7 +180,7 @@ precision_recall.help()
 # We can visualize the critical information as a plot, with only a few lines of code:
 
 # %%
-precision_recall.plot()
+_ = precision_recall.plot()
 
 # %%
 # Or we can access the raw information as a dataframe if additional analysis is needed:
@@ -193,7 +193,7 @@ precision_recall.frame()
 
 # %%
 confusion_matrix = simple_cv_report.metrics.confusion_matrix()
-confusion_matrix.plot()
+_ = confusion_matrix.plot()
 
 # %%
 # Skore also provides utilities to inspect models. Since our model is a linear
@@ -204,7 +204,7 @@ coefficients = simple_cv_report.inspection.coefficients()
 coefficients.frame()
 
 # %%
-coefficients.plot(select_k=15)
+_ = coefficients.plot(select_k=15)
 
 # %%
 # Model no. 2: Random forest
@@ -260,7 +260,7 @@ comparison_metrics = comparison.metrics.summarize()
 comparison_metrics.frame(favorability=True)
 
 # %%
-comparison.metrics.precision_recall().plot()
+_ = comparison.metrics.precision_recall().plot()
 
 # %%
 # Based on the previous tables and plots, it seems that the
@@ -294,7 +294,7 @@ final_metrics = final_report.metrics.summarize()
 final_metrics.frame()
 
 # %%
-final_report.metrics.confusion_matrix().plot()
+_ = final_report.metrics.confusion_matrix().plot()
 
 # %%
 # We can easily combine the results of the previous cross-validation together with
@@ -339,7 +339,7 @@ print(
 
 # %%
 final_coefficients.plot(select_k=15, sorting_order="descending")
-cv_coefficients.plot(select_k=15, sorting_order="descending")
+_ = cv_coefficients.plot(select_k=15, sorting_order="descending")
 
 # %%
 # They seem very similar, so we are done!

--- a/examples/integrations/plot_sklearn_api.py
+++ b/examples/integrations/plot_sklearn_api.py
@@ -87,13 +87,13 @@ xgb_report.metrics.summarize().frame()
 # We can easily get the summary of metrics, and also a ROC curve plot for example:
 
 # %%
-xgb_report.metrics.roc().plot()
+_ = xgb_report.metrics.roc().plot()
 
 # %%
 # We can also inspect our model:
 
 # %%
-xgb_report.inspection.permutation_importance().plot()
+_ = xgb_report.inspection.permutation_importance().plot()
 
 # %%
 # Custom model

--- a/examples/integrations/plot_skore_hub_project.py
+++ b/examples/integrations/plot_skore_hub_project.py
@@ -160,7 +160,7 @@ len(reports.reports_)
 reports.metrics.summarize().frame()
 
 # %%
-reports.metrics.roc().plot(subplot_by=None)
+_ = reports.metrics.roc().plot(subplot_by=None)
 
 # %%
 # Conclusion

--- a/examples/model_evaluation/plot_custom_metrics.py
+++ b/examples/model_evaluation/plot_custom_metrics.py
@@ -1,9 +1,9 @@
 """
 .. _example_custom_metrics:
 
-===========================================================
-`EstimatorReport.metrics.add`: Adapt skore to your use-case
-===========================================================
+================================
+Use a your own metric with skore
+================================
 
 By default, :meth:`~skore.EstimatorReport.metrics.summarize` reports a curated
 set of metrics for your ML task. In practice you often need domain-specific

--- a/examples/model_evaluation/plot_estimator_report.py
+++ b/examples/model_evaluation/plot_estimator_report.py
@@ -80,6 +80,7 @@ estimator
 from skore import EstimatorReport
 
 report = EstimatorReport(estimator, **split_data, pos_label=pos_label)
+report
 
 # %%
 #
@@ -141,10 +142,8 @@ report.metrics.timings()
 #
 # Since we obtain a pandas dataframe, we can also use the plotting interface of
 # pandas.
-import matplotlib.pyplot as plt
-
 ax = metric_report.plot.barh()
-ax.set_title("Metrics report")
+_ = ax.set_title("Metrics report")
 
 # %%
 #
@@ -218,7 +217,7 @@ report.metrics.add(
 )
 
 cost = report.metrics.summarize(metric="operational_decision_cost")
-cost
+cost.frame()
 
 # %%
 #
@@ -251,14 +250,12 @@ display.plot()
 # those display (slightly modified to improve the UI) in case we want to tweak some
 # of the plot properties. We can have quick look at the available attributes and
 # methods by calling the ``help`` method or simply by printing the display.
-display
-
-# %%
 display.help()
 
 # %%
 fig = display.plot()
-_ = fig.axes[0].set_title("Example of a ROC curve")
+fig.axes[0].set_title("Example of a ROC curve")
+fig
 
 # %%
 #
@@ -269,8 +266,9 @@ _ = fig.axes[0].set_title("Example of a ROC curve")
 start = time.time()
 # we already trigger the computation of the predictions in a previous call
 display = report.metrics.roc()
-display.plot()
+fig = display.plot()
 end = time.time()
+fig
 
 # %%
 print(f"Time taken to compute the ROC curve: {end - start:.2f} seconds")
@@ -283,8 +281,9 @@ report.clear_cache()
 # %%
 start = time.time()
 display = report.metrics.roc()
-display.plot()
+fig = display.plot()
 end = time.time()
+fig
 
 # %%
 print(f"Time taken to compute the ROC curve: {end - start:.2f} seconds")
@@ -303,7 +302,6 @@ print(f"Time taken to compute the ROC curve: {end - start:.2f} seconds")
 # Let's first start with a basic confusion matrix:
 cm_display = report.metrics.confusion_matrix()
 cm_display.plot()
-plt.show(block=True)
 
 # %%
 # In binary classification, a confusion matrix depends on the decision threshold used
@@ -311,29 +309,27 @@ plt.show(block=True)
 # threshold of 0.5, but confusion matrices are actually computed at every threshold
 # internally.
 
-# To visualize the confusion matrix at a different threshold, use the ``threshold_value``
-# parameter. For example, a threshold of 0.3 will classify more samples as positive:
+# To visualize the confusion matrix at a different threshold, use the
+# ``threshold_value`` parameter. For example, a threshold of 0.3 will classify
+# more samples as positive:
 cm_display.plot(threshold_value=0.3)
-plt.show(block=True)
 
 # %%
 # We can normalize the confusion matrix to get percentages instead of raw counts.
 # Here we normalize by true labels (rows):
 cm_display.plot(normalize="true")
-plt.show(block=True)
 
 # %%
 # More plotting options are available via ``heatmap_kwargs``, which are passed to
 # seaborn's heatmap. For example, we can customize the colormap and number format:
 cm_display.set_style(heatmap_kwargs={"cmap": "Greens", "fmt": ".2e"})
 cm_display.plot()
-plt.show(block=True)
 
 # %%
 # Finally, the confusion matrix can also be exported as a pandas DataFrame for further
 # analysis:
-cm_frame = cm_display.frame()
-cm_frame
+cm_display.frame()
+
 
 # %%
 # .. seealso::

--- a/examples/technical_details/plot_cache_mechanism.py
+++ b/examples/technical_details/plot_cache_mechanism.py
@@ -196,7 +196,7 @@ print(f"Time taken: {end - start:.2f} seconds")
 # We only use the cache to retrieve the `display` object and not directly the matplotlib
 # figure. It means that we can still customize the cached plot before displaying it:
 display.set_style(relplot_kwargs={"color": "tab:orange"})
-display.plot()
+_ = display.plot()
 
 # %%
 #

--- a/examples/technical_details/plot_skore_api.py
+++ b/examples/technical_details/plot_skore_api.py
@@ -94,7 +94,7 @@ metrics_display.frame()
 
 # %%
 # Draw the confusion matrix by calling ``plot()``:
-metrics_display.plot()
+_ = metrics_display.plot()
 
 # %%
 # Inspection accessor
@@ -105,7 +105,7 @@ metrics_display.plot()
 # These also return Display objects with the same ``plot()``, ``frame()``,
 # ``set_style()``, and ``help()`` methods.
 inspection_display = report.inspection.coefficients()
-inspection_display.plot(select_k=15, sorting_order="descending")
+_ = inspection_display.plot(select_k=15, sorting_order="descending")
 
 # %%
 # Second report type: cross-validation
@@ -122,10 +122,10 @@ cv_report = evaluate(estimator, X, y, splitter=3)
 cv_report.data.analyze().plot(kind="dist", x="mean radius", y="mean texture")
 
 # %%
-cv_report.metrics.confusion_matrix().plot()
+_ = cv_report.metrics.confusion_matrix().plot()
 
 # %%
-cv_report.inspection.coefficients().plot(select_k=10, sorting_order="descending")
+_ = cv_report.inspection.coefficients().plot(select_k=10, sorting_order="descending")
 
 # %%
 # Third report type: comparison

--- a/examples/technical_details/plot_skore_local_project.py
+++ b/examples/technical_details/plot_skore_local_project.py
@@ -90,7 +90,7 @@ len(reports.reports_)
 reports.metrics.summarize().frame()
 
 # %%
-reports.metrics.roc().plot(subplot_by=None)
+_ = reports.metrics.roc().plot(subplot_by=None)
 
 # %%
 project.delete("example-project", workspace=tmp_path)

--- a/examples/use_cases/plot_employee_salaries.py
+++ b/examples/use_cases/plot_employee_salaries.py
@@ -142,7 +142,9 @@ data_display
 # matrix of the dataset.
 
 # %%
-data_display.plot(kind="corr")
+fig = data_display.plot(kind="corr")
+fig.set_size_inches(10, 10)
+fig
 
 # %%
 # We get the results from some statistical metrics aggregated over the cross-validation
@@ -259,11 +261,7 @@ linear_model_report.help()
 # compute them on the fly (if not cached) and cache them for us.
 
 # %%
-import warnings
-
-with warnings.catch_warnings():
-    warnings.simplefilter(action="ignore", category=FutureWarning)
-    linear_model_report.cache_predictions()
+linear_model_report.cache_predictions()
 
 # %%
 # We can now have a look at the performance of the model with some standard metrics.
@@ -302,7 +300,7 @@ comparator.metrics.summarize().frame()
 # Here, we plot the actual-vs-predicted values for each split.
 
 # %%
-linear_model_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
+_ = linear_model_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
 
 # %%
 # Conclusion

--- a/examples/use_cases/plot_feature_importance.py
+++ b/examples/use_cases/plot_feature_importance.py
@@ -234,7 +234,7 @@ ridge_report.metrics.summarize().frame()
 # Let us plot the prediction error:
 
 # %%
-ridge_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
+_ = ridge_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
 
 # %%
 # We can observe that the model has issues predicting large house prices, due to the
@@ -258,7 +258,7 @@ ridge_report.inspection.coefficients().frame()
 # We can plot this pandas datafame:
 
 # %%
-ridge_report.inspection.coefficients().plot()
+_ = ridge_report.inspection.coefficients().plot()
 
 # %%
 # .. note::
@@ -402,7 +402,7 @@ comparator.metrics.summarize().frame()
 # Let us plot the prediction error:
 
 # %%
-engineered_ridge_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
+_ = engineered_ridge_report.metrics.prediction_error().plot(kind="actual_vs_predicted")
 
 # %%
 # About the clipping issue, compared to the prediction error of our previous model
@@ -825,7 +825,7 @@ plot_tree(
 # Now, let us look at the feature importance based on the MDI:
 
 # %%
-tree_report.inspection.impurity_decrease().plot()
+_ = tree_report.inspection.impurity_decrease().plot()
 
 # %%
 # For a decision tree, for each feature, the MDI is averaged across all splits in the
@@ -879,7 +879,7 @@ print(f"Number of trees in the forest: {n_estimators}")
 # Let us look into the MDI of our random forest:
 
 # %%
-rf_report.inspection.impurity_decrease().plot()
+_ = rf_report.inspection.impurity_decrease().plot()
 
 # %%
 # In a random forest, the MDI is computed by averaging the MDI of each feature across

--- a/examples/use_cases/plot_tracking_all_the_data_processing.py
+++ b/examples/use_cases/plot_tracking_all_the_data_processing.py
@@ -84,7 +84,7 @@ report = skore.EstimatorReport(pred, pos_label=1)
 report.metrics.roc_auc()
 
 # %%
-report.metrics.precision_recall().plot()
+_ = report.metrics.precision_recall().plot()
 
 # %%
 # Note that the preprocessing operations are captured in the skrub DataOp,


### PR DESCRIPTION
@thomass-dev 

As discussed, here is a PR that catch the figure representation in the example to avoid the textual output.