### PR TITLE
feat(skore): Add repr_mimebundle to MetricsSummaryDisplay

### DIFF
--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -11,7 +11,6 @@ from skore._sklearn.types import (
     ReportType,
 )
 from skore._utils._index import flatten_multi_index
-from skore._utils.repr import ReprHTMLMixin
 
 
 class MetricsSummaryRow(TypedDict):
@@ -50,7 +49,7 @@ class MetricsSummaryRow(TypedDict):
     split: NotRequired[int]
 
 
-class MetricsSummaryDisplay(ReprHTMLMixin, DisplayMixin):
+class MetricsSummaryDisplay(DisplayMixin):
     """Summarize evaluation metrics in a table.
 
     Parameters
@@ -397,7 +396,7 @@ class MetricsSummaryDisplay(ReprHTMLMixin, DisplayMixin):
 
             return df
 
-    def _html_repr(self) -> str:
+    def _repr_html_(self) -> str:
         return (
             f"{self.frame()._repr_html_()}"
             '<p role="note">Use <code>.frame()</code> to control the format'
@@ -406,6 +405,9 @@ class MetricsSummaryDisplay(ReprHTMLMixin, DisplayMixin):
 
     def __repr__(self) -> str:
         return f"{self.frame()!r}\nUse .frame() to control the format of the output."
+
+    def _repr_mimebundle_(self, **kwargs):
+        return {"text/plain": repr(self), "text/html": self._repr_html_()}
 
     @DisplayMixin.style_plot
     def plot(self) -> Figure:

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -11,6 +11,7 @@ from skore._sklearn.types import (
     ReportType,
 )
 from skore._utils._index import flatten_multi_index
+from skore._utils.repr import ReprHTMLMixin
 
 
 class MetricsSummaryRow(TypedDict):
@@ -49,7 +50,7 @@ class MetricsSummaryRow(TypedDict):
     split: NotRequired[int]
 
 
-class MetricsSummaryDisplay(DisplayMixin):
+class MetricsSummaryDisplay(ReprHTMLMixin, DisplayMixin):
     """Summarize evaluation metrics in a table.
 
     Parameters
@@ -395,6 +396,16 @@ class MetricsSummaryDisplay(DisplayMixin):
                 df = MetricsSummaryDisplay._flatten_index(df)
 
             return df
+
+    def _html_repr(self) -> str:
+        return (
+            f"{self.frame()._repr_html_()}"
+            '<p role="note">Use <code>.frame()</code> to control the format'
+            " of the output.</p>"
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.frame()!r}\nUse .frame() to control the format of the output."
 
     @DisplayMixin.style_plot
     def plot(self) -> Figure:

--- a/skore/tests/unit/displays/metrics_summary/test_common.py
+++ b/skore/tests/unit/displays/metrics_summary/test_common.py
@@ -1,0 +1,42 @@
+"""Tests for MetricsSummaryDisplay repr."""
+
+from skore import EstimatorReport
+
+_FRAME_HINT = "Use .frame() to control the format of the output."
+_FRAME_HINT_HTML = "<code>.frame()</code>"
+
+
+def test_repr_includes_frame_and_hint(forest_binary_classification_with_test):
+    """Check that __repr__ shows the default frame and a trailing hint."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    display = EstimatorReport(
+        estimator, X_test=X_test, y_test=y_test
+    ).metrics.summarize()
+
+    repr_str = repr(display)
+    assert repr_str.startswith(repr(display.frame()))
+    assert repr_str.endswith(_FRAME_HINT)
+
+
+def test_repr_html_includes_frame_and_hint(forest_binary_classification_with_test):
+    """Check that _repr_html_ shows the default frame and a trailing hint."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    display = EstimatorReport(
+        estimator, X_test=X_test, y_test=y_test
+    ).metrics.summarize()
+
+    html = display._repr_html_()
+    assert html.startswith(display.frame()._repr_html_())
+    assert _FRAME_HINT_HTML in html
+
+
+def test_repr_mimebundle(forest_binary_classification_with_test):
+    """Check that _repr_mimebundle_ returns text/plain and text/html."""
+    estimator, X_test, y_test = forest_binary_classification_with_test
+    display = EstimatorReport(
+        estimator, X_test=X_test, y_test=y_test
+    ).metrics.summarize()
+
+    bundle = display._repr_mimebundle_()
+    assert bundle["text/plain"] == repr(display)
+    assert bundle["text/html"] == display._repr_html_()

--- a/skore/tests/unit/displays/metrics_summary/test_common.py
+++ b/skore/tests/unit/displays/metrics_summary/test_common.py
@@ -2,9 +2,6 @@
 
 from skore import EstimatorReport
 
-_FRAME_HINT = "Use .frame() to control the format of the output."
-_FRAME_HINT_HTML = "<code>.frame()</code>"
-
 
 def test_repr_includes_frame_and_hint(forest_binary_classification_with_test):
     """Check that __repr__ shows the default frame and a trailing hint."""
@@ -15,7 +12,7 @@ def test_repr_includes_frame_and_hint(forest_binary_classification_with_test):
 
     repr_str = repr(display)
     assert repr_str.startswith(repr(display.frame()))
-    assert repr_str.endswith(_FRAME_HINT)
+    assert repr_str.endswith("Use .frame() to control the format of the output.")
 
 
 def test_repr_html_includes_frame_and_hint(forest_binary_classification_with_test):
@@ -27,16 +24,4 @@ def test_repr_html_includes_frame_and_hint(forest_binary_classification_with_tes
 
     html = display._repr_html_()
     assert html.startswith(display.frame()._repr_html_())
-    assert _FRAME_HINT_HTML in html
-
-
-def test_repr_mimebundle(forest_binary_classification_with_test):
-    """Check that _repr_mimebundle_ returns text/plain and text/html."""
-    estimator, X_test, y_test = forest_binary_classification_with_test
-    display = EstimatorReport(
-        estimator, X_test=X_test, y_test=y_test
-    ).metrics.summarize()
-
-    bundle = display._repr_mimebundle_()
-    assert bundle["text/plain"] == repr(display)
-    assert bundle["text/html"] == display._repr_html_()
+    assert "Use <code>.frame()</code> to control the format of the output." in html


### PR DESCRIPTION
Towards #2941.

Adds reprs to the output of `report.metrics.summarize()` which is the repr of the dataframe obtained after `.frame()` with default parameters + a suffix suggesting to use `.frame` to control the format of the ouput.

<img width="727" height="652" alt="image" src="https://github.com/user-attachments/assets/3d199719-241c-4abc-b1ea-0434983c7f86" />

<img width="750" height="448" alt="image" src="https://github.com/user-attachments/assets/f44ff5cd-e4b4-4911-a01c-d596538059a7" />
