### PR TITLE
feat(skore): Downsample by default to 500 thresholds ROC/PRC/confusion matrix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,14 @@ Changed
 
 Added
 -----
+- :meth:`EstimatorReport.metrics.roc`,
+  :meth:`EstimatorReport.metrics.precision_recall`,
+  :meth:`EstimatorReport.metrics.confusion_matrix` and their counterparts on
+  :class:`CrossValidationReport` and :class:`ComparisonReport` now cap the
+  number of thresholds stored per class on the ROC, precision-recall and
+  thresholded confusion-matrix displays to ``500``.
+  See :pr:`2942` by :user:`glemaitre`.
+
 - Added :class:`CalibrationDisplay` to  EstimatoReport as an inspection
   tool. Frames with columns "predicted_probability" and "true_probability",
   "label" (depending on the task) are calculated and can be plotted. Both

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -1022,6 +1022,12 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
         :class:`RocCurveDisplay`
             The ROC curve display.
 
+        Notes
+        -----
+        To keep the stored display lightweight, the ROC curve is downsampled to at most
+        500 points per class and per child report. Sampling is performed by picking
+        evenly-spaced indices on the sorted thresholds.
+
         Examples
         --------
         >>> from sklearn.datasets import load_breast_cancer
@@ -1075,6 +1081,12 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
         -------
         :class:`PrecisionRecallCurveDisplay`
             The precision-recall curve display.
+
+        Notes
+        -----
+        To keep the stored display lightweight, the precision-recall curve is
+        downsampled to at most 500 points per class and per child report. Sampling is
+        performed by picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------
@@ -1212,6 +1224,12 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
         -------
         :class:`ConfusionMatrixDisplay`
             The confusion matrix display.
+
+        Notes
+        -----
+        To keep the stored display lightweight, the thresholded one-vs-rest confusion
+        matrices are downsampled to at most 500 points per class and per child report.
+        Sampling is performed by picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -1227,9 +1227,9 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
 
         Notes
         -----
-        To keep the stored display lightweight, the thresholded one-vs-rest confusion
-        matrices are downsampled to at most 500 points per class and per child report.
-        Sampling is performed by picking evenly-spaced indices on the sorted thresholds.
+        To keep the stored display lightweight, the thresholded confusion matrices are
+        downsampled to at most 500 points per class and per child report. Sampling is
+        performed by picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1203,9 +1203,9 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
 
         Notes
         -----
-        To keep the stored display lightweight, the thresholded one-vs-rest confusion
-        matrices are downsampled to at most 500 points per class and per split. Sampling
-        is performed by picking evenly-spaced indices on the sorted thresholds.
+        To keep the stored display lightweight, the thresholded confusion matrices are
+        downsampled to at most 500 points per class and per split. Sampling is performed
+        by picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1005,6 +1005,12 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
         :class:`RocCurveDisplay`
             The ROC curve display.
 
+        Notes
+        -----
+        To keep the stored display lightweight, the ROC curve is downsampled to at most
+        500 points per class and per split. Sampling is performed by picking
+        evenly-spaced indices on the sorted thresholds.
+
         Examples
         --------
         >>> from sklearn.datasets import load_breast_cancer
@@ -1050,6 +1056,12 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
         -------
         :class:`PrecisionRecallCurveDisplay`
             The precision-recall curve display.
+
+        Notes
+        -----
+        To keep the stored display lightweight, the precision-recall curve is
+        downsampled to at most 500 points per class and per split. Sampling is performed
+        by picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------
@@ -1170,6 +1182,12 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
         -------
         :class:`ConfusionMatrixDisplay`
             The confusion matrix display.
+
+        Notes
+        -----
+        To keep the stored display lightweight, the thresholded one-vs-rest confusion
+        matrices are downsampled to at most 500 points per class and per split. Sampling
+        is performed by picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -1012,6 +1012,12 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         :class:`RocCurveDisplay`
             The ROC curve display.
 
+        Notes
+        -----
+        To keep the stored display lightweight, the ROC curve is downsampled
+        to at most 500 points per class. Sampling is performed by picking
+        evenly-spaced indices on the sorted thresholds.
+
         Examples
         --------
         >>> from sklearn.datasets import load_breast_cancer
@@ -1061,6 +1067,16 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         -------
         :class:`PrecisionRecallCurveDisplay`
             The precision-recall curve display.
+
+        Notes
+        -----
+        To keep the stored display lightweight, the precision-recall curve is
+        downsampled to at most 500 points per class. Sampling is performed by
+        picking evenly-spaced indices on the sorted thresholds returned by
+        scikit-learn (quantile-based sampling that preserves the empirical
+        threshold distribution). Curve endpoints are always kept and no
+        interpolation is performed. The reported average precision is
+        computed on the full curve and is therefore unaffected.
 
         Examples
         --------
@@ -1180,6 +1196,17 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         -------
         :class:`ConfusionMatrixDisplay`
             The confusion matrix display.
+
+        Notes
+        -----
+        To keep the stored display lightweight, the thresholded one-vs-rest
+        confusion matrices are downsampled to at most 500 points per class.
+        Sampling is performed by picking evenly-spaced indices on the sorted
+        thresholds returned by scikit-learn (quantile-based sampling that
+        preserves the empirical threshold distribution). Curve endpoints are
+        always kept and no interpolation is performed. Only the thresholded
+        matrices are affected; the predict-based ``n x n`` confusion matrix
+        is unchanged.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -1226,9 +1226,9 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
 
         Notes
         -----
-        To keep the stored display lightweight, the thresholded one-vs-rest
-        confusion matrices are downsampled to at most 500 points per class.
-        Sampling is performed by picking evenly-spaced indices on the sorted thresholds.
+        To keep the stored display lightweight, the thresholded confusion matrices are
+        downsampled to at most 500 points per class. Sampling is performed by picking
+        evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -1072,11 +1072,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         -----
         To keep the stored display lightweight, the precision-recall curve is
         downsampled to at most 500 points per class. Sampling is performed by
-        picking evenly-spaced indices on the sorted thresholds returned by
-        scikit-learn (quantile-based sampling that preserves the empirical
-        threshold distribution). Curve endpoints are always kept and no
-        interpolation is performed. The reported average precision is
-        computed on the full curve and is therefore unaffected.
+        picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------
@@ -1201,12 +1197,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         -----
         To keep the stored display lightweight, the thresholded one-vs-rest
         confusion matrices are downsampled to at most 500 points per class.
-        Sampling is performed by picking evenly-spaced indices on the sorted
-        thresholds returned by scikit-learn (quantile-based sampling that
-        preserves the empirical threshold distribution). Curve endpoints are
-        always kept and no interpolation is performed. Only the thresholded
-        matrices are affected; the predict-based ``n x n`` confusion matrix
-        is unchanged.
+        Sampling is performed by picking evenly-spaced indices on the sorted thresholds.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
@@ -15,6 +15,7 @@ from skore._sklearn._plot.utils import (
     _check_label,
     _ClassifierDisplayMixin,
     _concat_frames_with_column_data,
+    _downsample_thresholds_indices,
     _one_hot_encode,
     _validate_style_kwargs,
 )
@@ -407,6 +408,7 @@ class ConfusionMatrixDisplay(_ClassifierDisplayMixin, DisplayMixin):
         data_source: DataSource | Literal["both"],
         report_pos_label: PositiveLabel | None = None,
         y_scores: NDArray | None = None,
+        max_n_thresholds: int | None = 500,
         **kwargs,
     ) -> "ConfusionMatrixDisplay":
         """Compute the confusion matrix data for display.
@@ -439,6 +441,17 @@ class ConfusionMatrixDisplay(_ClassifierDisplayMixin, DisplayMixin):
         y_scores : ndarray of shape (n_samples, n_classes) or None
             Probability estimates or decision function values. None when the
             estimator only supports predict.
+
+        max_n_thresholds : int or None, default=500
+            Cap on the number of thresholds kept per class in the thresholded
+            one-vs-rest confusion matrices. When the number of thresholds
+            returned by scikit-learn exceeds ``max_n_thresholds``, the
+            thresholded view is downsampled by picking evenly-spaced indices
+            from the sorted thresholds (quantile-based sampling that preserves
+            the empirical threshold distribution). Endpoints are always kept
+            and no interpolation is performed. ``None`` disables downsampling.
+            Must be at least 2. Only affects the thresholded OvR matrices;
+            the predict-based ``n x n`` and OvR matrices are unchanged.
 
         **kwargs : dict
             Additional keyword arguments ignored for compatibility.
@@ -494,6 +507,17 @@ class ConfusionMatrixDisplay(_ClassifierDisplayMixin, DisplayMixin):
                     y_score=y_scores_arr[:, class_idx],
                     pos_label=1,
                 )
+                indices = _downsample_thresholds_indices(
+                    thresholds.size, max_n_thresholds
+                )
+                tns, fps, fns, tps, thresholds = (
+                    tns[indices],
+                    fps[indices],
+                    fns[indices],
+                    tps[indices],
+                    thresholds[indices],
+                )
+
                 cm = np.column_stack([tns, fps, fns, tps]).reshape(-1, 2, 2).astype(int)
                 df = cls._build_confusion_frame(
                     cm=cm,

--- a/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/confusion_matrix.py
@@ -443,15 +443,14 @@ class ConfusionMatrixDisplay(_ClassifierDisplayMixin, DisplayMixin):
             estimator only supports predict.
 
         max_n_thresholds : int or None, default=500
-            Cap on the number of thresholds kept per class in the thresholded
-            one-vs-rest confusion matrices. When the number of thresholds
-            returned by scikit-learn exceeds ``max_n_thresholds``, the
-            thresholded view is downsampled by picking evenly-spaced indices
-            from the sorted thresholds (quantile-based sampling that preserves
-            the empirical threshold distribution). Endpoints are always kept
-            and no interpolation is performed. ``None`` disables downsampling.
-            Must be at least 2. Only affects the thresholded OvR matrices;
-            the predict-based ``n x n`` and OvR matrices are unchanged.
+            Cap on the number of thresholds kept per class in the thresholded confusion
+            matrices. When the number of thresholds returned by scikit-learn exceeds
+            ``max_n_thresholds``, the thresholded view is downsampled by picking
+            evenly-spaced indices from the sorted thresholds (quantile-based sampling
+            that preserves the empirical threshold distribution). Endpoints are always
+            kept and no interpolation is performed. ``None`` disables downsampling. Must
+            be at least 2. Only affects the thresholded matrices; the predict-based
+            matrices are unchanged.
 
         **kwargs : dict
             Additional keyword arguments ignored for compatibility.

--- a/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
@@ -171,9 +171,8 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
     def plot(
         self,
         *,
-        subplot_by: (
-            Literal["auto", "label", "estimator", "data_source"] | None
-        ) = "auto",
+        subplot_by: Literal["auto", "label", "estimator", "data_source"]
+        | None = "auto",
         despine: bool = True,
         label: PositiveLabel = _DEFAULT,
     ) -> Figure:

--- a/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
@@ -15,6 +15,7 @@ from skore._sklearn._plot.utils import (
     _ClassifierDisplayMixin,
     _concat_frames_with_column_data,
     _despine_matplotlib_axis,
+    _downsample_thresholds_indices,
     _get_curve_plot_columns,
     _one_hot_encode,
     _validate_style_kwargs,
@@ -146,8 +147,9 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
     def plot(
         self,
         *,
-        subplot_by: Literal["auto", "label", "estimator", "data_source"]
-        | None = "auto",
+        subplot_by: (
+            Literal["auto", "label", "estimator", "data_source"] | None
+        ) = "auto",
         despine: bool = True,
         label: PositiveLabel = _DEFAULT,
     ) -> Figure:
@@ -322,6 +324,7 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         data_source: DataSource,
         report_pos_label: PositiveLabel = None,
         drop_intermediate: bool = True,
+        max_n_thresholds: int | None = 500,
     ) -> "PrecisionRecallCurveDisplay":
         """Plot precision-recall curve given binary class predictions.
 
@@ -355,6 +358,15 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
             on a plotted precision-recall curve. This is useful in order to
             create lighter precision-recall curves.
 
+        max_n_thresholds : int or None, default=500
+            Cap on the number of thresholds kept per class after the curve is
+            computed. When the number of thresholds returned by scikit-learn
+            exceeds ``max_n_thresholds``, the curve is downsampled by picking
+            evenly-spaced indices from the sorted thresholds (quantile-based
+            sampling that preserves the empirical threshold distribution).
+            Endpoints are always kept and no interpolation is performed.
+            ``None`` disables downsampling. Must be at least 2.
+
         Returns
         -------
         display : PrecisionRecallCurveDisplay
@@ -370,6 +382,7 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
                 y_true=y_true_onehot[:, class_idx],
                 y_pred=y_pred_arr[:, class_idx],
                 drop_intermediate=drop_intermediate,
+                max_n_thresholds=max_n_thresholds,
                 # metadata:
                 estimator=estimator_name,
                 data_source=data_source,
@@ -389,7 +402,9 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         )
 
     @staticmethod
-    def _compute_data_ovr(y_true, y_pred, drop_intermediate, **metadata):
+    def _compute_data_ovr(
+        y_true, y_pred, drop_intermediate, max_n_thresholds, **metadata
+    ):
         precision, recall, thresholds = precision_recall_curve(
             y_true,
             y_pred,
@@ -398,11 +413,20 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         )
         average_precision = average_precision_score(y_true, y_pred, pos_label=1)
 
+        precision = precision[:-1]
+        recall = recall[:-1]
+        indices = _downsample_thresholds_indices(thresholds.size, max_n_thresholds)
+        precision, recall, thresholds = (
+            precision[indices],
+            recall[indices],
+            thresholds[indices],
+        )
+
         curve_data = {
             **metadata,
             "threshold": thresholds,
-            "precision": precision[:-1],
-            "recall": recall[:-1],
+            "precision": precision,
+            "recall": recall,
         }
         n = thresholds.size
         for col in metadata:

--- a/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
@@ -15,6 +15,7 @@ from skore._sklearn._plot.utils import (
     _ClassifierDisplayMixin,
     _concat_frames_with_column_data,
     _despine_matplotlib_axis,
+    _downsample_thresholds_indices,
     _get_curve_plot_columns,
     _one_hot_encode,
     _validate_style_kwargs,
@@ -344,6 +345,7 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         data_source: DataSource,
         report_pos_label: PositiveLabel = None,
         drop_intermediate: bool = True,
+        max_n_thresholds: int | None = 500,
     ) -> "RocCurveDisplay":
         """Private method to create a RocCurveDisplay from predictions.
 
@@ -375,6 +377,15 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         drop_intermediate : bool, default=True
             Whether to drop intermediate points with identical value.
 
+        max_n_thresholds : int or None, default=500
+            Cap on the number of thresholds kept per class after the curve is
+            computed. When the number of thresholds returned by scikit-learn
+            exceeds ``max_n_thresholds``, the curve is downsampled by picking
+            evenly-spaced indices from the sorted thresholds (quantile-based
+            sampling that preserves the empirical threshold distribution).
+            Endpoints are always kept and no interpolation is performed.
+            ``None`` disables downsampling. Must be at least 2.
+
         Returns
         -------
         display : RocCurveDisplay
@@ -391,6 +402,7 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
                 y_true=y_true_onehot[:, class_idx],
                 y_pred=y_pred_arr[:, class_idx],
                 drop_intermediate=drop_intermediate,
+                max_n_thresholds=max_n_thresholds,
                 # metadata:
                 estimator=estimator_name,
                 data_source=data_source,
@@ -410,7 +422,9 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         )
 
     @staticmethod
-    def _compute_data_ovr(y_true, y_pred, drop_intermediate, **metadata):
+    def _compute_data_ovr(
+        y_true, y_pred, drop_intermediate, max_n_thresholds, **metadata
+    ):
         fpr, tpr, thresholds = roc_curve(
             y_true,
             y_pred,
@@ -418,6 +432,9 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
             drop_intermediate=drop_intermediate,
         )
         roc_auc = auc(fpr, tpr)
+
+        indices = _downsample_thresholds_indices(fpr.size, max_n_thresholds)
+        fpr, tpr, thresholds = fpr[indices], tpr[indices], thresholds[indices]
 
         curve_data = {
             **metadata,

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -486,3 +486,35 @@ def _check_label(labels: list, label: PositiveLabel, default_label: PositiveLabe
         # Ex: with `labels=[0, 1]` and `label=True`:
         # `label in labels` is true but `df.query("label == @label")` is empty.
         return labels[labels.index(label)]
+
+
+def _downsample_thresholds_indices(n_total: int, max_n: int | None) -> NDArray:
+    """Compute the indices to keep when downsampling a sorted threshold array.
+
+    Picks ``max_n`` evenly-spaced indices in ``[0, n_total - 1]``, which is
+    equivalent to quantile sampling on the empirical distribution of the
+    original thresholds. The first and last indices are always preserved so
+    that the endpoints of the curve are kept.
+
+    Parameters
+    ----------
+    n_total : int
+        Total number of available thresholds (i.e. length of the sorted
+        threshold array returned by scikit-learn).
+
+    max_n : int or None
+        Maximum number of thresholds to keep. ``None`` disables downsampling
+        and returns ``np.arange(n_total)``. Otherwise must be at least 2.
+
+    Returns
+    -------
+    indices : ndarray of int
+        Sorted, unique indices in ``[0, n_total - 1]`` to keep. When
+        ``max_n is None`` or ``n_total <= max_n``, the returned array is
+        ``np.arange(n_total)``.
+    """
+    if max_n is not None and max_n < 2:
+        raise ValueError(f"`max_n_thresholds` must be at least 2 (got {max_n}).")
+    if max_n is None or n_total <= max_n:
+        return np.arange(n_total)
+    return np.linspace(0, n_total - 1, max_n).astype(int)

--- a/skore/tests/unit/displays/test_utils.py
+++ b/skore/tests/unit/displays/test_utils.py
@@ -5,6 +5,7 @@ from sklearn.linear_model import LogisticRegression
 from skore import evaluate
 from skore._sklearn._plot.utils import (
     _adjust_fig_size,
+    _downsample_thresholds_indices,
     _get_adjusted_fig_size,
     _rotate_ticklabels,
     _validate_style_kwargs,
@@ -116,3 +117,41 @@ def test_apostrophe_in_label(binary_classification_data):
     fig = display.plot()
     legend_text = [t.get_text() for t in fig.axes[0].get_legend().get_texts()]
     assert any("A'B" in text for text in legend_text)
+
+
+@pytest.mark.parametrize("n_total", [0, 1, 5, 10, 1_000])
+def test_downsample_thresholds_indices_none(n_total):
+    """With ``max_n=None``, the helper returns ``np.arange(n_total)``."""
+    indices = _downsample_thresholds_indices(n_total, None)
+    np.testing.assert_array_equal(indices, np.arange(n_total))
+
+
+@pytest.mark.parametrize("n_total, max_n", [(5, 5), (5, 10), (0, 2), (1, 2)])
+def test_downsample_thresholds_indices_no_downsampling(n_total, max_n):
+    """When ``n_total <= max_n``, all indices are kept."""
+    indices = _downsample_thresholds_indices(n_total, max_n)
+    np.testing.assert_array_equal(indices, np.arange(n_total))
+
+
+@pytest.mark.parametrize(
+    "n_total, max_n", [(10, 5), (1_000, 100), (1_234, 500), (97, 3)]
+)
+def test_downsample_thresholds_indices_downsampling(n_total, max_n):
+    """When ``n_total > max_n``, exactly ``max_n`` indices are returned and
+    endpoints (0 and ``n_total - 1``) are preserved; indices are sorted and
+    strictly increasing.
+    """
+    indices = _downsample_thresholds_indices(n_total, max_n)
+    assert indices.shape == (max_n,)
+    assert indices[0] == 0
+    assert indices[-1] == n_total - 1
+    # The indices are sorted and strictly increasing (no duplicates) when
+    # ``max_n <= n_total``.
+    assert np.all(np.diff(indices) >= 1)
+
+
+@pytest.mark.parametrize("max_n", [0, 1, -3])
+def test_downsample_thresholds_indices_invalid(max_n):
+    """`max_n_thresholds` smaller than 2 raises a clear ``ValueError``."""
+    with pytest.raises(ValueError, match="must be at least 2"):
+        _downsample_thresholds_indices(10, max_n)

--- a/skore/tests/unit/reports/comparison/cross_validation/metrics/test_plot.py
+++ b/skore/tests/unit/reports/comparison/cross_validation/metrics/test_plot.py
@@ -1,0 +1,55 @@
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+from skore import ComparisonReport, CrossValidationReport
+
+
+@pytest.fixture(scope="module")
+def large_binary_classification_comparison_cv_report():
+    """Comparison of two cross-validation reports on a noisy binary
+    classification dataset large enough to produce more than 500 distinct
+    thresholds per split and per child report (so the internal 500-point cap
+    actually fires)."""
+    X, y = make_classification(
+        n_samples=4_000, n_features=4, flip_y=0.4, class_sep=0.3, random_state=0
+    )
+    report_1 = CrossValidationReport(LogisticRegression(C=1.0), X, y, splitter=2)
+    report_2 = CrossValidationReport(LogisticRegression(C=0.1), X, y, splitter=2)
+    return ComparisonReport([report_1, report_2])
+
+
+@pytest.mark.parametrize("metric", ["roc", "precision_recall"])
+def test_curve_capped_to_500_points(
+    large_binary_classification_comparison_cv_report, metric
+):
+    """The ROC and precision-recall curve displays are downsampled to at most
+    500 points per class, per split and per child report on the public API.
+    The fixture is calibrated so that the underlying scikit-learn curve has
+    more than 500 thresholds, so the assertion would fail if the cap was not
+    enforced."""
+    display = getattr(
+        large_binary_classification_comparison_cv_report.metrics, metric
+    )()
+    frame = display.frame()
+    sizes = frame.groupby(["estimator", "split", "label"], observed=True).size()
+    assert sizes.max() == 500
+
+
+def test_confusion_matrix_capped_to_500_thresholds(
+    large_binary_classification_comparison_cv_report,
+):
+    """The thresholded confusion matrix display is downsampled to at most
+    500 thresholds per class, per split and per child report on the public
+    API. The fixture is calibrated so that the underlying scikit-learn curve
+    has more than 500 thresholds, so the assertion would fail if the cap was
+    not enforced."""
+    display = (
+        large_binary_classification_comparison_cv_report.metrics.confusion_matrix()
+    )
+    df = display.confusion_matrix_thresholded
+    assert df is not None
+    n_thresholds = df.groupby(["estimator", "split", "label"], observed=True)[
+        "threshold"
+    ].nunique()
+    assert n_thresholds.max() == 500

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_plot.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_plot.py
@@ -1,0 +1,49 @@
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+from skore import ComparisonReport, EstimatorReport
+
+
+@pytest.fixture(scope="module")
+def large_binary_classification_comparison_report():
+    """Comparison of two estimator reports on a noisy binary classification
+    dataset large enough to produce more than 500 distinct thresholds per
+    child report (so the internal 500-point cap actually fires)."""
+    X, y = make_classification(
+        n_samples=4_000, n_features=4, flip_y=0.4, class_sep=0.3, random_state=0
+    )
+    report_1 = EstimatorReport(LogisticRegression(C=1.0).fit(X, y), X_test=X, y_test=y)
+    report_2 = EstimatorReport(LogisticRegression(C=0.1).fit(X, y), X_test=X, y_test=y)
+    return ComparisonReport([report_1, report_2])
+
+
+@pytest.mark.parametrize("metric", ["roc", "precision_recall"])
+def test_curve_capped_to_500_points(
+    large_binary_classification_comparison_report, metric
+):
+    """The ROC and precision-recall curve displays are downsampled to at most
+    500 points per class and per child report on the public API. The fixture
+    is calibrated so that the underlying scikit-learn curve has more than 500
+    thresholds, so the assertion would fail if the cap was not enforced."""
+    display = getattr(large_binary_classification_comparison_report.metrics, metric)()
+    frame = display.frame()
+    sizes = frame.groupby(["estimator", "label"], observed=True).size()
+    assert sizes.max() == 500
+
+
+def test_confusion_matrix_capped_to_500_thresholds(
+    large_binary_classification_comparison_report,
+):
+    """The thresholded confusion matrix display is downsampled to at most
+    500 thresholds per class and per child report on the public API. The
+    fixture is calibrated so that the underlying scikit-learn curve has more
+    than 500 thresholds, so the assertion would fail if the cap was not
+    enforced."""
+    display = large_binary_classification_comparison_report.metrics.confusion_matrix()
+    df = display.confusion_matrix_thresholded
+    assert df is not None
+    n_thresholds = df.groupby(["estimator", "label"], observed=True)[
+        "threshold"
+    ].nunique()
+    assert n_thresholds.max() == 500

--- a/skore/tests/unit/reports/cross_validation/metrics/test_plot.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_plot.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
 
 from skore import CrossValidationReport, RocCurveDisplay
 from skore._utils._testing import check_cache_unchanged
@@ -78,3 +80,40 @@ def test_seed_none(linear_regression_data):
         len(estimator_report._cache) == 2
         for estimator_report in report.estimator_reports_
     )
+
+
+@pytest.fixture(scope="module")
+def large_binary_classification_cv_report():
+    """Cross-validation report on a noisy binary classification dataset large
+    enough to produce more than 500 distinct thresholds per split (so the
+    internal 500-point cap actually fires)."""
+    X, y = make_classification(
+        n_samples=4_000, n_features=4, flip_y=0.4, class_sep=0.3, random_state=0
+    )
+    return CrossValidationReport(LogisticRegression(), X, y, splitter=2)
+
+
+@pytest.mark.parametrize("metric", ["roc", "precision_recall"])
+def test_curve_capped_to_500_points(large_binary_classification_cv_report, metric):
+    """The ROC and precision-recall curve displays are downsampled to at most
+    500 points per class and per split on the public API. The fixture is
+    calibrated so that the underlying scikit-learn curve has more than 500
+    thresholds, so the assertion would fail if the cap was not enforced."""
+    display = getattr(large_binary_classification_cv_report.metrics, metric)()
+    frame = display.frame()
+    sizes = frame.groupby(["split", "label"], observed=True).size()
+    assert sizes.max() == 500
+
+
+def test_confusion_matrix_capped_to_500_thresholds(
+    large_binary_classification_cv_report,
+):
+    """The thresholded confusion matrix display is downsampled to at most
+    500 thresholds per class and per split on the public API. The fixture is
+    calibrated so that the underlying scikit-learn curve has more than 500
+    thresholds, so the assertion would fail if the cap was not enforced."""
+    display = large_binary_classification_cv_report.metrics.confusion_matrix()
+    df = display.confusion_matrix_thresholded
+    assert df is not None
+    n_thresholds = df.groupby(["split", "label"], observed=True)["threshold"].nunique()
+    assert n_thresholds.max() == 500

--- a/skore/tests/unit/reports/estimator/metrics/test_plot.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_plot.py
@@ -175,3 +175,41 @@ def test_display_regression_switching_data_source(
     assert report._cache != {}
     display_second_call = getattr(report.metrics, display)(data_source="train", seed=0)
     assert display_first_call is not display_second_call
+
+
+@pytest.fixture(scope="module")
+def large_binary_classification_report():
+    """Binary classifier on a noisy dataset large enough to produce more than
+    500 distinct thresholds on the ROC, precision-recall and thresholded
+    confusion-matrix displays (so the internal 500-point cap actually fires)."""
+    X, y = make_classification(
+        n_samples=4_000, n_features=4, flip_y=0.4, class_sep=0.3, random_state=0
+    )
+    estimator = LogisticRegression().fit(X, y)
+    return EstimatorReport(estimator, X_test=X, y_test=y)
+
+
+@pytest.mark.parametrize("metric", ["roc", "precision_recall"])
+def test_curve_capped_to_500_points(large_binary_classification_report, metric):
+    """The ROC and precision-recall curve displays are downsampled to at most
+    500 points per class on the public API. The fixture is calibrated so that
+    the underlying scikit-learn curve has more than 500 thresholds, so the
+    assertion would fail if the cap was not enforced."""
+    display = getattr(large_binary_classification_report.metrics, metric)()
+    frame = display.frame()
+    sizes = frame.groupby("label", observed=True).size()
+    assert sizes.max() == 500
+
+
+def test_confusion_matrix_capped_to_500_thresholds(
+    large_binary_classification_report,
+):
+    """The thresholded confusion matrix display is downsampled to at most
+    500 thresholds per class on the public API. The fixture is calibrated so
+    that the underlying scikit-learn curve has more than 500 thresholds, so
+    the assertion would fail if the cap was not enforced."""
+    display = large_binary_classification_report.metrics.confusion_matrix()
+    df = display.confusion_matrix_thresholded
+    assert df is not None
+    n_thresholds = df.groupby("label", observed=True)["threshold"].nunique()
+    assert n_thresholds.max() == 500


### PR DESCRIPTION
closes #2920 

Limit the number of thresholds to be display to 500. The statistics are still computed on the full thresholds.

I don't think that we need to expose any parameter because it will be YAGNI.