### PR TITLE
docs(skore): Improve typing and doc for DataOp/SkrubLearner

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -33,13 +33,14 @@ if TYPE_CHECKING:
         _InspectionAccessor,
     )
     from skore._sklearn._cross_validation.metrics_accessor import _MetricsAccessor
+    from skore._sklearn.types import EstimatorLike
 
 
 _STATE_VERSION = 1
 
 
 def _generate_estimator_report(
-    estimator: BaseEstimator,
+    estimator: EstimatorLike,
     X: ArrayLike,
     y: ArrayLike,
     pos_label: PositiveLabel | None,
@@ -58,11 +59,11 @@ def _generate_estimator_report(
 
 
 def _check_estimator_and_data(
-    estimator: BaseEstimator,
+    estimator: EstimatorLike,
     X: ArrayLike | None,
     y: ArrayLike | None,
     data: dict | None,
-) -> tuple[bool, BaseEstimator, dict]:
+) -> tuple[bool, EstimatorLike, dict]:
     if is_skrub_learner(estimator):
         initialized_with_data_op = True
         if X is not None or y is not None:
@@ -97,13 +98,24 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
     Parameters
     ----------
     estimator : estimator object
-        Estimator to make the cross-validation report from.
+        Estimator to make the cross-validation report from. An estimator can
+        be one of the following:
 
-    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        - a scikit-learn compatible estimator as a :class:`~sklearn.base.BaseEstimator`;
+        - a skrub :class:`~skrub.DataOp` to preprocess the data;
+        - a skrub :class:`~skrub.SkrubLearner` extracted from a :class:`~skrub.DataOp`
+          by calling :meth:`~skrub.DataOp.skb.make_learner`.
+
+    X : {array-like, sparse matrix} of shape (n_samples, n_features) or None
         The data to fit. Can be for example a list, or an array.
 
-    y : array-like of shape (n_samples,) or (n_samples, n_outputs)
+    y : array-like of shape (n_samples,) or (n_samples, n_outputs) or None
         The target variable to try to predict in the case of supervised learning.
+
+    data : dict or None
+        When ``estimator`` is a skrub :class:`~skrub.SkrubLearner`, bindings for
+        variables contained in the DataOp that was used to create this learner
+        (e.g. ``{"X": X_df, "other_table": df, ...}``).
 
     pos_label : int, float, bool or str, default=None
         For binary classification, the positive class to use for metrics and displays
@@ -178,7 +190,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
 
     def __init__(
         self,
-        estimator: BaseEstimator,
+        estimator: EstimatorLike,
         X: ArrayLike | None = None,
         y: ArrayLike | None = None,
         data: dict | None = None,

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -35,14 +35,22 @@ if TYPE_CHECKING:
     from skore._sklearn._estimator.data_accessor import _DataAccessor
     from skore._sklearn._estimator.inspection_accessor import _InspectionAccessor
     from skore._sklearn._estimator.metrics_accessor import _MetricsAccessor
+    from skore._sklearn.types import EstimatorLike
 
 
 _STATE_VERSION = 1
 
 
 def _check_estimator_and_data(
-    estimator, X_train, y_train, X_test, y_test, train_data, test_data
-):
+    estimator: EstimatorLike,
+    X_train: ArrayLike | None,
+    y_train: ArrayLike | None,
+    X_test: ArrayLike | None,
+    y_test: ArrayLike | None,
+    train_data: dict | None,
+    test_data: dict | None,
+) -> tuple[bool, EstimatorLike, dict | None, dict | None]:
+    """Check and validate the estimator and data."""
     if is_skrub_learner(estimator):
         initialized_with_data_op = True
         if any(v is not None for v in (X_train, y_train, X_test, y_test)):
@@ -86,6 +94,12 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     estimator : estimator object
         Estimator to make the report from. When the estimator is not fitted,
         it is deep-copied to avoid side-effects. If it is fitted, it is cloned instead.
+        An estimator can be one of the following:
+
+        - a scikit-learn compatible estimator as a :class:`~sklearn.base.BaseEstimator`;
+        - a skrub :class:`~skrub.DataOp` to preprocess the data;
+        - a skrub :class:`~skrub.SkrubLearner` extracted from a :class:`~skrub.DataOp`
+          by calling :meth:`~skrub.DataOp.skb.make_learner`.
 
     fit : {"auto", True, False}, default="auto"
         Whether to fit the estimator on the training data. If "auto", the estimator
@@ -98,11 +112,21 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     y_train : array-like of shape (n_samples,) or (n_samples, n_outputs) or None
         Training target.
 
-    X_test : {array-like, sparse matrix} of shape (n_samples, n_features)
+    X_test : {array-like, sparse matrix} of shape (n_samples, n_features) or None
         Testing data. It should have the same structure as the training data.
 
-    y_test : array-like of shape (n_samples,) or (n_samples, n_outputs)
+    y_test : array-like of shape (n_samples,) or (n_samples, n_outputs) or None
         Testing target.
+
+    train_data : dict or None
+        When ``estimator`` is a skrub :class:`~skrub.SkrubLearner`, bindings for
+        variables contained in the DataOp that was used to create this learner
+        (e.g. ``{"X": X_df, "other_table": df, ...}``).
+
+    test_data : dict or None
+        When ``estimator`` is a skrub :class:`~skrub.SkrubLearner`, bindings for
+        variables contained in the DataOp that was used to create this learner
+        (e.g. ``{"X": X_df, "other_table": df, ...}``).
 
     pos_label : int, float, bool or str, default=None
         For binary classification, the positive class to use for metrics and displays
@@ -186,7 +210,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
 
     def __init__(
         self,
-        estimator: BaseEstimator | skrub.DataOp,
+        estimator: EstimatorLike,
         *,
         fit: Literal["auto"] | bool = "auto",
         X_train: ArrayLike | None = None,

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -180,9 +180,10 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
 
     def _fit_estimator(
         self,
-        estimator: BaseEstimator,
-        data,
-    ) -> tuple[BaseEstimator, float]:
+        estimator: EstimatorLike,
+        data: dict | None,
+    ) -> tuple[EstimatorLike, float]:
+        """Fit the estimator on the training data."""
         if data is None:
             raise ValueError(
                 "The training data is required to fit the estimator. "
@@ -194,7 +195,8 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         return estimator_, fit_time()
 
     @classmethod
-    def _copy_estimator(cls, estimator: BaseEstimator) -> BaseEstimator:
+    def _copy_estimator(cls, estimator: EstimatorLike) -> EstimatorLike:
+        """Copy the estimator."""
         try:
             return copy.deepcopy(estimator)
         except Exception as e:
@@ -482,8 +484,20 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 self._cache[time_key] = pred_time
                 self._cache[pred_key] = predictions
 
-    def _get_response_and_derived_predictions(self, data, response_method):
+    def _get_response_and_derived_predictions(
+        self,
+        data: dict,
+        response_method: Literal["predict", "predict_proba", "decision_function"],
+    ) -> tuple[ArrayLike, ArrayLike | None, float]:
         """Compute a response array and derive class predictions.
+
+        Parameters
+        ----------
+        data : dict
+            The data to use to compute the response and derive predictions.
+        response_method : str
+            The response method to use to compute the response and derive predictions.
+            Can be "decision_function" or "predict_proba".
 
         Returns
         -------

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from numpy.typing import ArrayLike
-from sklearn.base import BaseEstimator
 
 from skore import configuration
 from skore._sklearn._comparison.report import ComparisonReport
@@ -16,11 +15,11 @@ from skore._sklearn.train_test_split.train_test_split import TrainTestSplit
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from skore._sklearn.types import SKLearnCrossValidator
+    from skore._sklearn.types import EstimatorLike, SKLearnCrossValidator
 
 
 def evaluate(
-    estimator: BaseEstimator | list[BaseEstimator] | dict[str, BaseEstimator],
+    estimator: EstimatorLike | list[EstimatorLike] | dict[str, EstimatorLike],
     X: ArrayLike | list[ArrayLike | None] | dict[str, ArrayLike] | None = None,
     y: ArrayLike | None = None,
     data: dict | None = None,
@@ -38,8 +37,13 @@ def evaluate(
     Parameters
     ----------
     estimator : estimator object, list of estimators, or dict of estimators
-        A scikit-learn compatible estimator; a list of estimators to compare; or a
-        mapping of names to estimators.
+        The estimator to evaluate of several estimators to compare. An estimator can
+        be one of the following:
+
+        - a scikit-learn compatible estimator as a :class:`~sklearn.base.BaseEstimator`;
+        - a skrub :class:`~skrub.DataOp` to preprocess the data;
+        - a skrub :class:`~skrub.SkrubLearner` extracted from a :class:`~skrub.DataOp`
+          by calling :meth:`~skrub.DataOp.skb.make_learner`.
 
     X : array-like, list of array-like, dict of array-like, or None
         Feature matrix. When ``estimator`` is a list, ``X`` can be a list of
@@ -51,8 +55,13 @@ def evaluate(
         ``X`` is not supported when ``estimator`` is a dict; use a dict aligned on
         names or a single matrix.
 
-    y : array-like of shape (n_samples,)
+    y : array-like of shape (n_samples,), or None
         Target vector.
+
+    data : dict or None
+        When ``estimator`` is a skrub :class:`~skrub.SkrubLearner`, bindings for
+        variables contained in the DataOp that was used to create this learner
+        (e.g. ``{"X": X_df, "other_table": df, ...}``).
 
     splitter : float, int, str, or cross-validation object, default=0.2
         Determines how the data is split:

--- a/skore/src/skore/_sklearn/types.py
+++ b/skore/src/skore/_sklearn/types.py
@@ -4,6 +4,8 @@ from collections.abc import Callable, Iterator, Sequence
 from typing import Any, Literal, Protocol
 
 from numpy.typing import ArrayLike
+from sklearn.base import BaseEstimator
+from skrub import DataOp, SkrubLearner
 
 PlotBackend = Literal["matplotlib", "plotly"]
 
@@ -50,6 +52,8 @@ class SKLearnScorer(Protocol):
 
 
 MetricLike = str | Callable | SKLearnScorer
+
+EstimatorLike = BaseEstimator | DataOp | SkrubLearner
 
 
 class SKLearnCrossValidator(Protocol):


### PR DESCRIPTION
closes #2810

Adding the documentation for the `data` parameter for the `evaluate`, `EstimatorReport`, and `CrossValidationReport` and fix some typing related to those objects.