### PR TITLE
fix(skore/checks): Prevent memory bottleneck in CheckCorrelatedFeatures for high-dimensional data

### DIFF
--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -418,7 +418,7 @@ class CheckCorrelatedFeatures(Check):
             raise CheckNotApplicable()
         if isinstance(X, pd.DataFrame):
             X = X.select_dtypes(include="number")
-        if X.shape[1] < 2 or X.shape[1] > 1000
+        if X.shape[1] < 2 or X.shape[1] > 1000:
             raise CheckNotApplicable()
 
         corr = np.abs(spearmanr(X).statistic)

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -421,6 +421,9 @@ class CheckCorrelatedFeatures(Check):
         if X.shape[1] < 2:
             raise CheckNotApplicable()
 
+        if X.shape[1] > 1000:
+            raise CheckNotApplicable()
+
         corr = np.abs(spearmanr(X).statistic)
         if corr.ndim < 2:
             return None

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -418,10 +418,7 @@ class CheckCorrelatedFeatures(Check):
             raise CheckNotApplicable()
         if isinstance(X, pd.DataFrame):
             X = X.select_dtypes(include="number")
-        if X.shape[1] < 2:
-            raise CheckNotApplicable()
-
-        if X.shape[1] > 1000:
+        if X.shape[1] < 2 or X.shape[1] > 1000
             raise CheckNotApplicable()
 
         corr = np.abs(spearmanr(X).statistic)


### PR DESCRIPTION
Closes #2949
#### Description

This PR adds an early exit condition to `CheckCorrelatedFeatures` (SKD008) to prevent Out of Memory (OOM) crashes on high-dimensional datasets.

The `spearmanr(X)` calculation computes a dense $O(N^2)$ correlation matrix. If a user passes a dataset with tens of thousands of features, this attempts to allocate roughly 20 GB of contiguous RAM in a single block, immediately crashing standard machines or halting execution.

By raising `CheckNotApplicable()` when `X.shape[1] > 1000`, we safely skip the check for wide datasets, neutralizing the memory bottleneck without breaking downstream `summarize()` calls.

#### Contribution checklist

* [ ] Unit tests were added or updated (if necessary)
* [ ] Documentation was added or updated (if necessary)
* [x] The code passes our style conventions (you can check this by running pre-commit on your code
with `pre-commit run --all-files`)
* [x] All the tests pass (please test locally before pushing)
* [ ] The documentation builds and renders properly (if it does, our bot will add a comment linking
to a preview of the documentation to review it visually)
* [ ] A new changelog entry was added to CHANGELOG.rst (if necessary; typically, if your change
requires updating tests)
* [x] All the commits in the PR are signed (more information
[[here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
* [x] The pull request title respects the Conventional Commits convention (more information
[[here](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests)](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests))

#### AI usage disclosure

AI tools were involved for:

* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding