### PR TITLE
perf(mlflow): Enable data de-duplication for MLflow backend

### DIFF
--- a/skore/src/skore/_plugins/mlflow/project.py
+++ b/skore/src/skore/_plugins/mlflow/project.py
@@ -26,7 +26,7 @@ from mlflow.utils.logging_utils import MLFLOW_LOGGING_STREAM
 from sklearn.base import BaseEstimator
 
 from skore import CrossValidationReport, EstimatorReport
-from skore._plugins.serde import restore_data_in_state, split_data_from_state
+from skore._plugins.serde import externalize, internalize
 
 from .reports import (
     Artifact,
@@ -175,10 +175,7 @@ class Project:
                 "is already open. Call mlflow.end_run() before calling Project.put()."
             )
 
-        state = report.get_state()
-        # NOTE: `split_data_from_state` updates the state in-place.
-        for obj_id, obj_bytes in split_data_from_state(state):
-            self._write_object_in_storage(obj_id, obj_bytes)
+        state = externalize(report.get_state(), self._write_object_in_storage)
 
         with (
             disable_discrete_autologging(["sklearn"]),
@@ -239,9 +236,7 @@ class Project:
         except MlflowException as exc:
             raise KeyError(id) from exc
 
-        state = restore_data_in_state(
-            joblib.load(pickle_path), self._load_object_from_storage
-        )
+        state = internalize(joblib.load(pickle_path), self._load_object_from_storage)
         report_type = state["metadata"]["report_type"]
         if report_type == "estimator":
             return EstimatorReport.from_state(state)

--- a/skore/src/skore/_plugins/mlflow/project.py
+++ b/skore/src/skore/_plugins/mlflow/project.py
@@ -6,9 +6,10 @@ import logging
 import re
 import warnings
 from collections.abc import Iterable, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from datetime import UTC, datetime
 from importlib.metadata import version
+from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, TypedDict, cast
@@ -18,11 +19,14 @@ import mlflow
 import mlflow.sklearn
 import pandas as pd
 from mlflow.entities import Run as MLFlowRun
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, RestException
+from mlflow.tracking import MlflowClient
 from mlflow.utils.autologging_utils import disable_discrete_autologging
+from mlflow.utils.logging_utils import MLFLOW_LOGGING_STREAM
 from sklearn.base import BaseEstimator
 
 from skore import CrossValidationReport, EstimatorReport
+from skore._plugins.serde import restore_data_in_state, split_data_from_state
 
 from .reports import (
     Artifact,
@@ -35,6 +39,16 @@ from .reports import (
     iter_cv,
     iter_estimator,
 )
+
+try:
+    from mlflow.utils.logging_utils import (
+        suppress_logs_in_thread as _suppress_logs_in_thread,
+    )
+except ImportError:
+
+    @contextmanager
+    def _suppress_logs_in_thread() -> Iterator[None]:
+        yield
 
 
 class Metadata(TypedDict):  # noqa: D101
@@ -98,6 +112,14 @@ class Project:
             mlflow.set_tracking_uri(tracking_uri)
 
         self.__tracking_uri = mlflow.get_tracking_uri()
+        try:
+            self.__storage_experiment_id = mlflow.create_experiment("__skore-storage__")
+        except RestException:
+            storage_experiment = mlflow.get_experiment_by_name("__skore-storage__")
+            if storage_experiment is None:
+                raise
+            self.__storage_experiment_id = storage_experiment.experiment_id
+        self.__mlflow_client = MlflowClient()
         self.__name = name
         experiment = mlflow.set_experiment(name)
         self.__experiment_id = cast(str, experiment.experiment_id)
@@ -153,6 +175,11 @@ class Project:
                 "is already open. Call mlflow.end_run() before calling Project.put()."
             )
 
+        state = report.get_state()
+        # NOTE: `split_data_from_state` updates the state in-place.
+        for obj_id, obj_bytes in split_data_from_state(state):
+            self._write_object_in_storage(obj_id, obj_bytes)
+
         with (
             disable_discrete_autologging(["sklearn"]),
             mlflow.start_run(run_name=key, experiment_id=self.experiment_id),
@@ -170,7 +197,7 @@ class Project:
 
             with TemporaryDirectory() as tmp_dir:
                 pickle_path = Path(tmp_dir) / "report.pkl"
-                joblib.dump(report, pickle_path)
+                joblib.dump(state, pickle_path)
                 mlflow.log_artifact(local_path=str(pickle_path))
 
             mlflow.set_tag("skore_status", "completed")
@@ -212,7 +239,14 @@ class Project:
         except MlflowException as exc:
             raise KeyError(id) from exc
 
-        return cast(EstimatorReport | CrossValidationReport, joblib.load(pickle_path))
+        state = restore_data_in_state(
+            joblib.load(pickle_path), self._load_object_from_storage
+        )
+        report_type = state["metadata"]["report_type"]
+        if report_type == "estimator":
+            return EstimatorReport.from_state(state)
+        else:
+            return CrossValidationReport.from_state(state)
 
     def summarize(self) -> list[Metadata]:
         """Obtain metadata/metrics for all persisted models in insertion order."""
@@ -295,6 +329,47 @@ class Project:
             f"tracking_uri='{self.tracking_uri}')"
         )
 
+    def _write_object_in_storage(self, obj_id: str, obj_bytes: bytes) -> None:
+        with _suppress_mlflow_output():
+            runs = cast(
+                pd.DataFrame,
+                mlflow.search_runs(
+                    experiment_ids=[self.__storage_experiment_id],
+                    filter_string=f"attributes.run_name = '{obj_id}'",
+                ),
+            )
+            if not runs.empty:
+                return
+            with (
+                mlflow.start_run(
+                    run_name=obj_id, experiment_id=self.__storage_experiment_id
+                ),
+                TemporaryDirectory() as tmp_dir,
+            ):
+                bytes_path = Path(tmp_dir) / "obj"
+                with open(bytes_path, mode="wb") as f:
+                    f.write(obj_bytes)
+                mlflow.log_artifact(local_path=str(bytes_path))
+
+    def _load_object_from_storage(self, obj_id: str) -> bytes:
+        runs = cast(
+            pd.DataFrame,
+            mlflow.search_runs(
+                experiment_ids=[self.__storage_experiment_id],
+                filter_string=f"attributes.run_name = '{obj_id}'",
+            ),
+        )
+        if runs.empty:
+            raise FileNotFoundError()
+
+        run_id = runs.iloc[0]["run_id"]
+        local_path = self.__mlflow_client.download_artifacts(run_id, "obj")
+
+        with open(local_path, "rb") as f:
+            obj_bytes = f.read()
+
+        return obj_bytes
+
 
 ## Helpers for logging in MLFlow:
 
@@ -344,6 +419,22 @@ def _filterwarnings(category: type[Warning], msg: str) -> Iterator[None]:
             category=category,
         )
         yield
+
+
+@contextmanager
+def _suppress_mlflow_output() -> Iterator[None]:
+    """Silence MLflow event logs and stream output for internal storage writes."""
+    was_logging_enabled = MLFLOW_LOGGING_STREAM.enabled
+    MLFLOW_LOGGING_STREAM.enabled = False
+    try:
+        with (
+            _suppress_logs_in_thread(),
+            redirect_stdout(StringIO()),
+            redirect_stderr(StringIO()),
+        ):
+            yield
+    finally:
+        MLFLOW_LOGGING_STREAM.enabled = was_logging_enabled
 
 
 @contextmanager

--- a/skore/src/skore/_plugins/serde.py
+++ b/skore/src/skore/_plugins/serde.py
@@ -39,12 +39,12 @@ def externalize(
 ) -> dict[str, Any]:
     """Extract large artifacts in ``state`` to external storage.
 
-    Replace large artifacts in ``state`` with IDs.
+    Replace large artifacts in ``state`` with pointers.
 
     Parameters
     ----------
     state : dict[str, Any]
-        Report state whose ``"data"`` entries should be externalized.
+        Report state.
 
     artifact_writer : callable
         Called as ``artifact_writer(id, bytes)`` for each artifact extracted

--- a/skore/src/skore/_plugins/serde.py
+++ b/skore/src/skore/_plugins/serde.py
@@ -1,69 +1,85 @@
 import io
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
 
 import joblib
+
+ArtifactId: TypeAlias = str
 
 
 @dataclass
 class ArtifactPointer:
-    artifact_id: str
+    """A lazy reference to a serialized artifact.
 
-    @staticmethod
-    def load(artifact_bytes: bytes) -> Any:
-        raise NotImplementedError()
-
-    @staticmethod
-    def dump(artifact: Any) -> bytes:
-        raise NotImplementedError()
-
-
-class JoblibPointer(ArtifactPointer):
-    @staticmethod
-    def load(artifact_bytes: bytes) -> Any:
-        with io.BytesIO(artifact_bytes) as stream:
-            return joblib.load(stream)
-
-    @staticmethod
-    def dump(artifact: Any) -> bytes:
-        with io.BytesIO() as stream:
-            joblib.dump(artifact, stream)
-            return stream.getvalue()
-
-
-def split_data_from_state(
-    state: dict[str, Any],
-) -> Generator[tuple[str, bytes], None, None]:
-    """Extract data artifacts from a report state.
-
-    The input ``state`` is updated in place: each entry in ``state["data"]`` is
-    replaced by an artifact pointer, and the serialized artifact bytes are yielded.
+    A pointer replaces a heavy payload inside a report state so the bytes can
+    live elsewhere (typically content-addressed storage that de-duplicates
+    identical payloads across reports).
     """
-    data = {}
+
+    artifact_id: ArtifactId
+
+
+def joblib_dump(artifact: Any) -> bytes:
+    """Serialize the artifact into bytes suitable for storage."""
+    with io.BytesIO() as stream:
+        joblib.dump(artifact, stream)
+        return stream.getvalue()
+
+
+def joblib_load(artifact_bytes: bytes) -> Any:
+    """Deserialize the artifact from its stored byte representation."""
+    with io.BytesIO(artifact_bytes) as stream:
+        return joblib.load(stream)
+
+
+def externalize(
+    state: dict[str, Any],
+    artifact_writer: Callable[[ArtifactId, bytes], None],
+) -> dict[str, Any]:
+    """Extract large artifacts in ``state`` to external storage.
+
+    Replace large artifacts in ``state`` with IDs.
+
+    Parameters
+    ----------
+    state : dict[str, Any]
+        Report state whose ``"data"`` entries should be externalized.
+
+    artifact_writer : callable
+        Called as ``artifact_writer(id, bytes)`` for each artifact extracted
+        from ``state``; responsible for persisting ``bytes`` under ``id``.
+    """
+    new_data: dict[str, ArtifactPointer] = {}
     for key, obj in state["data"].items():
-        obj_bytes = JoblibPointer.dump(obj)
-        bytes_id = joblib.hash(obj_bytes)
-        yield (bytes_id, obj_bytes)
-        data[key] = JoblibPointer(bytes_id)
-    state |= {"data": data}
+        obj_bytes = joblib_dump(obj)
+        artifact_id = joblib.hash(obj_bytes)
+        artifact_writer(artifact_id, obj_bytes)
+        new_data[key] = ArtifactPointer(artifact_id)
+    return state | {"data": new_data}
 
 
-def restore_data_in_state(
+def internalize(
     state: Any,
-    artifact_loader: Callable[[str], bytes],
+    artifact_reader: Callable[[ArtifactId], bytes],
 ) -> Any:
-    """Restore artifact pointers in a report state.
+    """Replace artifact pointers in ``state`` with the data they point to.
 
-    Pointers are loaded with ``artifact_loader`` and deserialized; dictionaries
-    and lists are traversed recursively while other values are returned unchanged.
+    Parameters
+    ----------
+    state : Any
+        Possibly-nested structure (dict, list, or scalar) that may contain
+        :class:`ArtifactPointer` instances; traversed recursively.
+
+    artifact_loader : callable
+        Called as ``artifact_loader(artifact_id)`` for each pointer encountered.
     """
     if isinstance(state, ArtifactPointer):
-        artifact_bytes = artifact_loader(state.artifact_id)
-        return state.load(artifact_bytes)
+        artifact_bytes = artifact_reader(state.artifact_id)
+        return joblib_load(artifact_bytes)
     elif isinstance(state, dict):
-        return {k: restore_data_in_state(v, artifact_loader) for k, v in state.items()}
+        return {k: internalize(v, artifact_reader) for k, v in state.items()}
     elif isinstance(state, list):
-        return [restore_data_in_state(v, artifact_loader) for v in state]
+        return [internalize(v, artifact_reader) for v in state]
     else:
         return state

--- a/skore/src/skore/_plugins/serde.py
+++ b/skore/src/skore/_plugins/serde.py
@@ -20,14 +20,14 @@ class ArtifactPointer:
     artifact_id: ArtifactId
 
 
-def joblib_dump(artifact: Any) -> bytes:
+def dumps(artifact: Any) -> bytes:
     """Serialize the artifact into bytes suitable for storage."""
     with io.BytesIO() as stream:
         joblib.dump(artifact, stream)
         return stream.getvalue()
 
 
-def joblib_load(artifact_bytes: bytes) -> Any:
+def loads(artifact_bytes: bytes) -> Any:
     """Deserialize the artifact from its stored byte representation."""
     with io.BytesIO(artifact_bytes) as stream:
         return joblib.load(stream)
@@ -52,7 +52,7 @@ def externalize(
     """
     new_data: dict[str, ArtifactPointer] = {}
     for key, obj in state["data"].items():
-        obj_bytes = joblib_dump(obj)
+        obj_bytes = dumps(obj)
         artifact_id = joblib.hash(obj_bytes)
         artifact_writer(artifact_id, obj_bytes)
         new_data[key] = ArtifactPointer(artifact_id)
@@ -76,7 +76,7 @@ def internalize(
     """
     if isinstance(state, ArtifactPointer):
         artifact_bytes = artifact_reader(state.artifact_id)
-        return joblib_load(artifact_bytes)
+        return loads(artifact_bytes)
     elif isinstance(state, dict):
         return {k: internalize(v, artifact_reader) for k, v in state.items()}
     elif isinstance(state, list):

--- a/skore/src/skore/_plugins/serde.py
+++ b/skore/src/skore/_plugins/serde.py
@@ -9,8 +9,8 @@ ArtifactId: TypeAlias = str
 
 
 @dataclass
-class ArtifactPointer:
-    """A lazy reference to a serialized artifact.
+class JoblibPicklePointer:
+    """A lazy reference to an artifact serialized with joblib.
 
     A pointer replaces a heavy payload inside a report state so the bytes can
     live elsewhere (typically content-addressed storage that de-duplicates
@@ -50,12 +50,12 @@ def externalize(
         Called as ``artifact_writer(id, bytes)`` for each artifact extracted
         from ``state``; responsible for persisting ``bytes`` under ``id``.
     """
-    new_data: dict[str, ArtifactPointer] = {}
+    new_data: dict[str, JoblibPicklePointer] = {}
     for key, obj in state["data"].items():
         obj_bytes = dumps(obj)
         artifact_id = joblib.hash(obj_bytes)
         artifact_writer(artifact_id, obj_bytes)
-        new_data[key] = ArtifactPointer(artifact_id)
+        new_data[key] = JoblibPicklePointer(artifact_id)
     return state | {"data": new_data}
 
 
@@ -69,12 +69,12 @@ def internalize(
     ----------
     state : Any
         Possibly-nested structure (dict, list, or scalar) that may contain
-        :class:`ArtifactPointer` instances; traversed recursively.
+        :class:`JoblibPicklePointer` instances; traversed recursively.
 
     artifact_loader : callable
         Called as ``artifact_loader(artifact_id)`` for each pointer encountered.
     """
-    if isinstance(state, ArtifactPointer):
+    if isinstance(state, JoblibPicklePointer):
         artifact_bytes = artifact_reader(state.artifact_id)
         return loads(artifact_bytes)
     elif isinstance(state, dict):

--- a/skore/src/skore/_plugins/serde.py
+++ b/skore/src/skore/_plugins/serde.py
@@ -1,0 +1,69 @@
+import io
+from collections.abc import Callable, Generator
+from dataclasses import dataclass
+from typing import Any
+
+import joblib
+
+
+@dataclass
+class ArtifactPointer:
+    artifact_id: str
+
+    @staticmethod
+    def load(artifact_bytes: bytes) -> Any:
+        raise NotImplementedError()
+
+    @staticmethod
+    def dump(artifact: Any) -> bytes:
+        raise NotImplementedError()
+
+
+class JoblibPointer(ArtifactPointer):
+    @staticmethod
+    def load(artifact_bytes: bytes) -> Any:
+        with io.BytesIO(artifact_bytes) as stream:
+            return joblib.load(stream)
+
+    @staticmethod
+    def dump(artifact: Any) -> bytes:
+        with io.BytesIO() as stream:
+            joblib.dump(artifact, stream)
+            return stream.getvalue()
+
+
+def split_data_from_state(
+    state: dict[str, Any],
+) -> Generator[tuple[str, bytes], None, None]:
+    """Extract data artifacts from a report state.
+
+    The input ``state`` is updated in place: each entry in ``state["data"]`` is
+    replaced by an artifact pointer, and the serialized artifact bytes are yielded.
+    """
+    data = {}
+    for key, obj in state["data"].items():
+        obj_bytes = JoblibPointer.dump(obj)
+        bytes_id = joblib.hash(obj_bytes)
+        yield (bytes_id, obj_bytes)
+        data[key] = JoblibPointer(bytes_id)
+    state |= {"data": data}
+
+
+def restore_data_in_state(
+    state: Any,
+    artifact_loader: Callable[[str], bytes],
+) -> Any:
+    """Restore artifact pointers in a report state.
+
+    Pointers are loaded with ``artifact_loader`` and deserialized; dictionaries
+    and lists are traversed recursively while other values are returned unchanged.
+    """
+    if isinstance(state, ArtifactPointer):
+        artifact_bytes = artifact_loader(state.artifact_id)
+        return state.load(artifact_bytes)
+    elif isinstance(state, dict):
+        return {k: restore_data_in_state(v, artifact_loader) for k, v in state.items()}
+    elif isinstance(state, list):
+        return [restore_data_in_state(v, artifact_loader) for v in state]
+    else:
+        return state

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -17,6 +17,7 @@ from skore._externals._pandas_accessors import DirNamesMixin
 from skore._externals._sklearn_compat import _safe_indexing, is_clusterer
 from skore._sklearn._base import _BaseReport
 from skore._sklearn._checks.base import CheckCode
+from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
 from skore._sklearn._estimator.report import EstimatorReport
 from skore._sklearn.types import PositiveLabel, SKLearnCrossValidator
 from skore._utils._fixes import _validate_joblib_parallel_params
@@ -348,6 +349,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         report.estimator = state["estimator"]
         report._data = state["data"]
         report._split_indices = state["split_indices"]
+        report._checks_registry = list(_BUILTIN_CHECKS)
         # TODO? Include splitter in state?
         report._splitter = None
         report.n_jobs = None

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -284,7 +284,9 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         name : str
             The name of the metric to remove.
         """
-        self._parent._metric_registry.remove(name)
+        # `remove` takes the report as input so that the MetricRegistry does not
+        # need to have the report as an attribute, which would be a circular reference
+        self._parent._metric_registry.remove(report=self._parent, name=name)
 
     def fit_time(self, *, cast: bool = True) -> float | None:
         """Get time to fit the estimator.

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -365,7 +365,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 "test_data": self._test_data,
             },
             "predictions": predictions,
-            "metric_registry_data": self._metric_registry.data,
+            "metric_registry": self._metric_registry,
             # ---------- OPTIONAL STATE ------------
             # this part is less structured and not crucial for reconstructing a report
             # so we won't try ensuring backward compatibility.
@@ -408,8 +408,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 for (data_source, name), val in state["predictions"].items()
             }
         )
-        report._metric_registry = MetricRegistry(report)
-        report._metric_registry.data = state["metric_registry_data"]
+        report._metric_registry = state["metric_registry"]
         report._checks_registry = list(_BUILTIN_CHECKS)
 
         return report

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -22,6 +22,7 @@ from sklearn.utils.validation import _num_samples, check_is_fitted
 from skore._externals._pandas_accessors import DirNamesMixin
 from skore._externals._sklearn_compat import _safe_indexing, is_clusterer
 from skore._sklearn._base import _BaseReport
+from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
 from skore._sklearn.find_ml_task import _find_ml_task
 from skore._sklearn.metrics import MetricRegistry
 from skore._sklearn.types import DataSource, PositiveLabel
@@ -364,7 +365,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 "test_data": self._test_data,
             },
             "predictions": predictions,
-            "metric_registry": self._metric_registry,
+            "metric_registry_data": self._metric_registry.data,
             # ---------- OPTIONAL STATE ------------
             # this part is less structured and not crucial for reconstructing a report
             # so we won't try ensuring backward compatibility.
@@ -407,7 +408,9 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 for (data_source, name), val in state["predictions"].items()
             }
         )
-        report._metric_registry = state["metric_registry"]
+        report._metric_registry = MetricRegistry(report)
+        report._metric_registry.data = state["metric_registry_data"]
+        report._checks_registry = list(_BUILTIN_CHECKS)
 
         return report
 

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -379,7 +379,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         """Rebuild a report from :meth:`get_state` output."""
         version = state.get("version")
         if version != _STATE_VERSION:
-            # in the future, we could support some BW compatibility instead of crashing
+            # For now, no backward compatibility
             raise ValueError(f"Unexpected state version: {version!r}")
 
         report_type = state["metadata"]["report_type"]

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -893,9 +893,8 @@ class MetricRegistry(UserDict[str, Metric]):
         characteristics (e.g. the ML task and the estimator's prediction methods).
         """
         super().__init__()
-        self._report = report
 
-        # Needs to be called ``data`` since we inherit from :class:`UserDict`.
+        # Needs to be called ``data`` since we inherit from :class:`UserDict`
         self.data = OrderedDict(
             (metric.name, metric)
             for metric in BUILTIN_METRICS
@@ -942,7 +941,7 @@ class MetricRegistry(UserDict[str, Metric]):
         if position == "first":
             self.data.move_to_end(metric.name, last=False)
 
-    def remove(self, name: str) -> None:
+    def remove(self, *, report: EstimatorReport, name: str) -> None:
         """Remove a metric from the registry.
 
         Built-in metrics may be removed; they stay absent for the lifetime of this
@@ -958,11 +957,8 @@ class MetricRegistry(UserDict[str, Metric]):
         KeyError
             If `name` is not registered.
         """
-        if name not in self.data:
-            raise KeyError(name)
-
-        keys_to_delete = [k for k in self._report._cache if k[1] == name]
-        for k in keys_to_delete:
-            del self._report._cache[k]
-
         del self.data[name]
+
+        keys_to_delete = [k for k in report._cache if k[1] == name]
+        for k in keys_to_delete:
+            del report._cache[k]

--- a/skore/tests/unit/plugins/mlflow/test_project.py
+++ b/skore/tests/unit/plugins/mlflow/test_project.py
@@ -183,6 +183,24 @@ class TestProject:
         assert len(predictions) == len(reg_report.X_test)
         assert predictions == pytest.approx(expected_predictions)
 
+    def test_storage_deduplicates_data_artifacts(self):
+        project = Project("<project>")
+
+        project._write_object_in_storage("<object-id>", b"payload")
+        project._write_object_in_storage("<object-id>", b"payload")
+
+        storage_runs = mlflow.search_runs(
+            experiment_ids=[project._Project__storage_experiment_id],
+            filter_string="attributes.run_name = '<object-id>'",
+            output_format="list",
+        )
+
+        assert len(storage_runs) == 1
+        artifact_path = project._Project__mlflow_client.download_artifacts(
+            storage_runs[0].info.run_id, "obj"
+        )
+        assert Path(artifact_path).read_bytes() == b"payload"
+
     def test_put_cross_validation(self, cv_mclf_report):
         project = Project("<project>")
         project.put("<key>", cv_mclf_report)

--- a/skore/tests/unit/plugins/test_serde.py
+++ b/skore/tests/unit/plugins/test_serde.py
@@ -1,0 +1,40 @@
+import pytest
+
+from skore import CrossValidationReport, EstimatorReport
+from skore._plugins.serde import restore_data_in_state, split_data_from_state
+
+
+@pytest.fixture(
+    params=[
+        "estimator_reports_regression",
+        "cross_validation_reports_regression",
+    ],
+    ids=["estimator", "cross-validation"],
+)
+def report(request):
+    return request.getfixturevalue(request.param)[0]
+
+
+@pytest.mark.parametrize(
+    ("report_cls", "report_fixture"),
+    [
+        (EstimatorReport, "estimator_reports_regression"),
+        (CrossValidationReport, "cross_validation_reports_regression"),
+    ],
+    ids=["estimator", "cross-validation"],
+)
+def test_report_rebuilds_after_smart_serde(
+    request,
+    report_cls: type[EstimatorReport] | type[CrossValidationReport],
+    report_fixture: str,
+) -> None:
+    report = request.getfixturevalue(report_fixture)[0]
+    state = report.get_state()
+    artifacts = dict(split_data_from_state(state))
+
+    restored_state = restore_data_in_state(state, artifacts.__getitem__)
+
+    restored_report = report_cls.from_state(restored_state)
+    # test restored_report works:
+    restored_report.data.analyze()
+    restored_report.metrics.summarize()

--- a/skore/tests/unit/plugins/test_serde.py
+++ b/skore/tests/unit/plugins/test_serde.py
@@ -1,7 +1,6 @@
 import pytest
 
-from skore import CrossValidationReport, EstimatorReport
-from skore._plugins.serde import restore_data_in_state, split_data_from_state
+from skore._plugins.serde import externalize, internalize
 
 
 @pytest.fixture(
@@ -15,26 +14,13 @@ def report(request):
     return request.getfixturevalue(request.param)[0]
 
 
-@pytest.mark.parametrize(
-    ("report_cls", "report_fixture"),
-    [
-        (EstimatorReport, "estimator_reports_regression"),
-        (CrossValidationReport, "cross_validation_reports_regression"),
-    ],
-    ids=["estimator", "cross-validation"],
-)
-def test_report_rebuilds_after_smart_serde(
-    request,
-    report_cls: type[EstimatorReport] | type[CrossValidationReport],
-    report_fixture: str,
-) -> None:
-    report = request.getfixturevalue(report_fixture)[0]
-    state = report.get_state()
-    artifacts = dict(split_data_from_state(state))
+def test_report_rebuilds_after_smart_serde(report) -> None:
+    artifacts: dict[str, bytes] = {}
+    state = externalize(report.get_state(), artifacts.__setitem__)
 
-    restored_state = restore_data_in_state(state, artifacts.__getitem__)
+    restored_state = internalize(state, artifacts.__getitem__)
 
-    restored_report = report_cls.from_state(restored_state)
+    restored_report = report.__class__.from_state(restored_state)
     # test restored_report works:
     restored_report.data.analyze()
     restored_report.metrics.summarize()

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -1,3 +1,5 @@
+import pickle
+
 import joblib
 import numpy as np
 import pandas as pd
@@ -15,7 +17,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.utils._testing import _convert_container
 from sklearn.utils.validation import check_is_fitted
 
-from skore import CrossValidationReport, EstimatorReport
+from skore import CrossValidationReport, EstimatorReport, evaluate
 from skore._sklearn._cross_validation.report import _generate_estimator_report
 from skore._utils._testing import MockEstimator
 
@@ -343,6 +345,9 @@ def test_from_state_bypasses_init_and_restores_state(
     _ = report.get_predictions(data_source="test")
     report.cache_predictions()
 
+    # check repr doesn't crash:
+    restored._repr_html_()
+
 
 def test_get_from_state_with_complex_data_op():
     X, y = make_classification(random_state=0)
@@ -384,6 +389,9 @@ def test_get_from_state_with_complex_data_op():
     for pred, expected_pred in zip(preds, expected_preds, strict=True):
         np.testing.assert_array_equal(pred, expected_pred)
 
+    # check repr doesn't crash:
+    restored._repr_html_()
+
 
 def test_from_state_rejects_unknown_version(logistic_binary_classification_data):
     estimator, X, y = logistic_binary_classification_data
@@ -392,3 +400,24 @@ def test_from_state_rejects_unknown_version(logistic_binary_classification_data)
 
     with pytest.raises(ValueError, match="Unexpected state version"):
         CrossValidationReport.from_state(state)
+
+
+def test_state_has_no_unexpected_data_copy():
+    estimator = DummyClassifier()
+
+    def state_nbytes_without_data(report):
+        state = report.get_state()
+        state.pop("data")
+        return len(pickle.dumps(state))
+
+    X, y = make_classification(n_samples=50_000, n_features=30)
+    report = evaluate(estimator, X, y, splitter=0.2)
+    assert state_nbytes_without_data(report) < X.nbytes
+    report = evaluate(estimator, X, y, splitter=3)
+    assert state_nbytes_without_data(report) < X.nbytes
+
+    estimator = DummyRegressor()
+    report = evaluate(estimator, X, y, splitter=0.2)
+    assert state_nbytes_without_data(report) < X.nbytes
+    report = evaluate(estimator, X, y, splitter=3)
+    assert state_nbytes_without_data(report) < X.nbytes

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -402,22 +402,30 @@ def test_from_state_rejects_unknown_version(logistic_binary_classification_data)
         CrossValidationReport.from_state(state)
 
 
-def test_state_has_no_unexpected_data_copy():
-    estimator = DummyClassifier()
+@pytest.mark.parametrize(
+    "estimator",
+    [DummyClassifier(), DummyRegressor()],
+    ids=["classification", "regression"],
+)
+@pytest.mark.parametrize("splitter", [0.2, 3], ids=["estimator", "cross-validation"])
+def test_state_has_no_unexpected_data_copy(estimator, splitter):
+    """``state`` should only reference training data through ``state["data"]``."""
 
     def state_nbytes_without_data(report):
         state = report.get_state()
         state.pop("data")
         return len(pickle.dumps(state))
 
+    # Large dataset to increase our chances that X is much larger than all the other
+    # report attributes
+    # We use a classification-oriented dataset even for regression to avoid making the
+    # test more complex
     X, y = make_classification(n_samples=50_000, n_features=30)
-    report = evaluate(estimator, X, y, splitter=0.2)
-    assert state_nbytes_without_data(report) < X.nbytes
-    report = evaluate(estimator, X, y, splitter=3)
-    assert state_nbytes_without_data(report) < X.nbytes
+    report = evaluate(estimator, X, y, splitter=splitter)
 
-    estimator = DummyRegressor()
-    report = evaluate(estimator, X, y, splitter=0.2)
-    assert state_nbytes_without_data(report) < X.nbytes
-    report = evaluate(estimator, X, y, splitter=3)
+    # If the state "without data" is bigger than X, then this likely means that
+    # the state somehow still contains X. This may be a sign that an attribute of the
+    # report still holds a reference to the report (e.g. the metrics registry).
+    # However, this is a heuristic; if this test fails, it may also be because the state
+    # size is no longer dominated by the size of X.
     assert state_nbytes_without_data(report) < X.nbytes


### PR DESCRIPTION
#### Change description

This PR updates the MLflow project backend to serialize reports through `get_state` / `from_state`, and stores the heavy `state["data"]` entries as separate artifacts.

Those data artifacts are keyed by their `joblib.hash`, so identical data can be de-duplicated in the hidden MLflow storage experiment instead of being logged again for each report.

I also added small serde helper tests using real report states, plus a MLflow test checking that writing the same data artifact twice only creates one storage run.

#### AI usage disclosure

AI tools were involved for:
- Test generation
- Review-fix iteration
