### PR TITLE
feat: Support multimetric scorer functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,6 +95,9 @@ Added
   The reports also now have a :meth:`~EstimatorReport.metrics.score` method.
   See :pr:`2884` by :user:`auguste-probabl`.
 
+- The report metrics API now supports multimetric scorers in the form of
+  functions returning dictionaries. See :pr:`2933` by :user:`auguste-probabl`.
+
 - Added two new automated checks: SKD009 (model worse than baseline, issue) and
   SKD010 (model slower than baseline, issue). See :pr:`2906` by
   :user:`GaetandeCast`.

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numbers
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import pandas as pd
 from joblib import Parallel
@@ -18,7 +18,7 @@ from skore._sklearn._plot import (
     PredictionErrorDisplay,
     RocCurveDisplay,
 )
-from skore._sklearn._plot.metrics.metrics_summary_display import metric_score_to_rows
+from skore._sklearn._plot.metrics.metrics_summary_display import MetricsSummaryRow
 from skore._sklearn.metrics import MetricLike
 from skore._sklearn.types import Aggregate
 from skore._utils._accessor import _check_estimator_report_has_method
@@ -276,26 +276,22 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
 
         This helper allows passing kwargs to the sub-reports, unlike :meth:`summarize`.
         """
-        reports = self._parent.reports_
-        metric = reports[0]._metric_registry[metric_name]
-
-        rows = []
-        for split_idx, report in enumerate(reports):
-            score = getattr(report.metrics, metric_name)(
-                data_source=data_source, **kwargs
+        rows: list[MetricsSummaryRow] = []
+        for split_idx, report in enumerate(self._parent.reports_):
+            metric = report._metric_registry[metric_name]
+            metric_rows = metric.rows(report=report, data_source=data_source, **kwargs)
+            rows.extend(
+                cast(
+                    MetricsSummaryRow,
+                    row
+                    | {
+                        "estimator_name": report.estimator_name_,
+                        "data_source": data_source,
+                        "split": split_idx,
+                    },
+                )
+                for row in metric_rows
             )
-            split_rows = metric_score_to_rows(
-                score,
-                metric=metric,
-                ml_task=report._ml_task,
-                data_source=data_source,
-                estimator_name=report.estimator_name_,
-                pos_label=report.pos_label,
-                kwargs=kwargs or None,
-            )
-            for r in split_rows:
-                r["split"] = split_idx
-            rows.extend(split_rows)
 
         return MetricsSummaryDisplay(rows=rows, report_type="cross-validation")
 

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -16,7 +16,7 @@ from skore._sklearn._plot import (
     PredictionErrorDisplay,
     RocCurveDisplay,
 )
-from skore._sklearn._plot.metrics.metrics_summary_display import metric_score_to_rows
+from skore._sklearn._plot.metrics.metrics_summary_display import MetricsSummaryRow
 from skore._sklearn.metrics import (
     BUILTIN_METRICS,
     R2,
@@ -142,24 +142,21 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             parsed_metrics = [registry[m] for m in metric]
         else:
             parsed_metrics = list(registry.values())
-        parsed_metrics = cast(list[Metric], parsed_metrics)
 
-        rows = []
+        rows: list[MetricsSummaryRow] = []
         for parsed_metric in parsed_metrics:
-            score = parsed_metric(
+            metric_rows = parsed_metric.rows(
                 report=self._parent,
                 data_source=data_source,
                 **parsed_metric.kwargs,
             )
             rows.extend(
-                metric_score_to_rows(
-                    score,
-                    metric=parsed_metric,
-                    ml_task=self._parent._ml_task,
-                    data_source=data_source,
-                    estimator_name=self._parent.estimator_name_,
-                    pos_label=self._parent.pos_label,
-                )
+                row
+                | {
+                    "estimator_name": self._parent.estimator_name_,
+                    "data_source": data_source,
+                }
+                for row in metric_rows
             )
 
         return MetricsSummaryDisplay(rows=rows, report_type="estimator")
@@ -169,15 +166,19 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
     ) -> MetricsSummaryDisplay:
         """Compute a single metric, forwarding *kwargs* to the score function."""
         metric = self._parent._metric_registry[metric_name]
-        rows = metric_score_to_rows(
-            score=metric(report=self._parent, data_source=data_source, **kwargs),
-            metric=metric,
-            ml_task=self._parent._ml_task,
-            data_source=data_source,
-            estimator_name=self._parent.estimator_name_,
-            pos_label=self._parent.pos_label,
-            kwargs=kwargs or None,
-        )
+        rows = [
+            cast(
+                MetricsSummaryRow,
+                row
+                | {
+                    "estimator_name": self._parent.estimator_name_,
+                    "data_source": data_source,
+                },
+            )
+            for row in metric.rows(
+                report=self._parent, data_source=data_source, **kwargs
+            )
+        ]
         return MetricsSummaryDisplay(rows=rows, report_type="estimator")
 
     def available(self) -> list[str]:
@@ -299,7 +300,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         float or None
             The fit time in seconds, or `None` when not available.
         """
-        return FitTime()(report=self._parent, cast=cast)
+        return FitTime().pretty(report=self._parent, cast=cast)
 
     def predict_time(
         self,
@@ -323,7 +324,9 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         float or None
             The prediction time in seconds, or `None` when not available.
         """
-        return PredictTime()(report=self._parent, data_source=data_source, cast=cast)
+        return PredictTime().pretty(
+            report=self._parent, data_source=data_source, cast=cast
+        )
 
     def timings(self) -> dict:
         """Get all measured processing times related to the estimator.
@@ -404,7 +407,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.score()
         0.94...
         """
-        return Score()(report=self._parent, data_source=data_source)  # type: ignore[return-value]
+        return Score().pretty(report=self._parent, data_source=data_source)
 
     def accuracy(
         self,
@@ -437,7 +440,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.accuracy()
         0.94...
         """
-        return Accuracy()(report=self._parent, data_source=data_source)  # type: ignore[return-value]
+        return Accuracy().pretty(report=self._parent, data_source=data_source)
 
     def precision(
         self,
@@ -494,7 +497,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.precision()
         0.98...
         """
-        return Precision()(
+        return Precision().pretty(
             report=self._parent, data_source=data_source, average=average
         )
 
@@ -559,7 +562,9 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.recall()
         0.92...
         """
-        return Recall()(report=self._parent, data_source=data_source, average=average)
+        return Recall().pretty(
+            report=self._parent, data_source=data_source, average=average
+        )
 
     def brier_score(
         self,
@@ -592,7 +597,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.brier_score()
         0.03...
         """
-        return Brier()(report=self._parent, data_source=data_source)
+        return Brier().pretty(report=self._parent, data_source=data_source)
 
     def roc_auc(
         self,
@@ -660,7 +665,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.roc_auc()
         0.99...
         """
-        return RocAuc()(
+        return RocAuc().pretty(
             report=self._parent,
             data_source=data_source,
             average=average,
@@ -698,7 +703,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.log_loss()
         0.11...
         """
-        return LogLoss()(report=self._parent, data_source=data_source)  # type: ignore[return-value]
+        return LogLoss().pretty(report=self._parent, data_source=data_source)
 
     def r2(
         self,
@@ -744,7 +749,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.r2()
         0.34...
         """
-        return R2()(
+        return R2().pretty(
             report=self._parent, data_source=data_source, multioutput=multioutput
         )
 
@@ -792,7 +797,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.rmse()
         58.1...
         """
-        return Rmse()(
+        return Rmse().pretty(
             report=self._parent, data_source=data_source, multioutput=multioutput
         )
 
@@ -840,7 +845,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.mae()
         46.5...
         """
-        return Mae()(
+        return Mae().pretty(
             report=self._parent, data_source=data_source, multioutput=multioutput
         )
 
@@ -888,7 +893,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.mape()
         0.3...
         """
-        return Mape()(
+        return Mape().pretty(
             report=self._parent, data_source=data_source, multioutput=multioutput
         )
 

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -4,11 +4,9 @@ import pandas as pd
 from matplotlib.figure import Figure
 
 from skore._sklearn._plot.base import DisplayMixin
-from skore._sklearn.metrics import Metric
 from skore._sklearn.types import (
     Aggregate,
     DataSource,
-    MLTask,
     PositiveLabel,
     ReportType,
 )
@@ -49,69 +47,6 @@ class MetricsSummaryRow(TypedDict):
     average: str | None
     output: int | None
     split: NotRequired[int]
-
-
-def metric_score_to_rows(
-    score: float | list | dict,
-    *,
-    metric: Metric,
-    ml_task: MLTask,
-    data_source: DataSource,
-    estimator_name: str,
-    pos_label: PositiveLabel = None,
-    kwargs: dict[str, Any] | None = None,
-) -> list[MetricsSummaryRow]:
-    """Expand a metric score into display rows based on the ML task.
-
-    Parameters
-    ----------
-    score : float, dict, or list
-        The metric score.
-
-    metric : Metric
-        The metric instance (provides ``verbose_name``, ``icon``,
-        and default ``kwargs``).
-
-    ml_task : str
-        The ML task (e.g. ``"binary-classification"``).
-
-    data_source : {"test", "train"}
-        The data source to use.
-
-    estimator_name : str
-        Name shown in the display.
-
-    pos_label : label, default=None
-        Positive label for binary classification.
-
-    kwargs : dict, optional
-        Keyword arguments used for the score call. Default is ``metric.kwargs``.
-    """
-    if kwargs is None:
-        kwargs = metric.kwargs
-
-    row: MetricsSummaryRow = {
-        "metric_verbose_name": metric.verbose_name,
-        "estimator_name": estimator_name,
-        "data_source": data_source,
-        "greater_is_better": metric.greater_is_better,
-        "label": None,
-        "average": None,
-        "output": None,
-        "score": score,
-    }
-
-    if ml_task == "binary-classification" and kwargs.get("average") == "binary":
-        return [{**row, "label": kwargs.get("pos_label", pos_label)}]
-    if ml_task in ("binary-classification", "multiclass-classification"):
-        if isinstance(score, dict):
-            return [{**row, "label": label, "score": score[label]} for label in score]
-        return [{**row, "average": kwargs.get("average")}]
-    if ml_task == "multioutput-regression":
-        if isinstance(score, list):
-            return [{**row, "output": idx, "score": s} for idx, s in enumerate(score)]
-        return [{**row, "average": kwargs.get("multioutput")}]
-    return [row]
 
 
 class MetricsSummaryDisplay(DisplayMixin):

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -7,12 +7,13 @@ from collections import OrderedDict, UserDict
 from collections.abc import Callable
 from enum import Enum, auto
 from inspect import Parameter
-from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+from itertools import groupby
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, cast
 
 import numpy as np
 import sklearn
 import sklearn.metrics
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator
 from sklearn.metrics._scorer import _BaseScorer
 
@@ -50,6 +51,38 @@ _METRIC_ALIASES: dict[str, str] = {
     "max_error": "neg_max_error",
     "negative_likelihood_ratio": "neg_negative_likelihood_ratio",
 }
+
+
+class MetricRow(TypedDict):
+    """A single row of a metric output.
+
+    Parameters
+    ----------
+    metric_verbose_name : str
+        Human-readable metric name.
+
+    greater_is_better : bool or None
+        Whether higher values are better.
+
+    score : float
+        Scalar metric value.
+
+    label : label, default=None
+        Class label for per-class classification metrics.
+
+    average : str, default=None
+        Averaging mode when a metric is aggregated across labels or outputs.
+
+    output : int, default=None
+        Output index for multioutput regression metrics.
+    """
+
+    metric_verbose_name: str
+    greater_is_better: bool | None
+    score: float
+    label: PositiveLabel | None
+    average: str | None
+    output: int | None
 
 
 class FunctionKind(Enum):
@@ -102,6 +135,16 @@ class Metric:
 
     kwargs : dict, default={}
         Default keyword arguments for the scoring function.
+
+    Notes
+    -----
+    A metric's value flows through four layers, from raw to human-readable:
+
+    - :meth:`raw` performs the actual computation.
+    - :meth:`raw_cached` wraps :meth:`raw` and caches the result.
+    - :meth:`rows` outputs metric scores in a structured format.
+    - :meth:`pretty` outputs metric scores in a human-readable format, which may
+      differ from what the base metric returned.
     """
 
     def __init__(
@@ -135,123 +178,6 @@ class Metric:
         self.function = function
         self.function_kind = function_kind
 
-    def __getstate__(self) -> dict[str, Any]:
-        state = self.__dict__.copy()
-        if state.get("function") is not None:
-            try:
-                pickle.dumps(state["function"])
-            except Exception:
-                state["function"] = None
-        return state
-
-    @staticmethod
-    def available(report: EstimatorReport) -> bool:
-        """Whether this metric is applicable to the given report."""
-        return True
-
-    def __repr__(self) -> str:
-        args = [
-            f"name={self.name!r}",
-            f"verbose_name={self.verbose_name!r}",
-            f"function={self.function}",
-            f"greater_is_better={self.greater_is_better}",
-            f"response_method={self.response_method}",
-            f"kwargs={self.kwargs}",
-        ]
-
-        return f"Metric({', '.join(args)})"
-
-    def __call__(
-        self,
-        *,
-        report: EstimatorReport,
-        data_source: DataSource = "test",
-        **kwargs: Any,
-    ) -> float | dict[PositiveLabel, float] | list:
-        """Compute the metric score.
-
-        Parameters
-        ----------
-        report : EstimatorReport
-            The report to compute the metric for.
-
-        data_source : {"test", "train"}, default="test"
-            Which data split to use.
-
-        **kwargs
-            Additional keyword arguments passed to the scoring function.
-        """
-        # Merge default kwargs with call-time kwargs
-        merged_kwargs = self.kwargs | kwargs
-
-        cache_key = make_cache_key(data_source, self.name, merged_kwargs)
-        score = report._cache.get(cache_key)
-        if score is not None:
-            return score
-
-        score = self._compute(report=report, data_source=data_source, **merged_kwargs)
-
-        if isinstance(score, np.ndarray):
-            score = cast(NDArray, score).tolist()
-
-        if hasattr(score, "item"):
-            score = cast(NDArray, score).item()
-        elif isinstance(score, list):
-            if len(score) == 1:
-                score = score[0]
-            elif "classification" in report._ml_task:
-                score = dict(
-                    zip(report.learner_.classes_.tolist(), score, strict=False)
-                )
-
-        report._cache[cache_key] = score
-        return cast(float | dict[PositiveLabel, float] | list[float], score)
-
-    def _compute(
-        self,
-        *,
-        report: EstimatorReport,
-        data_source: DataSource,
-        **kwargs: Any,
-    ) -> Any:
-        """Compute the raw uncached score.
-
-        Override this hook when a metric's score cannot be expressed as
-        ``self.function(...)`` (see :class:`Score`). Subclasses that only need
-        to tweak kwargs should override :meth:`__call__` and delegate to
-        ``super().__call__``; the cache and post-processing live in
-        :meth:`__call__` and run for every override of this hook.
-        """
-        if self.function is None:
-            raise ValueError(f"Metric {self.name!r} has no scoring function.")
-
-        metric_params = inspect.signature(self.function).parameters
-        call_kwargs = kwargs.copy()
-        if "pos_label" in metric_params and "pos_label" not in call_kwargs:
-            call_kwargs["pos_label"] = report.pos_label
-
-        if self.function_kind == FunctionKind.METRIC:
-            assert self.response_method is not None
-
-            _, y_true = report._get_data_and_y_true(data_source=data_source)
-            y_pred = report._get_predictions(
-                data_source=data_source,
-                response_method=self.response_method,
-                pos_label=call_kwargs.get("pos_label", None),
-            )
-
-            return cast(MetricCallable, self.function)(y_true, y_pred, **call_kwargs)
-
-        assert self.function_kind == FunctionKind.SCORER
-        data, y_true = report._get_data_and_y_true(data_source=data_source)
-        X = data["_skrub_X"]
-        return cast(ScorerCallable, self.function)(
-            report.estimator_,
-            X,
-            y_true,
-            **call_kwargs,
-        )
-
     @staticmethod
     def new(
         metric: MetricLike | Metric,
@@ -261,7 +187,7 @@ class Metric:
         greater_is_better: bool = True,
         kwargs: dict[str, Any] | None = None,
     ) -> Metric:
-        """Convert a metric-like object into a :class:`Metric` instance.
+        """Create a :class:`Metric` from a metric-like object.
 
         Parameters
         ----------
@@ -383,6 +309,196 @@ class Metric:
                 "Expected a callable, sklearn scorer, or Metric instance."
             )
 
+    def __repr__(self) -> str:
+        """Return a representation of the metric."""
+        args = [
+            f"name={self.name!r}",
+            f"verbose_name={self.verbose_name!r}",
+            f"function={self.function}",
+            f"greater_is_better={self.greater_is_better}",
+            f"response_method={self.response_method}",
+            f"kwargs={self.kwargs}",
+        ]
+
+        return f"Metric({', '.join(args)})"
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return a pickle-safe representation of the metric."""
+        state = self.__dict__.copy()
+        if state.get("function") is not None:
+            try:
+                pickle.dumps(state["function"])
+            except Exception:
+                # function may be a closure or some other non-picklable object
+                state["function"] = None
+        return state
+
+    @staticmethod
+    def available(report: EstimatorReport) -> bool:
+        """Whether this metric is applicable to the given report.
+
+        Override this when the metric is not defined for every ML task or estimator
+        (e.g. accuracy is not a regression metric).
+        """
+        return True
+
+    def raw(
+        self,
+        *,
+        report: EstimatorReport,
+        data_source: DataSource = "test",
+        **kwargs: Any,
+    ) -> Any:
+        """Compute the raw metric on the given report.
+
+        Override this when the score cannot be expressed as ``self.function(...)``
+        (see :class:`Score`, :class:`FitTime`, :class:`PredictTime`). Subclasses that
+        only need to adjust kwargs before delegating should call ``super().raw(...)``
+        (see :class:`Precision`, :class:`Brier`, :class:`RocAuc`).
+
+        Parameters
+        ----------
+        report : EstimatorReport
+            The report to compute the metric for.
+
+        data_source : {"test", "train"}, default="test"
+            Which data split to use.
+
+        **kwargs
+            Additional keyword arguments passed to the scoring function.
+
+        Returns
+        -------
+        float or ndarray or dict
+            The computed metric value.
+        """
+        if self.function is None:
+            raise ValueError(f"Metric {self.name!r} has no scoring function.")
+
+        metric_params = inspect.signature(self.function).parameters
+        call_kwargs = kwargs.copy()
+        if "pos_label" in metric_params and "pos_label" not in call_kwargs:
+            call_kwargs["pos_label"] = report.pos_label
+
+        if self.function_kind == FunctionKind.METRIC:
+            assert self.response_method is not None
+
+            _, y_true = report._get_data_and_y_true(data_source=data_source)
+            y_pred = report._get_predictions(
+                data_source=data_source,
+                response_method=self.response_method,
+                pos_label=call_kwargs.get("pos_label", None),
+            )
+
+            return cast(MetricCallable, self.function)(y_true, y_pred, **call_kwargs)
+
+        assert self.function_kind == FunctionKind.SCORER
+
+        data, y_true = report._get_data_and_y_true(data_source=data_source)
+        X = data["_skrub_X"]
+        return cast(ScorerCallable, self.function)(
+            report.estimator_,
+            X,
+            y_true,
+            **call_kwargs,
+        )
+
+    def raw_cached(
+        self,
+        *,
+        report: EstimatorReport,
+        data_source: DataSource = "test",
+        **kwargs: Any,
+    ) -> Any:
+        """Compute the raw metric and cache it in the report."""
+        cache_key = make_cache_key(data_source, self.name, kwargs)
+        score = report._cache.get(cache_key)
+        if score is None:
+            score = self.raw(report=report, data_source=data_source, **kwargs)
+
+            report._cache[cache_key] = score
+
+        return score
+
+    def _row(
+        self,
+        *,
+        score: Any,
+        label: PositiveLabel | None = None,
+        average: str | None = None,
+        output: int | None = None,
+    ) -> MetricRow:
+        """Build a single :class:`MetricRow`."""
+        return MetricRow(
+            metric_verbose_name=self.verbose_name,
+            greater_is_better=self.greater_is_better,
+            score=score.item() if hasattr(score, "item") else score,
+            label=label,
+            average=average,
+            output=output,
+        )
+
+    def rows(
+        self,
+        *,
+        report: EstimatorReport,
+        data_source: DataSource,
+        **kwargs: Any,
+    ) -> list[MetricRow]:
+        """Compute the metric and expand it into one or more rows."""
+        merged_kwargs = self.kwargs | kwargs
+        score = self.raw_cached(report=report, data_source=data_source, **merged_kwargs)
+
+        if (
+            report._ml_task == "binary-classification"
+            and kwargs.get("average") == "binary"
+        ):
+            return [
+                self._row(
+                    score=score, label=merged_kwargs.get("pos_label", report.pos_label)
+                )
+            ]
+        if report._ml_task in ("binary-classification", "multiclass-classification"):
+            if isinstance(score, np.ndarray):
+                return [
+                    self._row(score=s, label=label)
+                    for label, s in zip(
+                        report.learner_.classes_.tolist(),
+                        score.tolist(),
+                        strict=False,
+                    )
+                ]
+            return [self._row(score=score, average=merged_kwargs.get("average"))]
+        if report._ml_task == "multioutput-regression":
+            if isinstance(score, np.ndarray):
+                return [
+                    self._row(score=s, output=idx)
+                    for idx, s in enumerate(score.tolist())
+                ]
+            return [self._row(score=score, average=merged_kwargs.get("multioutput"))]
+        return [self._row(score=score)]
+
+    def pretty(
+        self,
+        *,
+        report: EstimatorReport,
+        data_source: DataSource = "test",
+        **kwargs: Any,
+    ) -> Any:
+        """Compute the metric in a human-readable shape."""
+        rows = self.rows(report=report, data_source=data_source, **kwargs)
+
+        if len(rows) == 1:
+            return rows[0]["score"]
+
+        if rows[0]["label"] is not None:
+            # Multi-class classification
+            return {row["label"]: row["score"] for row in rows}
+
+        # Multioutput regression
+        # We assume rows are sorted by output
+        return np.array([row["score"] for row in rows])
+
 
 class FitTime(Metric):
     name = "fit_time"
@@ -395,9 +511,7 @@ class FitTime(Metric):
     def available(report: EstimatorReport) -> bool:
         return True
 
-    def __call__(
-        self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs
-    ):
+    def raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
         if cast and report.fit_time_ is None:
             return float("nan")
         return report.fit_time_
@@ -414,9 +528,7 @@ class PredictTime(Metric):
     def available(report: EstimatorReport) -> bool:
         return True
 
-    def __call__(
-        self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs
-    ):
+    def raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
         predict_time_cache_key = make_cache_key(data_source, "predict_time")
         return report._cache.get(
             predict_time_cache_key, (float("nan") if cast else None)
@@ -448,7 +560,7 @@ class Precision(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
-    def __call__(
+    def raw(
         self, *, report: EstimatorReport, data_source="test", average=None, **kwargs
     ):
         if report._ml_task == "binary-classification":
@@ -457,7 +569,7 @@ class Precision(Metric):
             elif average != "binary":
                 kwargs["pos_label"] = None
 
-        return super().__call__(
+        return super().raw(
             report=report, data_source=data_source, average=average, **kwargs
         )
 
@@ -474,7 +586,7 @@ class Recall(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
-    def __call__(
+    def raw(
         self, *, report: EstimatorReport, data_source="test", average=None, **kwargs
     ):
         if report._ml_task == "binary-classification":
@@ -483,7 +595,7 @@ class Recall(Metric):
             elif average != "binary":
                 kwargs["pos_label"] = None
 
-        return super().__call__(
+        return super().raw(
             report=report, data_source=data_source, average=average, **kwargs
         )
 
@@ -502,11 +614,11 @@ class Brier(Metric):
             report.learner_, "predict_proba"
         )
 
-    def __call__(self, *, report: EstimatorReport, data_source="test", **kwargs):
+    def raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
         # The Brier score in scikit-learn requests `pos_label` to ensure that
         # the integral encoding of `y_true` corresponds to the probabilities of
         # the `pos_label`.
-        return super().__call__(
+        return super().raw(
             report=report,
             data_source=data_source,
             pos_label=report.learner_.classes_[-1],
@@ -537,7 +649,7 @@ class RocAuc(Metric):
             y_score = y_score[:, 1]
         return sklearn.metrics.roc_auc_score(y_true, y_score, **kwargs)
 
-    def __call__(
+    def raw(
         self,
         *,
         report: EstimatorReport,
@@ -546,7 +658,7 @@ class RocAuc(Metric):
         multi_class="ovr",
         **kwargs,
     ):
-        return super().__call__(
+        return super().raw(
             report=report,
             data_source=data_source,
             average=average,
@@ -583,7 +695,7 @@ class R2(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def __call__(
+    def raw(
         self,
         *,
         report: EstimatorReport,
@@ -591,7 +703,7 @@ class R2(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().__call__(
+        return super().raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -608,7 +720,7 @@ class Rmse(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def __call__(
+    def raw(
         self,
         *,
         report: EstimatorReport,
@@ -616,7 +728,7 @@ class Rmse(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().__call__(
+        return super().raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -633,7 +745,7 @@ class Mae(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def __call__(
+    def raw(
         self,
         *,
         report: EstimatorReport,
@@ -641,7 +753,7 @@ class Mae(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().__call__(
+        return super().raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -658,7 +770,7 @@ class Mape(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def __call__(
+    def raw(
         self,
         *,
         report: EstimatorReport,
@@ -666,7 +778,7 @@ class Mape(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().__call__(
+        return super().raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -682,7 +794,7 @@ class Score(Metric):
     def available(report: EstimatorReport) -> bool:
         return hasattr(report.estimator_, "score")
 
-    def _compute(
+    def raw(
         self,
         *,
         report: EstimatorReport,

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -830,7 +830,7 @@ class Score(Metric):
         self,
         *,
         report: EstimatorReport,
-        data_source: DataSource,
+        data_source: DataSource = "test",
         **kwargs: Any,
     ) -> Any:
         # Both estimator paths accept the dict ``data`` directly:
@@ -838,7 +838,7 @@ class Score(Metric):
         # estimators; ``SkrubLearner`` takes the full env, preserving vars
         # beyond X/y (e.g. additional tables referenced by the DataOp).
         data, _ = report._get_data_and_y_true(data_source=data_source)
-        return report.learner_.score(data)
+        return report.learner_.score(data, **kwargs)
 
 
 # Order matters for default display

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -312,15 +312,17 @@ class Metric:
     def __repr__(self) -> str:
         """Return a representation of the metric."""
         args = [
-            f"name={self.name!r}",
-            f"verbose_name={self.verbose_name!r}",
-            f"function={self.function}",
-            f"greater_is_better={self.greater_is_better}",
-            f"response_method={self.response_method}",
-            f"kwargs={self.kwargs}",
+            "name",
+            "verbose_name",
+            "function",
+            "greater_is_better",
+            "response_method",
+            "kwargs",
         ]
 
-        return f"Metric({', '.join(args)})"
+        kwargs = [f"{a}={getattr(self, a)!r}" for a in args if hasattr(self, a)]
+
+        return f"Metric({', '.join(kwargs)})"
 
     def __getstate__(self) -> dict[str, Any]:
         """Return a pickle-safe representation of the metric."""

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -140,8 +140,8 @@ class Metric:
     -----
     A metric's value flows through four layers, from raw to human-readable:
 
-    - :meth:`raw` performs the actual computation.
-    - :meth:`raw_cached` wraps :meth:`raw` and caches the result.
+    - :meth:`_raw` performs the actual computation.
+    - :meth:`_raw_cached` wraps :meth:`_raw` and caches the result.
     - :meth:`rows` outputs metric scores in a structured format.
     - :meth:`pretty` outputs metric scores in a human-readable format, which may
       differ from what the base metric returned.
@@ -344,7 +344,7 @@ class Metric:
         """
         return True
 
-    def raw(
+    def _raw(
         self,
         *,
         report: EstimatorReport,
@@ -355,7 +355,7 @@ class Metric:
 
         Override this when the score cannot be expressed as ``self.function(...)``
         (see :class:`Score`, :class:`FitTime`, :class:`PredictTime`). Subclasses that
-        only need to adjust kwargs before delegating should call ``super().raw(...)``
+        only need to adjust kwargs before delegating should call ``super()._raw(...)``
         (see :class:`Precision`, :class:`Brier`, :class:`RocAuc`).
 
         Parameters
@@ -405,7 +405,7 @@ class Metric:
             **call_kwargs,
         )
 
-    def raw_cached(
+    def _raw_cached(
         self,
         *,
         report: EstimatorReport,
@@ -416,7 +416,7 @@ class Metric:
         cache_key = make_cache_key(data_source, self.name, kwargs)
         score = report._cache.get(cache_key)
         if score is None:
-            score = self.raw(report=report, data_source=data_source, **kwargs)
+            score = self._raw(report=report, data_source=data_source, **kwargs)
 
             report._cache[cache_key] = score
 
@@ -492,9 +492,28 @@ class Metric:
         data_source: DataSource,
         **kwargs: Any,
     ) -> list[MetricRow]:
-        """Compute the metric and expand it into one or more rows."""
+        """Compute the metric and expand it into one or more rows.
+
+        Parameters
+        ----------
+        report : EstimatorReport
+            The report to compute the metric for.
+
+        data_source : {"test", "train"}, default="test"
+            Which data split to use.
+
+        **kwargs
+            Additional keyword arguments passed to the scoring function.
+
+        Returns
+        -------
+        list of :class:`MetricRow`
+            The computed metric value(s).
+        """
         merged_kwargs = self.kwargs | kwargs
-        score = self.raw_cached(report=report, data_source=data_source, **merged_kwargs)
+        score = self._raw_cached(
+            report=report, data_source=data_source, **merged_kwargs
+        )
         return self._to_rows(score, report=report, **merged_kwargs)
 
     def _to_pretty(self, rows: list[MetricRow]) -> Any:
@@ -543,7 +562,7 @@ class FitTime(Metric):
     def available(report: EstimatorReport) -> bool:
         return True
 
-    def raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
+    def _raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
         if cast and report.fit_time_ is None:
             return float("nan")
         return report.fit_time_
@@ -560,7 +579,7 @@ class PredictTime(Metric):
     def available(report: EstimatorReport) -> bool:
         return True
 
-    def raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
+    def _raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
         predict_time_cache_key = make_cache_key(data_source, "predict_time")
         return report._cache.get(
             predict_time_cache_key, (float("nan") if cast else None)
@@ -592,7 +611,7 @@ class Precision(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
-    def raw(
+    def _raw(
         self, *, report: EstimatorReport, data_source="test", average=None, **kwargs
     ):
         if report._ml_task == "binary-classification":
@@ -601,7 +620,7 @@ class Precision(Metric):
             elif average != "binary":
                 kwargs["pos_label"] = None
 
-        return super().raw(
+        return super()._raw(
             report=report, data_source=data_source, average=average, **kwargs
         )
 
@@ -618,7 +637,7 @@ class Recall(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
-    def raw(
+    def _raw(
         self, *, report: EstimatorReport, data_source="test", average=None, **kwargs
     ):
         if report._ml_task == "binary-classification":
@@ -627,7 +646,7 @@ class Recall(Metric):
             elif average != "binary":
                 kwargs["pos_label"] = None
 
-        return super().raw(
+        return super()._raw(
             report=report, data_source=data_source, average=average, **kwargs
         )
 
@@ -646,11 +665,11 @@ class Brier(Metric):
             report.learner_, "predict_proba"
         )
 
-    def raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
+    def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
         # The Brier score in scikit-learn requests `pos_label` to ensure that
         # the integral encoding of `y_true` corresponds to the probabilities of
         # the `pos_label`.
-        return super().raw(
+        return super()._raw(
             report=report,
             data_source=data_source,
             pos_label=report.learner_.classes_[-1],
@@ -681,7 +700,7 @@ class RocAuc(Metric):
             y_score = y_score[:, 1]
         return sklearn.metrics.roc_auc_score(y_true, y_score, **kwargs)
 
-    def raw(
+    def _raw(
         self,
         *,
         report: EstimatorReport,
@@ -690,7 +709,7 @@ class RocAuc(Metric):
         multi_class="ovr",
         **kwargs,
     ):
-        return super().raw(
+        return super()._raw(
             report=report,
             data_source=data_source,
             average=average,
@@ -727,7 +746,7 @@ class R2(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def raw(
+    def _raw(
         self,
         *,
         report: EstimatorReport,
@@ -735,7 +754,7 @@ class R2(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().raw(
+        return super()._raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -752,7 +771,7 @@ class Rmse(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def raw(
+    def _raw(
         self,
         *,
         report: EstimatorReport,
@@ -760,7 +779,7 @@ class Rmse(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().raw(
+        return super()._raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -777,7 +796,7 @@ class Mae(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def raw(
+    def _raw(
         self,
         *,
         report: EstimatorReport,
@@ -785,7 +804,7 @@ class Mae(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().raw(
+        return super()._raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -802,7 +821,7 @@ class Mape(Metric):
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
-    def raw(
+    def _raw(
         self,
         *,
         report: EstimatorReport,
@@ -810,7 +829,7 @@ class Mape(Metric):
         multioutput="raw_values",
         **kwargs,
     ):
-        return super().raw(
+        return super()._raw(
             report=report, data_source=data_source, multioutput=multioutput, **kwargs
         )
 
@@ -826,7 +845,7 @@ class Score(Metric):
     def available(report: EstimatorReport) -> bool:
         return hasattr(report.estimator_, "score")
 
-    def raw(
+    def _raw(
         self,
         *,
         report: EstimatorReport,

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -438,25 +438,30 @@ class Metric:
             output=output,
         )
 
-    def rows(
+    def _to_rows(
         self,
+        score,
         *,
         report: EstimatorReport,
-        data_source: DataSource,
         **kwargs: Any,
     ) -> list[MetricRow]:
-        """Compute the metric and expand it into one or more rows."""
-        merged_kwargs = self.kwargs | kwargs
-        score = self.raw_cached(report=report, data_source=data_source, **merged_kwargs)
+        """Convert a score into one or more rows."""
+        if isinstance(score, dict):
+            # Multimetric scorer
+            result = []
+            for submetric_name, submetric_value in score.items():
+                rows = self._to_rows(submetric_value, report=report, kwargs=kwargs)
+                for r in rows:
+                    r["metric_verbose_name"] = submetric_name
+                result.extend(rows)
+            return result
 
         if (
             report._ml_task == "binary-classification"
             and kwargs.get("average") == "binary"
         ):
             return [
-                self._row(
-                    score=score, label=merged_kwargs.get("pos_label", report.pos_label)
-                )
+                self._row(score=score, label=kwargs.get("pos_label", report.pos_label))
             ]
         if report._ml_task in ("binary-classification", "multiclass-classification"):
             if isinstance(score, np.ndarray):
@@ -468,15 +473,50 @@ class Metric:
                         strict=False,
                     )
                 ]
-            return [self._row(score=score, average=merged_kwargs.get("average"))]
+            return [self._row(score=score, average=kwargs.get("average"))]
         if report._ml_task == "multioutput-regression":
             if isinstance(score, np.ndarray):
                 return [
                     self._row(score=s, output=idx)
                     for idx, s in enumerate(score.tolist())
                 ]
-            return [self._row(score=score, average=merged_kwargs.get("multioutput"))]
+            return [self._row(score=score, average=kwargs.get("multioutput"))]
         return [self._row(score=score)]
+
+    def rows(
+        self,
+        *,
+        report: EstimatorReport,
+        data_source: DataSource,
+        **kwargs: Any,
+    ) -> list[MetricRow]:
+        """Compute the metric and expand it into one or more rows."""
+        merged_kwargs = self.kwargs | kwargs
+        score = self.raw_cached(report=report, data_source=data_source, **merged_kwargs)
+        return self._to_rows(score, report=report, **merged_kwargs)
+
+    def _to_pretty(self, rows: list[MetricRow]) -> Any:
+        """Convert rows into a human-readable metric output."""
+        if len(rows) == 1:
+            return rows[0]["score"]
+
+        if len({row["metric_verbose_name"] for row in rows}) != 1:
+            # Multi-metric scorer
+            # We assume each submetric's values are grouped together
+            return {
+                name: self._to_pretty(list(rows_))
+                for name, rows_ in groupby(
+                    rows, key=lambda row: row["metric_verbose_name"]
+                )
+            }
+
+        if rows[0]["label"] is not None:
+            # Multi-class classification
+            return {row["label"]: row["score"] for row in rows}
+
+        # Multioutput regression
+        # We assume rows are sorted by output
+        return np.array([row["score"] for row in rows])
 
     def pretty(
         self,
@@ -487,17 +527,7 @@ class Metric:
     ) -> Any:
         """Compute the metric in a human-readable shape."""
         rows = self.rows(report=report, data_source=data_source, **kwargs)
-
-        if len(rows) == 1:
-            return rows[0]["score"]
-
-        if rows[0]["label"] is not None:
-            # Multi-class classification
-            return {row["label"]: row["score"] for row in rows}
-
-        # Multioutput regression
-        # We assume rows are sorted by output
-        return np.array([row["score"] for row in rows])
+        return self._to_pretty(rows)
 
 
 class FitTime(Metric):

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -26,9 +26,7 @@ def deep_contain(value, test_value):
         return False
 
 
-def test_interaction_cache_metrics(
-    linear_regression_multioutput_with_test,
-):
+def test_interaction_cache_metrics(linear_regression_multioutput_with_test):
     """Check that the cache take into account the 'kwargs' of a metric."""
     estimator, X_test, y_test = linear_regression_multioutput_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
@@ -184,6 +182,13 @@ def test_roc_multiclass_requires_predict_proba(
     report = EstimatorReport(classifier, X_test=X_test, y_test=y_test)
     assert hasattr(report.metrics, "roc_auc")
     report.metrics.roc_auc()
+
+
+def test_r2_returns_float(linear_regression_with_test):
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+
+    assert isinstance(report.metrics.r2(), float)
 
 
 # report.metrics.score

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -257,15 +257,3 @@ def test_score_skrub_learner_with_extra_env_vars():
     )
 
     assert isinstance(report.metrics.score(), float)
-
-
-@pytest.mark.filterwarnings("ignore:Precision is ill-defined")
-def test_score_appears_in_summarize_for_skrub_learner():
-    """The ``Score`` row is included in ``summarize().frame()`` for SkrubLearners."""
-    report = skrub_report(with_scoring=True)
-
-    frame = report.metrics.summarize().frame()
-
-    # FIXME: The sub-metric names should not be in the "Label" column
-    score_labels = frame.xs("Score", level="Metric").index.get_level_values("Label")
-    assert set(score_labels) == {"accuracy", "weighted_accuracy"}

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -979,12 +979,12 @@ def test_available_default(binary_classification_report):
     assert m.available(binary_classification_report) is True
 
 
-def test_call_no_function(binary_classification_report):
-    """Test that calling a Metric with no function raises."""
+def test_raw_no_function(binary_classification_report):
+    """Test that calling `Metric.raw` with no function raises."""
     m = Metric(name="abstract_metric", function=None)
     err_msg = "Metric 'abstract_metric' has no scoring function."
     with pytest.raises(ValueError, match=err_msg):
-        m(report=binary_classification_report)
+        m.raw(report=binary_classification_report, data_source="test")
 
 
 def test_metric_registry_repr(binary_classification_report):

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -5,7 +5,9 @@ import pickle
 import re
 
 import numpy as np
+import pandas as pd
 import pytest
+from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import (
     accuracy_score,
     get_scorer,
@@ -636,62 +638,82 @@ class TestDifferentMLTasks:
         report.metrics.add(scorer)
 
 
-class TestDictReturnValues:
-    """Test that metrics returning dicts work correctly (per-label scores).
+class TestMultiMetric:
+    """Test that metrics returning dicts work correctly (multimetric scorers)."""
 
-    Note: Multimetric scorers (single scorer returning multiple different metrics)
-    are NOT supported - users should add metrics separately.
-    """
-
-    def test_per_class_accuracy_dict(self, binary_classification_report):
-        """Test metric that returns per-class scores as dict."""
-        report = binary_classification_report
-
-        def per_class_accuracy(y_true, y_pred) -> dict[int, float]:
-            """Return accuracy for each class."""
-            accuracies = {}
-            for label in np.unique(y_true):
-                mask = y_true == label
-                accuracies[int(label)] = float((y_pred[mask] == label).mean())
-            return accuracies
-
-        def scorer(est, X, y_true):
-            y_pred = est.predict(X)
-            return per_class_accuracy(y_true, y_pred)
-
-        report.metrics.add(scorer, name="per_class_accuracy")
-
-        display = report.metrics.summarize(metric="per_class_accuracy")
-
-        metric_rows = display.data[
-            display.data["metric_verbose_name"] == "Per Class Accuracy"
-        ]
-        assert len(metric_rows) == 2
-        assert set(metric_rows["label"].values) == {0, 1}
-
-        # Cached correctly
-        with check_cache_unchanged(report._cache):
-            report.metrics.summarize(metric="per_class_accuracy")
-
-    def test_multimetric_scorer_not_recommended(self, binary_classification_report):
-        """Multimetric scorers are treated as per-label scores (not supported)."""
+    def test(self, binary_classification_report):
+        """Multimetric scorers are unpacked properly."""
         report = binary_classification_report
 
         def multimetric_scorer(y_true, y_pred):
             return {
                 "accuracy": accuracy_score(y_true, y_pred),
-                "precision": precision_score(y_true, y_pred, average="binary"),
+                "precision": precision_score(y_true, y_pred, average=None),
             }
 
         report.metrics.add(make_scorer(multimetric_scorer, response_method="predict"))
 
         display = report.metrics.summarize(metric="multimetric_scorer")
 
-        metric_rows = display.data[
-            display.data["metric_verbose_name"] == "Multimetric Scorer"
+        assert list(display.data["metric_verbose_name"]) == [
+            "accuracy",
+            "precision",  # Label 0
+            "precision",  # Label 1
         ]
-        # Not quite right...
-        assert set(metric_rows["label"]) == {"accuracy", "precision"}
+        assert list(display.data["label"]) == [pd.NA, np.int64(0), np.int64(1)]
+
+    def test_score(self, logistic_binary_classification_with_train_test):
+        """Setting an estimator's `score` method to a multimetric scorer works."""
+
+        def multimetric_scorer(y_true, y_pred):
+            return {
+                "accuracy": accuracy_score(y_true, y_pred),
+                "precision": precision_score(y_true, y_pred, average=None),
+            }
+
+        class MyEstimator(LogisticRegression):
+            def score(self, X, y, sample_weight=None):
+                y_pred = self.predict(X)
+                return multimetric_scorer(y, y_pred)
+
+        _, X_train, X_test, y_train, y_test = (
+            logistic_binary_classification_with_train_test
+        )
+
+        report = EstimatorReport(
+            MyEstimator(),
+            X_train=X_train,
+            y_train=y_train,
+            X_test=X_test,
+            y_test=y_test,
+        )
+
+        display = report.metrics.summarize(metric="score")
+
+        assert list(display.data["metric_verbose_name"]) == [
+            "accuracy",
+            "precision",  # Label 0
+            "precision",  # Label 1
+        ]
+        assert list(display.data["label"]) == [pd.NA, np.int64(0), np.int64(1)]
+
+    def test_preexisting_metric_name(self, binary_classification_report):
+        """If a multimetric scorer is added and it contains a submetric that has the
+        same name as a metric in the registry, then the metric name will appear more
+        than once."""
+        report = binary_classification_report
+
+        def multimetric_scorer(y_true, y_pred):
+            # NOTE: "Accuracy" is the name of a default metric
+            return {"Accuracy": 1000}
+
+        report.metrics.add(make_scorer(multimetric_scorer, response_method="predict"))
+
+        display = report.metrics.summarize()
+
+        results = display.data[display.data["metric_verbose_name"] == "Accuracy"]
+        # Our metric, then the default one
+        assert list(results["score"]) == [1000, 1.0]
 
 
 class TestStringScorerNames:

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -1001,12 +1001,12 @@ def test_available_default(binary_classification_report):
     assert m.available(binary_classification_report) is True
 
 
-def test_raw_no_function(binary_classification_report):
-    """Test that calling `Metric.raw` with no function raises."""
+def test_no_function(binary_classification_report):
+    """Test that calling `Metric.rows` with no function raises."""
     m = Metric(name="abstract_metric", function=None)
     err_msg = "Metric 'abstract_metric' has no scoring function."
     with pytest.raises(ValueError, match=err_msg):
-        m.raw(report=binary_classification_report, data_source="test")
+        m.rows(report=binary_classification_report, data_source="test")
 
 
 def test_metric_registry_repr(binary_classification_report):


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

If this is your first contribution, take a look at our contribution guidelines:
https://docs.skore.probabl.ai/stable/contributing.html
-->
#### Change description
<!--
Please describe what your contribution changes for skore.

Here is some inspiration for what to write here:
- Are you adding a new feature? Fixing a bug?
- Can you give an example of your change in action, e.g. a snippet of code or a plot?
- Is your change likely to break users' code?
- Are there any other details the reviewer should be aware of, such as API design choices, performance characteristics or edge cases?

Please reference issues/PRs when possible, e.g. "Fixes #1234", "Closes #3456", "See also #7890".
More information [here](https://github.com/blog/1506-closing-issues-via-pull-requests).
-->
Follow-up to #2898 which made multimetric scorers work only in the `.score()` case.

Multimetric scorers of the form `lambda estimator, X, y: {"metric_1": ..., "metric_2": ..., ...}` are now supported:
```python
from sklearn.datasets import load_iris
from sklearn.metrics import accuracy_score, precision_score, make_scorer
from sklearn.linear_model import LogisticRegression
from skore import evaluate

X, y = load_iris(return_X_y=True)
regressor = LogisticRegression()
report = evaluate(regressor, X, y, splitter=0.2)

def multimetric(y_true, y_pred):
    return {
        "metric_1": accuracy_score(y_true, y_pred),
        "metric_2": precision_score(y_true, y_pred, average=None),
    }

report.metrics.add(make_scorer(multimetric))

report.metrics.summarize().frame()

#                         LogisticRegression
# Metric           Label
# metric_1                          1.000000
# metric_2         0                1.000000
#                  1                1.000000
#                  2                1.000000
# Score                             1.000000
# Accuracy                          1.000000
# Precision        0                1.000000
#                  1                1.000000
#                  2                1.000000
# Recall           0                1.000000
#                  1                1.000000
#                  2                1.000000
# ROC AUC          0                1.000000
#                  1                1.000000
#                  2                1.000000
# Log loss                          0.134784
# Fit time (s)                      0.016429
# Predict time (s)                  0.000191

report.metrics.summarize(metric="multimetric").frame()

#                 LogisticRegression
# Metric   Label
# metric_1                       1.0
# metric_2 0                     1.0
#          1                     1.0
#          2                     1.0
```

This was done by refactoring the Metric internals to be able to output scores in a structured list of rows format, which could then be consumed either in this form by `summarize`, or re-formatted in a human-readable way for the `report.metrics.<metric>` methods.

#### Contribution checklist
<!--
Below are some of the criteria that the review will include.
Feel free to use it as a checklist to ensure that your contribution is high-quality.
-->
Changelog pending

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure you understand our [automated contributions policy](https://docs.skore.probabl.ai/stable/contributing.html#automated-contributions-policy)
-->
AI tools were involved for:
Nothing

<!-- Any other comments can go here. Thanks again for contributing! -->
