### PR TITLE
feat(skore): Better grouping in the help menu of the metrics accessor

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -211,12 +211,18 @@ def _summarize_report_metrics(
 class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
     """Base class for metrics accessor."""
 
-    # Help tree subgroups under ``.metrics``. ``Displays`` is a catch-all for
-    # methods that are neither registry management nor metric callables.
-    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+    # Help tree subgroups under ``.metrics``. Registry callables are injected
+    # into Metrics by ``_build_help_data``.
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...]]] = {
         "Registry": ("available", "add", "remove", "get"),
         "Metrics": ("fit_time", "predict_time", "score", "timings"),
-        "Displays": None,
+        "Displays": (
+            "summarize",
+            "roc",
+            "precision_recall",
+            "prediction_error",
+            "confusion_matrix",
+        ),
     }
 
     def _callable_metric_names(self) -> list[str]:
@@ -343,9 +349,9 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
         Names that are not valid identifiers (e.g. containing spaces) are excluded,
         since they cannot be called as ``report.metrics.<name>(...)``.
 
-        Methods are then partitioned into Registry / Metrics / Displays groups.
-        Metrics combines registry callables with static score helpers; Displays
-        collects remaining methods that are neither registry management nor metrics.
+        Methods are then partitioned into Registry / Metrics / Displays groups
+        using the ordered names in ``_HELP_METHOD_GROUPS``, with registry
+        callables injected into Metrics.
         """
         help_data = super()._build_help_data()
         known_names = {method.name for method in help_data.methods}
@@ -362,23 +368,27 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
         )
 
         by_name = {method.name: method for method in help_data.methods}
-        registry_names = self._HELP_METHOD_GROUPS["Registry"] or ()
-        static_metric_names = self._HELP_METHOD_GROUPS["Metrics"] or ()
-        registry_order = self._callable_metric_names()
-
-        registry_methods = [by_name[name] for name in registry_names if name in by_name]
-        metrics_methods = [
-            by_name[name] for name in registry_order if name in by_name
-        ] + [by_name[name] for name in static_metric_names if name in by_name]
-        claimed = {method.name for method in registry_methods + metrics_methods}
-        displays_methods = [
-            method for method in help_data.methods if method.name not in claimed
-        ]
-
         grouped_methods = {
-            "Registry": registry_methods,
-            "Metrics": metrics_methods,
-            "Displays": displays_methods,
+            "Registry": [
+                by_name[name]
+                for name in self._HELP_METHOD_GROUPS["Registry"]
+                if name in by_name
+            ],
+            "Metrics": [
+                by_name[name]
+                for name in self._callable_metric_names()
+                if name in by_name
+            ]
+            + [
+                by_name[name]
+                for name in self._HELP_METHOD_GROUPS["Metrics"]
+                if name in by_name
+            ],
+            "Displays": [
+                by_name[name]
+                for name in self._HELP_METHOD_GROUPS["Displays"]
+                if name in by_name
+            ],
         }
         help_data.groups = [
             MethodGroupHelp(branch_id=str(uuid4()), name=name, methods=methods)

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -32,7 +32,7 @@ from skore._utils.repr.base import (
     ReportHelpMixin,
     render_panel_to_plain_text,
 )
-from skore._utils.repr.data import MethodHelp, _build_method_groups
+from skore._utils.repr.data import MethodGroupHelp, MethodHelp
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -211,19 +211,12 @@ def _summarize_report_metrics(
 class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
     """Base class for metrics accessor."""
 
-    # Help tree subgroups under ``.metrics``. Explicit tuples list fixed methods;
-    # ``None`` is a catch-all for remaining methods (registry callables such as
-    # ``accuracy`` / ``r2``, plus static score helpers like ``timings``).
+    # Help tree subgroups under ``.metrics``. ``Displays`` is a catch-all for
+    # methods that are neither registry management nor metric callables.
     _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
         "Registry": ("available", "add", "remove", "get"),
-        "Metrics": None,
-        "Displays": (
-            "summarize",
-            "roc",
-            "precision_recall",
-            "prediction_error",
-            "confusion_matrix",
-        ),
+        "Metrics": ("fit_time", "predict_time", "score", "timings"),
+        "Displays": None,
     }
 
     def _callable_metric_names(self) -> list[str]:
@@ -351,8 +344,8 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
         since they cannot be called as ``report.metrics.<name>(...)``.
 
         Methods are then partitioned into Registry / Metrics / Displays groups.
-        The Metrics group is filled from the registry (plus remaining score helpers),
-        rather than a hardcoded list of metric names.
+        Metrics combines registry callables with static score helpers; Displays
+        collects remaining methods that are neither registry management nor metrics.
         """
         help_data = super()._build_help_data()
         known_names = {method.name for method in help_data.methods}
@@ -367,24 +360,47 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
             for name in self._callable_metric_names()
             if name not in known_names
         )
-        # Rebuild groups after injecting dynamic registry metrics.
-        help_data.groups = _build_method_groups(self, help_data.methods)
-        # Within Metrics, show registry callables first (registry order), then
-        # remaining static helpers (``fit_time``, ``timings``, ...).
-        if help_data.groups:
-            registry_order = self._callable_metric_names()
-            registry_set = set(registry_order)
-            for group in help_data.groups:
-                if group.name != "Metrics":
-                    continue
-                by_name = {method.name: method for method in group.methods}
-                group.methods = [
-                    by_name[name] for name in registry_order if name in by_name
-                ] + [
-                    method
-                    for method in group.methods
-                    if method.name not in registry_set
-                ]
+
+        by_name = {method.name: method for method in help_data.methods}
+        registry_names = self._HELP_METHOD_GROUPS["Registry"] or ()
+        static_metric_names = self._HELP_METHOD_GROUPS["Metrics"] or ()
+        registry_order = self._callable_metric_names()
+
+        registry_methods = [by_name[name] for name in registry_names if name in by_name]
+        metrics_methods = [
+            by_name[name] for name in registry_order if name in by_name
+        ] + [by_name[name] for name in static_metric_names if name in by_name]
+        claimed = {method.name for method in registry_methods + metrics_methods}
+        displays_methods = [
+            method for method in help_data.methods if method.name not in claimed
+        ]
+
+        groups: list[MethodGroupHelp] = []
+        if registry_methods:
+            groups.append(
+                MethodGroupHelp(
+                    branch_id=str(uuid4()),
+                    name="Registry",
+                    methods=registry_methods,
+                )
+            )
+        if metrics_methods:
+            groups.append(
+                MethodGroupHelp(
+                    branch_id=str(uuid4()),
+                    name="Metrics",
+                    methods=metrics_methods,
+                )
+            )
+        if displays_methods:
+            groups.append(
+                MethodGroupHelp(
+                    branch_id=str(uuid4()),
+                    name="Displays",
+                    methods=displays_methods,
+                )
+            )
+        help_data.groups = groups or None
         return help_data
 
     def _formatted_summary_frame(

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -375,32 +375,16 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
             method for method in help_data.methods if method.name not in claimed
         ]
 
-        groups: list[MethodGroupHelp] = []
-        if registry_methods:
-            groups.append(
-                MethodGroupHelp(
-                    branch_id=str(uuid4()),
-                    name="Registry",
-                    methods=registry_methods,
-                )
-            )
-        if metrics_methods:
-            groups.append(
-                MethodGroupHelp(
-                    branch_id=str(uuid4()),
-                    name="Metrics",
-                    methods=metrics_methods,
-                )
-            )
-        if displays_methods:
-            groups.append(
-                MethodGroupHelp(
-                    branch_id=str(uuid4()),
-                    name="Displays",
-                    methods=displays_methods,
-                )
-            )
-        help_data.groups = groups or None
+        grouped_methods = {
+            "Registry": registry_methods,
+            "Metrics": metrics_methods,
+            "Displays": displays_methods,
+        }
+        help_data.groups = [
+            MethodGroupHelp(branch_id=str(uuid4()), name=name, methods=methods)
+            for name, methods in grouped_methods.items()
+            if methods
+        ] or None
         return help_data
 
     def _formatted_summary_frame(

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -32,7 +32,7 @@ from skore._utils.repr.base import (
     ReportHelpMixin,
     render_panel_to_plain_text,
 )
-from skore._utils.repr.data import MethodHelp, _build_method_groups
+from skore._utils.repr.data import MethodHelp
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from skore._sklearn._cross_validation.report import CrossValidationReport
     from skore._sklearn._estimator.report import EstimatorReport
     from skore._sklearn._plot import MetricsSummaryDisplay
-    from skore._utils.repr.data import AccessorHelpData
 
 
 class _BaseReport(ReportHelpMixin):
@@ -360,44 +359,38 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
         """Add registry metrics to ``__dir__`` for tab-completion."""
         return list(set(super().__dir__()).union(self._callable_metric_names()))
 
-    def _build_help_data(self) -> AccessorHelpData:
-        """Include registry metrics in the help data.
+    def _extra_help_methods(self) -> list[MethodHelp]:
+        """Help entries for the registry metrics exposed through ``__getattr__``.
 
         Registry metrics are only reachable through ``__getattr__``, so they are not
         picked up by the default method-discovery logic used to build help data.
         Names that are not valid identifiers (e.g. containing spaces) are excluded,
         since they cannot be called as ``report.metrics.<name>(...)``.
-
-        Methods are then partitioned into Registry / Metrics / Displays groups
-        using the ordered names in ``_HELP_METHOD_GROUPS``, with registry
-        callables injected into Metrics.
         """
-        help_data = super()._build_help_data()
-        known_names = {method.name for method in help_data.methods}
         # Registry metrics have no Sphinx API page; show the summary tooltip only.
         # Keep registry order (``available()``) instead of sorting alphabetically.
-        help_data.methods.extend(
+        return [
             MethodHelp(
                 name=name,
                 parameters="(...)",
                 description=self._metric_help_description(name),
             )
             for name in self._callable_metric_names()
-            if name not in known_names
-        )
+        ]
 
-        # Registry callables are listed first in Metrics, ahead of the static score
-        # helpers declared on the class. Some helpers (e.g. ``fit_time``) are registry
-        # metrics on reports that do not define them as methods, hence the dedupe.
+    def _help_method_group_spec(self) -> dict[str, tuple[str, ...]]:
+        """Partition methods into Registry / Metrics / Displays groups.
+
+        Registry callables are listed first in Metrics, ahead of the static score
+        helpers declared on the class. Some helpers (e.g. ``fit_time``) are registry
+        metrics on reports that do not define them as methods, hence the dedupe.
+        """
         group_spec = dict(self._HELP_METHOD_GROUPS)
         registry_names = tuple(self._callable_metric_names())
         group_spec["Metrics"] = registry_names + tuple(
             name for name in group_spec["Metrics"] if name not in set(registry_names)
         )
-        help_data.groups = _build_method_groups(
-            self, help_data.methods, group_spec=group_spec
-        )
-        return help_data
+        return group_spec
 
     def _formatted_summary_frame(
         self,

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from functools import partial
 from importlib.metadata import version
 from keyword import iskeyword
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeVar
 from uuid import uuid4
 
 import pandas as pd
@@ -32,7 +32,7 @@ from skore._utils.repr.base import (
     ReportHelpMixin,
     render_panel_to_plain_text,
 )
-from skore._utils.repr.data import MethodHelp
+from skore._utils.repr.data import MethodHelp, _build_method_groups
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -211,6 +211,21 @@ def _summarize_report_metrics(
 class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
     """Base class for metrics accessor."""
 
+    # Help tree subgroups under ``.metrics``. Explicit tuples list fixed methods;
+    # ``None`` is a catch-all for remaining methods (registry callables such as
+    # ``accuracy`` / ``r2``, plus static score helpers like ``timings``).
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+        "Registry": ("available", "add", "remove", "get"),
+        "Metrics": None,
+        "Displays": (
+            "summarize",
+            "roc",
+            "precision_recall",
+            "prediction_error",
+            "confusion_matrix",
+        ),
+    }
+
     def _callable_metric_names(self) -> list[str]:
         """Registry metric names that can be exposed as ``metrics.<name>()``."""
         return [
@@ -334,10 +349,15 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
         picked up by the default method-discovery logic used to build help data.
         Names that are not valid identifiers (e.g. containing spaces) are excluded,
         since they cannot be called as ``report.metrics.<name>(...)``.
+
+        Methods are then partitioned into Registry / Metrics / Displays groups.
+        The Metrics group is filled from the registry (plus remaining score helpers),
+        rather than a hardcoded list of metric names.
         """
         help_data = super()._build_help_data()
         known_names = {method.name for method in help_data.methods}
         # Registry metrics have no Sphinx API page; show the summary tooltip only.
+        # Keep registry order (``available()``) instead of sorting alphabetically.
         help_data.methods.extend(
             MethodHelp(
                 name=name,
@@ -347,7 +367,24 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
             for name in self._callable_metric_names()
             if name not in known_names
         )
-        help_data.methods.sort(key=lambda method: method.name)
+        # Rebuild groups after injecting dynamic registry metrics.
+        help_data.groups = _build_method_groups(self, help_data.methods)
+        # Within Metrics, show registry callables first (registry order), then
+        # remaining static helpers (``fit_time``, ``timings``, ...).
+        if help_data.groups:
+            registry_order = self._callable_metric_names()
+            registry_set = set(registry_order)
+            for group in help_data.groups:
+                if group.name != "Metrics":
+                    continue
+                by_name = {method.name: method for method in group.methods}
+                group.methods = [
+                    by_name[name] for name in registry_order if name in by_name
+                ] + [
+                    method
+                    for method in group.methods
+                    if method.name not in registry_set
+                ]
         return help_data
 
     def _formatted_summary_frame(

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -32,7 +32,7 @@ from skore._utils.repr.base import (
     ReportHelpMixin,
     render_panel_to_plain_text,
 )
-from skore._utils.repr.data import MethodGroupHelp, MethodHelp
+from skore._utils.repr.data import MethodHelp, _build_method_groups
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -367,34 +367,17 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
             if name not in known_names
         )
 
-        by_name = {method.name: method for method in help_data.methods}
-        grouped_methods = {
-            "Registry": [
-                by_name[name]
-                for name in self._HELP_METHOD_GROUPS["Registry"]
-                if name in by_name
-            ],
-            "Metrics": [
-                by_name[name]
-                for name in self._callable_metric_names()
-                if name in by_name
-            ]
-            + [
-                by_name[name]
-                for name in self._HELP_METHOD_GROUPS["Metrics"]
-                if name in by_name
-            ],
-            "Displays": [
-                by_name[name]
-                for name in self._HELP_METHOD_GROUPS["Displays"]
-                if name in by_name
-            ],
-        }
-        help_data.groups = [
-            MethodGroupHelp(branch_id=str(uuid4()), name=name, methods=methods)
-            for name, methods in grouped_methods.items()
-            if methods
-        ] or None
+        # Registry callables are listed first in Metrics, ahead of the static score
+        # helpers declared on the class. Some helpers (e.g. ``fit_time``) are registry
+        # metrics on reports that do not define them as methods, hence the dedupe.
+        group_spec = dict(self._HELP_METHOD_GROUPS)
+        registry_names = tuple(self._callable_metric_names())
+        group_spec["Metrics"] = registry_names + tuple(
+            name for name in group_spec["Metrics"] if name not in set(registry_names)
+        )
+        help_data.groups = _build_method_groups(
+            self, help_data.methods, group_spec=group_spec
+        )
         return help_data
 
     def _formatted_summary_frame(

--- a/skore/src/skore/_utils/repr/common/_report_help_tree.html.j2
+++ b/skore/src/skore/_utils/repr/common/_report_help_tree.html.j2
@@ -14,11 +14,29 @@
                         <span class="name">.{{ accessor.name }}</span>
                     </label>
                     <div class="branch-content" id="{{ accessor.branch_id }}">
-                        {% for method in accessor.methods %}
-                            <div class="node method">
-                                <span class="method-name">{{ method_label(method) }}</span>
+                        {% if accessor.groups %}
+                            {% for group in accessor.groups %}
+                                <div class="node branch">
+                                    <label class="branch-label">
+                                        <input type="checkbox" class="toggle">
+                                        <span class="section-name">{{ group.name }}</span>
+                                    </label>
+                                    <div class="branch-content" id="{{ group.branch_id }}">
+                                        {% for method in group.methods %}
+                                            <div class="node method">
+                                                <span class="method-name">{{ method_label(method) }}</span>
+                                            </div>
+                                        {% endfor %}
+                                    </div>
                                 </div>
-                        {% endfor %}
+                            {% endfor %}
+                        {% else %}
+                            {% for method in accessor.methods %}
+                                <div class="node method">
+                                    <span class="method-name">{{ method_label(method) }}</span>
+                                </div>
+                            {% endfor %}
+                        {% endif %}
                     </div>
                 </div>
             {% endfor %}
@@ -69,11 +87,29 @@
                         <span class="name">.{{ accessor_name }}</span>
                     </label>
                     <div class="branch-content" id="{{ accessor_branch_id }}">
-                        {% for method in methods %}
-                            <div class="node method">
-                                <span class="method-name">{{ method_label(method) }}</span>
+                        {% if groups %}
+                            {% for group in groups %}
+                                <div class="node branch">
+                                    <label class="branch-label">
+                                        <input type="checkbox" class="toggle">
+                                        <span class="section-name">{{ group.name }}</span>
+                                    </label>
+                                    <div class="branch-content" id="{{ group.branch_id }}">
+                                        {% for method in group.methods %}
+                                            <div class="node method">
+                                                <span class="method-name">{{ method_label(method) }}</span>
+                                            </div>
+                                        {% endfor %}
+                                    </div>
                                 </div>
-                        {% endfor %}
+                            {% endfor %}
+                        {% else %}
+                            {% for method in methods %}
+                                <div class="node method">
+                                    <span class="method-name">{{ method_label(method) }}</span>
+                                </div>
+                            {% endfor %}
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/skore/src/skore/_utils/repr/common/_report_help_tree.html.j2
+++ b/skore/src/skore/_utils/repr/common/_report_help_tree.html.j2
@@ -18,7 +18,7 @@
                             {% for group in accessor.groups %}
                                 <div class="node branch">
                                     <label class="branch-label">
-                                        <input type="checkbox" class="toggle">
+                                        <input type="checkbox" class="toggle" checked>
                                         <span class="section-name">{{ group.name }}</span>
                                     </label>
                                     <div class="branch-content" id="{{ group.branch_id }}">
@@ -91,7 +91,7 @@
                             {% for group in groups %}
                                 <div class="node branch">
                                     <label class="branch-label">
-                                        <input type="checkbox" class="toggle">
+                                        <input type="checkbox" class="toggle" checked>
                                         <span class="section-name">{{ group.name }}</span>
                                     </label>
                                     <div class="branch-content" id="{{ group.branch_id }}">

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -411,16 +411,11 @@ def _build_method_groups(
 
     Returns ``None`` when the accessor's class does not declare
     ``_HELP_METHOD_GROUPS``. Otherwise iterates groups in declared order,
-    keeping only methods that are present in ``methods``.
-
-    Each group maps to either:
-
-    - a tuple of method names (order preserved; missing names are skipped), or
-    - ``None``, which acts as a catch-all for methods not claimed by any
-      explicitly listed group. At most one catch-all group is supported.
-
-    Methods present on the accessor but not listed in any explicit group, and
-    not absorbed by a catch-all, are appended to a final ``"Other"`` group.
+    keeping only methods that are present in ``methods`` and preserving the
+    order specified by ``_HELP_METHOD_GROUPS``. Empty groups are skipped.
+    Methods present on the accessor but not listed in any group are appended
+    to a final ``"Other"`` group; if no such method exists, no extra group
+    is added.
 
     Parameters
     ----------
@@ -433,55 +428,29 @@ def _build_method_groups(
     -------
     list of MethodGroupHelp or None
     """
-    group_spec: dict[str, tuple[str, ...] | None] | None = getattr(
+    group_spec: dict[str, tuple[str, ...]] | None = getattr(
         type(accessor), "_HELP_METHOD_GROUPS", None
     )
     if not group_spec:
         return None
 
     method_by_name = {m.name: m for m in methods}
-    declared = {n for names in group_spec.values() if names is not None for n in names}
+    declared = {n for names in group_spec.values() for n in names}
 
-    groups: list[MethodGroupHelp] = []
-    catch_all_name: str | None = None
-    for group_name, method_names in group_spec.items():
-        if method_names is None:
-            if catch_all_name is not None:
-                raise ValueError(
-                    f"{type(accessor).__name__}._HELP_METHOD_GROUPS has more than "
-                    "one catch-all group (value None)."
-                )
-            catch_all_name = group_name
-            # Placeholder; filled after explicit groups are resolved.
-            groups.append(
-                MethodGroupHelp(
-                    branch_id=str(uuid.uuid4()),
-                    name=group_name,
-                    methods=[],
-                )
-            )
-            continue
-
-        group_methods = [
-            method_by_name[name] for name in method_names if name in method_by_name
-        ]
-        if group_methods:
-            groups.append(
-                MethodGroupHelp(
-                    branch_id=str(uuid.uuid4()),
-                    name=group_name,
-                    methods=group_methods,
-                )
-            )
+    groups = [
+        MethodGroupHelp(
+            branch_id=str(uuid.uuid4()),
+            name=group_name,
+            methods=[
+                method_by_name[name] for name in method_names if name in method_by_name
+            ],
+        )
+        for group_name, method_names in group_spec.items()
+        if any(name in method_by_name for name in method_names)
+    ]
 
     remaining = [m for m in methods if m.name not in declared]
-    if catch_all_name is not None:
-        for group in groups:
-            if group.name == catch_all_name:
-                group.methods = remaining
-                break
-        groups = [g for g in groups if g.methods]
-    elif remaining:
+    if remaining:
         groups.append(
             MethodGroupHelp(
                 branch_id=str(uuid.uuid4()),

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -482,32 +482,17 @@ class _ReportHelpDataMixin(_BaseHelpDataMixin):
 
         accessors = []
         for accessor_attr, config in self._ACCESSOR_CONFIG.items():
-            accessor = getattr(self, accessor_attr)
-            # Prefer the accessor's own help data so dynamic methods (e.g. registry
-            # metrics) and declared groups are preserved in the report help tree.
-            if hasattr(accessor, "_build_help_data"):
-                accessor_help = accessor._build_help_data()
-                methods = accessor_help.methods
-                groups = accessor_help.groups
-            else:
-                methods = [
-                    self._build_method_data(
-                        name=name,
-                        method=method,
-                        obj=accessor,
-                        parent_obj=self,
-                        accessor_name=config["name"],
-                    )
-                    for name, method in get_public_methods(accessor)
-                ]
-                groups = _build_method_groups(accessor, methods)
+            # Accessors inherit ``_AccessorHelpDataMixin``, so their own help data
+            # already includes dynamic methods (e.g. registry metrics) and groups.
+            accessor_help = getattr(self, accessor_attr)._build_help_data()
+            methods = accessor_help.methods
             if methods:
                 accessors.append(
                     AccessorBranchHelp(
                         branch_id=str(uuid.uuid4()),
                         name=config["name"],
                         methods=methods,
-                        groups=groups,
+                        groups=accessor_help.groups,
                     )
                 )
 

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -34,10 +34,20 @@ class AttributeHelp:
 
 
 @dataclass
+class MethodGroupHelp:
+    """A named subgroup of methods under an accessor help tree."""
+
+    branch_id: str
+    name: str
+    methods: list[MethodHelp]
+
+
+@dataclass
 class AccessorBranchHelp:
     branch_id: str
     name: str
     methods: list[MethodHelp]
+    groups: list[MethodGroupHelp] | None = None
 
 
 @dataclass
@@ -59,6 +69,7 @@ class AccessorHelpData:
     accessor_name: str
     accessor_branch_id: str
     methods: list[MethodHelp]
+    groups: list[MethodGroupHelp] | None = None
 
 
 @dataclass
@@ -393,6 +404,97 @@ class _BaseHelpDataMixin(ABC):
         return items, section
 
 
+def _build_method_groups(
+    accessor: Any, methods: list[MethodHelp]
+) -> list[MethodGroupHelp] | None:
+    """Partition ``methods`` according to ``accessor._HELP_METHOD_GROUPS``.
+
+    Returns ``None`` when the accessor's class does not declare
+    ``_HELP_METHOD_GROUPS``. Otherwise iterates groups in declared order,
+    keeping only methods that are present in ``methods``.
+
+    Each group maps to either:
+
+    - a tuple of method names (order preserved; missing names are skipped), or
+    - ``None``, which acts as a catch-all for methods not claimed by any
+      explicitly listed group. At most one catch-all group is supported.
+
+    Methods present on the accessor but not listed in any explicit group, and
+    not absorbed by a catch-all, are appended to a final ``"Other"`` group.
+
+    Parameters
+    ----------
+    accessor : object
+        The accessor instance whose class may declare ``_HELP_METHOD_GROUPS``.
+    methods : list of MethodHelp
+        The full list of method help entries already built for the accessor.
+
+    Returns
+    -------
+    list of MethodGroupHelp or None
+    """
+    group_spec: dict[str, tuple[str, ...] | None] | None = getattr(
+        type(accessor), "_HELP_METHOD_GROUPS", None
+    )
+    if not group_spec:
+        return None
+
+    method_by_name = {m.name: m for m in methods}
+    declared = {
+        n for names in group_spec.values() if names is not None for n in names
+    }
+
+    groups: list[MethodGroupHelp] = []
+    catch_all_name: str | None = None
+    for group_name, method_names in group_spec.items():
+        if method_names is None:
+            if catch_all_name is not None:
+                raise ValueError(
+                    f"{type(accessor).__name__}._HELP_METHOD_GROUPS has more than "
+                    "one catch-all group (value None)."
+                )
+            catch_all_name = group_name
+            # Placeholder; filled after explicit groups are resolved.
+            groups.append(
+                MethodGroupHelp(
+                    branch_id=str(uuid.uuid4()),
+                    name=group_name,
+                    methods=[],
+                )
+            )
+            continue
+
+        group_methods = [
+            method_by_name[name] for name in method_names if name in method_by_name
+        ]
+        if group_methods:
+            groups.append(
+                MethodGroupHelp(
+                    branch_id=str(uuid.uuid4()),
+                    name=group_name,
+                    methods=group_methods,
+                )
+            )
+
+    remaining = [m for m in methods if m.name not in declared]
+    if catch_all_name is not None:
+        for group in groups:
+            if group.name == catch_all_name:
+                group.methods = remaining
+                break
+        groups = [g for g in groups if g.methods]
+    elif remaining:
+        groups.append(
+            MethodGroupHelp(
+                branch_id=str(uuid.uuid4()),
+                name="Other",
+                methods=remaining,
+            )
+        )
+
+    return groups or None
+
+
 class _ReportHelpDataMixin(_BaseHelpDataMixin):
     """Mixin responsible for building help data structures for reports.
 
@@ -410,22 +512,31 @@ class _ReportHelpDataMixin(_BaseHelpDataMixin):
         accessors = []
         for accessor_attr, config in self._ACCESSOR_CONFIG.items():
             accessor = getattr(self, accessor_attr)
-            methods = [
-                self._build_method_data(
-                    name=name,
-                    method=method,
-                    obj=accessor,
-                    parent_obj=self,
-                    accessor_name=config["name"],
-                )
-                for name, method in get_public_methods(accessor)
-            ]
+            # Prefer the accessor's own help data so dynamic methods (e.g. registry
+            # metrics) and declared groups are preserved in the report help tree.
+            if hasattr(accessor, "_build_help_data"):
+                accessor_help = accessor._build_help_data()
+                methods = accessor_help.methods
+                groups = accessor_help.groups
+            else:
+                methods = [
+                    self._build_method_data(
+                        name=name,
+                        method=method,
+                        obj=accessor,
+                        parent_obj=self,
+                        accessor_name=config["name"],
+                    )
+                    for name, method in get_public_methods(accessor)
+                ]
+                groups = _build_method_groups(accessor, methods)
             if methods:
                 accessors.append(
                     AccessorBranchHelp(
                         branch_id=str(uuid.uuid4()),
                         name=config["name"],
                         methods=methods,
+                        groups=groups,
                     )
                 )
 
@@ -487,6 +598,7 @@ class _AccessorHelpDataMixin(_BaseHelpDataMixin):
             accessor_name=accessor_name,
             accessor_branch_id=str(uuid.uuid4()),
             methods=methods,
+            groups=_build_method_groups(self, methods),
         )
 
 

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -405,17 +405,18 @@ class _BaseHelpDataMixin(ABC):
 
 
 def _build_method_groups(
-    accessor: Any, methods: list[MethodHelp]
+    accessor: Any,
+    methods: list[MethodHelp],
+    group_spec: dict[str, tuple[str, ...]] | None = None,
 ) -> list[MethodGroupHelp] | None:
     """Partition ``methods`` according to ``accessor._HELP_METHOD_GROUPS``.
 
-    Returns ``None`` when the accessor's class does not declare
-    ``_HELP_METHOD_GROUPS``. Otherwise iterates groups in declared order,
-    keeping only methods that are present in ``methods`` and preserving the
-    order specified by ``_HELP_METHOD_GROUPS``. Empty groups are skipped.
-    Methods present on the accessor but not listed in any group are appended
-    to a final ``"Other"`` group; if no such method exists, no extra group
-    is added.
+    Returns ``None`` when no group specification is available. Otherwise
+    iterates groups in declared order, keeping only methods that are present in
+    ``methods`` and preserving the declared order. Empty groups are skipped.
+
+    Every public method of a grouped accessor must be listed in a group, so
+    that none is silently dropped from the help tree.
 
     Parameters
     ----------
@@ -423,19 +424,32 @@ def _build_method_groups(
         The accessor instance whose class may declare ``_HELP_METHOD_GROUPS``.
     methods : list of MethodHelp
         The full list of method help entries already built for the accessor.
+    group_spec : dict of str to tuple of str, default=None
+        Group specification overriding ``accessor._HELP_METHOD_GROUPS``, for
+        accessors that extend a group with dynamically discovered methods.
 
     Returns
     -------
     list of MethodGroupHelp or None
+
+    Raises
+    ------
+    ValueError
+        If a method is not listed in any declared group.
     """
-    group_spec: dict[str, tuple[str, ...]] | None = getattr(
-        type(accessor), "_HELP_METHOD_GROUPS", None
-    )
+    if group_spec is None:
+        group_spec = getattr(type(accessor), "_HELP_METHOD_GROUPS", None)
     if not group_spec:
         return None
 
     method_by_name = {m.name: m for m in methods}
     declared = {n for names in group_spec.values() for n in names}
+
+    if ungrouped := sorted(m.name for m in methods if m.name not in declared):
+        raise ValueError(
+            f"{type(accessor).__name__}._HELP_METHOD_GROUPS does not list "
+            f"{', '.join(ungrouped)}. Every public method must belong to a group."
+        )
 
     groups = [
         MethodGroupHelp(
@@ -448,16 +462,6 @@ def _build_method_groups(
         for group_name, method_names in group_spec.items()
         if any(name in method_by_name for name in method_names)
     ]
-
-    remaining = [m for m in methods if m.name not in declared]
-    if remaining:
-        groups.append(
-            MethodGroupHelp(
-                branch_id=str(uuid.uuid4()),
-                name="Other",
-                methods=remaining,
-            )
-        )
 
     return groups or None
 

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -482,8 +482,6 @@ class _ReportHelpDataMixin(_BaseHelpDataMixin):
 
         accessors = []
         for accessor_attr, config in self._ACCESSOR_CONFIG.items():
-            # Accessors inherit ``_AccessorHelpDataMixin``, so their own help data
-            # already includes dynamic methods (e.g. registry metrics) and groups.
             accessor_help = getattr(self, accessor_attr)._build_help_data()
             methods = accessor_help.methods
             if methods:

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -440,9 +440,7 @@ def _build_method_groups(
         return None
 
     method_by_name = {m.name: m for m in methods}
-    declared = {
-        n for names in group_spec.values() if names is not None for n in names
-    }
+    declared = {n for names in group_spec.values() if names is not None for n in names}
 
     groups: list[MethodGroupHelp] = []
     catch_all_name: str | None = None

--- a/skore/src/skore/_utils/repr/data.py
+++ b/skore/src/skore/_utils/repr/data.py
@@ -549,6 +549,21 @@ class _AccessorHelpDataMixin(_BaseHelpDataMixin):
     _parent: Any
     _accessor_name: ClassVar[str]  # set by _register_accessor on concrete classes
 
+    def _extra_help_methods(self) -> list[MethodHelp]:
+        """Help entries for methods that attribute introspection cannot discover.
+
+        Overridden by accessors exposing methods through ``__getattr__``.
+        """
+        return []
+
+    def _help_method_group_spec(self) -> dict[str, tuple[str, ...]] | None:
+        """Ordered help subgroups for this accessor, or ``None`` when ungrouped.
+
+        Overridden by accessors whose groups depend on the instance rather than
+        only on the class-level ``_HELP_METHOD_GROUPS``.
+        """
+        return getattr(type(self), "_HELP_METHOD_GROUPS", None)
+
     def _build_help_data(self) -> AccessorHelpData:
         """Build data structure for Jinja2/Rich rendering for accessors."""
         accessor_name = self.__class__._accessor_name
@@ -563,13 +578,21 @@ class _AccessorHelpDataMixin(_BaseHelpDataMixin):
             )
             for name, method in get_public_methods(self)
         ]
+        known_names = {method.name for method in methods}
+        methods.extend(
+            method
+            for method in self._extra_help_methods()
+            if method.name not in known_names
+        )
         return AccessorHelpData(
             title=self._get_help_title(),
             root_node=root_node,
             accessor_name=accessor_name,
             accessor_branch_id=str(uuid.uuid4()),
             methods=methods,
-            groups=_build_method_groups(self, methods),
+            groups=_build_method_groups(
+                self, methods, group_spec=self._help_method_group_spec()
+            ),
         )
 
 

--- a/skore/src/skore/_utils/repr/rich_repr.py
+++ b/skore/src/skore/_utils/repr/rich_repr.py
@@ -40,10 +40,18 @@ class _RichReportHelpMixin(_ReportHelpDataMixin, _BaseRichHelpMixin):
         for accessor_data in data.get("accessors", []):
             branch = tree.add(f"[bold cyan].{accessor_data['name']}[/bold cyan]")
 
-            for method in accessor_data["methods"]:
-                displayed_name = f"{method['name']}(...)"
-                description = method["description"]
-                branch.add(f".{displayed_name.ljust(25)} - {description}")
+            if accessor_data.get("groups"):
+                for group in accessor_data["groups"]:
+                    sub = branch.add(f"[bold cyan]{group['name']}[/bold cyan]")
+                    for method in group["methods"]:
+                        displayed_name = f"{method['name']}(...)"
+                        description = method["description"]
+                        sub.add(f".{displayed_name.ljust(25)} - {description}")
+            else:
+                for method in accessor_data["methods"]:
+                    displayed_name = f"{method['name']}(...)"
+                    description = method["description"]
+                    branch.add(f".{displayed_name.ljust(25)} - {description}")
 
         base_methods = data.get("base_methods", [])
         if base_methods:
@@ -93,10 +101,18 @@ class _RichAccessorHelpMixin(_AccessorHelpDataMixin, _BaseRichHelpMixin):
         accessor_name = data.get("accessor_name", "")
         branch = tree.add(f"[bold cyan].{accessor_name}[/bold cyan]")
 
-        for method in data.get("methods", []):
-            displayed_name = f"{method['name']}(...)"
-            description = method["description"]
-            branch.add(f".{displayed_name}".ljust(26) + f" - {description}")
+        if data.get("groups"):
+            for group in data["groups"]:
+                sub = branch.add(f"[bold cyan]{group['name']}[/bold cyan]")
+                for method in group["methods"]:
+                    displayed_name = f"{method['name']}(...)"
+                    description = method["description"]
+                    sub.add(f".{displayed_name}".ljust(26) + f" - {description}")
+        else:
+            for method in data.get("methods", []):
+                displayed_name = f"{method['name']}(...)"
+                description = method["description"]
+                branch.add(f".{displayed_name}".ljust(26) + f" - {description}")
 
         return tree
 

--- a/skore/tests/unit/reports/test_dynamic_metrics.py
+++ b/skore/tests/unit/reports/test_dynamic_metrics.py
@@ -76,7 +76,9 @@ def test_help_groups_separate_registry_metrics_displays(report):
 
     help_data = report.metrics._build_help_data()
     assert help_data.groups is not None
-    by_name = {group.name: [m.name for m in group.methods] for group in help_data.groups}
+    by_name = {
+        group.name: [m.name for m in group.methods] for group in help_data.groups
+    }
     assert list(by_name) == ["Registry", "Metrics", "Displays"]
 
     assert by_name["Registry"] == ["available", "add", "remove", "get"]

--- a/skore/tests/unit/reports/test_dynamic_metrics.py
+++ b/skore/tests/unit/reports/test_dynamic_metrics.py
@@ -55,6 +55,36 @@ def test_help_custom_metric(report, capsys):
     # "Custom metric." was the previous hardcoded help fallback; ensure it does not
     # reappear when a docstring-derived description is available.
     assert "Custom metric." not in stdout
+    # Registry callables are separated from registry management and displays.
+    assert "Registry" in stdout
+    assert "Metrics" in stdout
+    assert "Displays" in stdout
+
+
+def test_help_groups_separate_registry_metrics_displays(report):
+    """Help data partitions methods into Registry / Metrics / Displays groups.
+
+    Registry callables (and custom metrics) land in Metrics; management helpers
+    in Registry; plot/summary helpers in Displays.
+    """
+
+    def custom(e, X, y):
+        """Custom score used in groups."""
+        return 1
+
+    report.metrics.add(custom)
+
+    help_data = report.metrics._build_help_data()
+    assert help_data.groups is not None
+    by_name = {group.name: [m.name for m in group.methods] for group in help_data.groups}
+    assert list(by_name) == ["Registry", "Metrics", "Displays"]
+
+    assert by_name["Registry"] == ["available", "add", "remove", "get"]
+    assert "custom" in by_name["Metrics"]
+    assert "r2" in by_name["Metrics"]
+    assert "summarize" in by_name["Displays"]
+    # Registry callables come before static score helpers in Metrics.
+    assert by_name["Metrics"].index("custom") < by_name["Metrics"].index("timings")
 
 
 def test_help_builtin_metric_description(report):

--- a/skore/tests/unit/reports/test_dynamic_metrics.py
+++ b/skore/tests/unit/reports/test_dynamic_metrics.py
@@ -65,7 +65,7 @@ def test_help_groups_separate_registry_metrics_displays(report):
     """Help data partitions methods into Registry / Metrics / Displays groups.
 
     Registry callables (and custom metrics) land in Metrics; management helpers
-    in Registry; plot/summary helpers in Displays.
+    in Registry; remaining plot/summary helpers in Displays.
     """
 
     def custom(e, X, y):
@@ -85,8 +85,16 @@ def test_help_groups_separate_registry_metrics_displays(report):
     assert "custom" in by_name["Metrics"]
     assert "r2" in by_name["Metrics"]
     assert "summarize" in by_name["Displays"]
+    assert "custom" not in by_name["Displays"]
+    assert "available" not in by_name["Displays"]
     # Registry callables come before static score helpers in Metrics.
     assert by_name["Metrics"].index("custom") < by_name["Metrics"].index("timings")
+
+
+def test_help_groups_are_expanded_by_default(report):
+    """HTML help unfolds Registry / Metrics / Displays without an extra click."""
+    html = report.metrics._create_help_html()
+    assert html.count('<input type="checkbox" class="toggle" checked>') >= 3
 
 
 def test_help_builtin_metric_description(report):

--- a/skore/tests/unit/reports/test_dynamic_metrics.py
+++ b/skore/tests/unit/reports/test_dynamic_metrics.py
@@ -65,7 +65,7 @@ def test_help_groups_separate_registry_metrics_displays(report):
     """Help data partitions methods into Registry / Metrics / Displays groups.
 
     Registry callables (and custom metrics) land in Metrics; management helpers
-    in Registry; remaining plot/summary helpers in Displays.
+    in Registry; ordered display helpers in Displays.
     """
 
     def custom(e, X, y):
@@ -84,6 +84,7 @@ def test_help_groups_separate_registry_metrics_displays(report):
     assert by_name["Registry"] == ["available", "add", "remove", "get"]
     assert "custom" in by_name["Metrics"]
     assert "r2" in by_name["Metrics"]
+    assert by_name["Displays"][0] == "summarize"
     assert "summarize" in by_name["Displays"]
     assert "custom" not in by_name["Displays"]
     assert "available" not in by_name["Displays"]

--- a/skore/tests/unit/reports/test_dynamic_metrics.py
+++ b/skore/tests/unit/reports/test_dynamic_metrics.py
@@ -4,6 +4,7 @@ from functools import partial
 import pytest
 import sklearn.metrics
 
+import skore._utils.repr.data as data_module
 from skore._sklearn.metrics import Metric
 from skore._utils.docscrape import docstring_summary
 
@@ -105,6 +106,21 @@ def test_help_groups_cover_every_method(report):
 
     assert sorted(grouped_names) == sorted(m.name for m in help_data.methods)
     assert len(grouped_names) == len(set(grouped_names))
+
+
+def test_help_groups_computed_once(report, monkeypatch):
+    """Registry metrics are grouped in a single pass, not grouped then regrouped."""
+    calls = []
+    original = data_module._build_method_groups
+
+    def counting(*args, **kwargs):
+        calls.append(args)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(data_module, "_build_method_groups", counting)
+    report.metrics._build_help_data()
+
+    assert len(calls) == 1
 
 
 def test_help_groups_are_expanded_by_default(report):

--- a/skore/tests/unit/reports/test_dynamic_metrics.py
+++ b/skore/tests/unit/reports/test_dynamic_metrics.py
@@ -85,11 +85,26 @@ def test_help_groups_separate_registry_metrics_displays(report):
     assert "custom" in by_name["Metrics"]
     assert "r2" in by_name["Metrics"]
     assert by_name["Displays"][0] == "summarize"
-    assert "summarize" in by_name["Displays"]
     assert "custom" not in by_name["Displays"]
     assert "available" not in by_name["Displays"]
     # Registry callables come before static score helpers in Metrics.
     assert by_name["Metrics"].index("custom") < by_name["Metrics"].index("timings")
+
+
+def test_help_groups_cover_every_method(report):
+    """Every method shown in the metrics help belongs to exactly one group."""
+
+    def custom(e, X, y):
+        """Custom score used in groups."""
+        return 1
+
+    report.metrics.add(custom)
+
+    help_data = report.metrics._build_help_data()
+    grouped_names = [m.name for group in help_data.groups for m in group.methods]
+
+    assert sorted(grouped_names) == sorted(m.name for m in help_data.methods)
+    assert len(grouped_names) == len(set(grouped_names))
 
 
 def test_help_groups_are_expanded_by_default(report):

--- a/skore/tests/unit/utils/repr/test_data.py
+++ b/skore/tests/unit/utils/repr/test_data.py
@@ -8,10 +8,13 @@ import pytest
 from sklearn.linear_model import LogisticRegression
 
 from skore._utils._testing import MockAccessor, MockDisplay, MockReport
+from typing import ClassVar
+
 from skore._utils.repr.data import (
     AccessorHelpData,
     DisplayHelpData,
     HelpSection,
+    MethodGroupHelp,
     MethodHelp,
     ReportHelpData,
     _AccessorHelpDataMixin,
@@ -447,7 +450,9 @@ def test_report_build_help_data_output_with_accessors(report_with_accessor):
     assert m.parameters == "()"
     assert "Fetch" in m.description
     assert m.doc_url.startswith("https://docs.skore.probabl.ai/")
-    assert "metrics" in m.doc_url and "fetch" in m.doc_url
+    # URLs come from the accessor's own help data (``_accessor_name``).
+    assert "mock_accessor" in m.doc_url and "fetch" in m.doc_url
+    assert branch.groups is None
 
 
 def test_report_build_help_data_output_excludes_empty_accessor():
@@ -483,3 +488,161 @@ def test_display_build_help_data_output(display_with_methods):
     for m in data.methods:
         assert isinstance(m, MethodHelp)
         assert m.doc_url.startswith("https://docs.skore.probabl.ai/")
+
+
+class _GroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
+    """Accessor declaring ``_HELP_METHOD_GROUPS`` for grouped-help tests.
+
+    Includes one orphan public method (``stray``) not listed in any group, which
+    should fall back into an ``"Other"`` group, and references a non-existent
+    method ``"never_existed"`` to verify it is silently skipped.
+    """
+
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+        "Registry": ("alpha", "beta", "never_existed"),
+        "Metrics": ("gamma", "delta"),
+        "Displays": ("epsilon",),
+    }
+
+    def alpha(self):
+        """Alpha method."""
+
+    def beta(self):
+        """Beta method."""
+
+    def gamma(self):
+        """Gamma method."""
+
+    def delta(self):
+        """Delta method."""
+
+    def epsilon(self):
+        """Epsilon method."""
+
+    def stray(self):
+        """Stray method not in any declared group."""
+
+    def _get_help_title(self) -> str:
+        return "Grouped accessor"
+
+
+class _CatchAllGroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
+    """Accessor with a catch-all (``None``) Metrics group."""
+
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+        "Registry": ("alpha", "beta"),
+        "Metrics": None,
+        "Displays": ("epsilon",),
+    }
+
+    def alpha(self):
+        """Alpha method."""
+
+    def beta(self):
+        """Beta method."""
+
+    def gamma(self):
+        """Gamma method."""
+
+    def delta(self):
+        """Delta method."""
+
+    def epsilon(self):
+        """Epsilon method."""
+
+    def _get_help_title(self) -> str:
+        return "Catch-all accessor"
+
+
+class _ReportWithGroupedAccessor(_ReportWithExplicitMethods):
+    """Report carrying a single accessor that exposes grouped methods."""
+
+    _ACCESSOR_CONFIG = {"metrics": {"name": "metrics"}}
+
+    def __init__(self, estimator, X_train=None, y_train=None, X_test=None, y_test=None):
+        super().__init__(
+            estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+        )
+        self.metrics = _GroupedAccessor(parent=self)
+
+
+@pytest.fixture
+def grouped_accessor():
+    """Accessor that declares `_HELP_METHOD_GROUPS`."""
+    X = np.array([[0, 0], [1, 1], [1, 0], [0, 1]])
+    y = np.array([0, 1, 1, 0])
+    estimator = LogisticRegression().fit(X, y)
+    return _GroupedAccessor(parent=_ReportWithExplicitMethods(estimator))
+
+
+@pytest.fixture
+def report_with_grouped_accessor():
+    """Report whose accessor declares `_HELP_METHOD_GROUPS`."""
+    X = np.array([[0, 0], [1, 1], [1, 0], [0, 1]])
+    y = np.array([0, 1, 1, 0])
+    estimator = LogisticRegression().fit(X, y)
+    return _ReportWithGroupedAccessor(estimator)
+
+
+def test_accessor_build_help_data_groups(grouped_accessor):
+    """`_AccessorHelpDataMixin._build_help_data` populates `groups` when the accessor
+    declares `_HELP_METHOD_GROUPS`.
+    """
+    data = grouped_accessor._build_help_data()
+    assert data.groups is not None
+    group_names = [g.name for g in data.groups]
+    assert group_names == ["Registry", "Metrics", "Displays", "Other"]
+    for g in data.groups:
+        assert isinstance(g, MethodGroupHelp)
+        assert g.branch_id != ""
+
+    by_name = {g.name: [m.name for m in g.methods] for g in data.groups}
+    assert by_name["Registry"] == ["alpha", "beta"]
+    assert by_name["Metrics"] == ["gamma", "delta"]
+    assert by_name["Displays"] == ["epsilon"]
+    assert by_name["Other"] == ["stray"]
+
+
+def test_accessor_build_help_data_groups_catch_all():
+    """A group with value ``None`` absorbs methods not listed elsewhere."""
+    X = np.array([[0, 0], [1, 1], [1, 0], [0, 1]])
+    y = np.array([0, 1, 1, 0])
+    estimator = LogisticRegression().fit(X, y)
+    accessor = _CatchAllGroupedAccessor(parent=_ReportWithExplicitMethods(estimator))
+    data = accessor._build_help_data()
+    assert data.groups is not None
+    by_name = {g.name: [m.name for m in g.methods] for g in data.groups}
+    assert list(by_name) == ["Registry", "Metrics", "Displays"]
+    assert by_name["Registry"] == ["alpha", "beta"]
+    assert by_name["Displays"] == ["epsilon"]
+    assert set(by_name["Metrics"]) == {"gamma", "delta"}
+    assert "Other" not in by_name
+
+
+def test_accessor_build_help_data_groups_none_when_not_declared(accessor_with_methods):
+    """`groups` is `None` when the accessor does not declare `_HELP_METHOD_GROUPS`."""
+    data = accessor_with_methods._build_help_data()
+    assert data.groups is None
+
+
+def test_report_build_help_data_groups(report_with_grouped_accessor):
+    """`_ReportHelpDataMixin._build_help_data` propagates `groups` to each accessor
+    branch.
+    """
+    data = report_with_grouped_accessor._build_help_data()
+    assert len(data.accessors) == 1
+    branch = data.accessors[0]
+    assert branch.groups is not None
+    assert [g.name for g in branch.groups] == [
+        "Registry",
+        "Metrics",
+        "Displays",
+        "Other",
+    ]
+
+
+def test_report_build_help_data_groups_none_when_not_declared(report_with_accessor):
+    """`groups` is `None` for accessors not declaring `_HELP_METHOD_GROUPS`."""
+    data = report_with_accessor._build_help_data()
+    assert len(data.accessors) == 1
+    assert data.accessors[0].groups is None

--- a/skore/tests/unit/utils/repr/test_data.py
+++ b/skore/tests/unit/utils/repr/test_data.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from sklearn.linear_model import LogisticRegression
 
+import skore._utils.repr.data as data_module
 from skore._utils._testing import MockAccessor, MockDisplay, MockReport
 from skore._utils.repr.data import (
     AccessorHelpData,
@@ -528,6 +529,24 @@ class _AccessorWithUngroupedMethod(_GroupedAccessor):
         """Stray method not in any declared group."""
 
 
+class _AccessorWithExtraHelpMethods(_GroupedAccessor):
+    """Accessor exposing extra help entries, as accessors using ``__getattr__`` do.
+
+    ``alpha`` duplicates a statically discovered method to check deduplication.
+    """
+
+    def _extra_help_methods(self):
+        return [
+            MethodHelp(name="dynamic", parameters="(...)", description="Dynamic."),
+            MethodHelp(name="alpha", parameters="(...)", description="Duplicate."),
+        ]
+
+    def _help_method_group_spec(self):
+        group_spec = dict(self._HELP_METHOD_GROUPS)
+        group_spec["Metrics"] = ("dynamic", *group_spec["Metrics"])
+        return group_spec
+
+
 class _ReportWithGroupedAccessor(_ReportWithExplicitMethods):
     """Report carrying a single accessor that exposes grouped methods."""
 
@@ -596,6 +615,38 @@ def test_accessor_build_help_data_groups_raise_when_method_ungrouped():
 
     with pytest.raises(ValueError, match="does not list stray"):
         accessor._build_help_data()
+
+
+def test_accessor_build_help_data_extra_methods(grouped_accessor):
+    """``_extra_help_methods`` entries are added once and grouped in a single pass."""
+    accessor = _AccessorWithExtraHelpMethods(parent=grouped_accessor._parent)
+
+    data = accessor._build_help_data()
+
+    names = [method.name for method in data.methods]
+    assert "dynamic" in names
+    # A static method of the same name wins over the extra entry.
+    assert names.count("alpha") == 1
+    alpha = next(method for method in data.methods if method.name == "alpha")
+    assert alpha.description != "Duplicate."
+
+    by_name = {g.name: [m.name for m in g.methods] for g in data.groups}
+    assert by_name["Metrics"] == ["dynamic", "gamma", "delta"]
+
+
+def test_accessor_build_help_data_groups_computed_once(grouped_accessor, monkeypatch):
+    """Grouping runs a single time per accessor help build."""
+    calls = []
+    original = data_module._build_method_groups
+
+    def counting(*args, **kwargs):
+        calls.append(args)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(data_module, "_build_method_groups", counting)
+    _AccessorWithExtraHelpMethods(parent=grouped_accessor._parent)._build_help_data()
+
+    assert len(calls) == 1
 
 
 def test_accessor_build_help_data_groups_none_when_not_declared(accessor_with_methods):

--- a/skore/tests/unit/utils/repr/test_data.py
+++ b/skore/tests/unit/utils/repr/test_data.py
@@ -492,9 +492,8 @@ def test_display_build_help_data_output(display_with_methods):
 class _GroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
     """Accessor declaring ``_HELP_METHOD_GROUPS`` for grouped-help tests.
 
-    Includes one orphan public method (``stray``) not listed in any group, which
-    should fall back into an ``"Other"`` group, and references a non-existent
-    method ``"never_existed"`` to verify it is silently skipped.
+    References a non-existent method ``"never_existed"`` to verify it is
+    silently skipped.
     """
 
     _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...]]] = {
@@ -518,11 +517,15 @@ class _GroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
     def epsilon(self):
         """Epsilon method."""
 
-    def stray(self):
-        """Stray method not in any declared group."""
-
     def _get_help_title(self) -> str:
         return "Grouped accessor"
+
+
+class _AccessorWithUngroupedMethod(_GroupedAccessor):
+    """Accessor whose ``stray`` method is missing from ``_HELP_METHOD_GROUPS``."""
+
+    def stray(self):
+        """Stray method not in any declared group."""
 
 
 class _ReportWithGroupedAccessor(_ReportWithExplicitMethods):
@@ -562,7 +565,7 @@ def test_accessor_build_help_data_groups(grouped_accessor):
     data = grouped_accessor._build_help_data()
     assert data.groups is not None
     group_names = [g.name for g in data.groups]
-    assert group_names == ["Registry", "Metrics", "Displays", "Other"]
+    assert group_names == ["Registry", "Metrics", "Displays"]
     for g in data.groups:
         assert isinstance(g, MethodGroupHelp)
         assert g.branch_id != ""
@@ -571,7 +574,28 @@ def test_accessor_build_help_data_groups(grouped_accessor):
     assert by_name["Registry"] == ["alpha", "beta"]
     assert by_name["Metrics"] == ["gamma", "delta"]
     assert by_name["Displays"] == ["epsilon"]
-    assert by_name["Other"] == ["stray"]
+
+
+def test_accessor_build_help_data_groups_cover_all_methods(grouped_accessor):
+    """Every public method of a grouped accessor lands in exactly one group."""
+    data = grouped_accessor._build_help_data()
+    grouped_names = [m.name for group in data.groups for m in group.methods]
+
+    assert sorted(grouped_names) == sorted(m.name for m in data.methods)
+    assert len(grouped_names) == len(set(grouped_names))
+
+
+def test_accessor_build_help_data_groups_raise_when_method_ungrouped():
+    """A method missing from `_HELP_METHOD_GROUPS` raises instead of being dropped."""
+    X = np.array([[0, 0], [1, 1], [1, 0], [0, 1]])
+    y = np.array([0, 1, 1, 0])
+    estimator = LogisticRegression().fit(X, y)
+    accessor = _AccessorWithUngroupedMethod(
+        parent=_ReportWithExplicitMethods(estimator)
+    )
+
+    with pytest.raises(ValueError, match="does not list stray"):
+        accessor._build_help_data()
 
 
 def test_accessor_build_help_data_groups_none_when_not_declared(accessor_with_methods):
@@ -588,12 +612,7 @@ def test_report_build_help_data_groups(report_with_grouped_accessor):
     assert len(data.accessors) == 1
     branch = data.accessors[0]
     assert branch.groups is not None
-    assert [g.name for g in branch.groups] == [
-        "Registry",
-        "Metrics",
-        "Displays",
-        "Other",
-    ]
+    assert [g.name for g in branch.groups] == ["Registry", "Metrics", "Displays"]
 
 
 def test_report_build_help_data_groups_none_when_not_declared(report_with_accessor):

--- a/skore/tests/unit/utils/repr/test_data.py
+++ b/skore/tests/unit/utils/repr/test_data.py
@@ -497,7 +497,7 @@ class _GroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
     method ``"never_existed"`` to verify it is silently skipped.
     """
 
-    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...]]] = {
         "Registry": ("alpha", "beta", "never_existed"),
         "Metrics": ("gamma", "delta"),
         "Displays": ("epsilon",),
@@ -523,34 +523,6 @@ class _GroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
 
     def _get_help_title(self) -> str:
         return "Grouped accessor"
-
-
-class _CatchAllGroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
-    """Accessor with a catch-all (``None``) Displays group."""
-
-    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
-        "Registry": ("alpha", "beta"),
-        "Metrics": ("gamma", "delta"),
-        "Displays": None,
-    }
-
-    def alpha(self):
-        """Alpha method."""
-
-    def beta(self):
-        """Beta method."""
-
-    def gamma(self):
-        """Gamma method."""
-
-    def delta(self):
-        """Delta method."""
-
-    def epsilon(self):
-        """Epsilon method."""
-
-    def _get_help_title(self) -> str:
-        return "Catch-all accessor"
 
 
 class _ReportWithGroupedAccessor(_ReportWithExplicitMethods):
@@ -600,22 +572,6 @@ def test_accessor_build_help_data_groups(grouped_accessor):
     assert by_name["Metrics"] == ["gamma", "delta"]
     assert by_name["Displays"] == ["epsilon"]
     assert by_name["Other"] == ["stray"]
-
-
-def test_accessor_build_help_data_groups_catch_all():
-    """A group with value ``None`` absorbs methods not listed elsewhere."""
-    X = np.array([[0, 0], [1, 1], [1, 0], [0, 1]])
-    y = np.array([0, 1, 1, 0])
-    estimator = LogisticRegression().fit(X, y)
-    accessor = _CatchAllGroupedAccessor(parent=_ReportWithExplicitMethods(estimator))
-    data = accessor._build_help_data()
-    assert data.groups is not None
-    by_name = {g.name: [m.name for m in g.methods] for g in data.groups}
-    assert list(by_name) == ["Registry", "Metrics", "Displays"]
-    assert by_name["Registry"] == ["alpha", "beta"]
-    assert by_name["Metrics"] == ["gamma", "delta"]
-    assert by_name["Displays"] == ["epsilon"]
-    assert "Other" not in by_name
 
 
 def test_accessor_build_help_data_groups_none_when_not_declared(accessor_with_methods):

--- a/skore/tests/unit/utils/repr/test_data.py
+++ b/skore/tests/unit/utils/repr/test_data.py
@@ -526,12 +526,12 @@ class _GroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
 
 
 class _CatchAllGroupedAccessor(MockAccessor, _AccessorHelpDataMixin):
-    """Accessor with a catch-all (``None``) Metrics group."""
+    """Accessor with a catch-all (``None``) Displays group."""
 
     _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
         "Registry": ("alpha", "beta"),
-        "Metrics": None,
-        "Displays": ("epsilon",),
+        "Metrics": ("gamma", "delta"),
+        "Displays": None,
     }
 
     def alpha(self):
@@ -613,8 +613,8 @@ def test_accessor_build_help_data_groups_catch_all():
     by_name = {g.name: [m.name for m in g.methods] for g in data.groups}
     assert list(by_name) == ["Registry", "Metrics", "Displays"]
     assert by_name["Registry"] == ["alpha", "beta"]
+    assert by_name["Metrics"] == ["gamma", "delta"]
     assert by_name["Displays"] == ["epsilon"]
-    assert set(by_name["Metrics"]) == {"gamma", "delta"}
     assert "Other" not in by_name
 
 

--- a/skore/tests/unit/utils/repr/test_data.py
+++ b/skore/tests/unit/utils/repr/test_data.py
@@ -1,6 +1,7 @@
 """Unit tests for helpers in ``skore._utils.repr.data``."""
 
 import re
+from typing import ClassVar
 from urllib.parse import quote
 
 import numpy as np
@@ -8,8 +9,6 @@ import pytest
 from sklearn.linear_model import LogisticRegression
 
 from skore._utils._testing import MockAccessor, MockDisplay, MockReport
-from typing import ClassVar
-
 from skore._utils.repr.data import (
     AccessorHelpData,
     DisplayHelpData,

--- a/skore/tests/unit/utils/repr/test_html_repr.py
+++ b/skore/tests/unit/utils/repr/test_html_repr.py
@@ -1,10 +1,10 @@
 """Unit tests for ``skore._utils.repr.html_repr``."""
 
+from typing import ClassVar
+
 import numpy as np
 import pytest
 from sklearn.linear_model import LogisticRegression
-
-from typing import ClassVar
 
 from skore._utils._testing import MockAccessor, MockDisplay, MockReport
 from skore._utils.repr.html_repr import (

--- a/skore/tests/unit/utils/repr/test_html_repr.py
+++ b/skore/tests/unit/utils/repr/test_html_repr.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 from sklearn.linear_model import LogisticRegression
 
+from typing import ClassVar
+
 from skore._utils._testing import MockAccessor, MockDisplay, MockReport
 from skore._utils.repr.html_repr import (
     _HTMLAccessorHelpMixin,
@@ -21,6 +23,43 @@ class _AccessorWithHTML(MockAccessor, _HTMLAccessorHelpMixin):
 
     def _get_help_title(self) -> str:
         return "Mock accessor"
+
+
+class _GroupedAccessorWithHTML(MockAccessor, _HTMLAccessorHelpMixin):
+    """Accessor declaring `_HELP_METHOD_GROUPS` with HTML help mixin."""
+
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+        "Registry": ("alpha", "beta"),
+        "Metrics": ("gamma",),
+        "Displays": ("epsilon",),
+    }
+
+    def alpha(self):
+        """Alpha method."""
+
+    def beta(self):
+        """Beta method."""
+
+    def gamma(self):
+        """Gamma method."""
+
+    def epsilon(self):
+        """Epsilon method."""
+
+    def _get_help_title(self) -> str:
+        return "Grouped accessor"
+
+
+class _ReportWithGroupedHTML(MockReport, _HTMLReportHelpMixin):
+    """Report whose accessor declares `_HELP_METHOD_GROUPS`."""
+
+    _ACCESSOR_CONFIG = {"metrics": {"name": "metrics"}}
+
+    def __init__(self, estimator, X_train=None, y_train=None, X_test=None, y_test=None):
+        super().__init__(
+            estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+        )
+        self.metrics = _GroupedAccessorWithHTML(parent=self)
 
 
 class _DisplayWithHTML(MockDisplay, _HTMLHelpDisplayMixin):
@@ -63,3 +102,22 @@ def test_html_display_help_mixin_creates_container():
     display = _DisplayWithHTML()
     html = display._create_help_html()
     assert "skore-display-help-" in html
+
+
+def test_html_accessor_help_mixin_renders_groups(report_with_html):
+    """Grouped accessor HTML help renders Registry / Metrics / Displays sections."""
+    accessor = _GroupedAccessorWithHTML(parent=report_with_html)
+    html = accessor._create_help_html()
+    for expected in ("Registry", "Metrics", "Displays", "alpha", "gamma", "epsilon"):
+        assert expected in html
+
+
+def test_html_report_help_mixin_renders_groups():
+    """Report HTML help propagates accessor method groups."""
+    X = np.array([[0, 0], [1, 1], [1, 0], [0, 1]])
+    y = np.array([0, 1, 1, 0])
+    estimator = LogisticRegression().fit(X, y)
+    report = _ReportWithGroupedHTML(estimator)
+    html = report._create_help_html()
+    for expected in ("Registry", "Metrics", "Displays", "alpha", "gamma", "epsilon"):
+        assert expected in html

--- a/skore/tests/unit/utils/repr/test_html_repr.py
+++ b/skore/tests/unit/utils/repr/test_html_repr.py
@@ -110,6 +110,8 @@ def test_html_accessor_help_mixin_renders_groups(report_with_html):
     html = accessor._create_help_html()
     for expected in ("Registry", "Metrics", "Displays", "alpha", "gamma", "epsilon"):
         assert expected in html
+    # Method groups are unfolded by default.
+    assert html.count('<input type="checkbox" class="toggle" checked>') >= 3
 
 
 def test_html_report_help_mixin_renders_groups():

--- a/skore/tests/unit/utils/repr/test_html_repr.py
+++ b/skore/tests/unit/utils/repr/test_html_repr.py
@@ -28,7 +28,7 @@ class _AccessorWithHTML(MockAccessor, _HTMLAccessorHelpMixin):
 class _GroupedAccessorWithHTML(MockAccessor, _HTMLAccessorHelpMixin):
     """Accessor declaring `_HELP_METHOD_GROUPS` with HTML help mixin."""
 
-    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...]]] = {
         "Registry": ("alpha", "beta"),
         "Metrics": ("gamma",),
         "Displays": ("epsilon",),

--- a/skore/tests/unit/utils/repr/test_rich_repr.py
+++ b/skore/tests/unit/utils/repr/test_rich_repr.py
@@ -74,7 +74,7 @@ class _GroupedAccessorWithRich(MockAccessor, _RichAccessorHelpMixin):
     """Accessor declaring `_HELP_METHOD_GROUPS` with rich help mixin."""
 
     _ACCESSOR_CONFIG: dict = {}
-    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...]]] = {
         "Registry": ("alpha", "beta"),
         "Metrics": ("gamma",),
         "Displays": ("epsilon",),

--- a/skore/tests/unit/utils/repr/test_rich_repr.py
+++ b/skore/tests/unit/utils/repr/test_rich_repr.py
@@ -1,13 +1,12 @@
 """Unit tests for ``skore._utils.repr.rich_repr``."""
 
 from io import StringIO
+from typing import ClassVar
 
 import numpy as np
 import pytest
 from rich.console import Console
 from sklearn.linear_model import LogisticRegression
-
-from typing import ClassVar
 
 from skore._utils._testing import MockAccessor, MockDisplay, MockReport
 from skore._utils.repr.rich_repr import (

--- a/skore/tests/unit/utils/repr/test_rich_repr.py
+++ b/skore/tests/unit/utils/repr/test_rich_repr.py
@@ -7,6 +7,8 @@ import pytest
 from rich.console import Console
 from sklearn.linear_model import LogisticRegression
 
+from typing import ClassVar
+
 from skore._utils._testing import MockAccessor, MockDisplay, MockReport
 from skore._utils.repr.rich_repr import (
     _RichAccessorHelpMixin,
@@ -67,6 +69,44 @@ class _DisplayWithRich(MockDisplay, _RichHelpDisplayMixin):
 
     def _get_help_title(self) -> str:
         return "Mock display"
+
+
+class _GroupedAccessorWithRich(MockAccessor, _RichAccessorHelpMixin):
+    """Accessor declaring `_HELP_METHOD_GROUPS` with rich help mixin."""
+
+    _ACCESSOR_CONFIG: dict = {}
+    _HELP_METHOD_GROUPS: ClassVar[dict[str, tuple[str, ...] | None]] = {
+        "Registry": ("alpha", "beta"),
+        "Metrics": ("gamma",),
+        "Displays": ("epsilon",),
+    }
+
+    def alpha(self):
+        """Alpha method."""
+
+    def beta(self):
+        """Beta method."""
+
+    def gamma(self):
+        """Gamma method."""
+
+    def epsilon(self):
+        """Epsilon method."""
+
+    def _get_help_title(self) -> str:
+        return "Grouped accessor"
+
+
+class _ReportWithGroupedRich(MockReport, _RichReportHelpMixin):
+    """Report whose accessor declares `_HELP_METHOD_GROUPS`."""
+
+    _ACCESSOR_CONFIG = {"metrics": {"name": "metrics"}}
+
+    def __init__(self, estimator, X_train=None, y_train=None, X_test=None, y_test=None):
+        super().__init__(
+            estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+        )
+        self.metrics = _GroupedAccessorWithRich(parent=self)
 
 
 @pytest.fixture
@@ -133,4 +173,35 @@ def test_rich_display_help_mixin_tree_and_title(display_with_rich):
         "some_attr",
         display_with_rich.__class__.__name__,
     ):
+        assert expected in out
+
+
+@pytest.fixture
+def grouped_accessor_with_rich(report_with_rich):
+    """Accessor declaring `_HELP_METHOD_GROUPS` with rich help mixin."""
+    return _GroupedAccessorWithRich(parent=report_with_rich)
+
+
+@pytest.fixture
+def report_with_grouped_rich():
+    """Report whose accessor declares `_HELP_METHOD_GROUPS`."""
+    X = np.array([[0, 0], [1, 1], [1, 0], [0, 1]])
+    y = np.array([0, 1, 1, 0])
+    estimator = LogisticRegression().fit(X, y)
+    return _ReportWithGroupedRich(estimator)
+
+
+def test_rich_accessor_help_mixin_renders_groups(grouped_accessor_with_rich):
+    """Grouped accessor rich help renders Registry / Metrics / Displays sections."""
+    panel = grouped_accessor_with_rich._create_help_panel()
+    out = _render_panel(panel)
+    for expected in ("Registry", "Metrics", "Displays", "alpha", "gamma", "epsilon"):
+        assert expected in out
+
+
+def test_rich_report_help_mixin_renders_groups(report_with_grouped_rich):
+    """Report rich help propagates accessor method groups."""
+    panel = report_with_grouped_rich._create_help_panel()
+    out = _render_panel(panel)
+    for expected in ("Registry", "Metrics", "Displays", "alpha", "gamma", "epsilon"):
         assert expected in out


### PR DESCRIPTION
closes https://github.com/probabl-ai/skore/issues/2746

This PR improves the help of the metrics accessor by grouping the registry management methods, the metrics to be called, and the displays in to sub groups.

For the moment, we are hard coding them but if the metrics are dynamically generated, we could easily leverage the registry to populate the the registry methods and the metrics.

My initial thought is to have the following design:

<img width="676" height="454" alt="image" src="https://github.com/user-attachments/assets/38b7e79c-1c99-4949-a8ac-c5275a641a01" />
