### PR TITLE
feat(skore-local-project): Support strings for `workspace`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,9 @@ Changed
 Added
 -----
 
+- :class:`Project` now accepts strings for the `workspace` argument. See :pr:`2832` by
+  :user:`auguste-probabl`.
+
 Removed
 -------
 

--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -229,9 +229,13 @@ class Project:
     @ensure_project_is_not_deleted
     def get(self, id: str) -> EstimatorReport | CrossValidationReport:
         """Get a persisted report by its id."""
-        with io.BytesIO(self.__artifacts_storage[id]) as stream:
-            report = joblib.load(stream)
-            return cast("EstimatorReport | CrossValidationReport", report)
+        if id in self.__artifacts_storage:
+            with io.BytesIO(self.__artifacts_storage[id]) as stream:
+                return cast(
+                    "EstimatorReport | CrossValidationReport", joblib.load(stream)
+                )
+
+        raise KeyError(id)
 
     @ensure_project_is_not_deleted
     def summarize(self) -> list[Metadata]:
@@ -266,7 +270,7 @@ class Project:
         )
 
     @staticmethod
-    def delete(name: str, *, workspace: Path | None = None) -> None:
+    def delete(name: str, *, workspace: str | Path | None = None) -> None:
         r"""
         Delete a local project.
 
@@ -274,7 +278,7 @@ class Project:
         ----------
         name : str
             The name of the project.
-        workspace : Path, optional
+        workspace : Path-like, optional
             The directory where the project (metadata and artifacts) are persisted.
 
             | The workspace can be shared between all the projects.

--- a/skore-local-project/src/skore_local_project/project.py
+++ b/skore-local-project/src/skore_local_project/project.py
@@ -102,7 +102,7 @@ class Project:
 
     @staticmethod
     def __setup_diskcache(
-        workspace: Path | None,
+        workspace: str | Path | None,
     ) -> tuple[
         Path,
         DiskCacheStorage,
@@ -115,6 +115,9 @@ class Project:
             else:
                 workspace = Path(platformdirs.user_data_dir()) / "skore"
 
+        if not isinstance(workspace, Path):
+            workspace = Path(workspace)
+
         for directory in ("projects", "metadata", "artifacts"):
             (workspace / directory).mkdir(parents=True, exist_ok=True)
 
@@ -125,7 +128,7 @@ class Project:
             DiskCacheStorage(workspace / "artifacts"),
         )
 
-    def __init__(self, name: str, *, workspace: Path | None = None):
+    def __init__(self, name: str, *, workspace: str | Path | None = None):
         r"""
         Initialize a local project.
 
@@ -136,7 +139,7 @@ class Project:
         ----------
         name : str
             The name of the project.
-        workspace : Path, optional
+        workspace : Path-like, optional
             The directory where the project (metadata and artifacts) are persisted.
 
             | The workspace can be shared between all the projects.
@@ -203,8 +206,8 @@ class Project:
             Metadata = CrossValidationReportMetadata
         else:
             raise TypeError(
-                f"Report must be a `skore.EstimatorReport` or `skore.CrossValidationRep"
-                f"ort` (found '{type(report)}')"
+                f"Report must be a `skore.EstimatorReport` or "
+                f"`skore.CrossValidationReport` (found '{type(report)}')"
             )
 
         artifact_id = str(report.id)
@@ -226,13 +229,9 @@ class Project:
     @ensure_project_is_not_deleted
     def get(self, id: str) -> EstimatorReport | CrossValidationReport:
         """Get a persisted report by its id."""
-        if id in self.__artifacts_storage:
-            with io.BytesIO(self.__artifacts_storage[id]) as stream:
-                return cast(
-                    "EstimatorReport | CrossValidationReport", joblib.load(stream)
-                )
-
-        raise KeyError(id)
+        with io.BytesIO(self.__artifacts_storage[id]) as stream:
+            report = joblib.load(stream)
+            return cast("EstimatorReport | CrossValidationReport", report)
 
     @ensure_project_is_not_deleted
     def summarize(self) -> list[Metadata]:

--- a/skore-local-project/tests/unit/test_project.py
+++ b/skore-local-project/tests/unit/test_project.py
@@ -1,6 +1,8 @@
 from io import BytesIO
+from pathlib import Path
 
 import joblib
+import pytest
 from pandas import DataFrame
 from pytest import fixture, raises
 from sklearn.datasets import make_classification, make_regression
@@ -165,8 +167,9 @@ class TestProject:
         assert isinstance(project._Project__metadata_storage, DiskCacheStorage)
         assert isinstance(project._Project__artifacts_storage, DiskCacheStorage)
 
-    def test_init_with_workspace(self, tmp_path):
-        project = Project("<project>", workspace=tmp_path)
+    @pytest.mark.parametrize("type", [str, Path])
+    def test_init_with_workspace(self, tmp_path, type):
+        project = Project("<project>", workspace=type(tmp_path))
 
         assert project.workspace == tmp_path
         assert project.name == "<project>"


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

If this is your first contribution, take a look at our contribution guidelines:
https://docs.skore.probabl.ai/stable/contributing.html
-->
#### Change description
<!--
Please describe what your contribution changes for skore.

Here is some inspiration for what to write here:
- Are you adding a new feature? Fixing a bug?
- Can you give an example of your change in action, e.g. a snippet of code or a plot?
- Is your change likely to break users' code?
- Are there any other details the reviewer should be aware of, such as API design choices, performance characteristics or edge cases?

Please reference issues/PRs when possible, e.g. "Fixes #1234", "Closes #3456", "See also #7890".
More information [here](https://github.com/blog/1506-closing-issues-via-pull-requests).
-->
Makes it possible to pass a string to `Project` for the `workspace` argument.

Closes #2791

#### Contribution checklist
<!--
Below are some of the criteria that the review will include.
Feel free to use it as a checklist to ensure that your contribution is high-quality.
-->

- [x] Unit tests were added or updated (if necessary)
- [ ] Documentation was added or updated (if necessary)
- [x] A new changelog entry was added to CHANGELOG.rst (if necessary; typically, if your change
requires updating tests)


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure you understand our [automated contributions policy](https://docs.skore.probabl.ai/stable/contributing.html#automated-contributions-policy)
-->
AI tools were not involved 

<!-- Any other comments can go here. Thanks again for contributing! -->
