### PR TITLE
fix: Make `EstimatorReport.metrics.get` raise when metric is not known

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -267,6 +267,10 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
 
         Parameters
         ----------
+        name : str
+            Name of the metric to compute. Get all available metrics with
+            :meth:`~ComparisonReport.metrics.available()`.
+
         data_source : {"test", "train"}, default="test"
             The data source to use.
 

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -227,6 +227,10 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
 
         Parameters
         ----------
+        name : str
+            Name of the metric to compute. Get all available metrics with
+            :meth:`~CrossValidationReport.metrics.available()`.
+
         data_source : {"test", "train"}, default="test"
             The data source to use.
 

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -321,7 +321,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         """
         metric = self._parent._metric_registry.get(name)
         if metric is None:
-            raise KeyError()
+            raise KeyError(name)
         return metric.pretty(report=self._parent, data_source=data_source, **kwargs)
 
     def fit_time(self, *, cast: bool = True) -> float | None:

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -321,7 +321,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         """
         metric = self._parent._metric_registry.get(name)
         if metric is None:
-            return None
+            raise KeyError()
         return metric.pretty(report=self._parent, data_source=data_source, **kwargs)
 
     def fit_time(self, *, cast: bool = True) -> float | None:

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -298,6 +298,10 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
 
         Parameters
         ----------
+        name : str
+            Name of the metric to compute. Get all available metrics with
+            :meth:`~EstimatorReport.metrics.available()`.
+
         data_source : {"test", "train"}, default="test"
             The data source to use.
 

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -267,14 +267,17 @@ def test_get(binary_classification_report):
     report = binary_classification_report
 
     assert report.metrics.get("precision") == 1
-    assert report.metrics.get("non-existing metric") is None
+
+    with pytest.raises(KeyError):
+        report.metrics.get("non-existing metric")
 
 
 def test_get_custom(binary_classification_report):
     """``get`` works for custom metrics."""
     report = binary_classification_report
 
-    assert report.metrics.get("hello") is None
+    with pytest.raises(KeyError):
+        report.metrics.get("hello")
 
     report.metrics.add(lambda estimator, X, y: 1, name="hello")
 


### PR DESCRIPTION
To align with the other reports
