### PR TITLE
fix(tests/plugin/mlflow): Deduplicate targets in CV multioutput-regression

### DIFF
--- a/skore/tests/unit/plugins/mlflow/conftest.py
+++ b/skore/tests/unit/plugins/mlflow/conftest.py
@@ -117,7 +117,10 @@ def cv_mreg_report() -> CrossValidationReport:
     X, y = load_diabetes(return_X_y=True, as_frame=True)
     y: pd.Series
     multi_target_y = pd.concat(
-        [y, y + y.sample(len(y))],
+        [
+            y.rename("target_0"),
+            (y + y.sample(len(y))).rename("target_1"),
+        ],
         axis=1,
     )
     return CrossValidationReport(


### PR DESCRIPTION
With scikit-learn `3.13` #2974 and narwhals:

```python-traceback
ERROR tests/unit/plugins/mlflow/test_reports.py::test_iter_cv_smoke[cv_mreg_report] - narwhals.exceptions.DuplicateError: Expected unique column names, got:
- 'target' 2 times
ERROR tests/unit/plugins/mlflow/test_reports.py::test_iter_cv_metrics_smoke[cv_mreg_report] - narwhals.exceptions.DuplicateError: Expected unique column names, got:
- 'target' 2 times
```