### PR TITLE
fix(skore): Improve contrast of dark theme mode

### DIFF
--- a/skore/src/skore/_utils/repr/theme.css
+++ b/skore/src/skore/_utils/repr/theme.css
@@ -15,12 +15,12 @@
 .container[data-theme="dark"],
 :host(.dark-theme),
 :host([data-theme="dark"]) {
-    --color-blue: #56B4DC;
-    --color-orange: #f97316;
+    --color-blue: #79c0ff;
+    --color-orange: #f8ab53;
     --color-text: #fff;
     --color-background: #0F0F0F;
-    --color-orange-hover: rgba(249, 115, 22, 0.2);
-    --color-blue-hover: rgba(86, 180, 220, 0.2);
+    --color-orange-hover: rgba(248, 171, 83, 0.2);
+    --color-blue-hover: rgba(121, 192, 255, 0.2);
     --color-row-stripe: rgba(255, 255, 255, 0.08);
 }
 

--- a/skore/src/skore/_utils/repr/theme.css
+++ b/skore/src/skore/_utils/repr/theme.css
@@ -15,12 +15,12 @@
 .container[data-theme="dark"],
 :host(.dark-theme),
 :host([data-theme="dark"]) {
-    --color-blue: #6b42f6;
+    --color-blue: #56B4DC;
     --color-orange: #f97316;
     --color-text: #fff;
-    --color-background: #000;
+    --color-background: #0F0F0F;
     --color-orange-hover: rgba(249, 115, 22, 0.2);
-    --color-blue-hover: rgba(107, 66, 246, 0.2);
+    --color-blue-hover: rgba(86, 180, 220, 0.2);
     --color-row-stripe: rgba(255, 255, 255, 0.08);
 }
 

--- a/skore/src/skore/_utils/repr/theme.css
+++ b/skore/src/skore/_utils/repr/theme.css
@@ -18,7 +18,7 @@
     --color-blue: #79c0ff;
     --color-orange: #f8ab53;
     --color-text: #fff;
-    --color-background: #0F0F0F;
+    --color-background: #0c1116;
     --color-orange-hover: rgba(248, 171, 83, 0.2);
     --color-blue-hover: rgba(121, 192, 255, 0.2);
     --color-row-stripe: rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
It is a proposal to solve the issue reported regarding the dark theme where the violet does not bring enough contrast.

I'm using the black, orange and blue as the one defined by GitHub in their color blind dark theme. It is not far from the original scikit-learn, skrub, skore color as well.

<img width="404" height="282" alt="image" src="https://github.com/user-attachments/assets/1c7cf4ae-0412-42db-9dec-eab0c4c1e21e" />

The index for the contrast is around 10 (https://webaim.org/resources/contrastchecker/)