### PR TITLE
docs(skore): List available methods in accesors' documentation

### DIFF
--- a/sphinx/_templates/autosummary/accessor.rst
+++ b/sphinx/_templates/autosummary/accessor.rst
@@ -5,6 +5,17 @@
 .. autoaccessor:: {{ (module.split('.')[1:] + [objname]) | join('.') }}
 
 {% set accessor_path = (module.split('.')[1:] + [objname]) | join('.') -%}
+{% if accessor_methods is defined and accessor_path in accessor_methods %}
+Methods
+~~~~~~~
+
+Here are the methods that are available through this accessor:
+
+{% for method_name, method_doc in accessor_methods[accessor_path] %}
+- :func:`~{{ objname }}.{{ method_name }}` -- {{ method_doc }}
+{% endfor %}
+{% endif %}
+
 {% if accessor_toctrees is defined and accessor_path in accessor_toctrees %}
 .. toctree::
    :hidden:

--- a/sphinx/sphinxext/generate_accessor_tables.py
+++ b/sphinx/sphinxext/generate_accessor_tables.py
@@ -215,8 +215,9 @@ def generate_accessor_tables(app: Sphinx, config: Any) -> None:
     output_path.write_text(rst_content)
     logger.info(f"Wrote accessor tables to {output_path}")
 
-    # Generate .inc files and collect toctree data for each accessor
+    # Generate .inc files and collect toctree/method data for each accessor
     accessor_toctrees: dict[str, list[str]] = {}
+    accessor_methods: dict[str, list[tuple[str, str]]] = {}
 
     for class_path, class_data in classes_data:
         class_name = class_data["name"]
@@ -260,6 +261,7 @@ def generate_accessor_tables(app: Sphinx, config: Any) -> None:
                 f"skore.{class_name}.{accessor_name}.{method_name}"
                 for method_name, _ in ordered
             ]
+            accessor_methods[accessor_path] = ordered
 
             for method_name, _ in ordered:
                 _write_accessor_method_stub(
@@ -268,6 +270,7 @@ def generate_accessor_tables(app: Sphinx, config: Any) -> None:
 
     ctx = dict(config.autosummary_context or {})
     ctx["accessor_toctrees"] = accessor_toctrees
+    ctx["accessor_methods"] = accessor_methods
     config.autosummary_context = ctx
 
 


### PR DESCRIPTION
Closes #2777

Adds a list of available methods from each accessor in their documentation.
<img width="1273" height="687" alt="image" src="https://github.com/user-attachments/assets/cc501009-c98c-456c-b2e9-57264c603693" />
