### PR TITLE
fix(skore): Correct unbalanced div tags returned by scikit-learn

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -650,10 +650,11 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         table_report_html = table_report.html_snippet()
 
         try:
-            estimator_html = self.estimator_._repr_html_()
+            estimator_html = repair_estimator_html_for_slotted_host(
+                self.estimator_._repr_html_()
+            )
         except Exception:
             estimator_html = f"<p>{html.escape(repr(self.estimator_))}</p>"
-        estimator_html = repair_estimator_html_for_slotted_host(estimator_html)
 
         diagnostic = self.diagnose()
         diagnostic_html = (

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -24,6 +24,7 @@ from skore._utils._progress_bar import track
 from skore._utils._skrub import eval_X_y, is_skrub_learner, to_estimator, to_learner
 from skore._utils.repr.data import get_documentation_url
 from skore._utils.repr.html_repr import render_template
+from skore._utils.repr.utils import repair_estimator_html_for_slotted_host
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -652,6 +653,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             estimator_html = self.estimator_._repr_html_()
         except Exception:
             estimator_html = f"<p>{html.escape(repr(self.estimator_))}</p>"
+        estimator_html = repair_estimator_html_for_slotted_host(estimator_html)
 
         diagnostic = self.diagnose()
         diagnostic_html = (

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -798,10 +798,11 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 .to_html(index=False)
             )
         try:
-            estimator_html = self.estimator_._repr_html_()
+            estimator_html = repair_estimator_html_for_slotted_host(
+                self.estimator_._repr_html_()
+            )
         except Exception:
             estimator_html = f"<p>{html.escape(repr(self.estimator_))}</p>"
-        estimator_html = repair_estimator_html_for_slotted_host(estimator_html)
 
         diagnostic = self.diagnose()
         diagnostic_html = (

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -30,6 +30,7 @@ from skore._utils._measure_time import MeasureTime
 from skore._utils._skrub import eval_X_y, is_skrub_learner, to_estimator, to_learner
 from skore._utils.repr.data import get_documentation_url
 from skore._utils.repr.html_repr import render_template
+from skore._utils.repr.utils import repair_estimator_html_for_slotted_host
 
 if TYPE_CHECKING:
     from skore._sklearn._estimator.data_accessor import _DataAccessor
@@ -800,6 +801,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
             estimator_html = self.estimator_._repr_html_()
         except Exception:
             estimator_html = f"<p>{html.escape(repr(self.estimator_))}</p>"
+        estimator_html = repair_estimator_html_for_slotted_host(estimator_html)
 
         diagnostic = self.diagnose()
         diagnostic_html = (

--- a/skore/src/skore/_utils/repr/utils.py
+++ b/skore/src/skore/_utils/repr/utils.py
@@ -18,7 +18,7 @@ def repair_estimator_html_for_slotted_host(html: str) -> str:
     following slotted elements inside the estimator subtree, so they no longer
     receive slot assignment and can appear under the wrong tab.
 
-    This function compares counts of ``<div`` vs ``</div>`` on a script-stripped copy
+    This function compares counts of ``<div>`` vs ``</div>`` on a script-stripped copy
     (so ``</div>`` inside ``<script>`` is ignored) and appends the deficit of closing
     ``</div>`` to the original string.
     """

--- a/skore/src/skore/_utils/repr/utils.py
+++ b/skore/src/skore/_utils/repr/utils.py
@@ -1,0 +1,31 @@
+"""Miscellaneous helpers for HTML repr and embedding (slots, fragments)."""
+
+from __future__ import annotations
+
+import re
+
+# Strip script bodies when counting <div> so strings like "</div>" in JS do not skew.
+_HTML_SCRIPT_RE = re.compile(r"<script\b[^>]*>.*?</script>", re.DOTALL | re.IGNORECASE)
+
+
+def repair_estimator_html_for_slotted_host(html: str) -> str:
+    """Append missing closing ``</div>`` tags so sibling slotted nodes stay valid.
+
+    Estimator HTML from ``estimator_._repr_html_()`` is concatenated in the light DOM
+    next to ``<div slot="table-report">`` and ``<div slot="diagnostic">`` on the
+    same shadow host. Named slots only consider **direct children** of that host; if
+    the sklearn fragment leaves ``<div>`` elements unclosed, the HTML parser nests the
+    following slotted elements inside the estimator subtree, so they no longer
+    receive slot assignment and can appear under the wrong tab.
+
+    This function compares counts of ``<div`` vs ``</div>`` on a script-stripped copy
+    (so ``</div>`` inside ``<script>`` is ignored) and appends the deficit of closing
+    ``</div>`` to the original string.
+    """
+    without_scripts = _HTML_SCRIPT_RE.sub("", html)
+    n_open = len(re.findall(r"<div\b", without_scripts))
+    n_close = len(re.findall(r"</div>", without_scripts))
+    deficit = n_open - n_close
+    if deficit > 0:
+        return f"{html}{'</div>' * deficit}"
+    return html

--- a/skore/src/skore/_utils/repr/utils.py
+++ b/skore/src/skore/_utils/repr/utils.py
@@ -22,7 +22,7 @@ def repair_estimator_html_for_slotted_host(html: str) -> str:
     (so ``</div>`` inside ``<script>`` is ignored) and appends the deficit of closing
     ``</div>`` to the original string.
     """
-    without_scripts = _HTML_SCRIPT_RE.sub("", html)
+    without_scripts = re.sub(_HTML_SCRIPT_RE, "", html)
     n_open = len(re.findall(r"<div\b", without_scripts))
     n_close = len(re.findall(r"</div>", without_scripts))
     deficit = n_open - n_close

--- a/skore/tests/unit/utils/repr/test_utils.py
+++ b/skore/tests/unit/utils/repr/test_utils.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``skore._utils.repr.utils`` (HTML fragment helpers)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from skore._utils.repr.utils import repair_estimator_html_for_slotted_host
+
+_SCRIPT_STRIP = re.compile(r"<script\b[^>]*>.*?</script>", re.DOTALL | re.IGNORECASE)
+
+
+def _div_open_close_counts(html: str) -> tuple[int, int]:
+    stripped = _SCRIPT_STRIP.sub("", html)
+    opens = len(re.findall(r"<div\b", stripped))
+    closes = len(re.findall(r"</div>", stripped))
+    return opens, closes
+
+
+class TestRepairEstimatorHtmlForSlottedHost:
+    """Closing-div repair keeps fragments parseable before sibling slotted markup."""
+
+    def test_balanced_fragment_unchanged(self):
+        html = '<div id="a"><div id="b">x</div></div>'
+        assert repair_estimator_html_for_slotted_host(html) is html
+        o, c = _div_open_close_counts(html)
+        assert o == c
+
+    @pytest.mark.parametrize(
+        ("raw", "expected_suffix"),
+        [
+            ('<div id="outer"><div id="inner">x</div>', "</div>"),
+            ("<div><div><div>x", "</div></div></div>"),
+        ],
+    )
+    def test_under_closed_divs_get_suffix(self, raw, expected_suffix):
+        out = repair_estimator_html_for_slotted_host(raw)
+        assert out == raw + expected_suffix
+        o, c = _div_open_close_counts(out)
+        assert o == c
+
+    def test_script_body_ignored_for_div_counts(self):
+        """``</div>`` inside ``<script>`` must not count as closing markup."""
+        raw = '<div id="a"><script>const s = "</div>";</script>'
+        out = repair_estimator_html_for_slotted_host(raw)
+        assert out.endswith("</div>")
+        assert out.count("</div>") == 2
+        o, c = _div_open_close_counts(out)
+        assert o == c
+
+    def test_repaired_plus_following_markup_balanced(self):
+        broken = '<div class="sk"><p>est</p>'
+        repaired = repair_estimator_html_for_slotted_host(broken)
+        following = '<div slot="table-report"></div>'
+        combined = repaired + following
+        o, c = _div_open_close_counts(combined)
+        assert o == c


### PR DESCRIPTION
closes #2801 

This PR tries to get around the bug in scikit-learn for which the HTML repr as unalanced `<div>` tag.

For the minimal reproducer in #2801, you get:

<img width="696" height="321" alt="image" src="https://github.com/user-attachments/assets/6c7f1154-3563-4806-ae76-ec06120d7fba" />
