### PR TITLE
chore(skore): Improve consistency of backslashes in docs

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/inspection_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/inspection_accessor.py
@@ -217,7 +217,7 @@ class _InspectionAccessor(_BaseAccessor["ComparisonReport"], DirNamesMixin):
             Has no effect if the estimator is not a :class:`~sklearn.pipeline.Pipeline`.
 
         metric : str, callable, scorer, or list of such instances or dict of such \
-            instances, default=None
+                instances, default=None
             The metric to pass to :func:`sklearn.inspection.permutation_importance`.
 
             - if ``None``, a suitable default will be used.

--- a/skore/src/skore/_sklearn/_cross_validation/inspection_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/inspection_accessor.py
@@ -116,7 +116,7 @@ class _InspectionAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
             Has no effect if the estimator is not a :class:`~sklearn.pipeline.Pipeline`.
 
         metric : str, callable, scorer, or list of such instances or dict of such \
-            instances, default=None
+                instances, default=None
             The metric to pass to :func:`sklearn.inspection.permutation_importance`.
 
             - if ``None``, a suitable default will be used.

--- a/skore/src/skore/_sklearn/_estimator/inspection_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/inspection_accessor.py
@@ -162,7 +162,7 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             Has no effect if the estimator is not a :class:`~sklearn.pipeline.Pipeline`.
 
         metric : str, callable, scorer, or list of such instances or dict of such \
-            instances, default=None
+                instances, default=None
             The metric to pass to :func:`sklearn.inspection.permutation_importance`.
 
             - if ``None``, a suitable default will be used.

--- a/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
@@ -146,8 +146,9 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
     def plot(
         self,
         *,
-        subplot_by: Literal["auto", "label", "estimator", "data_source"]
-        | None = "auto",
+        subplot_by: (
+            Literal["auto", "label", "estimator", "data_source"] | None
+        ) = "auto",
         despine: bool = True,
         label: PositiveLabel = _DEFAULT,
     ) -> Figure:
@@ -156,17 +157,17 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         Parameters
         ----------
         subplot_by : {"auto", "label", "estimator", "data_source"} or None, \
-            default="auto"
+                default="auto"
             Column to use for creating subplots. Options:
 
-            - "auto": None for EstimatorReport and Cross-Validation Report, \
+            - "auto": None for EstimatorReport and Cross-Validation Report,
               "estimator" for ComparisonReport
             - "label": one subplot per class when plotting one-vs-rest curves
             - "estimator": one subplot per estimator (comparison only)
-            - "data_source": one subplot per data source (EstimatorReport with both \
-                data sources only)
-            - None: no subplots (Not available for comparison in classification \
-                with no specified label)
+            - "data_source": one subplot per data source (EstimatorReport with both
+              data sources only)
+            - None: no subplots (Not available for comparison in classification
+              with no specified label)
 
         despine : bool, default=True
             Whether to remove the top and right spines from the plot.

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -147,8 +147,9 @@ class PredictionErrorDisplay(DisplayMixin):
     def plot(
         self,
         *,
-        subplot_by: Literal["auto", "data_source", "split", "estimator", "output"]
-        | None = "auto",
+        subplot_by: (
+            Literal["auto", "data_source", "split", "estimator", "output"] | None
+        ) = "auto",
         kind: Literal[
             "actual_vs_predicted", "residual_vs_predicted"
         ] = "residual_vs_predicted",
@@ -210,8 +211,9 @@ class PredictionErrorDisplay(DisplayMixin):
     def _plot_matplotlib(
         self,
         *,
-        subplot_by: Literal["auto", "data_source", "split", "estimator", "output"]
-        | None = "auto",
+        subplot_by: (
+            Literal["auto", "data_source", "split", "estimator", "output"] | None
+        ) = "auto",
         kind: Literal[
             "actual_vs_predicted", "residual_vs_predicted"
         ] = "residual_vs_predicted",

--- a/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
@@ -152,8 +152,9 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
     def plot(
         self,
         *,
-        subplot_by: Literal["auto", "label", "estimator", "data_source"]
-        | None = "auto",
+        subplot_by: (
+            Literal["auto", "label", "estimator", "data_source"] | None
+        ) = "auto",
         plot_chance_level: bool = True,
         despine: bool = True,
         label: PositiveLabel = _DEFAULT,
@@ -165,18 +166,18 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
         Parameters
         ----------
         subplot_by : {"auto", "label", "estimator", "data_source"} or None, \
-            default="auto"
+                default="auto"
             Column to use for creating subplots. Options:
 
-            - "auto": None for :class:`~skore.EstimatorReport` and \
-              :class:`~skore.CrossValidationReport`, "estimator" for \
+            - "auto": None for :class:`~skore.EstimatorReport` and
+              :class:`~skore.CrossValidationReport`, "estimator" for
               :class:`~skore.ComparisonReport`
             - "label": one subplot per class when plotting one-vs-rest curves
             - "estimator": one subplot per estimator (comparison only)
-            - "data_source": one subplot per data source \
+            - "data_source": one subplot per data source
               (:class:`~skore.EstimatorReport` with both data sources only)
-            - None: no subplots (Not available for comparison in classification \
-                with no specified label)
+            - None: no subplots (Not available for comparison in classification
+              with no specified label)
 
         plot_chance_level : bool, default=True
             Whether to plot the chance level.

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -266,12 +266,12 @@ def _get_curve_plot_columns(
 
     Rules:
     - Default ("auto"): None for EstimatorReport and Cross-Validation Report,
-        "estimator" for ComparisonReport
+      "estimator" for ComparisonReport
     - subplot_by=None disallowed for comparison when plotting one-vs-rest curves
     - subplot_by="estimator" only allowed for comparison reports
     - subplot_by="label" only allowed when plotting one-vs-rest curves
-    - subplot_by="data_source" only allowed for EstimatorReport with both data \
-        sources
+    - subplot_by="data_source" only allowed for EstimatorReport with both data
+      sources
     - hue priority: estimator > label > data_source (excluding col)
 
     Returns (col, hue, style) tuple where each can be None if not applicable.

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -89,7 +89,7 @@ def evaluate(
     Returns
     -------
     report : :class:`~skore.EstimatorReport`, :class:`~skore.CrossValidationReport` \
-        or :class:`~skore.ComparisonReport`
+            or :class:`~skore.ComparisonReport`
         The report corresponding to the evaluation strategy.
 
     Examples


### PR DESCRIPTION
Make the use of `\` consistent in the docstrings:

- `\` only used to break type where there is a need for an extra indent on next line