### PR TITLE
chore(skore/project/plugin): Assume all native plugins are installed

### DIFF
--- a/skore/src/skore/_project/plugin.py
+++ b/skore/src/skore/_project/plugin.py
@@ -46,13 +46,4 @@ def get(*, group: PluginGroup, mode: ProjectMode) -> Any:
     assert group in GROUPS, f"`group` must be in {GROUPS} (found {group})"
     assert mode in MODES, f"`mode` must be in {MODES} (found {mode})"
 
-    plugins = entry_points(group=group)
-
-    if mode not in plugins.names:
-        raise ValueError(
-            f"The mode `{mode}` is not supported. "
-            f"You can install the required dependencies with:\n"
-            f'    pip install "skore[{mode}]"'
-        )
-
-    return plugins[mode].load()
+    return entry_points(group=group)[mode].load()

--- a/skore/tests/unit/project/test_login.py
+++ b/skore/tests/unit/project/test_login.py
@@ -84,22 +84,3 @@ def test_login_hub(monkeypatch, FakeLogin):
     assert FakeLogin.called
     assert not FakeLogin.call_args.args
     assert FakeLogin.call_args.kwargs == {"arg1": 1, "arg2": 2}
-
-
-def test_login_hub_unknown_plugin(monkeypatch):
-    monkeypatch.setattr("skore._project.dependencies.requires", lambda _: [])
-    monkeypatch.setattr(
-        "skore._project.plugin.entry_points", lambda **kwargs: EntryPoints([])
-    )
-
-    from skore import login
-
-    with raises(
-        ValueError,
-        match=escape(
-            "The mode `hub` is not supported. "
-            "You can install the required dependencies with:\n"
-            '    pip install "skore[hub]"'
-        ),
-    ):
-        login(arg1=1, arg2=2)

--- a/skore/tests/unit/project/test_project.py
+++ b/skore/tests/unit/project/test_project.py
@@ -121,22 +121,6 @@ class TestProject:
             "workspace": "<workspace>",
         }
 
-    def test_init_local_unknown_plugin(self, monkeypatch, tmp_path):
-        monkeypatch.undo()
-        monkeypatch.setattr(
-            "skore._project.plugin.entry_points", lambda **kwargs: EntryPoints([])
-        )
-
-        with raises(
-            ValueError,
-            match=escape(
-                "The mode `local` is not supported. "
-                "You can install the required dependencies with:\n"
-                '    pip install "skore[local]"'
-            ),
-        ):
-            Project(mode="local", name="<name>")
-
     def test_init_local_missing_optional_dependency(self, monkeypatch):
         fake_library_name = uuid4().hex
 
@@ -207,22 +191,6 @@ class TestProject:
             "name": "<name>",
             "tracking_uri": "<uri>",
         }
-
-    def test_init_hub_unknown_plugin(self, monkeypatch, tmp_path):
-        monkeypatch.undo()
-        monkeypatch.setattr(
-            "skore._project.plugin.entry_points", lambda **kwargs: EntryPoints([])
-        )
-
-        with raises(
-            ValueError,
-            match=escape(
-                "The mode `hub` is not supported. "
-                "You can install the required dependencies with:\n"
-                '    pip install "skore[hub]"'
-            ),
-        ):
-            Project(mode="hub", name="<workspace>/<name>")
 
     def test_init_exception_wrong_ml_task(self, monkeypatch):
         """If the underlying Project implementation contains reports with


### PR DESCRIPTION
Since we are now in monopackage, where all plugins are natively available, we don't need anymore to ensure that external packages are installed.
