### PR TITLE
chore(skore): Revamp `show_versions`

### DIFF
--- a/skore/src/skore/_utils/_show_versions.py
+++ b/skore/src/skore/_utils/_show_versions.py
@@ -4,11 +4,45 @@ Utility methods to print system info for debugging.
 adapted from :func:`sklearn.show_versions`
 """
 
-import importlib
 import platform
 import re
 import sys
+from collections import defaultdict
 from typing import Any
+
+# PEP 508 markers: extract `extra == "…"` for optional dependency groups.
+_EXTRA_MARKER_RE = re.compile(r"""extra\s*==\s*["']([^"']+)["']""")
+
+# Optional dependency sections printed by :func:`show_versions` (plus Core).
+_SHOW_VERSION_EXTRAS = frozenset({"hub", "jupyter", "local", "mlflow"})
+
+
+def _extra_label_from_markers(markers: str) -> str:
+    """Return optional dependency group name(s) from marker string, or ``-``."""
+    if not markers.strip():
+        return "-"
+    found = _EXTRA_MARKER_RE.findall(markers)
+    if not found:
+        return "-"
+    return ",".join(sorted(set(found)))
+
+
+def _section_title(extra_label: str) -> str:
+    """Human-readable heading for a dependency group."""
+    return "skore" if extra_label == "-" else f"skore[{extra_label}]"
+
+
+def _sort_extra_keys(extra_label: str) -> tuple[int, str]:
+    """Core (no extra) first, then alphabetical extras."""
+    return (0 if extra_label == "-" else 1, extra_label)
+
+
+def _show_extra_section(extra_label: str) -> bool:
+    """Whether this dependency group is included in :func:`show_versions` output."""
+    if extra_label == "-":
+        return True
+    parts = {p.strip() for p in extra_label.split(",")}
+    return bool(parts & _SHOW_VERSION_EXTRAS)
 
 
 def _get_sys_info() -> dict[str, Any]:
@@ -31,7 +65,7 @@ def _get_sys_info() -> dict[str, Any]:
     return dict(blob)
 
 
-def _get_deps_info() -> dict[str, Any]:
+def _get_deps_info() -> list[tuple[str, str, Any]]:
     """Overview of the installed version of main dependencies.
 
     This function does not import the modules to collect the version numbers
@@ -39,39 +73,31 @@ def _get_deps_info() -> dict[str, Any]:
 
     Returns
     -------
-    deps_info: dict
-        version information on relevant Python libraries
+    deps_info: list of (name, extra, version)
+        Package name, optional-extra label from metadata (``-`` if not from an
+        extra), and installed version (or ``None`` if not installed).
 
     """
-    from importlib.metadata import PackageNotFoundError, version
+    from importlib.metadata import PackageNotFoundError, requires, version
 
-    deps = ["pip"]
-    extras = ["'hub'"]
+    dependencies = ["pip", "skore", *(requires("skore") or [])]
+    rows: list[tuple[str, str, Any]] = []
 
-    raw_requirements = importlib.metadata.requires("skore")
-    requirements: list[str] = [] if raw_requirements is None else raw_requirements
+    for dependency in dependencies:
+        head, _, markers = dependency.partition(";")
+        head = head.strip()
+        markers = markers.strip()
+        name = re.split(r"\s*(?:<|>|=|!|~|\[)", head, maxsplit=1)[0].strip()
+        extra_label = _extra_label_from_markers(markers)
 
-    for requirement in requirements:
-        if len(split := requirement.split("; extra == ")) > 1:
-            requirement, extra = split
-
-            if extra not in extras:
-                continue
-
-        # Extract just the package name before any version specifiers
-        package_name: str = re.split(r"[<>=~!]", requirement)[0].strip()
-        deps.append(package_name)
-
-    deps_info: dict[str, str | None] = {
-        "skore": version("skore"),
-    }
-
-    for modname in deps:
         try:
-            deps_info[modname] = version(modname)
+            ver = version(name)
         except PackageNotFoundError:
-            deps_info[modname] = None
-    return deps_info
+            ver = None
+
+        rows.append((name, extra_label, ver))
+
+    return rows
 
 
 def show_versions() -> None:
@@ -97,6 +123,22 @@ def show_versions() -> None:
     for k, stat in sys_info.items():
         print(f"{k:>10}: {stat}")  # noqa: T201
 
-    print("\nPython dependencies:")  # noqa: T201
-    for k, stat in deps_info.items():
-        print(f"{k:>13}: {stat}")  # noqa: T201
+    print("\nPython dependencies:\n")  # noqa: T201
+    by_extra: defaultdict[str, dict[str, Any]] = defaultdict(dict)
+    for name, extra, stat in deps_info:
+        if name not in by_extra[extra]:
+            by_extra[extra][name] = stat
+
+    first_section = True
+    for extra_label in sorted(by_extra, key=_sort_extra_keys):
+        if not _show_extra_section(extra_label):
+            continue
+        if not first_section:
+            print()  # noqa: T201
+        first_section = False
+
+        title = _section_title(extra_label)
+        print(title)  # noqa: T201
+        print("-" * len(title))  # noqa: T201
+        for name, stat in by_extra[extra_label].items():
+            print(f"{name:>13}: {stat}")  # noqa: T201

--- a/skore/tests/unit/utils/test_show_versions.py
+++ b/skore/tests/unit/utils/test_show_versions.py
@@ -1,4 +1,9 @@
-from skore._utils._show_versions import _get_deps_info, _get_sys_info, show_versions
+from skore._utils._show_versions import (
+    _get_deps_info,
+    _get_sys_info,
+    _show_extra_section,
+    show_versions,
+)
 
 
 def test_get_sys_info():
@@ -9,11 +14,20 @@ def test_get_sys_info():
     assert "machine" in sys_info
 
 
+def test_show_extra_section_filter():
+    assert _show_extra_section("-")
+    assert _show_extra_section("jupyter")
+    assert _show_extra_section("hub,sphinx")
+    assert not _show_extra_section("sphinx-base")
+    assert not _show_extra_section("sphinx")
+
+
 def test_get_deps_info():
     deps_info = _get_deps_info()
-    assert isinstance(deps_info, dict)
-    assert "pip" in deps_info
-    assert "skore" in deps_info
+    assert isinstance(deps_info, list)
+    names = {row[0] for row in deps_info}
+    assert "pip" in names
+    assert "skore" in names
 
 
 def test_show_versions(capfd):
@@ -32,6 +46,7 @@ def test_show_versions(capfd):
     assert "machine:" in captured.out
     assert "skore:" in captured.out
     assert "pip:" in captured.out
+    assert "\nskore\n" in captured.out
     assert "numpy:" in captured.out
     assert "rich" in captured.out
     assert "scikit-learn:" in captured.out


### PR DESCRIPTION
Fully LLM generated.

---

From

```python
Python dependencies:
        skore: 0.0.0+unknown
          pip: 26.1.1
       jinja2: 3.1.6
       joblib: 1.5.3
   matplotlib: 3.10.8
        numpy: 2.4.4
       pandas: 3.0.2
       plotly: 6.7.0
         rich: 15.0.0
 scikit-learn: 1.8.0
      seaborn: 0.13.2
 skore[local]: None
        skrub: 0.8.0
        httpx: 0.28.1
       orjson: 3.11.8
     pydantic: 2.13.1
rich[jupyter]: None
        scipy: 1.17.1
xgboost-cpu; (platform_system: None
xgboost; (platform_system: None
```

To

```python
Python dependencies:
skore
-----
          pip: 26.1.1
        skore: 0.0.0+unknown
       jinja2: 3.1.6
       joblib: 1.5.3
   matplotlib: 3.10.8
        numpy: 2.4.4
       pandas: 3.0.2
       plotly: 6.7.0
         rich: 15.0.0
 scikit-learn: 1.8.0
      seaborn: 0.13.2
        skrub: 0.8.0

skore[hub]
----------
        httpx: 0.28.1
       orjson: 3.11.8
     pydantic: 2.13.1
         rich: 15.0.0
        scipy: 1.17.1

skore[jupyter]
--------------
    anywidget: 0.10.0
      ipython: 9.12.0
   ipywidgets: 8.1.8

skore[local]
------------
    diskcache: 5.6.3
 platformdirs: 4.9.6

skore[mlflow]
-------------
       mlflow: 3.11.1
```