### PR TITLE
chore: Rename get_state/from_state to to_dict/from_dict

### DIFF
--- a/skore/src/skore/_plugins/mlflow/project.py
+++ b/skore/src/skore/_plugins/mlflow/project.py
@@ -175,7 +175,7 @@ class Project:
                 "is already open. Call mlflow.end_run() before calling Project.put()."
             )
 
-        state = externalize(report.get_state(), self._write_object_in_storage)
+        state = externalize(report.to_dict(), self._write_object_in_storage)
 
         with (
             disable_discrete_autologging(["sklearn"]),
@@ -239,9 +239,9 @@ class Project:
         state = internalize(joblib.load(pickle_path), self._load_object_from_storage)
         report_type = state["metadata"]["report_type"]
         if report_type == "estimator":
-            return EstimatorReport.from_state(state)
+            return EstimatorReport.from_dict(state)
         else:
-            return CrossValidationReport.from_state(state)
+            return CrossValidationReport.from_dict(state)
 
     def summarize(self) -> list[Metadata]:
         """Obtain metadata/metrics for all persisted models in insertion order."""

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -112,7 +112,7 @@ class _BaseReport(ReportHelpMixin):
             "skore-version": version("skore"),
             "creation-date": datetime.now(UTC).isoformat(),
             # comparison reports don't have a _report_type yet at init time
-            # but they don't have a `get_state` anyway:
+            # but they don't have a `to_dict` anyway:
             "report_type": getattr(self, "_report_type", "comparison"),
             "git_commit": git_commit(),
         }

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -301,7 +301,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                 )
             )
 
-    def get_state(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Return a serializable representation of the report state.
 
         This state is meant to ease serialization/deserialization of
@@ -309,7 +309,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         versions. In particular, this is more stable than pickling a report
         object directly, which can break when internal implementations change.
         """
-        sub_states = [report.get_state() for report in self.reports_]
+        sub_states = [report.to_dict() for report in self.reports_]
         for state in sub_states:
             # data can be reconstructed from X, y and split_indices
             state.pop("data")
@@ -328,8 +328,8 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         }
 
     @classmethod
-    def from_state(cls, state: dict[str, Any]) -> CrossValidationReport:
-        """Rebuild a report from :meth:`get_state` output."""
+    def from_dict(cls, state: dict[str, Any]) -> CrossValidationReport:
+        """Rebuild a report from :meth:`to_dict` output."""
         version = state.get("version", 0)
         if version != _STATE_VERSION:
             # in the future, we could support some BW compatibility instead of crashing
@@ -393,7 +393,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                     "test_data": split_data["test"],
                 },
             }
-            sub_report = EstimatorReport.from_state(sub_state_with_data)
+            sub_report = EstimatorReport.from_dict(sub_state_with_data)
             report.reports_.append(sub_report)
 
         return report

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -324,7 +324,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
                 f"It should be one of: {labels!r}."
             )
 
-    def get_state(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Return a serializable representation of the report state.
 
         This state is meant to ease serialization/deserialization of
@@ -378,8 +378,8 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         }
 
     @classmethod
-    def from_state(cls, state: dict[str, Any]) -> EstimatorReport:
-        """Rebuild a report from :meth:`get_state` output."""
+    def from_dict(cls, state: dict[str, Any]) -> EstimatorReport:
+        """Build a report from :meth:`to_dict` output."""
         version = state.get("version")
         if version != _STATE_VERSION:
             # For now, no backward compatibility

--- a/skore/tests/unit/plugins/test_serde.py
+++ b/skore/tests/unit/plugins/test_serde.py
@@ -16,11 +16,11 @@ def report(request):
 
 def test_report_rebuilds_after_smart_serde(report) -> None:
     artifacts: dict[str, bytes] = {}
-    state = externalize(report.get_state(), artifacts.__setitem__)
+    state = externalize(report.to_dict(), artifacts.__setitem__)
 
     restored_state = internalize(state, artifacts.__getitem__)
 
-    restored_report = report.__class__.from_state(restored_state)
+    restored_report = report.__class__.from_dict(restored_state)
     # test restored_report works:
     restored_report.data.summarize()
     restored_report.metrics.summarize()

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -310,21 +310,21 @@ def test_create_estimator_report_with_data_op():
     assert 0.0 <= float(accuracy) <= 1.0
 
 
-def test_from_state_bypasses_init_and_restores_state(
+def test_from_dict_bypasses_init_and_restores_state(
     monkeypatch, logistic_binary_classification_data
 ):
     estimator, X, y = logistic_binary_classification_data
     report = CrossValidationReport(estimator, X, y, splitter=2)
     expected_accuracy = report.metrics.accuracy()
     report.cache_predictions()
-    state = report.get_state()
+    state = report.to_dict()
 
     def _unexpected_init(self, *args, **kwargs):
-        raise AssertionError("__init__ should not be called by from_state")
+        raise AssertionError("__init__ should not be called by from_dict")
 
     monkeypatch.setattr(CrossValidationReport, "__init__", _unexpected_init)
 
-    restored = CrossValidationReport.from_state(state)
+    restored = CrossValidationReport.from_dict(state)
 
     assert restored.id == report.id
     assert restored.X is report.X
@@ -347,7 +347,7 @@ def test_from_state_bypasses_init_and_restores_state(
     restored._repr_html_()
 
 
-def test_get_from_state_with_complex_data_op():
+def test_get_from_dict_with_complex_data_op():
     X, y = make_classification(random_state=0)
     left = pd.DataFrame(
         {
@@ -376,9 +376,9 @@ def test_get_from_state_with_complex_data_op():
     report = CrossValidationReport(data_op, splitter=2)
     expected_accuracy = report.metrics.accuracy()
     expected_preds = report.get_predictions(data_source="test")
-    state = report.get_state()
+    state = report.to_dict()
 
-    restored = CrossValidationReport.from_state(state)
+    restored = CrossValidationReport.from_dict(state)
 
     # check fresh computations still work after restoring from state:
     restored.clear_cache()
@@ -391,13 +391,13 @@ def test_get_from_state_with_complex_data_op():
     restored._repr_html_()
 
 
-def test_from_state_rejects_unknown_version(logistic_binary_classification_data):
+def test_from_dict_rejects_unknown_version(logistic_binary_classification_data):
     estimator, X, y = logistic_binary_classification_data
     report = CrossValidationReport(estimator, X, y, splitter=2)
-    state = report.get_state() | {"version": 999}
+    state = report.to_dict() | {"version": 999}
 
     with pytest.raises(ValueError, match="Unexpected state version"):
-        CrossValidationReport.from_state(state)
+        CrossValidationReport.from_dict(state)
 
 
 @pytest.mark.parametrize(
@@ -410,7 +410,7 @@ def test_state_has_no_unexpected_data_copy(estimator, splitter):
     """``state`` should only reference training data through ``state["data"]``."""
 
     def state_nbytes_without_data(report):
-        state = report.get_state()
+        state = report.to_dict()
         state.pop("data")
         return len(pickle.dumps(state))
 

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -571,18 +571,18 @@ def test_report_with_data_op():
     assert isinstance(report.metrics.accuracy(), float)
 
 
-def test_get_state_after_predict_time(logistic_binary_classification_with_test):
-    """get_state should not fail after `predict_time` was called.
+def test_to_dict_after_predict_time(logistic_binary_classification_with_test):
+    """to_dict should not fail after `predict_time` was called.
 
     Non-regression test for https://github.com/probabl-ai/skore/pull/2950
     """
     estimator, X_test, y_test = logistic_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     report.metrics.predict_time()
-    report.get_state()
+    report.to_dict()
 
 
-def test_from_state_bypasses_init_and_restores_state(
+def test_from_dict_bypasses_init_and_restores_state(
     monkeypatch, logistic_binary_classification_with_test
 ):
     estimator, X_test, y_test = logistic_binary_classification_with_test
@@ -595,15 +595,15 @@ def test_from_state_bypasses_init_and_restores_state(
     expected_accuracy = report.metrics.accuracy()
     report.cache_predictions()
     report.metrics.add("f1", name="F1")
-    state = report.get_state()
+    state = report.to_dict()
     assert state["metadata"]["report_type"] == report._report_type
 
     def _unexpected_init(self, *args, **kwargs):
-        raise AssertionError("__init__ should not be called by from_state")
+        raise AssertionError("__init__ should not be called by from_dict")
 
     monkeypatch.setattr(EstimatorReport, "__init__", _unexpected_init)
 
-    restored = EstimatorReport.from_state(state)
+    restored = EstimatorReport.from_dict(state)
 
     assert restored.id == report.id
     assert restored.fit == report.fit
@@ -620,13 +620,13 @@ def test_from_state_bypasses_init_and_restores_state(
     assert "F1" in df.index
 
 
-def test_from_state_rejects_unknown_version(logistic_binary_classification_with_test):
+def test_from_dict_rejects_unknown_version(logistic_binary_classification_with_test):
     estimator, X_test, y_test = logistic_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
-    state = report.get_state() | {"version": 999}
+    state = report.to_dict() | {"version": 999}
 
     with pytest.raises(ValueError, match="Unexpected state version"):
-        EstimatorReport.from_state(state)
+        EstimatorReport.from_dict(state)
 
 
 def test_learner_report_root_node_not_an_estimator():

--- a/sphinx/sphinxext/generate_accessor_tables.py
+++ b/sphinx/sphinxext/generate_accessor_tables.py
@@ -290,7 +290,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value("accessor_summary_classes", [], "html")
     app.add_config_value(
         "accessor_summary_exclude_methods",
-        ["get_state", "from_state"],
+        ["to_dict", "from_dict"],
         "html",
     )
     app.connect("config-inited", generate_accessor_tables)


### PR DESCRIPTION
Feels a bit more explicit and clarifies that the two are complementary.
