### PR TITLE
fix(skore): In `Project`, check dependencies before trying to load those dependencies

### DIFF
--- a/skore/src/skore/_project/project.py
+++ b/skore/src/skore/_project/project.py
@@ -142,6 +142,8 @@ class Project:
                 f'`mode` must be "hub", "local" or "mlflow" (found {mode})'
             )
 
+        assert_optional_dependencies_installed(mode)
+
         return plugin.get(group="skore.plugins.project", mode=mode), parameters
 
     def __init__(self, name: str, *, mode: ProjectMode = "local", **kwargs):
@@ -175,8 +177,6 @@ class Project:
                 The URI of the MLflow tracking server.
         """
         plugin, parameters = Project.__setup_plugin(mode, name)
-
-        assert_optional_dependencies_installed(mode)
 
         self.__mode = mode
         self.__name = name

--- a/skore/tests/unit/project/test_project.py
+++ b/skore/tests/unit/project/test_project.py
@@ -155,6 +155,29 @@ class TestProject:
         ):
             Project(mode="local", name="<name>")
 
+    def test_init_local_missing_optional_dependency_without_plugin(self, monkeypatch):
+        """Non-regression test for missing extras before plugin discovery."""
+        fake_library_name = uuid4().hex
+
+        def fake_requires(name):
+            assert name == "skore"
+            return [f'{fake_library_name} ; extra == "local"']
+
+        monkeypatch.undo()
+        monkeypatch.setattr("skore._project.dependencies.requires", fake_requires)
+        monkeypatch.setattr(
+            "skore._project.plugin.entry_points", lambda **kwargs: EntryPoints([])
+        )
+
+        with raises(
+            ImportError,
+            match=escape(
+                f"Missing library: `{fake_library_name}`. "
+                "You can fix this error by installing `skore[local]`."
+            ),
+        ):
+            Project(mode="local", name="<name>")
+
     def test_init_hub(self, FakeHubProject, monkeypatch):
         monkeypatch.setattr("skore._project.dependencies.requires", lambda _: [])
 


### PR DESCRIPTION
#### Bug description

We call `assert_optional_dependencies_installed(mode)` after actually important the `skore._plugins.[mode]` module, which will import dependencies (like httpx or mlflow). So users don't get a nice error message but get a:
`ModuleNotFoundError: No module named 'httpx'`/`'mlflow'` error.

#### Change description

Move the call to `assert_optional_dependencies_installed` earlier.

#### AI usage disclosure

AI tools were involved for:
- Research and understanding
- Test generation
