### PR TITLE
fix(skore): Be more permissive with script tags matching

### DIFF
--- a/skore/src/skore/_utils/repr/utils.py
+++ b/skore/src/skore/_utils/repr/utils.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import re
 
 # Strip script bodies when counting <div> so strings like "</div>" in JS do not skew.
-_HTML_SCRIPT_RE = re.compile(r"<script\b[^>]*>.*?</script>", re.DOTALL | re.IGNORECASE)
+_HTML_SCRIPT_RE = re.compile(
+    r"<script\b[^>]*>.*?</script\s*[^>]*>", re.DOTALL | re.IGNORECASE
+)
 
 
 def repair_estimator_html_for_slotted_host(html: str) -> str:

--- a/skore/tests/unit/utils/repr/test_utils.py
+++ b/skore/tests/unit/utils/repr/test_utils.py
@@ -8,7 +8,9 @@ import pytest
 
 from skore._utils.repr.utils import repair_estimator_html_for_slotted_host
 
-_SCRIPT_STRIP = re.compile(r"<script\b[^>]*>.*?</script>", re.DOTALL | re.IGNORECASE)
+_SCRIPT_STRIP = re.compile(
+    r"<script\b[^>]*>.*?</script\s*[^>]*>", re.DOTALL | re.IGNORECASE
+)
 
 
 def _div_open_close_counts(html: str) -> tuple[int, int]:


### PR DESCRIPTION
While we know the source of the diagram, let's be more permissive to detect the `<script>` tag in the scikit-learn HTML diagram.