### PR TITLE
chore(skore): Enforce `warn_unused_configs` and `warn_redundant_casts` mypy rules

### DIFF
--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -167,6 +167,9 @@ convention = "numpy"
 
 [tool.mypy]
 exclude = ["src/skore/_externals/", "hatch/", "tests/"]
+# strict = false
+warn_unused_configs = true
+warn_redundant_casts = true
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from importlib.metadata import PackageNotFoundError, version
-from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 from uuid import uuid4
 
 import pandas as pd
@@ -169,7 +169,7 @@ class ChecksSummaryDisplay(DisplayHelpMixin):
             return self._header + "\nAll checks were either ignored or not applicable."
         lines = [self._header]
         for label, severity, _, _ in _TAB_SPECS:
-            df = self.frame(severity=cast(Literal["issue", "tip", "passed"], severity))
+            df = self.frame(severity=severity)
             if df.empty:
                 continue
             lines.append(f"{label}:")

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import ArrayLike
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.exceptions import UndefinedMetricWarning
 
@@ -45,7 +44,7 @@ def _get_metrics_data(report: _BaseReport) -> tuple:
         else DummyRegressor(strategy="mean"),
         X_train=report.X_train,
         y_train=report.y_train,
-        X_test=cast(ArrayLike, report.X_test),
+        X_test=report.X_test,
         y_test=report.y_test,
         pos_label=report.pos_label,
     )

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -921,7 +921,6 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         if cache_value is not None:
             return cache_value
 
-        data_source = cast(DataSource, data_source)
         _, y_true = self._parent._get_data_and_y_true(data_source=data_source)
 
         y_pred = self._parent._get_predictions(

--- a/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Literal, cast
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -446,7 +446,6 @@ class ConfusionMatrixDisplay(_ClassifierDisplayMixin, DisplayMixin):
             raise NotImplementedError(
                 "Displaying both data sources is not supported yet."
             )
-        data_source = cast(DataSource, data_source)
 
         classes = estimator.classes_
 


### PR DESCRIPTION
Extracted from https://github.com/probabl-ai/skore/pull/2857/, to allow `strict = true` on submodules.
