### PR TITLE
chore: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/01-feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Suggest a new feature, or enhancement to an existing feature.
-labels: ['needs-triage']
-type: feature
+labels: ['feature 🎁', 'needs-triage ⚠️']
 
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/02-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug Report
-description: Create a report to help us reproduce and correct the bug
-labels: ['needs-triage']
-type: bug
+description: Create a report to help us reproduce and fix the bug
+labels: ['bug 🐛', 'needs-triage ⚠️']
 
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/03-doc_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/03-doc_improvement.yml
@@ -1,7 +1,6 @@
 name: Documentation improvement
 description: Create a report to help us improve the documentation. Alternatively you can just open a pull request with the suggested change.
-labels: ['documentation', 'needs-triage']
-type: task
+labels: ['documentation 📖', 'needs-triage ⚠️']
 
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/99-blank_issue.yml
+++ b/.github/ISSUE_TEMPLATE/99-blank_issue.yml
@@ -1,8 +1,0 @@
-name: Blank issue
-description: Any kind of issue that doesn't fit the other templates.
-labels: ['needs-triage']
-
-body:
-- type: textarea
-  attributes:
-    label: "What would you like to say?"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Discord server
     url: https://discord.probabl.ai


### PR DESCRIPTION
- Fix labels
- Remove `type` as labels carry the same information
- Remove custom blank issue template as GitHub already provides one by default
