### PR TITLE
fix: Ensure that `report.metrics.summarize` and `report.metrics.<metric>` use the same cache keys

### DIFF
--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -147,6 +147,8 @@ class Metric:
       differ from what the base metric returned.
     """
 
+    kwargs: dict[str, Any] = {}
+
     def __init__(
         self,
         *,
@@ -166,7 +168,7 @@ class Metric:
         # When name is None, the metric is being instantiated from a subclass
         # (e.g. Accuracy()) whose fields are defined as class attributes.
         # Only `kwargs` needs to be set as an instance attribute.
-        self.kwargs = kwargs or {}
+        self.kwargs = kwargs or self.kwargs
 
         if name is None:
             return
@@ -557,13 +559,14 @@ class FitTime(Metric):
     greater_is_better = False
     function = None
     function_kind = None
+    kwargs = {"cast": True}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
         return True
 
-    def _raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
-        if cast and report._fit_time is None:
+    def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
+        if kwargs["cast"] and report._fit_time is None:
             return float("nan")
         return report._fit_time
 
@@ -574,6 +577,7 @@ class PredictTime(Metric):
     greater_is_better = False
     function = None
     function_kind = None
+    kwargs = {"cast": True}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
@@ -603,23 +607,20 @@ class Precision(Metric):
     response_method = "predict"
     greater_is_better = True
     function_kind = FunctionKind.METRIC
+    kwargs = {"average": None}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
-    def _raw(
-        self, *, report: EstimatorReport, data_source="test", average=None, **kwargs
-    ):
+    def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
         if report._ml_task == "binary-classification":
-            if average is None and report.pos_label is not None:
-                average = "binary"
-            elif average != "binary":
+            if kwargs["average"] is None and report.pos_label is not None:
+                kwargs["average"] = "binary"
+            elif kwargs["average"] != "binary":
                 kwargs["pos_label"] = None
 
-        return super()._raw(
-            report=report, data_source=data_source, average=average, **kwargs
-        )
+        return super()._raw(report=report, data_source=data_source, **kwargs)
 
 
 class Recall(Metric):
@@ -629,23 +630,20 @@ class Recall(Metric):
     response_method = "predict"
     greater_is_better = True
     function_kind = FunctionKind.METRIC
+    kwargs = {"average": None}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
-    def _raw(
-        self, *, report: EstimatorReport, data_source="test", average=None, **kwargs
-    ):
+    def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
         if report._ml_task == "binary-classification":
-            if average is None and report.pos_label is not None:
-                average = "binary"
-            elif average != "binary":
+            if kwargs["average"] is None and report.pos_label is not None:
+                kwargs["average"] = "binary"
+            elif kwargs["average"] != "binary":
                 kwargs["pos_label"] = None
 
-        return super()._raw(
-            report=report, data_source=data_source, average=average, **kwargs
-        )
+        return super()._raw(report=report, data_source=data_source, **kwargs)
 
 
 class Brier(Metric):
@@ -680,6 +678,7 @@ class RocAuc(Metric):
     response_method = ("predict_proba", "decision_function")
     greater_is_better = True
     function_kind = FunctionKind.METRIC
+    kwargs = {"average": None, "multi_class": "ovr"}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
@@ -696,23 +695,6 @@ class RocAuc(Metric):
         if y_score.ndim == 2 and y_score.shape[1] == 2:
             y_score = y_score[:, 1]
         return sklearn.metrics.roc_auc_score(y_true, y_score, **kwargs)
-
-    def _raw(
-        self,
-        *,
-        report: EstimatorReport,
-        data_source="test",
-        average=None,
-        multi_class="ovr",
-        **kwargs,
-    ):
-        return super()._raw(
-            report=report,
-            data_source=data_source,
-            average=average,
-            multi_class=multi_class,
-            **kwargs,
-        )
 
 
 class LogLoss(Metric):
@@ -738,22 +720,11 @@ class R2(Metric):
     response_method = "predict"
     greater_is_better = True
     function_kind = FunctionKind.METRIC
+    kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
-
-    def _raw(
-        self,
-        *,
-        report: EstimatorReport,
-        data_source="test",
-        multioutput="raw_values",
-        **kwargs,
-    ):
-        return super()._raw(
-            report=report, data_source=data_source, multioutput=multioutput, **kwargs
-        )
 
 
 class Rmse(Metric):
@@ -763,22 +734,11 @@ class Rmse(Metric):
     response_method = "predict"
     greater_is_better = False
     function_kind = FunctionKind.METRIC
+    kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
-
-    def _raw(
-        self,
-        *,
-        report: EstimatorReport,
-        data_source="test",
-        multioutput="raw_values",
-        **kwargs,
-    ):
-        return super()._raw(
-            report=report, data_source=data_source, multioutput=multioutput, **kwargs
-        )
 
 
 class Mae(Metric):
@@ -788,22 +748,11 @@ class Mae(Metric):
     response_method = "predict"
     greater_is_better = False
     function_kind = FunctionKind.METRIC
+    kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
-
-    def _raw(
-        self,
-        *,
-        report: EstimatorReport,
-        data_source="test",
-        multioutput="raw_values",
-        **kwargs,
-    ):
-        return super()._raw(
-            report=report, data_source=data_source, multioutput=multioutput, **kwargs
-        )
 
 
 class Mape(Metric):
@@ -813,22 +762,11 @@ class Mape(Metric):
     response_method = "predict"
     greater_is_better = False
     function_kind = FunctionKind.METRIC
+    kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
     def available(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
-
-    def _raw(
-        self,
-        *,
-        report: EstimatorReport,
-        data_source="test",
-        multioutput="raw_values",
-        **kwargs,
-    ):
-        return super()._raw(
-            report=report, data_source=data_source, multioutput=multioutput, **kwargs
-        )
 
 
 class Score(Metric):

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -583,8 +583,11 @@ class PredictTime(Metric):
     def available(report: EstimatorReport) -> bool:
         return True
 
-    def _raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
-        return report._predict_time.get(data_source, float("nan") if cast else None)
+    def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
+        predict_time = report._predict_time.get(data_source)
+        if predict_time is None:
+            return float("nan") if kwargs["cast"] else None
+        return predict_time
 
 
 class Accuracy(Metric):

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -375,7 +375,7 @@ def test_pos_label_overwrite(metric, metric_fn):
     assert score_A == pytest.approx(metric_fn(y, classifier.predict(X), pos_label="A"))
 
 
-# Cache and data_source
+# Cache
 
 
 def test_cache(forest_binary_classification_with_test):
@@ -390,6 +390,19 @@ def test_cache(forest_binary_classification_with_test):
     with check_cache_unchanged(report._cache):
         result_from_cache = report.metrics.summarize()
     assert_frame_equal(result.data, result_from_cache.data)
+
+
+def test_cache_interaction(linear_regression_with_test):
+    """Calling a metric explicitly after calling summarize() should hit the cache."""
+    estimator, X_test, y_test = linear_regression_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    report.metrics.summarize(metric="r2")
+
+    with check_cache_unchanged(report._cache):
+        report.metrics.r2()
+
+
+# Data source
 
 
 def test_data_source_both(forest_binary_classification_data):

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -392,14 +392,23 @@ def test_cache(forest_binary_classification_with_test):
     assert_frame_equal(result.data, result_from_cache.data)
 
 
-def test_cache_interaction(linear_regression_with_test):
+@pytest.mark.parametrize(
+    "metric, fixture",
+    [
+        ("predict_time", "forest_binary_classification_with_test"),
+        ("precision", "forest_binary_classification_with_test"),
+        ("roc_auc", "forest_binary_classification_with_test"),
+        ("r2", "linear_regression_with_test"),
+    ],
+)
+def test_cache_interaction(request, metric, fixture):
     """Calling a metric explicitly after calling summarize() should hit the cache."""
-    estimator, X_test, y_test = linear_regression_with_test
+    estimator, X_test, y_test = request.getfixturevalue(fixture)
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    report.metrics.summarize(metric="r2")
+    report.metrics.summarize(metric=metric)
 
     with check_cache_unchanged(report._cache):
-        report.metrics.r2()
+        getattr(report.metrics, metric)()
 
 
 # Data source


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

If this is your first contribution, take a look at our contribution guidelines:
https://docs.skore.probabl.ai/stable/contributing.html
-->
#### Change description
<!--
Please describe what your contribution changes for skore.

Here is some inspiration for what to write here:
- Are you adding a new feature? Fixing a bug?
- Can you give an example of your change in action, e.g. a snippet of code or a plot?
- Is your change likely to break users' code?
- Are there any other details the reviewer should be aware of, such as API design choices, performance characteristics or edge cases?

Please reference issues/PRs when possible, e.g. "Fixes #1234", "Closes #3456", "See also #7890".
More information [here](https://github.com/blog/1506-closing-issues-via-pull-requests).
-->
Even if the two share mostly the same code, the way they are called in `_raw_cached` causes one to use cache key `(data_source, "r2", ('mapping', ()))` while the other uses `(data_source, "r2", ('mapping', ('multioutput', 'raw_values'),))`.

#### Contribution checklist
<!--
Below are some of the criteria that the review will include.
Feel free to use it as a checklist to ensure that your contribution is high-quality.
-->

- [x] Unit tests were added or updated (if necessary)


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure you understand our [automated contributions policy](https://docs.skore.probabl.ai/stable/contributing.html#automated-contributions-policy)
-->
AI tools were involved for:
Nothing
<!-- Any other comments can go here. Thanks again for contributing! -->
