### PR TITLE
docs: Add checks summary in getting started

### DIFF
--- a/examples/getting_started/plot_getting_started.py
+++ b/examples/getting_started/plot_getting_started.py
@@ -148,6 +148,12 @@ simple_cv_report.help()
 simple_cv_report.data.analyze()
 
 # %%
+# Additionally we can run automatic checks on the model and get a summary of the findings:
+
+# %%
+simple_cv_report.checks.summarize()
+
+# %%
 # But we can also quickly get an overview of the performance of our model,
 # using :meth:`~skore.CrossValidationReport.metrics.summarize`:
 


### PR DESCRIPTION
Adds `checks.summarize()` in the section that explores the different accessors.

Supercedes #2957 