### PR TITLE
docs(skore): Use the california housing dataset on landing page

### DIFF
--- a/sphinx/sphinxext/landing_page.py
+++ b/sphinx/sphinxext/landing_page.py
@@ -15,9 +15,10 @@ import matplotlib.pyplot as plt
 from jinja2 import Environment, FileSystemLoader
 from sphinx.application import Sphinx
 
+# Use California housing dataset for reproducibility, see https://github.com/probabl-ai/skore/issues/2963
 DATA_LOADING_CODE = """\
-from skrub.datasets import fetch_employee_salaries
-dataset = fetch_employee_salaries()
+from skrub.datasets import fetch_california_housing
+dataset = fetch_california_housing()
 df = dataset.X
 y = dataset.y"""
 


### PR DESCRIPTION
Closes #2963

This PR changes the landing page to use the `california_housing` dataset from skrub. This avoids usage of `StringEncoder` in `tabular_pipeline` so the outputs are reproducible. 

As a bonus side effect, the prediction error plot is a little nicer I think, in the sense that it provides insight: The house values are capped in the dataset and we can distinguish some groups in the splits.