### PR TITLE
fix(docs): Reference scikit learn's train_test_split instead of skore's

### DIFF
--- a/examples/getting_started/plot_getting_started.py
+++ b/examples/getting_started/plot_getting_started.py
@@ -67,7 +67,7 @@ TableReport(german_credit.frame)
 # development and cross-validation, while the left-out set will only be used at the end
 # to validate our final model.
 #
-# Unlike scikit-learn's :func:`~skore.train_test_split`, skore's version provides
+# Unlike scikit-learn's :func:`~sklearn.model_selection.train_test_split`, skore's version provides
 # helpful diagnostics about potential issues with your data split, such as class
 # imbalance.
 


### PR DESCRIPTION
there was wrong mention of scikit learn function as skore function that was fixed here 