### PR TITLE
fix(skore-hub-project/tests): Call `cache_predictions()` before testing checksum of report

### DIFF
--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.5/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.11/scikit-learn-1.8/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.5/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.12/scikit-learn-1.8/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.5/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.13/scikit-learn-1.8/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/ci/requirements/skore-hub-project/python-3.14/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.14/scikit-learn-1.7/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/ci/requirements/skore-hub-project/python-3.14/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore-hub-project/python-3.14/scikit-learn-1.8/test-requirements.txt
@@ -209,7 +209,7 @@ seaborn==0.13.2
     # via skore
 six==1.17.0
     # via python-dateutil
-skore==0.15.0
+skore==0.17.0
     # via skore-hub-project (skore-hub-project/pyproject.toml)
 skore-local-project==0.0.6
     # via skore

--- a/skore-hub-project/tests/unit/report/test_cross_validation_report.py
+++ b/skore-hub-project/tests/unit/report/test_cross_validation_report.py
@@ -504,6 +504,8 @@ class TestCrossValidationReportPayload:
     )
     @mark.respx()
     def test_model_dump_classification(self, small_cv_binary_classification, payload):
+        small_cv_binary_classification.cache_predictions()
+
         _, checksum = serialize(small_cv_binary_classification)
 
         payload_dict = payload.model_dump()

--- a/skore-hub-project/tests/unit/report/test_estimator_report.py
+++ b/skore-hub-project/tests/unit/report/test_estimator_report.py
@@ -172,6 +172,8 @@ class TestEstimatorReportPayload:
 
     @mark.respx()
     def test_model_dump(self, binary_classification, payload):
+        binary_classification.cache_predictions()
+
         _, checksum = serialize(binary_classification)
 
         payload_dict = payload.model_dump()


### PR DESCRIPTION
Following https://github.com/probabl-ai/skore/pull/2760 and the release of `skore==0.17.0`.
