### PR TITLE
ci: Drop support of scikit-learn `1.5` in favor of `1.9`

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -68,8 +68,8 @@ defaults:
 
 env:
   PYTHON: '3.14'
-  SCIKIT_LEARN: '1.8'
-  LOCKFILE: 'ci/requirements/skore/python-3.14/scikit-learn-1.8/sphinx-requirements.txt'
+  SCIKIT_LEARN: '1.9'
+  LOCKFILE: 'ci/requirements/skore/python-3.14/scikit-learn-1.9/sphinx-requirements.txt'
 
 jobs:
   sphinx-changes:

--- a/README.md
+++ b/README.md
@@ -115,17 +115,18 @@ Join our mission to promote open-source and make machine learning development mo
 
 Skore is tested on Linux and Windows, for at most 4 versions of Python, and at most 4 versions of scikit-learn:
 - Python 3.11
-  - scikit-learn 1.5
-  - scikit-learn 1.8
+  - scikit-learn 1.6
+  - scikit-learn 1.9
 - Python 3.12
-  - scikit-learn 1.5
-  - scikit-learn 1.8
+  - scikit-learn 1.6
+  - scikit-learn 1.9
 - Python 3.13
-  - scikit-learn 1.5
-  - scikit-learn 1.8
+  - scikit-learn 1.6
+  - scikit-learn 1.9
 - Python 3.14
   - scikit-learn 1.7
   - scikit-learn 1.8
+  - scikit-learn 1.9
 
 ---
 

--- a/ci/pip-compile.sh
+++ b/ci/pip-compile.sh
@@ -41,7 +41,7 @@ case $1 in
         shift
         ;;
     "--sphinx-requirements")
-        COMBINATIONS+=('skore|sphinx|3.14|["scikit-learn==1.8.*"]')
+        COMBINATIONS+=('skore|sphinx|3.14|["scikit-learn==1.9.*"]')
         shift
         ;;
     *)

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -258,7 +258,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -404,7 +404,7 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tomli==2.4.1
     # via coverage
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -439,7 +439,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
@@ -22,7 +22,7 @@ attrs==26.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -37,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,7 +64,7 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,7 +72,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
@@ -106,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,11 +118,11 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
+huey==3.0.1
     # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -132,7 +132,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -182,19 +182,17 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
-    # via
-    #   --override skore/overrides.txt
-    #   skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow==3.13.0
+    # via skore (skore/pyproject.toml)
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
+narwhals==2.22.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -214,21 +212,21 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -255,7 +253,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -266,9 +264,9 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
@@ -294,7 +292,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -344,7 +342,7 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
@@ -364,7 +362,7 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.8.0
+scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -378,7 +376,7 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -390,7 +388,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -398,12 +396,14 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
+tomli==2.4.1
+    # via coverage
 traitlets==5.15.0
     # via
     #   ipython
@@ -411,17 +411,23 @@ traitlets==5.15.0
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via
+    #   aiohttp
+    #   aiosignal
     #   alembic
+    #   anyio
     #   anywidget
     #   fastapi
     #   graphene
+    #   ipython
     #   mlflow-skinny
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+    #   optype
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -433,9 +439,9 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
     # via

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
@@ -60,7 +60,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -222,7 +222,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -351,7 +351,7 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tomli==2.4.1
     # via coverage
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -384,7 +384,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
@@ -1,9 +1,3 @@
-aiohappyeyeballs==2.6.2
-    # via aiohttp
-aiohttp==3.13.5
-    # via mlflow
-aiosignal==1.4.0
-    # via aiohttp
 alembic==1.18.4
     # via mlflow
 annotated-doc==0.0.4
@@ -18,14 +12,10 @@ anywidget==0.11.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
-attrs==26.1.0
-    # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
-    # via
-    #   mlflow-skinny
-    #   mlflow-tracing
+cachetools==5.5.2
+    # via mlflow-skinny
 certifi==2026.5.20
     # via
     #   httpcore
@@ -37,7 +27,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,23 +38,19 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
-    # via
-    #   google-auth
-    #   mlflow
+cryptography==48.0.0
+    # via google-auth
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
-    # via
-    #   mlflow-skinny
-    #   mlflow-tracing
+databricks-sdk==0.114.0
+    # via mlflow-skinny
 decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,24 +58,16 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
     #   python-discovery
     #   virtualenv
 flask==3.1.3
-    # via
-    #   flask-cors
-    #   mlflow
-flask-cors==6.0.2
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
-frozenlist==1.8.0
-    # via
-    #   aiohttp
-    #   aiosignal
 gitdb==4.0.12
     # via gitpython
 gitpython==3.1.50
@@ -106,7 +84,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==23.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,21 +96,18 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
-    # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
     #   requests
-    #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.9.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -153,6 +128,7 @@ jinja2==3.1.6
     # via
     #   skore (skore/pyproject.toml)
     #   flask
+    #   mlflow
     #   skrub
 joblib==1.5.3
     # via
@@ -164,6 +140,8 @@ kiwisolver==1.5.0
     # via matplotlib
 mako==1.3.12
     # via alembic
+markdown==3.10.2
+    # via mlflow
 markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
@@ -182,17 +160,13 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
-    # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
-    # via mlflow
-mlflow-tracing==3.12.0
-    # via mlflow
-multidict==6.7.1
+mlflow==2.22.5
     # via
-    #   aiohttp
-    #   yarl
-narwhals==2.21.2
+    #   --override skore/overrides.txt
+    #   skore (skore/pyproject.toml)
+mlflow-skinny==2.22.5
+    # via mlflow
+narwhals==2.22.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -208,39 +182,29 @@ numpy==2.4.6
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   skops
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
-    #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
-    # via
-    #   mlflow-skinny
-    #   mlflow-tracing
-opentelemetry-sdk==1.42.0
-    # via
-    #   mlflow-skinny
-    #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-sdk==1.42.1
+    # via mlflow-skinny
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==24.2
     # via
     #   gunicorn
     #   matplotlib
     #   mlflow-skinny
-    #   mlflow-tracing
     #   plotly
     #   pytest
-    #   skops
 pandas==2.3.3
     # via
     #   skore (skore/pyproject.toml)
@@ -253,7 +217,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -264,26 +228,18 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
-    # via skops
 prompt-toolkit==3.0.52
     # via ipython
-propcache==0.5.2
-    # via
-    #   aiohttp
-    #   yarl
 protobuf==6.33.6
     # via
     #   databricks-sdk
     #   mlflow-skinny
-    #   mlflow-tracing
-    #   opentelemetry-proto
 psutil==7.2.2
     # via ipython
 psygnal==0.15.1
@@ -292,7 +248,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==19.0.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -307,7 +263,6 @@ pydantic==2.13.4
     #   skore (skore/pyproject.toml)
     #   fastapi
     #   mlflow-skinny
-    #   mlflow-tracing
 pydantic-core==2.46.4
     # via pydantic
 pydot==4.0.1
@@ -342,10 +297,8 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
-python-dotenv==1.2.2
-    # via mlflow-skinny
 pytz==2026.2
     # via pandas
 pyyaml==6.0.3
@@ -362,33 +315,29 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.8.0
+scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
     #   mlflow
-    #   skops
     #   skrub
 scipy==1.17.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
-    #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
-skops==0.14.0
-    # via mlflow
 skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -396,12 +345,12 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
-    # via
-    #   fastapi
-    #   mlflow-skinny
+starlette==1.2.1
+    # via fastapi
 threadpoolctl==3.6.0
     # via scikit-learn
+tomli==2.4.1
+    # via coverage
 traitlets==5.15.0
     # via
     #   ipython
@@ -409,12 +358,12 @@ traitlets==5.15.0
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via
-    #   aiosignal
     #   alembic
     #   anyio
     #   anywidget
     #   fastapi
     #   graphene
+    #   ipython
     #   mlflow-skinny
     #   opentelemetry-api
     #   opentelemetry-sdk
@@ -435,23 +384,17 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
-    # via
-    #   prettytable
-    #   prompt-toolkit
+    # via prompt-toolkit
 werkzeug==3.1.8
-    # via
-    #   flask
-    #   flask-cors
+    # via flask
 widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
-    # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -260,7 +260,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -406,7 +406,7 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tomli==2.4.1
     # via coverage
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -441,7 +441,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
@@ -22,7 +22,7 @@ attrs==26.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -37,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,7 +64,7 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,7 +72,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
@@ -106,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,11 +118,11 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
+huey==3.0.1
     # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -132,7 +132,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -182,18 +182,20 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
-    # via plotly
+narwhals==2.22.0
+    # via
+    #   plotly
+    #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.6
@@ -212,21 +214,21 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -253,7 +255,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -264,9 +266,9 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
@@ -292,7 +294,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +344,7 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
@@ -362,7 +364,7 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.8.0
+scikit-learn==1.9.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -376,7 +378,7 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -388,7 +390,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -396,12 +398,14 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
+tomli==2.4.1
+    # via coverage
 traitlets==5.15.0
     # via
     #   ipython
@@ -409,17 +413,23 @@ traitlets==5.15.0
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via
+    #   aiohttp
+    #   aiosignal
     #   alembic
+    #   anyio
     #   anywidget
     #   fastapi
     #   graphene
+    #   ipython
     #   mlflow-skinny
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+    #   optype
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -431,9 +441,9 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
     # via

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
@@ -22,7 +22,7 @@ attrs==26.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -37,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,7 +64,7 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,7 +72,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
@@ -106,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,11 +118,11 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
+huey==3.0.1
     # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -132,7 +132,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -182,17 +182,17 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
+narwhals==2.22.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -212,21 +212,21 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -253,7 +253,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -264,9 +264,9 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
@@ -292,7 +292,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +342,7 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
@@ -362,7 +362,7 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.5.2
+scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -376,7 +376,7 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -388,7 +388,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -396,7 +396,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
@@ -409,6 +409,7 @@ traitlets==5.15.0
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via
+    #   aiohttp
     #   aiosignal
     #   alembic
     #   anyio
@@ -435,9 +436,9 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
     # via

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -258,7 +258,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -402,7 +402,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -436,7 +436,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
@@ -22,7 +22,7 @@ attrs==26.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -37,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,7 +64,7 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,7 +72,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
@@ -106,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,11 +118,11 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
+huey==3.0.1
     # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -132,7 +132,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -182,18 +182,20 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
-    # via plotly
+narwhals==2.22.0
+    # via
+    #   plotly
+    #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.6
@@ -212,21 +214,21 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -253,7 +255,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -264,9 +266,9 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
@@ -292,7 +294,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +344,7 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
@@ -362,7 +364,7 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.5.2
+scikit-learn==1.9.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -376,7 +378,7 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -388,7 +390,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -396,7 +398,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
@@ -409,7 +411,10 @@ traitlets==5.15.0
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via
+    #   aiohttp
+    #   aiosignal
     #   alembic
+    #   anyio
     #   anywidget
     #   fastapi
     #   graphene
@@ -417,9 +422,11 @@ typing-extensions==4.15.0
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+    #   optype
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -431,9 +438,9 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
     # via

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -260,7 +260,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -404,7 +404,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -438,7 +438,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -258,7 +258,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -402,7 +402,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -431,7 +431,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -362,7 +362,7 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.7.2
+scikit-learn==1.6.1
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
@@ -22,7 +22,7 @@ attrs==26.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -37,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,7 +64,7 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,7 +72,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
@@ -106,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,11 +118,11 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
+huey==3.0.1
     # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -132,7 +132,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -182,18 +182,20 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
-    # via plotly
+narwhals==2.22.0
+    # via
+    #   plotly
+    #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.6
@@ -212,21 +214,21 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -243,7 +245,6 @@ packaging==26.2
     #   skops
 pandas==2.3.3
     # via
-    #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   seaborn
@@ -254,7 +255,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -265,9 +266,9 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
@@ -293,7 +294,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -343,7 +344,7 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
@@ -363,7 +364,7 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.8.0
+scikit-learn==1.9.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -377,7 +378,7 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -389,7 +390,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -397,7 +398,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
@@ -432,9 +433,9 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
     # via

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -260,7 +260,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -404,7 +404,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -433,7 +433,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -258,7 +258,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -402,7 +402,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -431,7 +431,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -258,7 +258,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -402,7 +402,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -431,7 +431,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
@@ -22,7 +22,7 @@ attrs==26.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -37,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,7 +64,7 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,7 +72,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
@@ -106,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,11 +118,11 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
+huey==3.0.1
     # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -132,7 +132,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -182,17 +182,17 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
+narwhals==2.22.0
     # via plotly
 nodeenv==1.10.0
     # via pre-commit
@@ -212,21 +212,21 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -253,7 +253,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -264,9 +264,9 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
@@ -292,7 +292,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +342,7 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
@@ -376,7 +376,7 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -388,7 +388,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -396,7 +396,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
@@ -431,9 +431,9 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
     # via

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/sphinx-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/sphinx-requirements.txt
@@ -271,7 +271,7 @@ platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   choreographer
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 polars==1.41.2
     # via skore (skore/pyproject.toml)
@@ -438,7 +438,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -469,7 +469,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 wcwidth==0.7.0
     # via

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/sphinx-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/sphinx-requirements.txt
@@ -1,11 +1,17 @@
+accessible-pygments==0.0.5
+    # via pydata-sphinx-theme
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
+alabaster==1.0.0
+    # via sphinx
 alembic==1.18.4
     # via mlflow
+altair==6.1.0
+    # via skore (skore/pyproject.toml)
 annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0
@@ -14,15 +20,22 @@ anyio==4.13.0
     # via
     #   httpx
     #   starlette
-anywidget==0.11.0
-    # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
 attrs==26.1.0
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   jsonschema
+    #   referencing
+babel==2.18.0
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.14.3
+    # via pydata-sphinx-theme
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -33,11 +46,11 @@ certifi==2026.5.20
     #   requests
 cffi==2.0.0
     # via cryptography
-cfgv==3.5.0
-    # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+choreographer==1.3.0
+    # via kaleido
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +61,13 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
-    # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,20 +75,17 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
-    # via virtualenv
 docker==7.1.0
     # via mlflow
-execnet==2.1.2
-    # via pytest-xdist
+docutils==0.21.2
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+    #   sphinx-tabs
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
-    # via
-    #   python-discovery
-    #   virtualenv
 flask==3.1.3
     # via
     #   flask-cors
@@ -106,7 +114,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -115,53 +123,54 @@ h11==0.16.0
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via
-    #   skore (skore/pyproject.toml)
-    #   respx
-huey==2.6.0
+    # via skore (skore/pyproject.toml)
+huey==3.0.1
     # via mlflow
-identify==2.6.19
-    # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
     #   requests
     #   yarl
+imagesize==2.0.0
+    # via sphinx
 importlib-metadata==9.0.0
     # via mlflow-skinny
-iniconfig==2.3.0
-    # via pytest
-ipython==9.13.0
-    # via
-    #   skore (skore/pyproject.toml)
-    #   ipywidgets
+ipython==9.14.0
+    # via ipywidgets
 ipython-pygments-lexers==1.1.1
     # via ipython
 ipywidgets==8.1.8
-    # via
-    #   skore (skore/pyproject.toml)
-    #   anywidget
-    #   rich
+    # via rich
 itsdangerous==2.2.0
     # via flask
 jedi==0.20.0
-    # via
-    #   skore (skore/pyproject.toml)
-    #   ipython
+    # via ipython
 jinja2==3.1.6
     # via
     #   skore (skore/pyproject.toml)
+    #   altair
     #   flask
     #   skrub
+    #   sphinx
 joblib==1.5.3
     # via
     #   skore (skore/pyproject.toml)
     #   scikit-learn
+jsonschema==4.26.0
+    # via altair
+jsonschema-specifications==2025.9.1
+    # via jsonschema
 jupyterlab-widgets==3.0.16
     # via ipywidgets
+kaleido==1.3.0
+    # via skore (skore/pyproject.toml)
 kiwisolver==1.5.0
     # via matplotlib
+logistro==2.0.1
+    # via
+    #   choreographer
+    #   kaleido
 mako==1.3.12
     # via alembic
 markdown-it-py==4.2.0
@@ -182,65 +191,68 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
-    # via plotly
-nodeenv==1.10.0
-    # via pre-commit
+narwhals==2.22.0
+    # via
+    #   altair
+    #   plotly
+    #   scikit-learn
 numpy==2.4.6
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
     #   matplotlib
     #   mlflow
-    #   numpy-typing-compat
-    #   optype
     #   pandas
     #   scikit-learn
     #   scipy
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
-    # via optype
-opentelemetry-api==1.42.0
+    #   xgboost-cpu
+numpydoc==1.10.0
+    # via skore (skore/pyproject.toml)
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
-    # via scipy-stubs
 orjson==3.11.9
-    # via skore (skore/pyproject.toml)
+    # via
+    #   skore (skore/pyproject.toml)
+    #   kaleido
 packaging==26.2
     # via
+    #   altair
     #   gunicorn
+    #   kaleido
     #   matplotlib
     #   mlflow-skinny
     #   mlflow-tracing
     #   plotly
-    #   pytest
     #   skops
+    #   sphinx
+    #   sphinx-autosummary-accessors
 pandas==2.3.3
     # via
     #   skore (skore/pyproject.toml)
@@ -252,24 +264,19 @@ parso==0.8.7
 pexpect==4.9.0
     # via ipython
 pillow==12.2.0
-    # via matplotlib
-platformdirs==4.9.6
+    # via
+    #   matplotlib
+    #   sphinx-gallery
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
-    #   python-discovery
-    #   virtualenv
+    #   choreographer
 plotly==6.7.0
     # via skore (skore/pyproject.toml)
-pluggy==1.6.0
-    # via
-    #   pytest
-    #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
-pre-commit==4.6.0
-    # via skore (skore/pyproject.toml)
 prettytable==3.17.0
     # via skops
 prompt-toolkit==3.0.52
@@ -286,16 +293,12 @@ protobuf==6.33.6
     #   opentelemetry-proto
 psutil==7.2.2
     # via ipython
-psygnal==0.15.1
-    # via anywidget
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
-    # via
-    #   skore (skore/pyproject.toml)
-    #   mlflow
+pyarrow==24.0.0
+    # via mlflow
 pyasn1==0.6.3
     # via pyasn1-modules
 pyasn1-modules==0.4.2
@@ -310,59 +313,52 @@ pydantic==2.13.4
     #   mlflow-tracing
 pydantic-core==2.46.4
     # via pydantic
+pydata-sphinx-theme==0.18.0
+    # via skore (skore/pyproject.toml)
 pydot==4.0.1
     # via skrub
 pygments==2.20.0
     # via
+    #   accessible-pygments
     #   ipython
     #   ipython-pygments-lexers
-    #   pytest
+    #   pydata-sphinx-theme
     #   rich
+    #   sphinx
+    #   sphinx-tabs
 pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
-pytest==9.0.3
-    # via
-    #   skore (skore/pyproject.toml)
-    #   pytest-cov
-    #   pytest-order
-    #   pytest-randomly
-    #   pytest-xdist
-pytest-cov==7.1.0
-    # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
-    # via skore (skore/pyproject.toml)
-pytest-randomly==4.1.0
-    # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
-    # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
-    # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
 pytz==2026.2
     # via pandas
 pyyaml==6.0.3
+    # via mlflow-skinny
+referencing==0.37.0
     # via
-    #   mlflow-skinny
-    #   pre-commit
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.34.2
     # via
     #   databricks-sdk
     #   docker
     #   mlflow-skinny
     #   skrub
-respx==0.23.1
-    # via skore (skore/pyproject.toml)
+    #   sphinx
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.5.2
+rpds-py==2026.5.1
+    # via
+    #   jsonschema
+    #   referencing
+scikit-learn==1.9.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -376,10 +372,11 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
-    # via skore (skore/pyproject.toml)
+    #   xgboost-cpu
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
+simplejson==4.1.1
+    # via choreographer
 six==1.17.0
     # via python-dateutil
 skops==0.14.0
@@ -388,7 +385,46 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+snowballstemmer==3.1.1
+    # via sphinx
+soupsieve==2.8.4
+    # via beautifulsoup4
+sphinx==8.1.3
+    # via
+    #   skore (skore/pyproject.toml)
+    #   numpydoc
+    #   pydata-sphinx-theme
+    #   sphinx-autosummary-accessors
+    #   sphinx-copybutton
+    #   sphinx-design
+    #   sphinx-gallery
+    #   sphinx-issues
+    #   sphinx-tabs
+sphinx-autosummary-accessors==2025.3.1
+    # via skore (skore/pyproject.toml)
+sphinx-copybutton==0.5.2
+    # via skore (skore/pyproject.toml)
+sphinx-design==0.7.0
+    # via skore (skore/pyproject.toml)
+sphinx-gallery==0.21.0
+    # via skore (skore/pyproject.toml)
+sphinx-issues==6.0.0
+    # via skore (skore/pyproject.toml)
+sphinx-tabs==3.5.0
+    # via skore (skore/pyproject.toml)
+sphinxcontrib-applehelp==2.0.0
+    # via sphinx
+sphinxcontrib-devhelp==2.0.0
+    # via sphinx
+sphinxcontrib-htmlhelp==2.1.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==2.0.0
+    # via sphinx
+sphinxcontrib-serializinghtml==2.0.0
+    # via sphinx
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -396,14 +432,12 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.1
-    # via coverage
 traitlets==5.15.0
     # via
     #   ipython
@@ -411,22 +445,19 @@ traitlets==5.15.0
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via
-    #   aiosignal
     #   alembic
-    #   anyio
-    #   anywidget
+    #   altair
+    #   beautifulsoup4
     #   fastapi
     #   graphene
-    #   ipython
     #   mlflow-skinny
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-    #   optype
     #   pydantic
     #   pydantic-core
+    #   pydata-sphinx-theme
     #   sqlalchemy
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -438,10 +469,8 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
-    # via pre-commit
 wcwidth==0.7.0
     # via
     #   prettytable
@@ -452,7 +481,7 @@ werkzeug==3.1.8
     #   flask-cors
 widgetsnbextension==4.0.15
     # via ipywidgets
-xdoctest==1.3.2
+xgboost-cpu==3.2.0
     # via skore (skore/pyproject.toml)
 yarl==1.24.2
     # via aiohttp

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
@@ -1,17 +1,11 @@
-accessible-pygments==0.0.5
-    # via pydata-sphinx-theme
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alabaster==1.0.0
-    # via sphinx
 alembic==1.18.4
     # via mlflow
-altair==6.1.0
-    # via skore (skore/pyproject.toml)
 annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0
@@ -20,22 +14,15 @@ anyio==4.13.0
     # via
     #   httpx
     #   starlette
+anywidget==0.11.0
+    # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
 attrs==26.1.0
-    # via
-    #   aiohttp
-    #   jsonschema
-    #   referencing
-babel==2.18.0
-    # via
-    #   pydata-sphinx-theme
-    #   sphinx
-beautifulsoup4==4.14.3
-    # via pydata-sphinx-theme
+    # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -46,11 +33,11 @@ certifi==2026.5.20
     #   requests
 cffi==2.0.0
     # via cryptography
+cfgv==3.5.0
+    # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-choreographer==1.3.0
-    # via kaleido
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -61,13 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-cryptography==46.0.7
+coverage[toml]==7.14.1
+    # via pytest-cov
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -75,17 +64,20 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
+distlib==0.4.1
+    # via virtualenv
 docker==7.1.0
     # via mlflow
-docutils==0.21.2
-    # via
-    #   pydata-sphinx-theme
-    #   sphinx
-    #   sphinx-tabs
+execnet==2.1.2
+    # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
+filelock==3.29.0
+    # via
+    #   python-discovery
+    #   virtualenv
 flask==3.1.3
     # via
     #   flask-cors
@@ -114,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -123,54 +115,53 @@ h11==0.16.0
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via skore (skore/pyproject.toml)
-huey==2.6.0
+    # via
+    #   skore (skore/pyproject.toml)
+    #   respx
+huey==3.0.1
     # via mlflow
-idna==3.15
+identify==2.6.19
+    # via pre-commit
+idna==3.18
     # via
     #   anyio
     #   httpx
     #   requests
     #   yarl
-imagesize==2.0.0
-    # via sphinx
 importlib-metadata==9.0.0
     # via mlflow-skinny
-ipython==9.13.0
-    # via ipywidgets
+iniconfig==2.3.0
+    # via pytest
+ipython==9.14.0
+    # via
+    #   skore (skore/pyproject.toml)
+    #   ipywidgets
 ipython-pygments-lexers==1.1.1
     # via ipython
 ipywidgets==8.1.8
-    # via rich
+    # via
+    #   skore (skore/pyproject.toml)
+    #   anywidget
+    #   rich
 itsdangerous==2.2.0
     # via flask
 jedi==0.20.0
-    # via ipython
+    # via
+    #   skore (skore/pyproject.toml)
+    #   ipython
 jinja2==3.1.6
     # via
     #   skore (skore/pyproject.toml)
-    #   altair
     #   flask
     #   skrub
-    #   sphinx
 joblib==1.5.3
     # via
     #   skore (skore/pyproject.toml)
     #   scikit-learn
-jsonschema==4.26.0
-    # via altair
-jsonschema-specifications==2025.9.1
-    # via jsonschema
 jupyterlab-widgets==3.0.16
     # via ipywidgets
-kaleido==1.3.0
-    # via skore (skore/pyproject.toml)
 kiwisolver==1.5.0
     # via matplotlib
-logistro==2.0.1
-    # via
-    #   choreographer
-    #   kaleido
 mako==1.3.12
     # via alembic
 markdown-it-py==4.2.0
@@ -191,67 +182,67 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
+narwhals==2.22.0
     # via
-    #   altair
     #   plotly
+    #   scikit-learn
+nodeenv==1.10.0
+    # via pre-commit
 numpy==2.4.6
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
     #   matplotlib
     #   mlflow
+    #   numpy-typing-compat
+    #   optype
     #   pandas
     #   scikit-learn
     #   scipy
     #   seaborn
     #   skops
     #   skrub
-    #   xgboost-cpu
-numpydoc==1.10.0
-    # via skore (skore/pyproject.toml)
-opentelemetry-api==1.42.0
+numpy-typing-compat==20251206.2.4
+    # via optype
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
+optype[numpy]==0.17.1
+    # via scipy-stubs
 orjson==3.11.9
-    # via
-    #   skore (skore/pyproject.toml)
-    #   kaleido
+    # via skore (skore/pyproject.toml)
 packaging==26.2
     # via
-    #   altair
     #   gunicorn
-    #   kaleido
     #   matplotlib
     #   mlflow-skinny
     #   mlflow-tracing
     #   plotly
+    #   pytest
     #   skops
-    #   sphinx
-    #   sphinx-autosummary-accessors
 pandas==2.3.3
     # via
     #   skore (skore/pyproject.toml)
@@ -263,19 +254,24 @@ parso==0.8.7
 pexpect==4.9.0
     # via ipython
 pillow==12.2.0
-    # via
-    #   matplotlib
-    #   sphinx-gallery
-platformdirs==4.9.6
+    # via matplotlib
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
-    #   choreographer
+    #   python-discovery
+    #   virtualenv
 plotly==6.7.0
     # via skore (skore/pyproject.toml)
-polars==1.40.1
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
+pre-commit==4.6.0
+    # via skore (skore/pyproject.toml)
 prettytable==3.17.0
     # via skops
 prompt-toolkit==3.0.52
@@ -292,12 +288,16 @@ protobuf==6.33.6
     #   opentelemetry-proto
 psutil==7.2.2
     # via ipython
+psygnal==0.15.1
+    # via anywidget
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
-    # via mlflow
+pyarrow==24.0.0
+    # via
+    #   skore (skore/pyproject.toml)
+    #   mlflow
 pyasn1==0.6.3
     # via pyasn1-modules
 pyasn1-modules==0.4.2
@@ -312,52 +312,59 @@ pydantic==2.13.4
     #   mlflow-tracing
 pydantic-core==2.46.4
     # via pydantic
-pydata-sphinx-theme==0.18.0
-    # via skore (skore/pyproject.toml)
 pydot==4.0.1
     # via skrub
 pygments==2.20.0
     # via
-    #   accessible-pygments
     #   ipython
     #   ipython-pygments-lexers
-    #   pydata-sphinx-theme
+    #   pytest
     #   rich
-    #   sphinx
-    #   sphinx-tabs
 pyparsing==3.3.2
     # via
     #   matplotlib
     #   pydot
+pytest==9.0.3
+    # via
+    #   skore (skore/pyproject.toml)
+    #   pytest-cov
+    #   pytest-order
+    #   pytest-randomly
+    #   pytest-xdist
+pytest-cov==7.1.0
+    # via skore (skore/pyproject.toml)
+pytest-order==1.4.0
+    # via skore (skore/pyproject.toml)
+pytest-randomly==4.1.0
+    # via skore (skore/pyproject.toml)
+pytest-xdist==3.8.0
+    # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   graphene
     #   matplotlib
     #   pandas
+python-discovery==1.4.0
+    # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
 pytz==2026.2
     # via pandas
 pyyaml==6.0.3
-    # via mlflow-skinny
-referencing==0.37.0
     # via
-    #   jsonschema
-    #   jsonschema-specifications
+    #   mlflow-skinny
+    #   pre-commit
 requests==2.34.2
     # via
     #   databricks-sdk
     #   docker
     #   mlflow-skinny
     #   skrub
-    #   sphinx
+respx==0.23.1
+    # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-rpds-py==0.30.0
-    # via
-    #   jsonschema
-    #   referencing
-scikit-learn==1.8.0
+scikit-learn==1.9.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -371,11 +378,10 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-    #   xgboost-cpu
+scipy-stubs==1.17.1.5
+    # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
-simplejson==4.1.1
-    # via choreographer
 six==1.17.0
     # via python-dateutil
 skops==0.14.0
@@ -384,46 +390,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-snowballstemmer==3.0.1
-    # via sphinx
-soupsieve==2.8.3
-    # via beautifulsoup4
-sphinx==8.1.3
-    # via
-    #   skore (skore/pyproject.toml)
-    #   numpydoc
-    #   pydata-sphinx-theme
-    #   sphinx-autosummary-accessors
-    #   sphinx-copybutton
-    #   sphinx-design
-    #   sphinx-gallery
-    #   sphinx-issues
-    #   sphinx-tabs
-sphinx-autosummary-accessors==2025.3.1
-    # via skore (skore/pyproject.toml)
-sphinx-copybutton==0.5.2
-    # via skore (skore/pyproject.toml)
-sphinx-design==0.7.0
-    # via skore (skore/pyproject.toml)
-sphinx-gallery==0.21.0
-    # via skore (skore/pyproject.toml)
-sphinx-issues==6.0.0
-    # via skore (skore/pyproject.toml)
-sphinx-tabs==3.5.0
-    # via skore (skore/pyproject.toml)
-sphinxcontrib-applehelp==2.0.0
-    # via sphinx
-sphinxcontrib-devhelp==2.0.0
-    # via sphinx
-sphinxcontrib-htmlhelp==2.1.0
-    # via sphinx
-sphinxcontrib-jsmath==1.0.1
-    # via sphinx
-sphinxcontrib-qthelp==2.0.0
-    # via sphinx
-sphinxcontrib-serializinghtml==2.0.0
-    # via sphinx
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -431,7 +398,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
@@ -445,8 +412,7 @@ traitlets==5.15.0
 typing-extensions==4.15.0
     # via
     #   alembic
-    #   altair
-    #   beautifulsoup4
+    #   anywidget
     #   fastapi
     #   graphene
     #   mlflow-skinny
@@ -455,7 +421,6 @@ typing-extensions==4.15.0
     #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
-    #   pydata-sphinx-theme
     #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.2
@@ -468,8 +433,10 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
+virtualenv==21.4.2
+    # via pre-commit
 wcwidth==0.7.0
     # via
     #   prettytable
@@ -480,7 +447,7 @@ werkzeug==3.1.8
     #   flask-cors
 widgetsnbextension==4.0.15
     # via ipywidgets
-xgboost-cpu==3.2.0
+xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
 yarl==1.24.2
     # via aiohttp

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -260,7 +260,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -404,7 +404,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -433,7 +433,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
@@ -1,3 +1,9 @@
+aiohappyeyeballs==2.6.2
+    # via aiohttp
+aiohttp==3.14.0
+    # via mlflow
+aiosignal==1.4.0
+    # via aiohttp
 alembic==1.18.4
     # via mlflow
 annotated-doc==0.0.4
@@ -12,10 +18,14 @@ anywidget==0.11.0
     # via skore (skore/pyproject.toml)
 asttokens==3.0.1
     # via stack-data
+attrs==26.1.0
+    # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==5.5.2
-    # via mlflow-skinny
+cachetools==7.1.4
+    # via
+    #   mlflow-skinny
+    #   mlflow-tracing
 certifi==2026.5.20
     # via
     #   httpcore
@@ -27,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -38,19 +48,23 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
 cryptography==48.0.0
-    # via google-auth
+    # via
+    #   google-auth
+    #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
-    # via mlflow-skinny
+databricks-sdk==0.114.0
+    # via
+    #   mlflow-skinny
+    #   mlflow-tracing
 decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -58,16 +72,24 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
     #   python-discovery
     #   virtualenv
 flask==3.1.3
+    # via
+    #   flask-cors
+    #   mlflow
+flask-cors==6.0.2
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
+frozenlist==1.8.0
+    # via
+    #   aiohttp
+    #   aiosignal
 gitdb==4.0.12
     # via gitpython
 gitpython==3.1.50
@@ -84,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -96,18 +118,21 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
+huey==3.0.1
+    # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-metadata==8.9.0
+    #   yarl
+importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -128,7 +153,6 @@ jinja2==3.1.6
     # via
     #   skore (skore/pyproject.toml)
     #   flask
-    #   mlflow
     #   skrub
 joblib==1.5.3
     # via
@@ -140,8 +164,6 @@ kiwisolver==1.5.0
     # via matplotlib
 mako==1.3.12
     # via alembic
-markdown==3.10.2
-    # via mlflow
 markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
@@ -160,14 +182,22 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==2.22.5
+mlflow==3.13.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
-mlflow-skinny==2.22.5
+mlflow-skinny==3.13.0
     # via mlflow
-narwhals==2.21.2
-    # via plotly
+mlflow-tracing==3.13.0
+    # via mlflow
+multidict==6.7.1
+    # via
+    #   aiohttp
+    #   yarl
+narwhals==2.22.0
+    # via
+    #   plotly
+    #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.6
@@ -182,29 +212,39 @@ numpy==2.4.6
     #   scikit-learn
     #   scipy
     #   seaborn
+    #   skops
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
+    #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-sdk==1.42.0
-    # via mlflow-skinny
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-proto==1.42.1
+    # via
+    #   mlflow-skinny
+    #   mlflow-tracing
+opentelemetry-sdk==1.42.1
+    # via
+    #   mlflow-skinny
+    #   mlflow-tracing
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==24.2
+packaging==26.2
     # via
     #   gunicorn
     #   matplotlib
     #   mlflow-skinny
+    #   mlflow-tracing
     #   plotly
     #   pytest
+    #   skops
 pandas==2.3.3
     # via
     #   skore (skore/pyproject.toml)
@@ -217,7 +257,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -228,18 +268,26 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
+prettytable==3.17.0
+    # via skops
 prompt-toolkit==3.0.52
     # via ipython
+propcache==0.5.2
+    # via
+    #   aiohttp
+    #   yarl
 protobuf==6.33.6
     # via
     #   databricks-sdk
     #   mlflow-skinny
+    #   mlflow-tracing
+    #   opentelemetry-proto
 psutil==7.2.2
     # via ipython
 psygnal==0.15.1
@@ -248,7 +296,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==19.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -263,6 +311,7 @@ pydantic==2.13.4
     #   skore (skore/pyproject.toml)
     #   fastapi
     #   mlflow-skinny
+    #   mlflow-tracing
 pydantic-core==2.46.4
     # via pydantic
 pydot==4.0.1
@@ -297,8 +346,10 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
+python-dotenv==1.2.2
+    # via mlflow-skinny
 pytz==2026.2
     # via pandas
 pyyaml==6.0.3
@@ -315,29 +366,33 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.5.2
+scikit-learn==1.9.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
     #   mlflow
+    #   skops
     #   skrub
 scipy==1.17.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
+    #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
 six==1.17.0
     # via python-dateutil
+skops==0.14.0
+    # via mlflow
 skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -345,12 +400,12 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.0.0
-    # via fastapi
+starlette==1.2.1
+    # via
+    #   fastapi
+    #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.1
-    # via coverage
 traitlets==5.15.0
     # via
     #   ipython
@@ -359,20 +414,16 @@ traitlets==5.15.0
 typing-extensions==4.15.0
     # via
     #   alembic
-    #   anyio
     #   anywidget
     #   fastapi
     #   graphene
-    #   ipython
     #   mlflow-skinny
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-    #   optype
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -384,17 +435,23 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
-    # via prompt-toolkit
+    # via
+    #   prettytable
+    #   prompt-toolkit
 werkzeug==3.1.8
-    # via flask
+    # via
+    #   flask
+    #   flask-cors
 widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
+yarl==1.24.2
+    # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -262,7 +262,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -406,7 +406,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -435,7 +435,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
@@ -74,7 +74,7 @@ executing==2.2.1
     # via stack-data
 fastapi==0.136.3
     # via mlflow-skinny
-filelock==3.29.0
+filelock==3.29.1
     # via
     #   python-discovery
     #   virtualenv
@@ -261,7 +261,7 @@ platformdirs==4.10.0
     #   skore (skore/pyproject.toml)
     #   python-discovery
     #   virtualenv
-plotly==6.7.0
+plotly==6.8.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
@@ -405,7 +405,7 @@ starlette==1.2.1
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.0
+traitlets==5.15.1
     # via
     #   ipython
     #   ipywidgets
@@ -434,7 +434,7 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via mlflow-skinny
 virtualenv==21.4.2
     # via pre-commit

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.0
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
@@ -22,7 +22,7 @@ attrs==26.1.0
     # via aiohttp
 blinker==1.9.0
     # via flask
-cachetools==7.1.3
+cachetools==7.1.4
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -37,7 +37,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   flask
     #   mlflow-skinny
@@ -48,15 +48,15 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.0
+coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.110.0
+databricks-sdk==0.114.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
@@ -64,7 +64,7 @@ decorator==5.3.1
     # via ipython
 diskcache==5.6.3
     # via skore (skore/pyproject.toml)
-distlib==0.4.0
+distlib==0.4.1
     # via virtualenv
 docker==7.1.0
     # via mlflow
@@ -72,7 +72,7 @@ execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.1
+fastapi==0.136.3
     # via mlflow-skinny
 filelock==3.29.0
     # via
@@ -106,7 +106,7 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.5.1
     # via sqlalchemy
-gunicorn==25.3.0
+gunicorn==26.0.0
     # via mlflow
 h11==0.16.0
     # via
@@ -118,11 +118,11 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==2.6.0
+huey==3.0.1
     # via mlflow
 identify==2.6.19
     # via pre-commit
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -132,7 +132,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.13.0
+ipython==9.14.0
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -182,18 +182,20 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.12.0
+mlflow==3.13.0
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.12.0
+mlflow-skinny==3.13.0
     # via mlflow
-mlflow-tracing==3.12.0
+mlflow-tracing==3.13.0
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.21.2
-    # via plotly
+narwhals==2.22.0
+    # via
+    #   plotly
+    #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.6
@@ -212,21 +214,21 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.0
+opentelemetry-api==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.0
+opentelemetry-proto==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.0
+opentelemetry-sdk==1.42.1
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b0
+opentelemetry-semantic-conventions==0.63b1
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -243,6 +245,7 @@ packaging==26.2
     #   skops
 pandas==2.3.3
     # via
+    #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   seaborn
@@ -253,7 +256,7 @@ pexpect==4.9.0
     # via ipython
 pillow==12.2.0
     # via matplotlib
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via
     #   skore (skore/pyproject.toml)
     #   python-discovery
@@ -264,9 +267,9 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.40.1
+polars==1.41.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 pre-commit==4.6.0
     # via skore (skore/pyproject.toml)
@@ -292,7 +295,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==23.0.1
+pyarrow==24.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +345,7 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.3.1
+python-discovery==1.4.0
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
@@ -362,7 +365,7 @@ respx==0.23.1
     # via skore (skore/pyproject.toml)
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-scikit-learn==1.8.0
+scikit-learn==1.9.0
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
@@ -376,7 +379,7 @@ scipy==1.17.1
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.4
+scipy-stubs==1.17.1.5
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -388,7 +391,7 @@ skrub==0.9.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.49
+sqlalchemy==2.0.50
     # via
     #   alembic
     #   mlflow
@@ -396,14 +399,12 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==0.52.1
+starlette==1.2.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-tomli==2.4.1
-    # via coverage
 traitlets==5.15.0
     # via
     #   ipython
@@ -411,22 +412,17 @@ traitlets==5.15.0
     #   matplotlib-inline
 typing-extensions==4.15.0
     # via
-    #   aiosignal
     #   alembic
-    #   anyio
     #   anywidget
     #   fastapi
     #   graphene
-    #   ipython
     #   mlflow-skinny
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-    #   optype
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -438,9 +434,9 @@ urllib3==2.7.0
     # via
     #   docker
     #   requests
-uvicorn==0.47.0
+uvicorn==0.48.0
     # via mlflow-skinny
-virtualenv==21.3.3
+virtualenv==21.4.2
     # via pre-commit
 wcwidth==0.7.0
     # via

--- a/skore/supported-versions.json
+++ b/skore/supported-versions.json
@@ -1,23 +1,32 @@
 [
-    {"os": "ubuntu-latest", "python": "3.11", "dependencies": ["scikit-learn==1.5.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.11", "dependencies": ["scikit-learn==1.5.*", "mlflow==2.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.11", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.12", "dependencies": ["scikit-learn==1.5.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.12", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.13", "dependencies": ["scikit-learn==1.5.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.13", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.11", "dependencies": ["scikit-learn==1.6.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.11", "dependencies": ["scikit-learn==1.6.*", "mlflow==2.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.11", "dependencies": ["scikit-learn==1.9.*"], "coverage": false},
+
+    {"os": "ubuntu-latest", "python": "3.12", "dependencies": ["scikit-learn==1.6.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.12", "dependencies": ["scikit-learn==1.9.*"], "coverage": false},
+
+    {"os": "ubuntu-latest", "python": "3.13", "dependencies": ["scikit-learn==1.6.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.13", "dependencies": ["scikit-learn==1.9.*"], "coverage": false},
+
     {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.7.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.8.*", "pandas==2.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.8.*", "mlflow==3.*"], "coverage": false},
-    {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.8.*"], "coverage": true},
-    {"os": "windows-latest", "python": "3.11", "dependencies": ["scikit-learn==1.5.*", "mlflow==2.*"], "coverage": false},
-    {"os": "windows-latest", "python": "3.11", "dependencies": ["scikit-learn==1.5.*"], "coverage": false},
-    {"os": "windows-latest", "python": "3.11", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
-    {"os": "windows-latest", "python": "3.12", "dependencies": ["scikit-learn==1.5.*"], "coverage": false},
-    {"os": "windows-latest", "python": "3.12", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
-    {"os": "windows-latest", "python": "3.13", "dependencies": ["scikit-learn==1.5.*"], "coverage": false},
-    {"os": "windows-latest", "python": "3.13", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.9.*", "pandas==2.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.9.*", "mlflow==3.*"], "coverage": false},
+    {"os": "ubuntu-latest", "python": "3.14", "dependencies": ["scikit-learn==1.9.*"], "coverage": true},
+
+    {"os": "windows-latest", "python": "3.11", "dependencies": ["scikit-learn==1.6.*", "mlflow==2.*"], "coverage": false},
+    {"os": "windows-latest", "python": "3.11", "dependencies": ["scikit-learn==1.6.*"], "coverage": false},
+    {"os": "windows-latest", "python": "3.11", "dependencies": ["scikit-learn==1.9.*"], "coverage": false},
+
+    {"os": "windows-latest", "python": "3.12", "dependencies": ["scikit-learn==1.6.*"], "coverage": false},
+    {"os": "windows-latest", "python": "3.12", "dependencies": ["scikit-learn==1.9.*"], "coverage": false},
+
+    {"os": "windows-latest", "python": "3.13", "dependencies": ["scikit-learn==1.6.*"], "coverage": false},
+    {"os": "windows-latest", "python": "3.13", "dependencies": ["scikit-learn==1.9.*"], "coverage": false},
+
     {"os": "windows-latest", "python": "3.14", "dependencies": ["scikit-learn==1.7.*"], "coverage": false},
     {"os": "windows-latest", "python": "3.14", "dependencies": ["scikit-learn==1.8.*"], "coverage": false},
-    {"os": "windows-latest", "python": "3.14", "dependencies": ["scikit-learn==1.8.*", "mlflow==3.*"], "coverage": false}
+    {"os": "windows-latest", "python": "3.14", "dependencies": ["scikit-learn==1.9.*"], "coverage": false},
+    {"os": "windows-latest", "python": "3.14", "dependencies": ["scikit-learn==1.9.*", "mlflow==3.*"], "coverage": false}
 ]


### PR DESCRIPTION
Following https://github.com/probabl-ai/skore/pull/2967.
