### PR TITLE
chore: Make `EstimatorReport.fit_time_` private

### DIFF
--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -501,11 +501,11 @@ class CheckSlowerThanBaseline(Check):
         report = cast("EstimatorReport", report)
         baseline = _baseline_estimator_report(report, kind="fast")
 
-        if report.fit_time_ is None or baseline.fit_time_ is None:
+        if report._fit_time is None or baseline._fit_time is None:
             raise CheckNotApplicable()
 
-        slowness_ratio = report.fit_time_ / baseline.fit_time_
-        if slowness_ratio < 2.0 or report.fit_time_ - baseline.fit_time_ < 0.05:
+        slowness_ratio = report._fit_time / baseline._fit_time
+        if slowness_ratio < 2.0 or report._fit_time - baseline._fit_time < 0.05:
             return None
 
         report_test = collect_scores(report, data_source="test")

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -162,10 +162,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
     estimator_name_ : str
         The name of the estimator.
 
-    fit_time_ : float or None
-        The time taken to fit the estimator, in seconds. If the estimator is not
-        internally fitted, the value is `None`.
-
     ml_task : str
         The machine learning task inferred from the data and estimator.
 
@@ -300,7 +296,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
 
         self._predict_time: PredictTime = {}
         self._pos_label = pos_label
-        self.fit_time_ = self._fit_time
         self._ml_task = _find_ml_task(self.y_test, estimator=self.estimator_)
         self._cache = Cache()
         # NOTE: Reports are immutable so we don't need cache invalidation
@@ -355,7 +350,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
             "estimator": self.estimator,
             "ml_task": self._ml_task,
             "fit": self._fit,
-            "fit_time": self.fit_time_,
+            "fit_time": self._fit_time,
             "predict_time": self._predict_time,
             "pos_label": self._pos_label,
             "learner": self.learner_,
@@ -391,7 +386,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         report._initialized_with_data_op = state["initialized_with_data_op"]
         report._ml_task = state["ml_task"]
         report._fit = state["fit"]
-        report.fit_time_ = state["fit_time"]
+        report._fit_time = state["fit_time"]
         report._predict_time = state["predict_time"]
         report._pos_label = state["pos_label"]
         report.learner_ = state["learner"]

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -563,9 +563,9 @@ class FitTime(Metric):
         return True
 
     def _raw(self, *, report: EstimatorReport, data_source="test", cast=True, **kwargs):
-        if cast and report.fit_time_ is None:
+        if cast and report._fit_time is None:
             return float("nan")
-        return report.fit_time_
+        return report._fit_time
 
 
 class PredictTime(Metric):

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -553,7 +553,7 @@ def test_from_state_bypasses_init_and_restores_state(
 
     assert restored.id == report.id
     assert restored.fit == report.fit
-    assert restored.fit_time_ == report.fit_time_
+    assert restored._fit_time == report._fit_time
     assert restored.X_test is report.X_test
     assert restored.ml_task == report.ml_task
     assert restored.pos_label == report.pos_label


### PR DESCRIPTION
For symmetry with `_predict_time`. Fit time remains accessible via `report.metrics.fit_time` and `report.metrics.timings` and `report.metrics.summarize`.
