### PR TITLE
feat(skore): Add position parameter when adding metric in registry

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -135,6 +135,7 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
         name: str | None = None,
         response_method: str | list[str] = "predict",
         greater_is_better: bool = True,
+        position: Literal["first", "last"] = "first",
         **kwargs: Any,
     ) -> None:
         """Add a custom metric to be included in :meth:`summarize` by default.
@@ -153,6 +154,10 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
 
         greater_is_better : bool, default=True
             Whether higher values are better (only for callables).
+
+        position : {"first", "last"}, default="first"
+            Where to place the metric in default :meth:`summarize` ordering
+            for each compared report. See :meth:`EstimatorReport.metrics.add`.
 
         **kwargs : Any
             Default keyword arguments passed to the score function at call
@@ -183,6 +188,7 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
                 name=name,
                 response_method=response_method,
                 greater_is_better=greater_is_better,
+                position=position,
                 **kwargs,
             )
 

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -117,6 +117,7 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
         name: str | None = None,
         response_method: str | list[str] = "predict",
         greater_is_better: bool = True,
+        position: Literal["first", "last"] = "first",
         **kwargs: Any,
     ) -> None:
         """Add a custom metric to be included in :meth:`summarize` by default.
@@ -135,6 +136,10 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
 
         greater_is_better : bool, default=True
             Whether higher values are better (only for callables).
+
+        position : {"first", "last"}, default="first"
+            Where to place the metric in default :meth:`summarize` ordering
+            for each split report. See :meth:`EstimatorReport.metrics.add`.
 
         **kwargs : Any
             Default keyword arguments passed to the score function at call
@@ -165,6 +170,7 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
                 name=name,
                 response_method=response_method,
                 greater_is_better=greater_is_better,
+                position=position,
                 **kwargs,
             )
 

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -180,6 +180,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         name: str | None = None,
         response_method: str | list[str] = "predict",
         greater_is_better: bool = True,
+        position: Literal["first", "last"] = "first",
         **kwargs: Any,
     ) -> None:
         """Add a custom metric to be included in :meth:`summarize` by default.
@@ -207,6 +208,11 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
 
         greater_is_better : bool, default=True
             Whether higher values are better (only for callables).
+
+        position : {"first", "last"}, default="first"
+            Where to place the metric in default :meth:`summarize` ordering.
+            ``"first"`` inserts at the front; repeated ``"first"`` adds stack
+            newest-first. ``"last"`` appends at the end.
 
         **kwargs : Any
             Default keyword arguments passed to the score function at call
@@ -237,7 +243,8 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
                 response_method=response_method,
                 greater_is_better=greater_is_better,
                 kwargs=kwargs,
-            )
+            ),
+            position=position,
         )
 
     def fit_time(self, cast: bool = True) -> float | None:

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -641,13 +641,13 @@ class MetricRegistry(UserDict[str, Metric]):
                 f"Cannot add {metric.name!r}: it is a built-in metric name."
             )
 
-        # Invalidate cached results when re-adding an existing metric
         if metric.name in self.data:
-            keys_to_delete = [k for k in self._report._cache if k[1] == metric.name]
-            for k in keys_to_delete:
-                del self._report._cache[k]
+            raise ValueError(
+                f"Cannot add {metric.name!r}: it already exists. "
+                "Remove it before adding it again."
+            )
 
         self.data[metric.name] = metric
-        
+
         if position == "first":
             self.data.move_to_end(metric.name, last=False)

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import copy
 import inspect
 import pickle
-from collections import UserDict
+from collections import OrderedDict, UserDict
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import sklearn
@@ -588,13 +588,18 @@ BUILTIN_METRICS: list[Metric] = [
 class MetricRegistry(UserDict[str, Metric]):
     """Registry of metric instances for a report.
 
+    ``data`` is an :class:`collections.OrderedDict` so iteration order matches default
+    metric display order (e.g. :meth:`~skore.EstimatorReport.metrics.summarize`).
+
     Parameters
     ----------
     report : EstimatorReport
         The parent report.
     """
 
-    def __init__(self, report: EstimatorReport):
+    data: OrderedDict[str, Metric]
+
+    def __init__(self, report: EstimatorReport) -> None:
         """Construct a MetricRegistry.
 
         The report is analyzed to filter metrics depending on the report's
@@ -603,24 +608,37 @@ class MetricRegistry(UserDict[str, Metric]):
         super().__init__()
         self._report = report
 
-        # Needs to be called `data` since we inherit from UserDict
-        self.data = {
-            metric.name: metric
+        # Needs to be called ``data`` since we inherit from :class:`UserDict`.
+        self.data = OrderedDict(
+            (metric.name, metric)
             for metric in BUILTIN_METRICS
             if metric.available(report)
-        }
+        )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self.data.keys())})"
 
-    def add(self, metric: Metric) -> None:
+    def add(
+        self,
+        metric: Metric,
+        *,
+        position: Literal["first", "last"] = "first",
+    ) -> None:
         """Add a custom metric to the registry.
 
         Parameters
         ----------
         metric : Metric
             The metric instance to add.
+
+        position : {"first", "last"}, default="first"
+            Where to place the metric in iteration order (e.g. default
+            :meth:`~skore.EstimatorReport.metrics.summarize` row order).
+            ``"first"`` inserts at the front; ``"last"`` at the end.
         """
+        if position not in ("first", "last"):
+            raise ValueError(f"position must be 'first' or 'last', got {position!r}.")
+
         if metric.name in [m.name for m in BUILTIN_METRICS]:
             raise ValueError(
                 f"Cannot add {metric.name!r}: it is a built-in metric name."
@@ -633,3 +651,4 @@ class MetricRegistry(UserDict[str, Metric]):
                 del self._report._cache[k]
 
         self.data[metric.name] = metric
+        self.data.move_to_end(metric.name, last=(position == "last"))

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -588,9 +588,6 @@ BUILTIN_METRICS: list[Metric] = [
 class MetricRegistry(UserDict[str, Metric]):
     """Registry of metric instances for a report.
 
-    ``data`` is an :class:`collections.OrderedDict` so iteration order matches default
-    metric display order (e.g. :meth:`~skore.EstimatorReport.metrics.summarize`).
-
     Parameters
     ----------
     report : EstimatorReport

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -648,6 +648,8 @@ class MetricRegistry(UserDict[str, Metric]):
                 del self._report._cache[k]
 
         self.data[metric.name] = metric
-        
+
         if position == "first":
             self.data.move_to_end(metric.name, last=False)
+        else:
+            self.data.move_to_end(metric.name, last=True)

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -641,13 +641,13 @@ class MetricRegistry(UserDict[str, Metric]):
                 f"Cannot add {metric.name!r}: it is a built-in metric name."
             )
 
+        # Invalidate cached results when re-adding an existing metric
         if metric.name in self.data:
-            raise ValueError(
-                f"Cannot add {metric.name!r}: it already exists. "
-                "Remove it before adding it again."
-            )
+            keys_to_delete = [k for k in self._report._cache if k[1] == metric.name]
+            for k in keys_to_delete:
+                del self._report._cache[k]
 
         self.data[metric.name] = metric
-
+        
         if position == "first":
             self.data.move_to_end(metric.name, last=False)

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -648,4 +648,6 @@ class MetricRegistry(UserDict[str, Metric]):
                 del self._report._cache[k]
 
         self.data[metric.name] = metric
-        self.data.move_to_end(metric.name, last=(position == "last"))
+        
+        if position == "first":
+            self.data.move_to_end(metric.name, last=False)

--- a/skore/tests/unit/reports/estimator/metrics/test_add.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_add.py
@@ -295,8 +295,8 @@ class TestAddPosition:
         assert keys[1] == "accuracy"
         assert keys[-1] == "m_last"
 
-    def test_readd_raises_without_remove(self, binary_classification_report):
-        """Re-adding the same metric name raises and asks to remove first."""
+    def test_readd_moves_to_last(self, binary_classification_report):
+        """Re-adding the same name with position updates order and summarize works."""
         report = binary_classification_report
 
         def score_v1(y_true, y_pred):
@@ -311,16 +311,16 @@ class TestAddPosition:
         def score_v2(y_true, y_pred):
             return 1.0
 
-        err_msg = re.escape(
-            "Cannot add 'reorder_me': it already exists. Remove it before adding it "
-            "again."
+        report.metrics.add(
+            make_scorer(score_v2, response_method="predict"),
+            name="reorder_me",
+            position="last",
         )
-        with pytest.raises(ValueError, match=err_msg):
-            report.metrics.add(
-                make_scorer(score_v2, response_method="predict"),
-                name="reorder_me",
-                position="last",
-            )
+        keys = list(report._metric_registry.keys())
+        assert keys[-1] == "reorder_me"
+
+        display = report.metrics.summarize(metric="reorder_me")
+        assert display.data["score"].iloc[0] == 1.0
 
     def test_metric_registry_add_invalid_position(self, binary_classification_report):
         """MetricRegistry.add rejects unknown position values."""
@@ -354,8 +354,8 @@ class TestCacheBehavior:
         with check_cache_unchanged(report._cache):
             report.metrics.summarize(metric="counting_metric")
 
-    def test_duplicate_add_keeps_existing_cache(self, binary_classification_report):
-        """Duplicate add fails and leaves existing metric cache untouched."""
+    def test_readd_invalidates_cache(self, binary_classification_report):
+        """Test that re-adding a metric invalidates its cache only."""
         report = binary_classification_report
 
         def metric1(y_true, y_pred):
@@ -374,26 +374,22 @@ class TestCacheBehavior:
         report.metrics.summarize(metric="metric1")
         report.metrics.summarize(metric="metric2")
 
-        # Attempt duplicate add of metric1 with a new function
+        # Re-add metric1 with a new function
         def metric1(y_true, y_pred):
             return 0.3
 
         scorer1_v2 = make_scorer(metric1, response_method="predict")
-        err_msg = re.escape(
-            "Cannot add 'metric1': it already exists. Remove it before adding it again."
-        )
-        with pytest.raises(ValueError, match=err_msg):
-            report.metrics.add(scorer1_v2)
+        report.metrics.add(scorer1_v2)
 
         # metric2 should use cache
         with check_cache_unchanged(report._cache):
             result2 = report.metrics.summarize(metric="metric2")
 
-        # metric1 should still use cache from the original scorer
-        with check_cache_unchanged(report._cache):
+        # metric1 should compute fresh
+        with check_cache_changed(report._cache):
             result1 = report.metrics.summarize(metric="metric1")
 
-        assert result1.data["score"].iloc[0] == 0.1
+        assert result1.data["score"].iloc[0] == 0.3
         assert result2.data["score"].iloc[0] == 0.2
 
     def test_different_metrics_have_separate_cache(self, binary_classification_report):
@@ -467,8 +463,8 @@ class TestEdgeCases:
         with pytest.raises(AttributeError, match=err_msg):
             report.metrics.summarize(metric="accuracy_score")
 
-    def test_duplicate_name_raises(self, binary_classification_report):
-        """Adding with duplicate name raises and keeps the original metric."""
+    def test_duplicate_name_replaces(self, binary_classification_report):
+        """Test that adding with duplicate name silently replaces."""
         report = binary_classification_report
 
         def score(y_true, y_pred):
@@ -485,17 +481,13 @@ class TestEdgeCases:
         def score(y_true, y_pred):
             return 1
 
-        err_msg = re.escape(
-            "Cannot add 'score': it already exists. Remove it before adding it again."
-        )
-        with pytest.raises(ValueError, match=err_msg):
-            report.metrics.add(make_scorer(score, response_method="predict"))
+        report.metrics.add(make_scorer(score, response_method="predict"))
 
         assert len(report._metric_registry) == nb_metrics_before_overwriting
 
-        # summarize still reflects the original metric
+        # `summarize` contains only the new output
         result = report.metrics.summarize(metric="score")
-        assert result.data["score"].iloc[0] == 0
+        assert result.data["score"].iloc[0] == 1
 
 
 class TestDifferentMLTasks:
@@ -679,18 +671,17 @@ class TestStringScorerNames:
 
     def test_without_neg_prefix(self, regression_report):
         """Test that metric strings passed without 'neg_' prefix can be added and
-        duplicate registration raises an explicit error."""
+        produce the same result as with it."""
         report = regression_report
 
         report.metrics.add("mean_squared_error")
-        assert "mean_squared_error" in report._metric_registry
+        registry_without = report._metric_registry.copy()
+        assert "mean_squared_error" in registry_without
 
-        err_msg = re.escape(
-            "Cannot add 'mean_squared_error': it already exists. Remove it before "
-            "adding it again."
-        )
-        with pytest.raises(ValueError, match=err_msg):
-            report.metrics.add("neg_mean_squared_error")
+        report.metrics.add("neg_mean_squared_error")
+        registry_with = report._metric_registry
+
+        assert registry_with.keys() == registry_without.keys()
 
     def test_invalid_string_scorer_name(self, binary_classification_report):
         """Test that invalid sklearn scorer names raise an error."""

--- a/skore/tests/unit/reports/estimator/metrics/test_add.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_add.py
@@ -295,8 +295,8 @@ class TestAddPosition:
         assert keys[1] == "accuracy"
         assert keys[-1] == "m_last"
 
-    def test_readd_moves_to_last(self, binary_classification_report):
-        """Re-adding the same name with position updates order and summarize works."""
+    def test_readd_raises_without_remove(self, binary_classification_report):
+        """Re-adding the same metric name raises and asks to remove first."""
         report = binary_classification_report
 
         def score_v1(y_true, y_pred):
@@ -311,16 +311,16 @@ class TestAddPosition:
         def score_v2(y_true, y_pred):
             return 1.0
 
-        report.metrics.add(
-            make_scorer(score_v2, response_method="predict"),
-            name="reorder_me",
-            position="last",
+        err_msg = re.escape(
+            "Cannot add 'reorder_me': it already exists. Remove it before adding it "
+            "again."
         )
-        keys = list(report._metric_registry.keys())
-        assert keys[-1] == "reorder_me"
-
-        display = report.metrics.summarize(metric="reorder_me")
-        assert display.data["score"].iloc[0] == 1.0
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add(
+                make_scorer(score_v2, response_method="predict"),
+                name="reorder_me",
+                position="last",
+            )
 
     def test_metric_registry_add_invalid_position(self, binary_classification_report):
         """MetricRegistry.add rejects unknown position values."""
@@ -354,8 +354,8 @@ class TestCacheBehavior:
         with check_cache_unchanged(report._cache):
             report.metrics.summarize(metric="counting_metric")
 
-    def test_readd_invalidates_cache(self, binary_classification_report):
-        """Test that re-adding a metric invalidates its cache only."""
+    def test_duplicate_add_keeps_existing_cache(self, binary_classification_report):
+        """Duplicate add fails and leaves existing metric cache untouched."""
         report = binary_classification_report
 
         def metric1(y_true, y_pred):
@@ -374,22 +374,26 @@ class TestCacheBehavior:
         report.metrics.summarize(metric="metric1")
         report.metrics.summarize(metric="metric2")
 
-        # Re-add metric1 with a new function
+        # Attempt duplicate add of metric1 with a new function
         def metric1(y_true, y_pred):
             return 0.3
 
         scorer1_v2 = make_scorer(metric1, response_method="predict")
-        report.metrics.add(scorer1_v2)
+        err_msg = re.escape(
+            "Cannot add 'metric1': it already exists. Remove it before adding it again."
+        )
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add(scorer1_v2)
 
         # metric2 should use cache
         with check_cache_unchanged(report._cache):
             result2 = report.metrics.summarize(metric="metric2")
 
-        # metric1 should compute fresh
-        with check_cache_changed(report._cache):
+        # metric1 should still use cache from the original scorer
+        with check_cache_unchanged(report._cache):
             result1 = report.metrics.summarize(metric="metric1")
 
-        assert result1.data["score"].iloc[0] == 0.3
+        assert result1.data["score"].iloc[0] == 0.1
         assert result2.data["score"].iloc[0] == 0.2
 
     def test_different_metrics_have_separate_cache(self, binary_classification_report):
@@ -463,8 +467,8 @@ class TestEdgeCases:
         with pytest.raises(AttributeError, match=err_msg):
             report.metrics.summarize(metric="accuracy_score")
 
-    def test_duplicate_name_replaces(self, binary_classification_report):
-        """Test that adding with duplicate name silently replaces."""
+    def test_duplicate_name_raises(self, binary_classification_report):
+        """Adding with duplicate name raises and keeps the original metric."""
         report = binary_classification_report
 
         def score(y_true, y_pred):
@@ -481,13 +485,17 @@ class TestEdgeCases:
         def score(y_true, y_pred):
             return 1
 
-        report.metrics.add(make_scorer(score, response_method="predict"))
+        err_msg = re.escape(
+            "Cannot add 'score': it already exists. Remove it before adding it again."
+        )
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add(make_scorer(score, response_method="predict"))
 
         assert len(report._metric_registry) == nb_metrics_before_overwriting
 
-        # `summarize` contains only the new output
+        # summarize still reflects the original metric
         result = report.metrics.summarize(metric="score")
-        assert result.data["score"].iloc[0] == 1
+        assert result.data["score"].iloc[0] == 0
 
 
 class TestDifferentMLTasks:
@@ -671,17 +679,18 @@ class TestStringScorerNames:
 
     def test_without_neg_prefix(self, regression_report):
         """Test that metric strings passed without 'neg_' prefix can be added and
-        produce the same result as with it."""
+        duplicate registration raises an explicit error."""
         report = regression_report
 
         report.metrics.add("mean_squared_error")
-        registry_without = report._metric_registry.copy()
-        assert "mean_squared_error" in registry_without
+        assert "mean_squared_error" in report._metric_registry
 
-        report.metrics.add("neg_mean_squared_error")
-        registry_with = report._metric_registry
-
-        assert registry_with.keys() == registry_without.keys()
+        err_msg = re.escape(
+            "Cannot add 'mean_squared_error': it already exists. Remove it before "
+            "adding it again."
+        )
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add("neg_mean_squared_error")
 
     def test_invalid_string_scorer_name(self, binary_classification_report):
         """Test that invalid sklearn scorer names raise an error."""

--- a/skore/tests/unit/reports/estimator/metrics/test_add.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_add.py
@@ -218,6 +218,123 @@ class TestSummarizeIntegration:
         }
 
 
+class TestAddPosition:
+    """Tests for metric registry ordering (first vs last)."""
+
+    def test_default_first_lifo_before_builtins(self, binary_classification_report):
+        """New metrics default to the front; last added is first among customs."""
+        report = binary_classification_report
+
+        def metric_a(y_true, y_pred):
+            return 0.0
+
+        def metric_b(y_true, y_pred):
+            return 1.0
+
+        report.metrics.add(
+            make_scorer(metric_a, response_method="predict"), name="metric_a"
+        )
+        report.metrics.add(
+            make_scorer(metric_b, response_method="predict"), name="metric_b"
+        )
+
+        keys = list(report._metric_registry.keys())
+        assert keys[0] == "metric_b"
+        assert keys[1] == "metric_a"
+        assert keys[2] == "accuracy"
+
+        display = report.metrics.summarize()
+        assert display.data.iloc[0]["metric_verbose_name"] == "Metric B"
+
+    def test_position_last_appends_in_order(self, binary_classification_report):
+        """Last-position adds appear after all built-ins, in insertion order."""
+        report = binary_classification_report
+
+        def metric_a(y_true, y_pred):
+            return 0.0
+
+        def metric_b(y_true, y_pred):
+            return 1.0
+
+        report.metrics.add(
+            make_scorer(metric_a, response_method="predict"),
+            name="metric_a",
+            position="last",
+        )
+        report.metrics.add(
+            make_scorer(metric_b, response_method="predict"),
+            name="metric_b",
+            position="last",
+        )
+
+        keys = list(report._metric_registry.keys())
+        assert keys[-2] == "metric_a"
+        assert keys[-1] == "metric_b"
+
+    def test_mixed_first_and_last(self, binary_classification_report):
+        """First metric at front, last metric at end, built-ins unchanged in between."""
+        report = binary_classification_report
+
+        def m_first(y_true, y_pred):
+            return 0.0
+
+        def m_last(y_true, y_pred):
+            return 1.0
+
+        report.metrics.add(
+            make_scorer(m_first, response_method="predict"), name="m_first"
+        )
+        report.metrics.add(
+            make_scorer(m_last, response_method="predict"),
+            name="m_last",
+            position="last",
+        )
+
+        keys = list(report._metric_registry.keys())
+        assert keys[0] == "m_first"
+        assert keys[1] == "accuracy"
+        assert keys[-1] == "m_last"
+
+    def test_readd_moves_to_last(self, binary_classification_report):
+        """Re-adding the same name with position updates order and summarize works."""
+        report = binary_classification_report
+
+        def score_v1(y_true, y_pred):
+            return 0.0
+
+        report.metrics.add(
+            make_scorer(score_v1, response_method="predict"), name="reorder_me"
+        )
+        keys_after_first = list(report._metric_registry.keys())
+        assert keys_after_first[0] == "reorder_me"
+
+        def score_v2(y_true, y_pred):
+            return 1.0
+
+        report.metrics.add(
+            make_scorer(score_v2, response_method="predict"),
+            name="reorder_me",
+            position="last",
+        )
+        keys = list(report._metric_registry.keys())
+        assert keys[-1] == "reorder_me"
+
+        display = report.metrics.summarize(metric="reorder_me")
+        assert display.data["score"].iloc[0] == 1.0
+
+    def test_metric_registry_add_invalid_position(self, binary_classification_report):
+        """MetricRegistry.add rejects unknown position values."""
+        report = binary_classification_report
+        m = Metric(
+            name="only_for_position_test",
+            score_func=accuracy_score,
+            response_method="predict",
+            greater_is_better=True,
+        )
+        with pytest.raises(ValueError, match="position must be 'first' or 'last'"):
+            report._metric_registry.add(m, position="middle")  # type: ignore[arg-type]
+
+
 class TestCacheBehavior:
     """Test caching behavior with added metrics."""
 

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -15,7 +15,7 @@ from sklearn.metrics import (
 )
 
 from skore import EstimatorReport
-from skore._sklearn.metrics import Metric, MissingKwargsError
+from skore._sklearn.metrics import FunctionKind, Metric, MissingKwargsError
 from skore._utils._testing import check_cache_changed, check_cache_unchanged
 
 
@@ -337,8 +337,8 @@ class TestAddPosition:
         assert keys[1] == "accuracy"
         assert keys[-1] == "m_last"
 
-    def test_readd_moves_to_last(self, binary_classification_report):
-        """Re-adding the same name with position updates order and summarize works."""
+    def test_readd_raises_without_remove(self, binary_classification_report):
+        """Re-adding the same metric name raises and asks to remove first."""
         report = binary_classification_report
 
         def score_v1(y_true, y_pred):
@@ -353,25 +353,26 @@ class TestAddPosition:
         def score_v2(y_true, y_pred):
             return 1.0
 
-        report.metrics.add(
-            make_scorer(score_v2, response_method="predict"),
-            name="reorder_me",
-            position="last",
+        err_msg = re.escape(
+            "Cannot add 'reorder_me': it already exists. "
+            "Remove it first using the `remove` method."
         )
-        keys = list(report._metric_registry.keys())
-        assert keys[-1] == "reorder_me"
-
-        display = report.metrics.summarize(metric="reorder_me")
-        assert display.data["score"].iloc[0] == 1.0
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add(
+                make_scorer(score_v2, response_method="predict"),
+                name="reorder_me",
+                position="last",
+            )
 
     def test_metric_registry_add_invalid_position(self, binary_classification_report):
         """MetricRegistry.add rejects unknown position values."""
         report = binary_classification_report
         m = Metric(
             name="only_for_position_test",
-            score_func=accuracy_score,
+            function=accuracy_score,
             response_method="predict",
             greater_is_better=True,
+            function_kind=FunctionKind.METRIC,
         )
         with pytest.raises(ValueError, match="position must be 'first' or 'last'"):
             report._metric_registry.add(m, position="middle")  # type: ignore[arg-type]


### PR DESCRIPTION
Currently, the user metric is always shown after our predefined metric. If a user is adding a metric, I think that we should provide the possibility to show it first also.

So I'm adding a `position` argument and use an `OrderedDict` to accommodate this use-case.