### PR TITLE
fix(skore): Fix CSS style link in diagnostic for light/dark mode

### DIFF
--- a/skore/src/skore/_utils/repr/diagnostic_display-content.html.j2
+++ b/skore/src/skore/_utils/repr/diagnostic_display-content.html.j2
@@ -16,7 +16,7 @@
                         <li>
                             [{{ row.code }}] {{ row.title }}.
                             {%- if row.explanation %} {{ row.explanation }}{% endif %}
-                            {%- if row.documentation_url %} Read more about this <a href="{{ row.documentation_url }}" target="_blank" rel="noopener noreferrer">here</a>.{% endif %}
+                            {%- if row.documentation_url %} Read more about this <a href="{{ row.documentation_url }}" target="_blank" rel="noopener noreferrer" class="report-hint-note-link">here</a>.{% endif %}
                         </li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
This is fixing the style of the link in the diagnosis that redirect to the documentation.

We uses a blue that is readable in both dark / light modes as for other link.