### PR TITLE
fix(skore): Fix estimator report for skrub learners

### DIFF
--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import skrub
 from numpy.typing import ArrayLike
-from sklearn.base import BaseEstimator, MetaEstimatorMixin, clone
+from sklearn.base import BaseEstimator, clone
 from sklearn.exceptions import NotFittedError
 from sklearn.pipeline import Pipeline
 from sklearn.utils._response import (
@@ -535,9 +535,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         `decision_function(X)`. The result is cached because running the probe
         requires extra predictions.
         """
-        if isinstance(self._estimator, MetaEstimatorMixin | Pipeline):
-            return False
-
         response_methods = ["decision_function", "predict_proba"]
         try:
             method = _check_response_method(self._estimator, response_methods)

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -517,7 +517,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         """
         with MeasureTime() as pred_time:
             response = getattr(self._estimator, response_method)(data)
-        classes = to_estimator(self._estimator).classes_
+        classes = self._estimator.classes_
         if response_method == "decision_function":
             if self.ml_task == "binary-classification":
                 response = np.vstack((-response, response)).T
@@ -535,13 +535,12 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         `decision_function(X)`. The result is cached because running the probe
         requires extra predictions.
         """
-        estimator = to_estimator(self._estimator)
-        if isinstance(estimator, MetaEstimatorMixin | Pipeline):
+        if isinstance(self._estimator, MetaEstimatorMixin | Pipeline):
             return False
 
         response_methods = ["decision_function", "predict_proba"]
         try:
-            method = _check_response_method(estimator, response_methods)
+            method = _check_response_method(self._estimator, response_methods)
         except AttributeError:
             return False
         data = self.train_data if self.test_data is None else self.test_data

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -70,6 +70,6 @@ def to_learner(estimator: BaseEstimator):
 
 def to_estimator(learner: _LearnerAdapter):
     assert isinstance(learner, _LearnerAdapter), (
-        "to_learner is used to unwrap _LearnerAdapter wrappers, got: {learner!r}"
+        f"to_estimator is used to unwrap _LearnerAdapter wrappers, got: {learner!r}"
     )
     return learner.estimator

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -68,10 +68,8 @@ def to_learner(estimator: BaseEstimator):
     return _LearnerAdapter(estimator)
 
 
-def to_estimator(learner: skrub.SkrubLearner):
-    if isinstance(learner, _LearnerAdapter):
-        return learner.estimator
-    estimator = getattr(learner.data_op._skrub_impl, "estimator_", None)
-    if estimator is not None:
-        return estimator
-    return learner.find_fitted_estimator("estimator")
+def to_estimator(learner: _LearnerAdapter):
+    assert isinstance(learner, _LearnerAdapter), (
+        "to_learner is used to unwrap _LearnerAdapter wrappers, got: {learner!r}"
+    )
+    return learner.estimator

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -211,7 +211,6 @@ def test_get_predictions_is_correct_for_special_classifiers(estimator):
         report.get_predictions(data_source="test"),
         report.estimator_.predict(report.X_test),
     )
-    assert not report._can_skip_predict
 
 
 def test_pickle(forest_binary_classification_with_test):

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -574,3 +574,15 @@ def test_from_state_rejects_unknown_version(logistic_binary_classification_with_
 
     with pytest.raises(ValueError, match="Unexpected state version"):
         EstimatorReport.from_state(state)
+
+
+def test_learner_report_root_node_not_an_estimator():
+    data_op = (
+        skrub.X().skb.apply(DummyClassifier(), y=skrub.y()).skb.apply_func(lambda x: x)
+    )
+    X, y = make_classification()
+    split = data_op.skb.train_test_split({"X": X, "y": y})
+    report = EstimatorReport(
+        data_op.skb.make_learner(), train_data=split["train"], test_data=split["test"]
+    )
+    report.metrics.summarize(metric="accuracy")


### PR DESCRIPTION
do not rely on to_estimator when the report was initialized with a skrub learner to avoid an error (see test)

we do not need the conversion here as the learner exposes the methods we check and the classes_ attribute