### PR TITLE
feat(skore): Add available method to know the available metrics in registry

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 import warnings
 from typing import Any, Literal
@@ -127,6 +129,37 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
                 for estimator_name in self._parent.reports_
             ],
         )
+
+    def available(self, report_name: str | None = None) -> list[str]:
+        """List available metric names in the registry.
+
+        Parameters
+        ----------
+        report_name : str, default=None
+            Name of the sub-report to list metrics from. If `None`, returns the
+            union of metric names across all sub-reports.
+
+        Returns
+        -------
+        list[str]
+            The list of available metric names.
+        """
+        reports = self._parent.reports_
+        if report_name is not None:
+            if report_name not in reports:
+                valid_names = ", ".join(reports)
+                raise ValueError(
+                    f"Unknown report name: {report_name!r}. "
+                    f"Available report names are: {valid_names}."
+                )
+            return reports[report_name].metrics.available()
+
+        keys = dict.fromkeys(
+            metric
+            for report in reports.values()
+            for metric in report.metrics.available()
+        )
+        return list(keys)
 
     def add(
         self,

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from typing import Any, Literal
 
@@ -109,6 +111,16 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
             report_type="cross-validation",
             extra_rows_data=[{"split": i} for i in range(len(summaries))],
         )
+
+    def available(self) -> list[str]:
+        """List available metric names in the registry.
+
+        Returns
+        -------
+        list[str]
+            The list of available metric names.
+        """
+        return self._parent.estimator_reports_[0].metrics.available()
 
     def add(
         self,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import Any, Literal, cast
 
@@ -172,6 +174,16 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             kwargs=kwargs or None,
         )
         return MetricsSummaryDisplay(rows=rows, report_type="estimator")
+
+    def available(self) -> list[str]:
+        """List available metric names in the registry.
+
+        Returns
+        -------
+        list[str]
+            The list of available metric names.
+        """
+        return list(self._parent._metric_registry)
 
     def add(
         self,

--- a/skore/tests/unit/reports/comparison/test_metrics.py
+++ b/skore/tests/unit/reports/comparison/test_metrics.py
@@ -47,3 +47,82 @@ def test_favorability_undefined_metrics(report):
     expected_values = {"(↗︎)", "(↘︎)"}
     actual_values = set(metrics_df["Favorability"].to_numpy())
     assert actual_values.issubset(expected_values)
+
+
+@pytest.mark.parametrize("report", [EstimatorReport, CrossValidationReport])
+def test_available_union(report):
+    X, y = make_classification(random_state=0)
+    estimators = {"LinearSVC": LinearSVC(), "LogisticRegression": LogisticRegression()}
+
+    if report is EstimatorReport:
+        reports = {
+            name: EstimatorReport(
+                est, X_train=X, X_test=X, y_train=y, y_test=y, pos_label=1
+            )
+            for name, est in estimators.items()
+        }
+    else:
+        reports = {
+            name: CrossValidationReport(est, X=X, y=y, pos_label=1)
+            for name, est in estimators.items()
+        }
+
+    comparison_report = ComparisonReport(reports)
+    available = comparison_report.metrics.available()
+    expected = list(
+        dict.fromkeys(
+            metric
+            for sub_report in comparison_report.reports_.values()
+            for metric in sub_report.metrics.available()
+        )
+    )
+
+    assert available == expected
+
+
+@pytest.mark.parametrize("report", [EstimatorReport, CrossValidationReport])
+def test_available_for_single_report_name(report):
+    X, y = make_classification(random_state=0)
+    estimators = {"LinearSVC": LinearSVC(), "LogisticRegression": LogisticRegression()}
+
+    if report is EstimatorReport:
+        reports = {
+            name: EstimatorReport(
+                est, X_train=X, X_test=X, y_train=y, y_test=y, pos_label=1
+            )
+            for name, est in estimators.items()
+        }
+    else:
+        reports = {
+            name: CrossValidationReport(est, X=X, y=y, pos_label=1)
+            for name, est in estimators.items()
+        }
+
+    comparison_report = ComparisonReport(reports)
+    assert (
+        comparison_report.metrics.available("LinearSVC")
+        == reports["LinearSVC"].metrics.available()
+    )
+
+
+@pytest.mark.parametrize("report", [EstimatorReport, CrossValidationReport])
+def test_available_with_unknown_report_name_raises(report):
+    X, y = make_classification(random_state=0)
+    estimators = {"LinearSVC": LinearSVC(), "LogisticRegression": LogisticRegression()}
+
+    if report is EstimatorReport:
+        reports = {
+            name: EstimatorReport(
+                est, X_train=X, X_test=X, y_train=y, y_test=y, pos_label=1
+            )
+            for name, est in estimators.items()
+        }
+    else:
+        reports = {
+            name: CrossValidationReport(est, X=X, y=y, pos_label=1)
+            for name, est in estimators.items()
+        }
+
+    comparison_report = ComparisonReport(reports)
+    with pytest.raises(ValueError, match="Unknown report name"):
+        comparison_report.metrics.available("unknown")

--- a/skore/tests/unit/reports/test_common.py
+++ b/skore/tests/unit/reports/test_common.py
@@ -48,6 +48,26 @@ def test_metrics_repr(report):
     assert "metrics" in result.lower()
 
 
+def test_metrics_available_returns_metric_keys(report):
+    metrics = report.metrics.available()
+
+    assert isinstance(metrics, list)
+    assert metrics
+    assert all(isinstance(metric, str) for metric in metrics)
+
+
+def test_metrics_available_updates_after_add(report):
+    metrics_before = set(report.metrics.available())
+    scorer = make_scorer(
+        mean_squared_error, greater_is_better=False, response_method="predict"
+    )
+    report.metrics.add(scorer)
+
+    metrics_after = set(report.metrics.available())
+    assert metrics_before.issubset(metrics_after)
+    assert "mean_squared_error" in metrics_after
+
+
 def test_metrics_add_scorer(report):
     scorer = make_scorer(
         mean_squared_error, greater_is_better=False, response_method="predict"


### PR DESCRIPTION
Add an `available` to have a programmatic way to list the available key metric from the registry.