### PR TITLE
fix(skore/docs/checks): Fix broken links to checks documentation

### DIFF
--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -161,7 +161,7 @@ class CheckMetricsConsistencyAcrossSplits(Check):
     code = "SKD003"
     title = "Inconsistent performance across splits"
     report_type = "cross-validation"
-    docs_url = "skd003-inconsistent_performance"
+    docs_url = "skd003-inconsistent-performance"
     severity = "issue"
 
     def check_function(self, report: _BaseReport) -> str | None:
@@ -202,7 +202,7 @@ class CheckHighClassImbalance(Check):
     code = "SKD004"
     title = "High class imbalance"
     report_type = "estimator"
-    docs_url = "skd004-high_class_imbalance"
+    docs_url = "skd004-high-class-imbalance"
     severity = "issue"
 
     def check_function(self, report: _BaseReport) -> str | None:
@@ -241,7 +241,7 @@ class CheckUnderrepresentedClasses(Check):
     code = "SKD005"
     title = "Underrepresented classes"
     report_type = "estimator"
-    docs_url = "skd005-underrepresented_classes"
+    docs_url = "skd005-underrepresented-classes"
     severity = "issue"
 
     def check_function(self, report: _BaseReport) -> str | None:
@@ -280,7 +280,7 @@ class CheckCoefficientsInterpretation(Check):
     code = "SKD006"
     title = "Coefficient interpretation"
     report_type = "estimator"
-    docs_url = "skd006-unscaled_coefficients"
+    docs_url = "skd006-unscaled-coefficients"
     severity = "tip"
 
     def check_function(self, report: _BaseReport) -> str | None:

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -113,7 +113,7 @@ How to reduce the risk
 - collect richer data if possible.
 
 
-.. _skd003-inconsistent_performance:
+.. _skd003-inconsistent-performance:
 
 SKD003 - Inconsistent performance across splits
 -----------------------------------------------
@@ -156,7 +156,7 @@ How to reduce the risk
 - increase the size of the dataset to improve stability.
 
 
-.. _skd004-high_class_imbalance:
+.. _skd004-high-class-imbalance:
 
 SKD004 - High class imbalance
 ------------------------------
@@ -186,7 +186,7 @@ How to reduce the risk
 - collect more data for the minority class if possible.
 
 
-.. _skd005-underrepresented_classes:
+.. _skd005-underrepresented-classes:
 
 SKD005 - Underrepresented classes
 ---------------------------------
@@ -216,7 +216,7 @@ How to reduce the risk
 - collect more data for the underrepresented classes if possible.
 
 
-.. _skd006-unscaled_coefficients:
+.. _skd006-unscaled-coefficients:
 
 SKD006 - Coefficient interpretation
 ------------------------------------


### PR DESCRIPTION
Fix broken documentation links for checks SKD003-006 by replacing underscores with hyphens in `docs_url` attributes and RST labels, matching the HTML anchors Sphinx actually generates.