### PR TITLE
docs(skore): Fix the color of link sticking to default apart from landing page

### DIFF
--- a/sphinx/_static/css/custom.css
+++ b/sphinx/_static/css/custom.css
@@ -221,23 +221,6 @@ html[data-theme="dark"] .project-summary-image {
   padding-bottom: 2.5rem !important;
 }
 
-/* Change the colors to the orange and blue of skore */
-html[data-theme="dark"] {
-  --pst-color-primary: #f89a36;
-  --pst-color-secondary: #3499cd;
-  --pst-color-inline-code-links: var(--pst-color-primary);
-}
-
-/*
-Choose darker colors for light to ensure at least AA contrast https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast
-Tool to test: https://docusaurus.io/docs/styling-layout
-*/
-html[data-theme="light"] {
-  --pst-color-primary: #ad5d06;
-  --pst-color-secondary: #297ba6;
-  --pst-color-inline-code-links: var(--pst-color-primary);
-}
-
 /** Styling **************************************************************/
 
 /* Make the footer a bit less visible */
@@ -301,6 +284,10 @@ div.sk-landing-container a:hover > code,
 div.sk-landing-container a:visited > code,
 div.sk-landing-container a:visited:hover > code {
   color: #DA7007;
+}
+
+div.sk-landing-container {
+  --pst-color-inline-code-links: #DA7007;
 }
 
 div.sk-landing-container code {


### PR DESCRIPTION
Currently we have an issue with the color of hyperlink in the documentation:

<img width="239" height="119" alt="image" src="https://github.com/user-attachments/assets/c65eb178-8c17-4945-b337-919d58acbcfe" />

The reason is that we are changing the default for the landing page to have orange link

<img width="521" height="163" alt="image" src="https://github.com/user-attachments/assets/de187bb6-1aad-4f11-97b1-e0c69110e709" />

Here, I proposed to keep the default everywhere apart of the landing page where we want to enforce the orange color.