### PR TITLE
feat(skore/checks): Add checks on hyperparameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,8 @@ Changed
 
 Added
 -----
+- Added automated check SKD014 (hyperparameters at search edge, issue) for
+  :class:`~sklearn.model_selection.BaseSearchCV` estimators.
 - Added :class:`CalibrationDisplay` to  EstimatoReport as an inspection
   tool. Frames with columns "predicted_probability" and "true_probability",
   "label" (depending on the task) are calculated and can be plotted. Both

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numbers
 import warnings
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -13,6 +14,7 @@ from sklearn.ensemble import (
 )
 from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.linear_model import LogisticRegression, RidgeCV
+from sklearn.model_selection._search import BaseSearchCV
 
 from skore._externals._skrub_compat import tabular_pipeline
 from skore._sklearn._checks._utils import (
@@ -536,6 +538,70 @@ class CheckSlowerThanBaseline(Check):
         return None
 
 
+class CheckHyperparamsAtSearchEdge(Check):
+    """Check whether tuned hyperparameters sit at the search boundary (SKD014).
+
+    For :class:`~sklearn.model_selection.BaseSearchCV` estimators, flags when any
+    numeric ``best_params_`` value equals the minimum or maximum distinct value
+    tried for that parameter. Non-numeric hyperparameters (``bool``, strings, ``None``,
+    and similar) are skipped because extending the search range is not meaningful.
+    """
+
+    code = "SKD014"
+    title = "Hyperparameters at search edge"
+    report_type = "estimator"
+    docs_url = "skd014-hyperparams-at-search-edge"
+    severity = "issue"
+
+    def check_function(self, report: _BaseReport) -> str | None:
+        report = cast("EstimatorReport", report)
+        estimator = report.estimator_
+        if not isinstance(estimator, BaseSearchCV):
+            raise CheckNotApplicable()
+
+        param_rows = estimator.cv_results_.get("params")
+        if param_rows is None:
+            raise CheckNotApplicable()
+
+        edge_params: list[tuple[str, str]] = []
+        for name, best_value in estimator.best_params_.items():
+            distinct = list(
+                dict.fromkeys(
+                    setting[name] for setting in param_rows if name in setting
+                )
+            )
+            if len(distinct) < 2 or not all(
+                isinstance(v, numbers.Real) and not isinstance(v, (bool, np.bool_))
+                for v in distinct
+            ):
+                continue
+            search_low, search_high = min(distinct), max(distinct)
+            if not isinstance(best_value, numbers.Real) or isinstance(
+                best_value, (bool, np.bool_)
+            ):
+                continue
+            if np.isclose(
+                float(best_value), float(search_low), rtol=0.0, atol=0.0, equal_nan=True
+            ):
+                edge_params.append((name, "minimum"))
+            elif np.isclose(
+                float(best_value),
+                float(search_high),
+                rtol=0.0,
+                atol=0.0,
+                equal_nan=True,
+            ):
+                edge_params.append((name, "maximum"))
+
+        if not edge_params:
+            return None
+        details = ", ".join(f"{name} ({bound})" for name, bound in edge_params)
+        return (
+            f"{len(edge_params)} hyperparameter(s) are on the edge of the explored"
+            f" search space: {details}. Consider extending the search range."
+        )
+
+
 _BUILTIN_CHECKS = [
     CheckOverfitting(),
     CheckUnderfitting(),
@@ -547,4 +613,5 @@ _BUILTIN_CHECKS = [
     CheckCorrelatedFeatures(),
     CheckWorseThanBaseline(),
     CheckSlowerThanBaseline(),
+    CheckHyperparamsAtSearchEdge(),
 ]

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -732,31 +732,32 @@ class CheckHyperparamsAtSearchEdge(Check):
         if not isinstance(estimator, BaseSearchCV):
             raise CheckNotApplicable()
 
-        param_rows = estimator.cv_results_.get("params")
-        if param_rows is None:
+        param_combinations = estimator.cv_results_.get("params")
+        if param_combinations is None:
             raise CheckNotApplicable()
 
-        edge_params: list[tuple[str, str]] = []
-        for name, best_value in estimator.best_params_.items():
-            distinct = list(
-                dict.fromkeys(
-                    setting[name] for setting in param_rows if name in setting
-                )
-            )
-            if len(distinct) < 2 or not all(
-                isinstance(v, numbers.Real) and not isinstance(v, (bool, np.bool_))
-                for v in distinct
+        edge_params = []
+        for param_name, best_value in estimator.best_params_.items():
+            tried = [
+                param_combination[param_name]
+                for param_combination in param_combinations
+                if param_name in param_combination
+            ]
+            if len(set(tried)) < 2 or not all(
+                isinstance(value, numbers.Real)
+                and not isinstance(value, bool | np.bool_)
+                for value in tried
             ):
                 continue
-            search_low, search_high = min(distinct), max(distinct)
+            search_low, search_high = min(tried), max(tried)
             if not isinstance(best_value, numbers.Real) or isinstance(
-                best_value, (bool, np.bool_)
+                best_value, bool | np.bool_
             ):
                 continue
             if np.isclose(
                 float(best_value), float(search_low), rtol=0.0, atol=0.0, equal_nan=True
             ):
-                edge_params.append((name, "minimum"))
+                edge_params.append((param_name, "minimum"))
             elif np.isclose(
                 float(best_value),
                 float(search_high),
@@ -764,7 +765,7 @@ class CheckHyperparamsAtSearchEdge(Check):
                 atol=0.0,
                 equal_nan=True,
             ):
-                edge_params.append((name, "maximum"))
+                edge_params.append((param_name, "maximum"))
 
         if not edge_params:
             return None

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -7,7 +7,12 @@ import pytest
 from sklearn.datasets import make_classification, make_regression
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.linear_model import LinearRegression, LogisticRegression, RidgeCV
+from sklearn.experimental import enable_halving_search_cv  # noqa: F401
+from sklearn.linear_model import LinearRegression, LogisticRegression, Ridge, RidgeCV
+from sklearn.model_selection import (
+    GridSearchCV,
+    RandomizedSearchCV,
+)
 from sklearn.tree import DecisionTreeRegressor
 from skrub import tabular_pipeline
 
@@ -17,6 +22,7 @@ from skore._sklearn._checks.base import (
     ChecksSummaryDisplay,
     _get_issue_documentation_url,
 )
+from skore._sklearn._checks.model_checks import CheckHyperparamsAtSearchEdge
 
 
 @pytest.fixture(params=[LinearRegression(), tabular_pipeline(LinearRegression())])
@@ -216,6 +222,97 @@ def test_skd010_not_detected_for_fast_model(regression_data):
     report = evaluate(RidgeCV(), X, y)
     codes = set(report.checks.summarize().frame(severity="issue")["code"])
     assert "SKD010" not in codes
+
+
+def _prefit_grid_search_report(X, y, search):
+    search.fit(X, y)
+    return evaluate(search, X, y, splitter="prefit")
+
+
+@pytest.mark.parametrize(
+    "param_grid", [{"alpha": [0.1, 1.0, 10.0]}, {"alpha": [10.0, 0.1, 1.0]}]
+)
+def test_skd014_raises_at_numeric_edge(regression_data, monkeypatch, param_grid):
+    """SKD014 flags when best is at the numeric min/max of tried values."""
+    X, y = regression_data
+    report = _prefit_grid_search_report(
+        X, y, GridSearchCV(Ridge(), param_grid=param_grid, cv=2)
+    )
+    monkeypatch.setattr(report.estimator_, "best_params_", {"alpha": 0.1})
+    issues = report.checks.summarize().frame(severity="issue").set_index("code")
+    assert "SKD014" in issues.index
+    explanation = issues.loc["SKD014", "explanation"]
+    assert "alpha" in explanation
+    assert "minimum" in explanation
+
+
+@pytest.mark.parametrize(
+    "param_grid", [{"alpha": [1.0, 2.0, 3.0]}, {"alpha": [3.0, 1.0, 2.0]}]
+)
+def test_skd014_not_raised_for_interior_best(regression_data, monkeypatch, param_grid):
+    """SKD014 is absent when the best value is not at the tried min or max."""
+    X, y = regression_data
+    report = _prefit_grid_search_report(
+        X, y, GridSearchCV(Ridge(), param_grid=param_grid, cv=2)
+    )
+    monkeypatch.setattr(report.estimator_, "best_params_", {"alpha": 2.0})
+    codes = set(report.checks.summarize().frame(severity="issue")["code"])
+    assert "SKD014" not in codes
+
+
+@pytest.mark.parametrize("prefit", [True, False])
+def test_skd014_prefit_and_evaluate_fit(regression_data, monkeypatch, prefit):
+    """SKD014 runs for prefit and evaluate-fitted GridSearchCV reports."""
+    X, y = regression_data
+    search = GridSearchCV(Ridge(), param_grid={"alpha": [10.0, 0.1, 1.0]}, cv=2)
+    if prefit:
+        report = _prefit_grid_search_report(X, y, search)
+    else:
+        report = evaluate(search, X, y)
+    monkeypatch.setattr(report.estimator_, "best_params_", {"alpha": 0.1})
+    issues = report.checks.summarize().frame(severity="issue").set_index("code")
+    assert "SKD014" in issues.index
+    assert "minimum" in issues.loc["SKD014", "explanation"]
+
+
+def test_skd014_not_applicable_for_plain_estimator(regression_data):
+    """SKD014 raises CheckNotApplicable when the report estimator isn't BaseSearchCV."""
+    X, y = regression_data
+    report = evaluate(LinearRegression(), X, y)
+    with pytest.raises(CheckNotApplicable):
+        CheckHyperparamsAtSearchEdge().check_function(report)
+
+
+@pytest.mark.parametrize(
+    "param_grid", [{"fit_intercept": [False, True]}, {"solver": ["svd", "cholesky"]}]
+)
+def test_skd014_skips_non_numeric_hyperparameters(regression_data, param_grid):
+    """SKD014 ignores bool, string, and other non-numeric search parameters."""
+    X, y = regression_data
+    report = _prefit_grid_search_report(
+        X, y, GridSearchCV(Ridge(), param_grid=param_grid, cv=2)
+    )
+    codes = set(report.checks.summarize().frame(severity="issue")["code"])
+    assert "SKD014" not in codes
+
+
+@pytest.mark.parametrize(
+    "search",
+    [
+        GridSearchCV(Ridge(), param_grid={"alpha": [0.1, 1.0, 10.0]}, cv=2),
+        RandomizedSearchCV(
+            Ridge(), param_distributions={"alpha": [0.1, 1.0, 10.0]}, cv=2
+        ),
+    ],
+)
+def test_skd014_search_classes(regression_data, monkeypatch, search):
+    """SKD014 runs for GridSearchCV and RandomizedSearchCV using cv_results_."""
+    X, y = regression_data
+    report = _prefit_grid_search_report(X, y, search)
+    monkeypatch.setattr(report.estimator_, "best_params_", {"alpha": 0.1})
+    issues = report.checks.summarize().frame(severity="issue").set_index("code")
+    assert "SKD014" in issues.index
+    assert "minimum" in issues.loc["SKD014", "explanation"]
 
 
 def test_ignore_checks(monkeypatch, regression_report):

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -441,7 +441,6 @@ How to reduce the risk
 - check that the input pipeline (encoding, scaling) is not the actual bottleneck.
 
 
-
 .. _skd011-golden-feature:
 
 SKD011 - Golden feature
@@ -449,7 +448,6 @@ SKD011 - Golden feature
 
 This check is *slow*: it requires fitting one model per feature. Skip it with
 ``fast_mode=True``.
-
 
 How it is detected
 ^^^^^^^^^^^^^^^^^^
@@ -553,10 +551,7 @@ How to reduce the risk
 ^^^^^^^^^^^^^^^^^^^^^^
 
 - use a time-based splitter such as
-  :class:`~sklearn.model_selection.TimeSeriesSplit`,
-- sort the data chronologically and split on a fixed cut-off date,
-- exclude rows whose timestamps fall after the chosen training window.
-
+  :class:`~sklearn.model_selection.TimeSeriesSplit` or similar.
 
 .. _skd014-hyperparams-at-search-edge:
 
@@ -570,31 +565,19 @@ The check runs only when the report's estimator is a fitted
 :class:`~sklearn.model_selection.GridSearchCV` or
 :class:`~sklearn.model_selection.RandomizedSearchCV`).
 
-The check applies only to **numeric** hyperparameters (integers and floats, not
-``bool``). For each such parameter, `skore` collects every distinct value
-evaluated during the search and flags an issue when the value selected in
-``best_params_`` matches the **minimum or maximum** of those values, i.e. the
-numeric extremes of what was explored, regardless of the order values appear in
-``param_grid``.
-
-A numeric parameter is **not** flagged when fewer than two distinct values were
-tried.
-
-The check detects an issue when at least one numeric hyperparameter is on the
-boundary of the explored search space.
+Only numeric hyperparameters are considered. For each one, `skore` flags an
+issue when ``best_params_`` equals the **minimum or maximum** distinct value
+tried during the search. Order in ``param_grid`` does not matter.
 
 Why it matters
 ^^^^^^^^^^^^^^
 When the best hyperparameters sit on the boundary of what was actually explored,
 the true optimum may lie outside the searched range. Extending the grid or
-distributions is often worthwhile before trusting the selected model.
+distributions is often worthwhile.
 
 How to reduce the risk
 ^^^^^^^^^^^^^^^^^^^^^^
 
-- extend ``param_grid`` or ``param_distributions`` beyond the flagged bounds;
+- extend ``param_grid`` or ``param_distributions`` beyond the flagged bounds,
 - for :class:`~sklearn.model_selection.RandomizedSearchCV`, increase ``n_iter``
-  and sample from a wider range;
-- for successive halving searches, ensure early candidates cover a wide enough range;
-- re-run search after shifting bounds based on the flagged direction (minimum vs
-  maximum).
+  and sample from a wider range.

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -369,6 +369,9 @@ exceeds ``max(0.01, 0.05 * |baseline|)``.
 
 The check detects an issue when a **strict majority** of comparable metrics vote.
 
+Why it matters
+^^^^^^^^^^^^^^
+
 If the model does not match or beat a sensible off-the-shelf baseline, the modeling
 effort may not be worth its complexity: a simpler, well-tuned default could deliver the
 same quality with less risk of overfitting or maintenance burden.
@@ -408,6 +411,9 @@ the test set, with the same ``max(0.01, 0.05 * |baseline|)`` adaptive threshold.
 The check detects an issue when the slowness gate holds **and** a strict majority of
 comparable metrics vote.
 
+Why it matters
+^^^^^^^^^^^^^^
+
 A model that is much slower than a simple linear baseline but does not deliver
 better predictive quality wastes compute and engineering time. The added complexity
 is rarely justified when a fast linear model already captures the signal.
@@ -420,3 +426,47 @@ How to reduce the risk
   hyperparameter grids),
 - profile fit time to understand the dominant cost,
 - check that the input pipeline (encoding, scaling) is not the actual bottleneck.
+
+
+.. _skd014-hyperparams-at-search-edge:
+
+SKD014 - Hyperparameters at search edge
+---------------------------------------
+
+How it is detected
+^^^^^^^^^^^^^^^^^^
+
+The check runs only when the report's estimator is a fitted
+:class:`~sklearn.model_selection.BaseSearchCV` object (e.g.
+:class:`~sklearn.model_selection.GridSearchCV` or
+:class:`~sklearn.model_selection.RandomizedSearchCV`).
+
+The check applies only to **numeric** hyperparameters (integers and floats, not
+``bool``). For each such parameter, `skore` collects every distinct value
+evaluated during the search and flags an issue when the value selected in
+``best_params_`` matches the **minimum or maximum** of those values, i.e. the
+numeric extremes of what was explored, regardless of the order values appear in
+``param_grid``.
+
+A numeric parameter is **not** flagged when fewer than two distinct values were
+tried.
+
+The check detects an issue when at least one numeric hyperparameter is on the
+boundary of the explored search space.
+
+Why it matters
+^^^^^^^^^^^^^^
+
+When the best hyperparameters sit on the boundary of what was actually explored,
+the true optimum may lie outside the searched range. Extending the grid or
+distributions is often worthwhile before trusting the selected model.
+
+How to reduce the risk
+^^^^^^^^^^^^^^^^^^^^^^
+
+- extend ``param_grid`` or ``param_distributions`` beyond the flagged bounds;
+- for :class:`~sklearn.model_selection.RandomizedSearchCV`, increase ``n_iter``
+  and sample from a wider range;
+- for successive halving searches, ensure early candidates cover a wide enough range;
+- re-run search after shifting bounds based on the flagged direction (minimum vs
+  maximum).


### PR DESCRIPTION
add SKD014: Hyperparameters at search edge

For fitted `BaseSearchCV` estimators, flags when a numeric `best_params_` value equals the min or max of what was actually tried in search (from `cv_results_`). Non-numeric params are ignored. Suggests widening the search range when the optimum may lie outside the explored bounds.

Towards #2670. Splitting in different PRs as the other two require more work.