### PR TITLE
chore(skore/pyproject): Remove `3.10` from classifiers in favor of `3.14`

### DIFF
--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
   "Operating System :: Unix",
   "Operating System :: MacOS",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "joblib",


### PR DESCRIPTION
Closes https://github.com/probabl-ai/skore/issues/2885.
