### PR TITLE
feat: Compute `estimator.score` in `summarize`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ uv.lock
 # mlflow
 mlflow.db
 mlruns
+
+.claude

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,7 @@ Added
   now includes a ``score`` row corresponding to the estimator's default score, obtained
   by running ``estimator.score()``. It supports :class:`skrub.DataOp` estimators,
   for which scorings can be registered with :meth:`~skrub.DataOp.skb.with_scoring`.
+  The reports also now have a :meth:`~EstimatorReport.metrics.score` method.
   See :pr:`2884` by :user:`auguste-probabl`.
 
 Removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,12 @@ Added
   high-cardinality features, tip) and SKD008 (highly correlated input features,
   issue). See :pr:`2883` by :user:`GaetandeCast`.
 
+- :meth:`~EstimatorReport.metrics.summarize` (and ``summarize`` on the other reports)
+  now includes a ``score`` row corresponding to the estimator's default score, obtained
+  by running ``estimator.score()``. It supports :class:`skrub.DataOp` estimators,
+  for which scorings can be registered with :meth:`~skrub.DataOp.skb.with_scoring`.
+  See :pr:`2884` by :user:`auguste-probabl`.
+
 Removed
 -------
 

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -334,6 +334,55 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
 
             return timings
 
+    @available_if(_check_any_sub_report_has_metric("score"))
+    def score(
+        self,
+        *,
+        data_source: DataSource = "test",
+        aggregate: Aggregate | None = ("mean", "std"),
+    ) -> pd.DataFrame:
+        """Compute the estimator's default score.
+
+        This calls the underlying estimator's ``score`` method on the chosen data
+        source. For :class:`skrub.DataOp` estimators, scorings registered via
+        :meth:`~skrub.DataOp.skb.with_scoring` are used.
+
+        Parameters
+        ----------
+        data_source : {"test", "train"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the report.
+            - "train" : use the train set provided when creating the report.
+
+        aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
+            Function to aggregate the scores across the cross-validation splits.
+            None will return the scores for each split.
+            Ignored when comparison is between :class:`~skore.EstimatorReport` instances
+
+        Returns
+        -------
+        pd.DataFrame
+            The estimator's default score.
+
+        Examples
+        --------
+        >>> from sklearn.datasets import load_breast_cancer
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> from skore import evaluate
+        >>> X, y = load_breast_cancer(return_X_y=True)
+        >>> estimator_1 = LogisticRegression(max_iter=10000, random_state=42)
+        >>> estimator_2 = LogisticRegression(max_iter=10000, random_state=43)
+        >>> comparison_report = evaluate([estimator_1, estimator_2], X, y, splitter=0.2)
+        >>> comparison_report.metrics.score()
+        Estimator      LogisticRegression_1  LogisticRegression_2
+        Metric
+        Score                       0.94...               0.94...
+        """
+        return self._metric("score", data_source=data_source).frame(
+            aggregate=aggregate,
+        )
+
     @available_if(_check_any_sub_report_has_metric("accuracy"))
     def accuracy(
         self,

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -301,6 +301,58 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
 
         return MetricsSummaryDisplay(rows=rows, report_type="cross-validation")
 
+    @available_if(_check_estimator_report_has_method("metrics", "score"))
+    def score(
+        self,
+        *,
+        data_source: DataSource = "test",
+        aggregate: Aggregate | None = ("mean", "std"),
+        flat_index: bool = False,
+    ) -> pd.DataFrame:
+        """Compute the estimator's default score.
+
+        This calls the underlying estimator's ``score`` method on the chosen data
+        source. For :class:`skrub.DataOp` estimators, scorings registered via
+        :meth:`~skrub.DataOp.skb.with_scoring` are used.
+
+        Parameters
+        ----------
+        data_source : {"test", "train"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the report.
+            - "train" : use the train set provided when creating the report.
+
+        aggregate : {"mean", "std"}, list of such str or None, default=("mean", "std")
+            Function to aggregate the scores across the cross-validation splits.
+            None will return the scores for each split.
+
+        flat_index : bool, default=True
+            Whether to return a flat index or a multi-index.
+
+        Returns
+        -------
+        pd.DataFrame
+            The estimator's default score.
+
+        Examples
+        --------
+        >>> from sklearn.datasets import load_breast_cancer
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> from skore import evaluate
+        >>> X, y = load_breast_cancer(return_X_y=True)
+        >>> classifier = LogisticRegression(max_iter=10_000)
+        >>> report = evaluate(classifier, X, y, splitter=2)
+        >>> report.metrics.score(flat_index=False)
+                LogisticRegression
+                            mean      std
+        Metric
+        Score              0.94...  0.00...
+        """
+        return self._metric("score", data_source=data_source).frame(
+            aggregate=aggregate, flat_index=flat_index
+        )
+
     @available_if(_check_estimator_report_has_method("metrics", "accuracy"))
     def accuracy(
         self,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -34,6 +34,7 @@ from skore._sklearn.metrics import (
     Recall,
     Rmse,
     RocAuc,
+    Score,
 )
 from skore._sklearn.types import DataSource, PositiveLabel
 from skore._utils._accessor import _check_supported_ml_task
@@ -354,6 +355,42 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         }
 
         return fit_time | predict_times
+
+    def score(
+        self,
+        *,
+        data_source: DataSource = "test",
+    ) -> Any:
+        """Compute the estimator's default score.
+
+        This calls the underlying estimator's ``score`` method on the chosen data
+        source. For :class:`skrub.DataOp` estimators, scorings registered via
+        :meth:`~skrub.DataOp.skb.with_scoring` are used.
+
+        Parameters
+        ----------
+        data_source : {"test", "train"}, default="test"
+            The data source to use.
+
+            - "test" : use the test set provided when creating the report.
+            - "train" : use the train set provided when creating the report.
+
+        Returns
+        -------
+        The default score of the estimator.
+
+        Examples
+        --------
+        >>> from sklearn.datasets import load_breast_cancer
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> from skore import evaluate
+        >>> X, y = load_breast_cancer(return_X_y=True)
+        >>> classifier = LogisticRegression(max_iter=10_000)
+        >>> report = evaluate(classifier, X, y, splitter=0.2)
+        >>> report.metrics.score()
+        0.94...
+        """
+        return Score()(report=self._parent, data_source=data_source)  # type: ignore[return-value]
 
     def accuracy(
         self,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -102,6 +102,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         ... )
                     LogisticRegression Favorability
         Metric
+        Score                  0.94...         (↗︎)
         Accuracy               0.94...         (↗︎)
         Precision              0.98...         (↗︎)
         Recall                 0.92...         (↗︎)
@@ -118,6 +119,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         ... ).frame(favorability=True).drop(["Fit time (s)", "Predict time (s)"])
                      LogisticRegression (train)  LogisticRegression (test)  Favorability
         Metric
+        Score                           0.96...                     0.94...          (↗︎)
         Accuracy                        0.96...                     0.94...          (↗︎)
         Precision                       0.96...                     0.98...          (↗︎)
         Recall                          0.97...                     0.92...          (↗︎)

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -189,35 +189,7 @@ class Metric:
         if score is not None:
             return score
 
-        if self.function is None:
-            raise ValueError(f"Metric {self.name!r} has no scoring function.")
-
-        metric_params = inspect.signature(self.function).parameters
-        call_kwargs = merged_kwargs.copy()
-        if "pos_label" in metric_params and "pos_label" not in call_kwargs:
-            call_kwargs["pos_label"] = report.pos_label
-
-        if self.function_kind == FunctionKind.METRIC:
-            assert self.response_method is not None
-
-            _, y_true = report._get_data_and_y_true(data_source=data_source)
-            y_pred = report._get_predictions(
-                data_source=data_source,
-                response_method=self.response_method,
-                pos_label=call_kwargs.get("pos_label", None),
-            )
-
-            score = cast(MetricCallable, self.function)(y_true, y_pred, **call_kwargs)
-        elif self.function_kind == FunctionKind.SCORER:
-            data, y_true = report._get_data_and_y_true(data_source=data_source)
-            X = data["_skrub_X"]
-
-            score = cast(ScorerCallable, self.function)(
-                report.estimator_,
-                X,
-                y_true,
-                **call_kwargs,
-            )
+        score = self._compute(report=report, data_source=data_source, **merged_kwargs)
 
         if isinstance(score, np.ndarray):
             score = cast(NDArray, score).tolist()
@@ -234,6 +206,51 @@ class Metric:
 
         report._cache[cache_key] = score
         return cast(float | dict[PositiveLabel, float] | list[float], score)
+
+    def _compute(
+        self,
+        *,
+        report: EstimatorReport,
+        data_source: DataSource,
+        **kwargs: Any,
+    ) -> Any:
+        """Compute the raw uncached score.
+
+        Override this hook when a metric's score cannot be expressed as
+        ``self.function(...)`` (see :class:`Score`). Subclasses that only need
+        to tweak kwargs should override :meth:`__call__` and delegate to
+        ``super().__call__``; the cache and post-processing live in
+        :meth:`__call__` and run for every override of this hook.
+        """
+        if self.function is None:
+            raise ValueError(f"Metric {self.name!r} has no scoring function.")
+
+        metric_params = inspect.signature(self.function).parameters
+        call_kwargs = kwargs.copy()
+        if "pos_label" in metric_params and "pos_label" not in call_kwargs:
+            call_kwargs["pos_label"] = report.pos_label
+
+        if self.function_kind == FunctionKind.METRIC:
+            assert self.response_method is not None
+
+            _, y_true = report._get_data_and_y_true(data_source=data_source)
+            y_pred = report._get_predictions(
+                data_source=data_source,
+                response_method=self.response_method,
+                pos_label=call_kwargs.get("pos_label", None),
+            )
+
+            return cast(MetricCallable, self.function)(y_true, y_pred, **call_kwargs)
+
+        assert self.function_kind == FunctionKind.SCORER
+        data, y_true = report._get_data_and_y_true(data_source=data_source)
+        X = data["_skrub_X"]
+        return cast(ScorerCallable, self.function)(
+            report.estimator_,
+            X,
+            y_true,
+            **call_kwargs,
+        )
 
     @staticmethod
     def new(
@@ -654,8 +671,35 @@ class Mape(Metric):
         )
 
 
+class Score(Metric):
+    name = "score"
+    verbose_name = "Score"
+    greater_is_better = True
+    function = None
+    function_kind = None
+
+    @staticmethod
+    def available(report: EstimatorReport) -> bool:
+        return hasattr(report.estimator_, "score")
+
+    def _compute(
+        self,
+        *,
+        report: EstimatorReport,
+        data_source: DataSource,
+        **kwargs: Any,
+    ) -> Any:
+        # Both estimator paths accept the dict ``data`` directly:
+        # ``_LearnerAdapter`` unpacks ``_skrub_X``/``_skrub_y`` for sklearn
+        # estimators; ``SkrubLearner`` takes the full env, preserving vars
+        # beyond X/y (e.g. additional tables referenced by the DataOp).
+        data, _ = report._get_data_and_y_true(data_source=data_source)
+        return report.learner_.score(data)
+
+
 # Order matters for default display
 BUILTIN_METRICS: list[Metric] = [
+    Score(),
     Accuracy(),
     Precision(),
     Recall(),

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -10,12 +10,12 @@ from skore._sklearn.types import EstimatorLike
 
 def eval_X_y(data_op: DataOp, env: dict) -> dict:
     """
-    Return a dict in which X and y have been materialized.
+    Return a dict in which ``X`` and ``y`` have been materialized.
 
-    The result is similar to .skb.train_test_split outputs.
-    It ensures we can retrieve the ground truth to compute metrics, and that X
-    and y are materialized so that results will be consistent even if there is
-    randomness in the production of X and y (e.g. they are unsorted database
+    The result is similar to what ``.skb.train_test_split`` outputs.
+    It ensures we can retrieve the ground truth to compute metrics, and that ``X``
+    and ``y`` are materialized, so that results will be consistent even if there is
+    randomness in the production of ``X`` and ``y`` (e.g. they are unsorted database
     query results).
     """
     return data_op.skb.train_test_split(

--- a/skore/tests/unit/displays/metrics_summary/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/metrics_summary/test_comparison_cross_validation.py
@@ -14,7 +14,7 @@ def test_aggregate_none(comparison_cross_validation_reports_binary_classificatio
 
     assert result.columns.to_list() == ["Value"]
     assert result.index.names == ["Metric", "Label", "Estimator", "Split"]
-    assert len(result) == 40
+    assert len(result) == 44
 
 
 def test_aggregate_none_flat_index(
@@ -27,7 +27,7 @@ def test_aggregate_none_flat_index(
     result = report.metrics.summarize().frame(aggregate=None, flat_index=True)
 
     assert result.columns.to_list() == ["Value"]
-    assert len(result) == 40
+    assert len(result) == 44
 
 
 def test_default(comparison_cross_validation_reports_binary_classification):
@@ -47,7 +47,7 @@ def test_default(comparison_cross_validation_reports_binary_classification):
             names=[None, "Estimator"],
         ),
     )
-    assert len(result) == 10
+    assert len(result) == 11
 
 
 def test_default_regression(comparison_cross_validation_reports_regression):
@@ -73,7 +73,7 @@ def test_default_regression(comparison_cross_validation_reports_regression):
     assert_index_equal(
         result.index,
         pd.Index(
-            ["R²", "RMSE", "MAE", "MAPE", "Fit time (s)", "Predict time (s)"],
+            ["Score", "R²", "RMSE", "MAE", "MAPE", "Fit time (s)", "Predict time (s)"],
             name="Metric",
         ),
     )
@@ -117,7 +117,7 @@ def test_favorability(comparison_cross_validation_reports_binary_classification)
             names=[None, "Estimator"],
         ),
     )
-    assert len(result) == 10
+    assert len(result) == 11
 
 
 def test_init_with_report_names(binary_classification_data):

--- a/skore/tests/unit/displays/metrics_summary/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_comparison_estimator.py
@@ -13,6 +13,7 @@ def test_data_source_both(
     result = report.metrics.summarize(data_source="both").frame()
 
     assert result.index.to_list() == [
+        ("Score", ""),
         ("Accuracy", ""),
         ("Precision", "0"),
         ("Precision", "1"),
@@ -45,6 +46,7 @@ def test_flat_index(estimator_reports_binary_classification):
     result_df = result.frame(flat_index=True)
     assert isinstance(result_df.index, pd.Index)
     assert result_df.index.tolist() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",

--- a/skore/tests/unit/displays/metrics_summary/test_cross_validation.py
+++ b/skore/tests/unit/displays/metrics_summary/test_cross_validation.py
@@ -21,7 +21,7 @@ def test_aggregate_mean(forest_binary_classification_data):
 
     assert isinstance(result.columns, pd.MultiIndex)
     assert result.columns.tolist() == [("RandomForestClassifier", "mean")]
-    assert result.shape == (10, 1)
+    assert result.shape == (11, 1)
 
 
 def test_aggregate_mean_std(forest_binary_classification_data):
@@ -37,7 +37,7 @@ def test_aggregate_mean_std(forest_binary_classification_data):
         ("RandomForestClassifier", "mean"),
         ("RandomForestClassifier", "std"),
     ]
-    assert result.shape == (10, 2)
+    assert result.shape == (11, 2)
 
 
 def test_aggregate_none(forest_binary_classification_data):
@@ -53,7 +53,7 @@ def test_aggregate_none(forest_binary_classification_data):
         ("RandomForestClassifier", "Split #0"),
         ("RandomForestClassifier", "Split #1"),
     ]
-    assert result.shape == (10, 2)
+    assert result.shape == (11, 2)
 
 
 def test_favorability_with_aggregate_mean_std(forest_binary_classification_data):
@@ -113,6 +113,7 @@ def test_flat_index_binary_classification(forest_binary_classification_data):
     result_flat = display.frame(aggregate=["mean", "std"], flat_index=True)
     assert isinstance(result_flat.index, pd.Index)
     assert result_flat.index.tolist() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",
@@ -140,6 +141,7 @@ def test_multioutput_with_flat_index(linear_regression_multioutput_data):
     assert isinstance(result_flat.index, pd.Index)
     # Note: "R²" is lowercased
     assert result_flat.index.tolist() == [
+        "score",
         "r²_0",
         "r²_1",
         "rmse_0",
@@ -188,6 +190,7 @@ def test_flat_index_with_favorability(forest_binary_classification_data):
 
     assert isinstance(result.index, pd.Index)
     assert result.index.tolist() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",
@@ -240,6 +243,7 @@ def test_data_source_both_flat_index(forest_binary_classification_data):
         f"{name}_(test)_std",
     ]
     assert result.index.tolist() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",
@@ -263,7 +267,7 @@ def test_multiclass_classification(forest_multiclass_classification_data):
 
     assert isinstance(result.index, pd.MultiIndex)
     assert result.index.names == ["Metric", "Label"]
-    assert result.shape == (13, 2)
+    assert result.shape == (14, 2)
 
 
 def test_with_mixed_favorability(forest_binary_classification_data):

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -53,6 +53,7 @@ def test_flat_index_multiclass(forest_multiclass_classification_with_test):
     result_flat = display.frame(favorability=False, flat_index=True)
     assert isinstance(result_flat.index, pd.Index)
     assert result_flat.index.to_list() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",
@@ -78,7 +79,7 @@ def test_flat_index_multioutput(linear_regression_multioutput_with_test):
     result_multi = display.frame(favorability=False, flat_index=False)
     assert isinstance(result_multi.index, pd.MultiIndex)
     assert result_multi.index.names == ["Metric", "Output"]
-    assert result_multi.shape == (10, 1)
+    assert result_multi.shape == (11, 1)
     assert result_multi.loc[("R²", "0"), "LinearRegression"] == 1
     assert result_multi.loc[("R²", "1"), "LinearRegression"] == 1
 
@@ -86,6 +87,7 @@ def test_flat_index_multioutput(linear_regression_multioutput_with_test):
     assert isinstance(result_flat.index, pd.Index)
     # Note: "R²" is lowercased
     assert result_flat.index.to_list() == [
+        "score",
         "r²_0",
         "r²_1",
         "rmse_0",
@@ -134,6 +136,7 @@ def test_flat_index_with_favorability(forest_binary_classification_with_test):
 
     assert isinstance(result.index, pd.Index)
     assert result.index.to_list() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",
@@ -185,6 +188,7 @@ def test_data_source_both_flat_index(forest_binary_classification_data):
         "RandomForestClassifier (test)",
     ]
     assert result.index.to_list() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",

--- a/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
@@ -53,6 +53,17 @@ def case_timings_with_predictions(
 
 
 @pytest.fixture
+def case_score(comparison_cross_validation_reports_binary_classification):
+    expected_index = pd.Index(["Score"], name="Metric")
+    return (
+        comparison_cross_validation_reports_binary_classification,
+        "score",
+        expected_index,
+        expected_columns,
+    )
+
+
+@pytest.fixture
 def case_accuracy(comparison_cross_validation_reports_binary_classification):
     expected_index = pd.Index(["Accuracy"], name="Metric")
     return (
@@ -181,6 +192,7 @@ def case(request):
     [
         "case_timings_no_predictions",
         "case_timings_with_predictions",
+        "case_score",
         "case_accuracy",
         "case_precision",
         "case_recall",
@@ -205,6 +217,7 @@ def test_metrics(case):
     [
         "case_timings_no_predictions",
         "case_timings_with_predictions",
+        "case_score",
         "case_accuracy",
         "case_precision",
         "case_recall",

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -10,6 +10,17 @@ from skore import ComparisonReport, EstimatorReport
     "metric_name, expected",
     [
         (
+            "score",
+            pd.DataFrame(
+                [[0.45, 0.55]],
+                columns=pd.Index(
+                    ["DummyClassifier_1", "DummyClassifier_2"],
+                    name="Estimator",
+                ),
+                index=pd.Index(["Score"], name="Metric"),
+            ),
+        ),
+        (
             "accuracy",
             pd.DataFrame(
                 [[0.45, 0.55]],
@@ -113,6 +124,17 @@ def test_binary_classification(
 @pytest.mark.parametrize(
     "metric_name, expected",
     [
+        (
+            "score",
+            pd.DataFrame(
+                [[-0.061173, -0.061173]],
+                columns=pd.Index(
+                    ["DummyRegressor_1", "DummyRegressor_2"],
+                    name="Estimator",
+                ),
+                index=pd.Index(["Score"], name="Metric"),
+            ),
+        ),
         (
             "rmse",
             pd.DataFrame(

--- a/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
@@ -76,6 +76,7 @@ def _check_results_single_metric(report, metric, expected_n_splits, expected_nb_
         ("brier_score", 1),
         ("roc_auc", 1),
         ("log_loss", 1),
+        ("score", 1),
     ],
 )
 def test_binary_classification(forest_binary_classification_data, metric, nb_stats):
@@ -95,6 +96,7 @@ def test_binary_classification(forest_binary_classification_data, metric, nb_sta
         ("recall", 3),
         ("roc_auc", 3),
         ("log_loss", 1),
+        ("score", 1),
     ],
 )
 def test_multiclass_classification(
@@ -109,7 +111,14 @@ def test_multiclass_classification(
 
 
 @pytest.mark.parametrize(
-    "metric, nb_stats", [("r2", 1), ("rmse", 1), ("mae", 1), ("mape", 1)]
+    "metric, nb_stats",
+    [
+        ("r2", 1),
+        ("rmse", 1),
+        ("mae", 1),
+        ("mape", 1),
+        ("score", 1),
+    ],
 )
 def test_regression(linear_regression_data, metric, nb_stats):
     """Check the behaviour of the metrics methods available for regression."""
@@ -119,7 +128,14 @@ def test_regression(linear_regression_data, metric, nb_stats):
 
 
 @pytest.mark.parametrize(
-    "metric, nb_stats", [("r2", 2), ("rmse", 2), ("mae", 2), ("mape", 2)]
+    "metric, nb_stats",
+    [
+        ("r2", 2),
+        ("rmse", 2),
+        ("mae", 2),
+        ("mape", 2),
+        ("score", 1),
+    ],
 )
 def test_regression_multioutput(linear_regression_multioutput_data, metric, nb_stats):
     """Check the behaviour of the metrics methods available for regression."""

--- a/skore/tests/unit/reports/cross_validation/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_summarize.py
@@ -86,6 +86,7 @@ def test_binary_classification_forest(forest_binary_classification_data):
             "Brier score",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="RandomForestClassifier",
     )
@@ -119,6 +120,7 @@ def test_binary_classification_svc(svc_binary_classification_data):
             "ROC AUC",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="SVC",
     )
@@ -143,6 +145,7 @@ def test_multiclass_classification_forest(forest_multiclass_classification_data)
             "ROC AUC",
             "Predict time (s)",
             "Fit time (s)",
+            "Score",
         },
         expected_estimator_name="RandomForestClassifier",
     )
@@ -173,6 +176,7 @@ def test_multiclass_classification_svc(svc_multiclass_classification_data):
             "Recall",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="SVC",
     )
@@ -199,6 +203,7 @@ def test_regression(linear_regression_data):
             "MAPE",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="LinearRegression",
     )
@@ -222,6 +227,7 @@ def test_multioutput_regression(linear_regression_multioutput_data):
             "MAPE",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="LinearRegression",
     )
@@ -247,6 +253,7 @@ def test_without_predict_proba(custom_classifier_no_predict_proba_data):
             "Recall",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="CustomClassifierPredictOnly",
     )

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -1,8 +1,11 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 import pytest
+import skrub
 from sklearn.datasets import make_classification
+from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import (
     precision_score,
@@ -181,3 +184,83 @@ def test_roc_multiclass_requires_predict_proba(
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
     assert hasattr(report.metrics, "roc_auc")
     report.metrics.roc_auc()
+
+
+# report.metrics.score
+
+
+def test_score_matches_sklearn_score(logistic_binary_classification_with_train_test):
+    """For a plain sklearn estimator, ``score`` returns ``estimator.score(X, y)``."""
+    estimator, X_train, X_test, y_train, y_test = (
+        logistic_binary_classification_with_train_test
+    )
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+
+    assert report.metrics.score() == report.estimator_.score(X_test, y_test)
+
+
+def skrub_report(*, with_scoring):
+    X, y = make_classification(random_state=0)
+
+    # String-labeled y avoids the int/str clash in MetricsSummaryDisplay's label
+    # column when ``Score`` emits a dict keyed by scorer name.
+    y = np.where(y == 1, "pos", "neg")
+
+    data_op = skrub.X(X).skb.apply(DummyClassifier(), y=skrub.y(y))
+    if with_scoring:
+        data_op = data_op.skb.with_scoring("accuracy").skb.with_scoring(
+            "accuracy", name="weighted_accuracy"
+        )
+
+    learner = data_op.skb.make_learner()
+    split = data_op.skb.train_test_split()
+    return EstimatorReport(learner, train_data=split["train"], test_data=split["test"])
+
+
+@pytest.mark.parametrize("with_scoring", [False, True])
+def test_score_skrub_learner(with_scoring):
+    """``score`` on a report containing a SkrubLearner returns the same result
+    as ``score`` on the learner directly.
+
+    Non-regression test: previously ``SkrubLearner.score`` was called as
+    ``score(X, y)`` but it expects an environment dict.
+    """
+    report = skrub_report(with_scoring=with_scoring)
+
+    assert report.metrics.score() == report.estimator_.score(
+        {"_skrub_X": report.X_test, "_skrub_y": report.y_test}
+    )
+
+
+def test_score_skrub_learner_with_extra_env_vars():
+    """``score`` works when the DataOp env has variables beyond X and y."""
+    df = pd.DataFrame({"feat": np.arange(20, dtype=float), "target": ["a", "b"] * 10})
+    data = skrub.var("df", df)
+    weight = skrub.var("weight", 0.5)
+
+    X = data[["feat"]].skb.mark_as_X()
+    weighted_X = X * weight  # brings in `weight` after marking the X
+    y = data["target"].skb.mark_as_y()
+
+    data_op = weighted_X.skb.apply(DummyClassifier(), y=y)
+    learner = data_op.skb.make_learner()
+    split = data_op.skb.train_test_split()
+    report = EstimatorReport(
+        learner, train_data=split["train"], test_data=split["test"]
+    )
+
+    assert isinstance(report.metrics.score(), float)
+
+
+@pytest.mark.filterwarnings("ignore:Precision is ill-defined")
+def test_score_appears_in_summarize_for_skrub_learner():
+    """The ``Score`` row is included in ``summarize().frame()`` for SkrubLearners."""
+    report = skrub_report(with_scoring=True)
+
+    frame = report.metrics.summarize().frame()
+
+    # FIXME: The sub-metric names should not be in the "Label" column
+    score_labels = frame.xs("Score", level="Metric").index.get_level_values("Label")
+    assert set(score_labels) == {"accuracy", "weighted_accuracy"}

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -305,7 +305,7 @@ class TestAddPosition:
         keys = list(report._metric_registry.keys())
         assert keys[0] == "metric_b"
         assert keys[1] == "metric_a"
-        assert keys[2] == "accuracy"
+        assert keys[2] == "score"
 
         display = report.metrics.summarize()
         assert display.data.iloc[0]["metric_verbose_name"] == "Metric B"
@@ -356,7 +356,7 @@ class TestAddPosition:
 
         keys = list(report._metric_registry.keys())
         assert keys[0] == "m_first"
-        assert keys[1] == "accuracy"
+        assert keys[1] == "score"
         assert keys[-1] == "m_last"
 
     def test_readd_raises_without_remove(self, binary_classification_report):
@@ -532,31 +532,31 @@ class TestEdgeCases:
         """Adding with duplicate name raises and keeps the original metric."""
         report = binary_classification_report
 
-        def score(y_true, y_pred):
+        def my_metric(y_true, y_pred):
             return 0
 
-        report.metrics.add(make_scorer(score, response_method="predict"))
+        report.metrics.add(make_scorer(my_metric, response_method="predict"))
 
         nb_metrics_before_overwriting = len(report._metric_registry)
 
-        result = report.metrics.summarize(metric="score")
+        result = report.metrics.summarize(metric="my_metric")
         assert result.data["score"].iloc[0] == 0
 
         # add a new metric with the same name
-        def score(y_true, y_pred):
+        def my_metric(y_true, y_pred):
             return 1
 
         err_msg = re.escape(
-            "Cannot add 'score': it already exists. "
+            "Cannot add 'my_metric': it already exists. "
             "Remove it first using the `remove` method."
         )
         with pytest.raises(ValueError, match=err_msg):
-            report.metrics.add(make_scorer(score, response_method="predict"))
+            report.metrics.add(make_scorer(my_metric, response_method="predict"))
 
         assert len(report._metric_registry) == nb_metrics_before_overwriting
 
         # summarize still reflects the original metric
-        result = report.metrics.summarize(metric="score")
+        result = report.metrics.summarize(metric="my_metric")
         assert result.data["score"].iloc[0] == 0
 
 

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -11,10 +11,12 @@ Organised by metric input type, then corner cases:
 import numpy as np
 import pandas as pd
 import pytest
+import skrub
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 from sklearn.base import clone
 from sklearn.datasets import make_classification
+from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import precision_score, recall_score
 from sklearn.model_selection import train_test_split
@@ -81,6 +83,7 @@ def test_default(forest_binary_classification_with_test, metric):
             "Brier score",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="RandomForestClassifier",
     )
@@ -102,6 +105,7 @@ def test_default_binary_classification_svc(svc_binary_classification_with_test):
             "ROC AUC",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="SVC",
     )
@@ -125,6 +129,7 @@ def test_default_multiclass_classification_forest(
             "ROC AUC",
             "Predict time (s)",
             "Fit time (s)",
+            "Score",
         },
         expected_estimator_name="RandomForestClassifier",
     )
@@ -150,6 +155,7 @@ def test_default_multiclass_classification_svc(svc_multiclass_classification_wit
             "Recall",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="SVC",
     )
@@ -176,6 +182,7 @@ def test_default_regression(linear_regression_with_test):
             "MAPE",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="LinearRegression",
     )
@@ -199,6 +206,7 @@ def test_default_multioutput_regression(linear_regression_multioutput_with_test)
             "MAPE",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="LinearRegression",
     )
@@ -224,6 +232,7 @@ def test_default_without_predict_proba(custom_classifier_no_predict_proba_with_t
             "Recall",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="CustomClassifierPredictOnly",
     )
@@ -266,6 +275,7 @@ def test_pos_label(forest_binary_classification_with_test):
             "Brier score",
             "Fit time (s)",
             "Predict time (s)",
+            "Score",
         },
         expected_estimator_name="RandomForestClassifier",
     )
@@ -297,6 +307,7 @@ def test_pos_label_strings(forest_binary_classification_with_test):
         "Brier score",
         "Fit time (s)",
         "Predict time (s)",
+        "Score",
     }
 
     labels = display.data.set_index("metric_verbose_name").loc["Precision", "label"]
@@ -324,6 +335,7 @@ def test_pos_label_bool(forest_binary_classification_with_test):
         "Brier score",
         "Fit time (s)",
         "Predict time (s)",
+        "Score",
     }
 
     labels = display.data.set_index("metric_verbose_name").loc["Precision", "label"]
@@ -402,3 +414,90 @@ def test_data_source_both(forest_binary_classification_data):
 
     test_data = display_both.data[display_both.data["data_source"] == "test"]
     assert_array_equal(test_data["score"], display_test.data["score"])
+
+
+# Score metric
+
+
+def _compute_score(report, **kwargs):
+    """Compute the raw ``score`` metric value via the report's registry."""
+    metric = report._metric_registry["score"]
+    return metric(report=report, **kwargs)
+
+
+def _make_skrub_report(*, with_scoring):
+    X, y = make_classification(n_samples=20, random_state=0)
+    # String-labeled y avoids the int/str clash in MetricsSummaryDisplay's label
+    # column when ``Score`` emits a dict keyed by scorer name.
+    y = np.where(y == 1, "pos", "neg")
+    data_op = skrub.X(X).skb.apply(DummyClassifier(), y=skrub.y(y))
+    if with_scoring:
+        data_op = data_op.skb.with_scoring("accuracy").skb.with_scoring(
+            "accuracy", name="weighted_accuracy"
+        )
+    learner = data_op.skb.make_learner()
+    split = data_op.skb.train_test_split()
+    return EstimatorReport(learner, train_data=split["train"], test_data=split["test"])
+
+
+def test_score_matches_sklearn_score(logistic_binary_classification_with_train_test):
+    """For a plain sklearn estimator, ``score`` returns ``estimator.score(X, y)``."""
+    estimator, X_train, X_test, y_train, y_test = (
+        logistic_binary_classification_with_train_test
+    )
+    report = EstimatorReport(
+        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
+    )
+
+    assert _compute_score(report) == report.estimator_.score(X_test, y_test)
+
+
+def test_score_skrub_learner_with_custom_scoring_returns_dict():
+    """``score`` on a SkrubLearner with ``with_scoring`` returns a dict of scorers.
+
+    Non-regression test: previously ``SkrubLearner.score`` was called as
+    ``score(X, y)`` but it expects an environment dict.
+    """
+    report = _make_skrub_report(with_scoring=True)
+
+    result = _compute_score(report)
+
+    assert isinstance(result, dict)
+    assert set(result) == {"accuracy", "weighted_accuracy"}
+    assert all(isinstance(v, float) for v in result.values())
+
+
+def test_score_skrub_learner_without_custom_scoring_returns_float():
+    """Without ``with_scoring``, ``score`` returns the default float score."""
+    report = _make_skrub_report(with_scoring=False)
+
+    assert isinstance(_compute_score(report), float)
+
+
+def test_score_appears_in_summarize_for_skrub_learner():
+    """The ``Score`` row is included in ``summarize().frame()`` for SkrubLearners."""
+    report = _make_skrub_report(with_scoring=True)
+
+    frame = report.metrics.summarize().frame()
+
+    score_labels = frame.xs("Score", level="Metric").index.get_level_values("Label")
+    assert set(score_labels) == {"accuracy", "weighted_accuracy"}
+
+
+def test_score_skrub_learner_with_extra_env_vars():
+    """``score`` works when the DataOp env has variables beyond X and y."""
+    df = pd.DataFrame({"feat": np.arange(20, dtype=float), "target": ["a", "b"] * 10})
+    data = skrub.var("df", df)
+    weight = skrub.var("weight", 0.5)
+
+    X = data[["feat"]].skb.mark_as_X()
+    weighted_X = X * weight  # brings in `weight` after marking the X
+    y = data["target"].skb.mark_as_y()
+    data_op = weighted_X.skb.apply(DummyClassifier(), y=y)
+    learner = data_op.skb.make_learner()
+    split = data_op.skb.train_test_split()
+    report = EstimatorReport(
+        learner, train_data=split["train"], test_data=split["test"]
+    )
+
+    assert isinstance(_compute_score(report), float)

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -11,12 +11,10 @@ Organised by metric input type, then corner cases:
 import numpy as np
 import pandas as pd
 import pytest
-import skrub
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 from sklearn.base import clone
 from sklearn.datasets import make_classification
-from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import precision_score, recall_score
 from sklearn.model_selection import train_test_split
@@ -414,90 +412,3 @@ def test_data_source_both(forest_binary_classification_data):
 
     test_data = display_both.data[display_both.data["data_source"] == "test"]
     assert_array_equal(test_data["score"], display_test.data["score"])
-
-
-# Score metric
-
-
-def _compute_score(report, **kwargs):
-    """Compute the raw ``score`` metric value via the report's registry."""
-    metric = report._metric_registry["score"]
-    return metric(report=report, **kwargs)
-
-
-def _make_skrub_report(*, with_scoring):
-    X, y = make_classification(n_samples=20, random_state=0)
-    # String-labeled y avoids the int/str clash in MetricsSummaryDisplay's label
-    # column when ``Score`` emits a dict keyed by scorer name.
-    y = np.where(y == 1, "pos", "neg")
-    data_op = skrub.X(X).skb.apply(DummyClassifier(), y=skrub.y(y))
-    if with_scoring:
-        data_op = data_op.skb.with_scoring("accuracy").skb.with_scoring(
-            "accuracy", name="weighted_accuracy"
-        )
-    learner = data_op.skb.make_learner()
-    split = data_op.skb.train_test_split()
-    return EstimatorReport(learner, train_data=split["train"], test_data=split["test"])
-
-
-def test_score_matches_sklearn_score(logistic_binary_classification_with_train_test):
-    """For a plain sklearn estimator, ``score`` returns ``estimator.score(X, y)``."""
-    estimator, X_train, X_test, y_train, y_test = (
-        logistic_binary_classification_with_train_test
-    )
-    report = EstimatorReport(
-        estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
-    )
-
-    assert _compute_score(report) == report.estimator_.score(X_test, y_test)
-
-
-def test_score_skrub_learner_with_custom_scoring_returns_dict():
-    """``score`` on a SkrubLearner with ``with_scoring`` returns a dict of scorers.
-
-    Non-regression test: previously ``SkrubLearner.score`` was called as
-    ``score(X, y)`` but it expects an environment dict.
-    """
-    report = _make_skrub_report(with_scoring=True)
-
-    result = _compute_score(report)
-
-    assert isinstance(result, dict)
-    assert set(result) == {"accuracy", "weighted_accuracy"}
-    assert all(isinstance(v, float) for v in result.values())
-
-
-def test_score_skrub_learner_without_custom_scoring_returns_float():
-    """Without ``with_scoring``, ``score`` returns the default float score."""
-    report = _make_skrub_report(with_scoring=False)
-
-    assert isinstance(_compute_score(report), float)
-
-
-def test_score_appears_in_summarize_for_skrub_learner():
-    """The ``Score`` row is included in ``summarize().frame()`` for SkrubLearners."""
-    report = _make_skrub_report(with_scoring=True)
-
-    frame = report.metrics.summarize().frame()
-
-    score_labels = frame.xs("Score", level="Metric").index.get_level_values("Label")
-    assert set(score_labels) == {"accuracy", "weighted_accuracy"}
-
-
-def test_score_skrub_learner_with_extra_env_vars():
-    """``score`` works when the DataOp env has variables beyond X and y."""
-    df = pd.DataFrame({"feat": np.arange(20, dtype=float), "target": ["a", "b"] * 10})
-    data = skrub.var("df", df)
-    weight = skrub.var("weight", 0.5)
-
-    X = data[["feat"]].skb.mark_as_X()
-    weighted_X = X * weight  # brings in `weight` after marking the X
-    y = data["target"].skb.mark_as_y()
-    data_op = weighted_X.skb.apply(DummyClassifier(), y=y)
-    learner = data_op.skb.make_learner()
-    split = data_op.skb.train_test_split()
-    report = EstimatorReport(
-        learner, train_data=split["train"], test_data=split["test"]
-    )
-
-    assert isinstance(_compute_score(report), float)

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -223,9 +223,10 @@ def test_flat_index(forest_binary_classification_with_test):
     estimator, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     result = report.metrics.summarize().frame(flat_index=True)
-    assert result.shape == (10, 1)
+    assert result.shape == (11, 1)
     assert isinstance(result.index, pd.Index)
     assert result.index.tolist() == [
+        "score",
         "accuracy",
         "precision_0",
         "precision_1",


### PR DESCRIPTION
Create a new `Score` Metric to compute `estimator.score(X, y)`. This metric also takes into account the case where the estimator is a `skrub.DataOp`.

Note: For now, if the metric returns a dict, then there is no error but the metric names show up in the Label column of `report.metrics.summarize`. This will be addressed later.

Addresses part of #2884

#### Contribution checklist
<!--
Below are some of the criteria that the review will include.
Feel free to use it as a checklist to ensure that your contribution is high-quality.
-->

- [x] Unit tests were added or updated (if necessary)
- [ ] Documentation was added or updated (if necessary)
- [x] A new changelog entry was added to CHANGELOG.rst (if necessary; typically, if your change
requires updating tests)


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure you understand our [automated contributions policy](https://docs.skore.probabl.ai/stable/contributing.html#automated-contributions-policy)
-->
AI tools were involved for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

<!-- Any other comments can go here. Thanks again for contributing! -->
