### PR TITLE
fix(skore): Compatibility with scikit-learn 1.9.dev0

### DIFF
--- a/skore/src/skore/_sklearn/_plot/inspection/permutation_importance.py
+++ b/skore/src/skore/_sklearn/_plot/inspection/permutation_importance.py
@@ -179,7 +179,7 @@ class PermutationImportanceDisplay(DisplayMixin):
 
         if issparse(X_transformed):
             X_transformed = cast(spmatrix, X_transformed)
-            X_transformed = X_transformed.todense()
+            X_transformed = np.asarray(X_transformed.todense())
 
         scores = permutation_importance(
             estimator=estimator,

--- a/skore/tests/unit/plugins/hub/conftest.py
+++ b/skore/tests/unit/plugins/hub/conftest.py
@@ -313,11 +313,12 @@ def monkeypatch_sklearn_estimator_html_repr(monkeypatch):
 
     https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/_repr_html/estimator.py#L21
     """
-    from importlib.metadata import version
+    import sklearn
+    from sklearn.utils.fixes import parse_version
 
-    package_version = [int(number) for number in version("scikit-learn").split(".")]
+    sklearn_version = parse_version(parse_version(sklearn.__version__).base_version)
 
-    if package_version >= [1, 7, 0]:
+    if sklearn_version >= parse_version("1.7"):
         importpath = "sklearn.utils._repr_html.estimator._IDCounter.get_id"
     else:
         importpath = "sklearn.utils._estimator_html_repr._IDCounter.get_id"


### PR DESCRIPTION
When testing with scikit-learn `main` branch, I get two bugs:

- error parse `dev0`
- a conversion problem because there is a sparse matrix that is densified to a matrix and not an array. So we need to call `np.asarray` that is no-op in the case a sparse array converted to a numpy array.