### PR TITLE
feat(skore/ComparisonReport): Add `to_markdown`

### DIFF
--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -113,6 +113,23 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
             ],
         )
 
+    def _formatted_summary_frame(
+        self,
+        *,
+        data_source: DataSource = "test",
+        metric: str | list[str] | None = None,
+    ) -> pd.DataFrame:
+        frame = self.summarize(data_source=data_source, metric=metric).frame()
+        frame = frame.rename_axis(
+            None
+            if self._parent._report_type == "comparison-estimator"
+            else [None, None],
+            axis="columns",
+        )
+        if self._parent._report_type == "comparison-cross-validation":
+            frame = frame.swaplevel(axis="columns")
+        return frame
+
     def _metric(
         self, metric_name: str, *, data_source: DataSource, **kwargs: Any
     ) -> MetricsSummaryDisplay:
@@ -1044,14 +1061,14 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
     def __repr__(self) -> str:
         return (
             "Metrics summary:\n"
-            f"{self.summarize().frame()!r}\n"
+            f"{self._formatted_summary_frame()!r}\n"
             "Explore available methods with .help()."
         )
 
     def _repr_html_(self) -> str:
         return (
             "<p>Metrics summary:</p>"
-            f"{self.summarize().frame()._repr_html_()}"
+            f"{self._formatted_summary_frame()._repr_html_()}"
             '<p role="note">Explore available methods with '
             "<code>.help()</code>.</p>"
         )

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -20,7 +20,10 @@ from skore._sklearn.types import PositiveLabel
 from skore._utils._progress_bar import track
 from skore._utils.repr.data import get_documentation_url
 from skore._utils.repr.html_repr import render_template
-from skore._utils.repr.markdown import comparison_estimator_markdown_context
+from skore._utils.repr.markdown import (
+    comparison_data_markdown_context,
+    comparison_estimator_markdown_context,
+)
 
 if TYPE_CHECKING:
     from skore._sklearn._checks.accessor import _ChecksAccessor
@@ -589,9 +592,9 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
     def to_markdown(self) -> str:
         """Return a markdown summary of the report.
 
-        The summary contains three sections (Estimator, Metrics, Checks) that
-        mirror the tabs of the HTML representation. Each section ends with a pointer
-        to the corresponding accessor for full details.
+        The summary contains four sections (Estimators, Metrics, Checks, Data) that
+        mirror the tabs of the HTML representation. Metrics and Checks sections end
+        with a pointer to the corresponding accessor for full details.
 
         Returns
         -------
@@ -612,6 +615,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
             "comparison_report_markdown.j2",
             {
                 **comparison_estimator_markdown_context(self),
+                **comparison_data_markdown_context(self),
                 "metrics_text": repr(metrics_frame),
                 "checks_text": repr(self.checks.summarize(fast_mode=True)),
             },

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -586,7 +586,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         return f"""{self.__class__.__name__}:
         {list(self.reports_.keys())!r}
 
-        {self.metrics.summarize(data_source="test").frame()}
+        {self.metrics._formatted_summary_frame(data_source="test")}
         Call `report.to_markdown()` for a markdown summary of the report's contents."""
 
     def to_markdown(self) -> str:
@@ -601,16 +601,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         str
             The markdown summary of the report.
         """
-        metrics_frame = (
-            self.metrics.summarize(data_source="test")
-            .frame()
-            .rename_axis(
-                None if self._report_type == "comparison-estimator" else [None, None],
-                axis="columns",
-            )
-        )
-        if self._report_type == "comparison-cross-validation":
-            metrics_frame = metrics_frame.swaplevel(axis="columns")
+        metrics_frame = self.metrics._formatted_summary_frame(data_source="test")
         return render_template(
             "comparison_report_markdown.j2",
             {
@@ -623,16 +614,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
 
     def _repr_html_(self) -> str:
         """HTML representation with a selector to inspect one compared report."""
-        metrics_frame = (
-            self.metrics.summarize(data_source="test")
-            .frame()
-            .rename_axis(
-                None if self._report_type == "comparison-estimator" else [None, None],
-                axis="columns",
-            )
-        )
-        if self._report_type == "comparison-cross-validation":
-            metrics_frame = metrics_frame.swaplevel(axis="columns")
+        metrics_frame = self.metrics._formatted_summary_frame(data_source="test")
         metrics_html = metrics_frame.reset_index().to_html(index=False)
 
         comparison_reports = []

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -20,6 +20,7 @@ from skore._sklearn.types import PositiveLabel
 from skore._utils._progress_bar import track
 from skore._utils.repr.data import get_documentation_url
 from skore._utils.repr.html_repr import render_template
+from skore._utils.repr.markdown import comparison_estimator_markdown_context
 
 if TYPE_CHECKING:
     from skore._sklearn._checks.accessor import _ChecksAccessor
@@ -579,7 +580,42 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
 
     def __repr__(self) -> str:
         """Return a string representation."""
-        return f"{self.__class__.__name__}(...)"
+        return f"""{self.__class__.__name__}:
+        {list(self.reports_.keys())!r}
+
+        {self.metrics.summarize(data_source="test").frame()}
+        Call `report.to_markdown()` for a markdown summary of the report's contents."""
+
+    def to_markdown(self) -> str:
+        """Return a markdown summary of the report.
+
+        The summary contains three sections (Estimator, Metrics, Checks) that
+        mirror the tabs of the HTML representation. Each section ends with a pointer
+        to the corresponding accessor for full details.
+
+        Returns
+        -------
+        str
+            The markdown summary of the report.
+        """
+        metrics_frame = (
+            self.metrics.summarize(data_source="test")
+            .frame()
+            .rename_axis(
+                None if self._report_type == "comparison-estimator" else [None, None],
+                axis="columns",
+            )
+        )
+        if self._report_type == "comparison-cross-validation":
+            metrics_frame = metrics_frame.swaplevel(axis="columns")
+        return render_template(
+            "comparison_report_markdown.j2",
+            {
+                **comparison_estimator_markdown_context(self),
+                "metrics_text": repr(metrics_frame),
+                "checks_text": repr(self.checks.summarize(fast_mode=True)),
+            },
+        )
 
     def _repr_html_(self) -> str:
         """HTML representation with a selector to inspect one compared report."""

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -721,11 +721,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                     f" (± {timings.loc['Predict time test (s)', 'std']:.3f})"
                 ),
                 "n_folds": len(self.reports_),
-                "splitter_repr": (
-                    repr(self.splitter)
-                    if self.splitter is not None
-                    else f"{len(self.split_indices)} folds"
-                ),
+                "splitter_repr": repr(self.splitter),
                 "metrics_text": metrics_text,
                 **markdown_data_section(summary, data_label="full"),
             },

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -721,7 +721,11 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                     f" (± {timings.loc['Predict time test (s)', 'std']:.3f})"
                 ),
                 "n_folds": len(self.reports_),
-                "splitter_repr": repr(self.splitter),
+                "splitter_repr": (
+                    repr(self.splitter)
+                    if self.splitter is not None
+                    else f"{len(self.split_indices)} folds"
+                ),
                 "metrics_text": metrics_text,
                 **markdown_data_section(summary, data_label="full"),
             },

--- a/skore/src/skore/_utils/repr/comparison_report_markdown.j2
+++ b/skore/src/skore/_utils/repr/comparison_report_markdown.j2
@@ -1,9 +1,14 @@
 {%- autoescape false -%}
 # ComparisonReport: {{ estimator_labels | join(', ') }}
 
-## Estimator
+## Estimators
 
-| | {% for label in estimator_labels %}{{ label }} | {% endfor %}
+- ml task: {{ ml_task }}
+{%- if pos_label_repr is not none %}
+- pos_label: {{ pos_label_repr }}
+{%- endif %}
+
+| report name | {% for label in estimator_labels %}{{ label }} | {% endfor %}
 | --- | {% for _ in estimator_labels %} --- | {% endfor %}
 {%- for row in estimator_rows %}
 | {{ row.label }} | {% for value in row.cells %}{{ value }} | {% endfor %}

--- a/skore/src/skore/_utils/repr/comparison_report_markdown.j2
+++ b/skore/src/skore/_utils/repr/comparison_report_markdown.j2
@@ -1,0 +1,27 @@
+{%- autoescape false -%}
+# ComparisonReport: {{ estimator_labels | join(', ') }}
+
+## Estimator
+
+| | {% for label in estimator_labels %}{{ label }} | {% endfor %}
+| --- | {% for _ in estimator_labels %} --- | {% endfor %}
+{%- for row in estimator_rows %}
+| {{ row.label }} | {% for value in row.cells %}{{ value }} | {% endfor %}
+{%- endfor %}
+
+## Metrics
+
+```text
+{{ metrics_text }}
+
+Get the metrics results and control output format with: `report.metrics.summarize().frame()`.
+```
+
+## Checks (fast mode)
+
+```text
+{{ checks_text }}
+```
+
+Get the full checks results with: `report.checks.summarize()`.
+{%- endautoescape %}

--- a/skore/src/skore/_utils/repr/comparison_report_markdown.j2
+++ b/skore/src/skore/_utils/repr/comparison_report_markdown.j2
@@ -29,4 +29,21 @@ Get the metrics results and control output format with: `report.metrics.summariz
 ```
 
 Get the full checks results with: `report.checks.summarize()`.
+
+## Data
+{%- if data_mode == "unified" %}
+Computed on the {{ data_label }} dataset (n_rows={{ data_n_rows }}, n_columns={{ data_n_columns }}, n_constant_columns={{ data_n_constant_columns }}).
+
+| column | dtype | null_count | n_unique |
+| ------ | ----- | ---------- | -------- |
+{%- for col in data_columns %}
+| {{ col.name }} | {{ col.dtype }} | {{ col.null_count }} | {{ col.n_unique }} |
+{%- endfor %}
+{%- else %}
+| report name | n_rows | n_columns |
+| --- | --- | --- |
+{%- for row in data_shapes %}
+| {{ row.report_name }} | {{ row.n_rows }} | {{ row.n_columns }} |
+{%- endfor %}
+{%- endif %}
 {%- endautoescape %}

--- a/skore/src/skore/_utils/repr/markdown.py
+++ b/skore/src/skore/_utils/repr/markdown.py
@@ -5,6 +5,7 @@ from typing import Any
 import skrub
 from sklearn.base import MetaEstimatorMixin
 from sklearn.pipeline import Pipeline
+from skrub._reporting._summarize import summarize_dataframe
 
 from skore._sklearn.types import EstimatorLike
 from skore._utils._skrub import is_skrub_learner
@@ -101,6 +102,67 @@ def comparison_estimator_markdown_context(comparison_report: Any) -> dict[str, o
                 "cells": [metadata.get(row_label) or "" for metadata in metadata_list],
             }
             for row_label in row_labels
+        ],
+    }
+
+
+def comparison_data_markdown_context(comparison_report: Any) -> dict[str, object]:
+    all_report_data = []
+    for report_name, report in comparison_report.reports_.items():
+        if report._report_type == "cross-validation":
+            all_report_data.append(
+                {
+                    "report_name": report_name,
+                    "data_label": "full",
+                    "dataframe": report.data._prepare_dataframe_for_display(
+                        with_y=True,
+                        subsample=None,
+                        subsample_strategy="head",
+                        seed=None,
+                    ),
+                }
+            )
+        else:  # "estimator"
+            all_report_data.append(
+                {
+                    "report_name": report_name,
+                    "data_label": "full" if report.X_train is not None else "test",
+                    "dataframe": report.data._prepare_dataframe_for_display(
+                        data_source="both" if report.X_train is not None else "test",
+                        with_y=True,
+                        subsample=None,
+                        subsample_strategy="head",
+                        seed=None,
+                    ),
+                }
+            )
+    first_report_data = all_report_data[0]
+
+    if all(
+        report_data["dataframe"].equals(first_report_data["dataframe"])
+        for report_data in all_report_data[1:]
+    ):
+        summary = summarize_dataframe(
+            first_report_data["dataframe"],
+            with_plots=False,
+            with_associations=False,
+            verbose=0,
+        )
+        return {
+            "data_mode": "unified",
+            **markdown_data_section(
+                summary, data_label=first_report_data["data_label"]
+            ),
+        }
+    return {
+        "data_mode": "shapes",
+        "data_shapes": [
+            {
+                "report_name": report_data["report_name"],
+                "n_rows": report_data["dataframe"].shape[0],
+                "n_columns": report_data["dataframe"].shape[1],
+            }
+            for report_data in all_report_data
         ],
     }
 

--- a/skore/src/skore/_utils/repr/markdown.py
+++ b/skore/src/skore/_utils/repr/markdown.py
@@ -46,6 +46,66 @@ def report_markdown_context(report: Any) -> dict[str, object]:
     }
 
 
+def _subreport_estimator_metadata(report: Any) -> dict[str, str | None]:
+    timings = report.metrics.timings()
+    metadata: dict[str, str | None] = {
+        "name": f"`{report.estimator_name_}`",
+        "kind": _markdown_estimator_kind(report.estimator),
+        "ml task": report.ml_task,
+        "pos_label": (
+            repr(report._pos_label) if report._pos_label is not None else None
+        ),
+    }
+    if report._report_type == "cross-validation":
+        metadata["fit time"] = (
+            f"{timings.loc['Fit time (s)', 'mean']:.3f} s"
+            f" (± {timings.loc['Fit time (s)', 'std']:.3f})"
+        )
+        metadata["predict time (on test set)"] = (
+            f"{timings.loc['Predict time test (s)', 'mean']:.3f} s"
+            f" (± {timings.loc['Predict time test (s)', 'std']:.3f})"
+        )
+        metadata["cross-validation folds"] = str(len(report.reports_))
+        metadata["splitter"] = repr(report.splitter)
+    else:
+        fit_time = timings.get("fit_time")
+        predict_time = timings.get("predict_time_test")
+        metadata["fit time"] = f"{fit_time:.3g} s" if fit_time is not None else None
+        metadata["predict time (on test set)"] = (
+            f"{predict_time:.3g} s" if predict_time is not None else None
+        )
+    return metadata
+
+
+def comparison_estimator_markdown_context(comparison_report: Any) -> dict[str, object]:
+    labels = list(comparison_report.reports_.keys())
+    metadata_list = [
+        _subreport_estimator_metadata(report)
+        for report in comparison_report.reports_.values()
+    ]
+    row_labels = [
+        "name",
+        "kind",
+        "ml task",
+        "fit time",
+        "predict time (on test set)",
+    ]
+    if any(metadata.get("pos_label") is not None for metadata in metadata_list):
+        row_labels.append("pos_label")
+    if comparison_report._report_type == "comparison-cross-validation":
+        row_labels.extend(["cross-validation folds", "splitter"])
+    return {
+        "estimator_labels": labels,
+        "estimator_rows": [
+            {
+                "label": row_label,
+                "cells": [metadata.get(row_label) or "" for metadata in metadata_list],
+            }
+            for row_label in row_labels
+        ],
+    }
+
+
 def markdown_data_section(summary: dict, *, data_label: str) -> dict[str, object]:
     return {
         "data_label": data_label,

--- a/skore/src/skore/_utils/repr/markdown.py
+++ b/skore/src/skore/_utils/repr/markdown.py
@@ -49,12 +49,8 @@ def report_markdown_context(report: Any) -> dict[str, object]:
 def _subreport_estimator_metadata(report: Any) -> dict[str, str | None]:
     timings = report.metrics.timings()
     metadata: dict[str, str | None] = {
-        "name": f"`{report.estimator_name_}`",
+        "estimator name": f"`{report.estimator_name_}`",
         "kind": _markdown_estimator_kind(report.estimator),
-        "ml task": report.ml_task,
-        "pos_label": (
-            repr(report._pos_label) if report._pos_label is not None else None
-        ),
     }
     if report._report_type == "cross-validation":
         metadata["fit time"] = (
@@ -84,18 +80,21 @@ def comparison_estimator_markdown_context(comparison_report: Any) -> dict[str, o
         for report in comparison_report.reports_.values()
     ]
     row_labels = [
-        "name",
+        "estimator name",
         "kind",
-        "ml task",
         "fit time",
         "predict time (on test set)",
     ]
-    if any(metadata.get("pos_label") is not None for metadata in metadata_list):
-        row_labels.append("pos_label")
     if comparison_report._report_type == "comparison-cross-validation":
         row_labels.extend(["cross-validation folds", "splitter"])
     return {
         "estimator_labels": labels,
+        "ml_task": comparison_report._ml_task,
+        "pos_label_repr": (
+            repr(comparison_report._pos_label)
+            if comparison_report._pos_label is not None
+            else None
+        ),
         "estimator_rows": [
             {
                 "label": row_label,

--- a/skore/src/skore/_utils/repr/markdown.py
+++ b/skore/src/skore/_utils/repr/markdown.py
@@ -144,6 +144,7 @@ def comparison_data_markdown_context(comparison_report: Any) -> dict[str, object
 
     if all(
         report_data["dataframe"].equals(first_report_data["dataframe"])
+        and report_data["data_label"] == first_report_data["data_label"]
         for report_data in all_report_data[1:]
     ):
         summary = summarize_dataframe(

--- a/skore/src/skore/_utils/repr/markdown.py
+++ b/skore/src/skore/_utils/repr/markdown.py
@@ -63,7 +63,11 @@ def _subreport_estimator_metadata(report: Any) -> dict[str, str | None]:
             f" (± {timings.loc['Predict time test (s)', 'std']:.3f})"
         )
         metadata["cross-validation folds"] = str(len(report.reports_))
-        metadata["splitter"] = repr(report.splitter)
+        metadata["splitter"] = (
+            repr(report.splitter)
+            if report.splitter is not None
+            else f"{len(report.split_indices)} folds"
+        )
     else:
         fit_time = timings.get("fit_time")
         predict_time = timings.get("predict_time_test")

--- a/skore/tests/unit/reports/comparison/test_report.py
+++ b/skore/tests/unit/reports/comparison/test_report.py
@@ -453,6 +453,51 @@ def test_create_estimator_report_tabular_rejects_test_data(binary_classification
     [
         "comparison_estimator_reports_binary_classification",
         "comparison_cross_validation_reports_binary_classification",
+    ],
+)
+def test_to_markdown(comparison_fixture, request):
+    report = request.getfixturevalue(comparison_fixture)
+    markdown = report.to_markdown()
+    assert markdown.startswith("# ComparisonReport:")
+    for section in ("## Estimator", "## Metrics", "## Checks (fast mode)"):
+        assert section in markdown
+    assert "## Data" not in markdown
+    for label in report.reports_:
+        assert label in markdown
+    assert "report.metrics.summarize().frame()" in markdown
+    assert "report.checks.summarize()" in markdown
+    assert "Mute a check with .checks.summarize(ignore=['<code>'])." in markdown
+    assert "| estimator |" not in markdown
+    assert "estimator_" not in markdown
+    if "cross_validation" in comparison_fixture:
+        assert "cross-validation folds" in markdown
+        assert "splitter" in markdown
+    assert "fit time" in markdown
+    assert "predict time" in markdown
+
+
+@pytest.mark.parametrize(
+    "comparison_fixture",
+    [
+        "comparison_estimator_reports_binary_classification",
+        "comparison_cross_validation_reports_binary_classification",
+    ],
+)
+def test_text_repr(comparison_fixture, request):
+    report = request.getfixturevalue(comparison_fixture)
+    repr_str = repr(report)
+    assert repr_str.startswith("ComparisonReport:")
+    assert "to_markdown()" in repr_str
+    for label in report.reports_:
+        assert label in repr_str
+    assert "Accuracy" in repr_str
+
+
+@pytest.mark.parametrize(
+    "comparison_fixture",
+    [
+        "comparison_estimator_reports_binary_classification",
+        "comparison_cross_validation_reports_binary_classification",
         "comparison_estimator_reports_multiclass_classification",
         "comparison_cross_validation_reports_multiclass_classification",
         "comparison_estimator_reports_regression",

--- a/skore/tests/unit/reports/comparison/test_report.py
+++ b/skore/tests/unit/reports/comparison/test_report.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 import skrub
 from sklearn.datasets import make_classification
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression, RidgeClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.svm import LinearSVC
 
@@ -19,6 +19,7 @@ from skore import (
     ComparisonReport,
     CrossValidationReport,
     EstimatorReport,
+    evaluate,
 )
 from skore._externals._sklearn_compat import convert_container
 
@@ -469,11 +470,23 @@ def test_to_markdown(comparison_fixture, request):
     assert "Mute a check with .checks.summarize(ignore=['<code>'])." in markdown
     assert "| estimator |" not in markdown
     assert "estimator_" not in markdown
+    assert "- ml task:" in markdown
     if "cross_validation" in comparison_fixture:
         assert "cross-validation folds" in markdown
         assert "splitter" in markdown
     assert "fit time" in markdown
     assert "predict time" in markdown
+
+
+def test_to_markdown_pos_label():
+    X, y = make_classification(n_classes=2, random_state=0)
+    markdown = evaluate(
+        [RidgeClassifier(), LogisticRegression()],
+        X,
+        y,
+        pos_label=0,
+    ).to_markdown()
+    assert "- pos_label: 0" in markdown
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/reports/comparison/test_report.py
+++ b/skore/tests/unit/reports/comparison/test_report.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 import skrub
 from sklearn.datasets import make_classification
-from sklearn.linear_model import LogisticRegression, RidgeClassifier
+from sklearn.linear_model import LinearRegression, LogisticRegression, RidgeClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.svm import LinearSVC
 
@@ -460,9 +460,10 @@ def test_to_markdown(comparison_fixture, request):
     report = request.getfixturevalue(comparison_fixture)
     markdown = report.to_markdown()
     assert markdown.startswith("# ComparisonReport:")
-    for section in ("## Estimator", "## Metrics", "## Checks (fast mode)"):
+    for section in ("## Estimators", "## Metrics", "## Checks (fast mode)", "## Data"):
         assert section in markdown
-    assert "## Data" not in markdown
+    assert "n_rows=" in markdown
+    assert "| column | dtype |" in markdown
     for label in report.reports_:
         assert label in markdown
     assert "report.metrics.summarize().frame()" in markdown
@@ -487,6 +488,18 @@ def test_to_markdown_pos_label():
         pos_label=0,
     ).to_markdown()
     assert "- pos_label: 0" in markdown
+
+
+def test_to_markdown_different_datasets():
+    X1, y = make_classification(n_samples=100, n_features=20, random_state=0)
+    X2, _ = make_classification(n_samples=100, n_features=10, random_state=1)
+    report = evaluate([LinearRegression(), LinearRegression()], [X1, X2], y)
+    markdown = report.to_markdown()
+    assert "## Data" in markdown
+    assert "| report name | n_rows | n_columns |" in markdown
+    assert "| column | dtype |" not in markdown
+    for label in report.reports_:
+        assert label in markdown
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -242,12 +242,14 @@ def _assert_cross_validation_report_repr_html(
     assert "CrossValidationReport.metrics" in html_out
 
 
-def test_repr_mentions_to_markdown(forest_binary_classification_data):
+def test_text_repr(forest_binary_classification_data):
     estimator, X, y = forest_binary_classification_data
     report = evaluate(estimator, X, y, splitter=2)
     repr_str = repr(report)
-    assert "to_markdown()" in repr_str
+    assert repr_str.startswith("CrossValidationReport:")
     assert report.estimator_name_ in repr_str
+    assert "to_markdown()" in repr_str
+    assert "Accuracy" in repr_str
 
 
 def test_to_markdown(forest_binary_classification_data):

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -485,6 +485,16 @@ def test_prefit_no_train_data_repr_methods(prefit_regression_report_no_train_dat
     assert "R²" in fragments["metrics_summary"]
 
 
+def test_text_repr(forest_binary_classification_data):
+    estimator, X, y = forest_binary_classification_data
+    report = evaluate(estimator, X, y, splitter=0.2)
+    repr_str = repr(report)
+    assert repr_str.startswith("EstimatorReport:")
+    assert report.estimator_name_ in repr_str
+    assert "to_markdown()" in repr_str
+    assert "Accuracy" in repr_str
+
+
 def test_to_markdown(forest_binary_classification_data):
     estimator, X, y = forest_binary_classification_data
     report = evaluate(estimator, X, y, splitter=0.2)

--- a/skore/tests/unit/utils/repr/test_accessors.py
+++ b/skore/tests/unit/utils/repr/test_accessors.py
@@ -63,9 +63,15 @@ def test_data_accessor_repr(report_with_data):
         assert method.name in html
 
 
+def _metrics_summary_frame(metrics_accessor):
+    if hasattr(metrics_accessor, "_formatted_summary_frame"):
+        return metrics_accessor._formatted_summary_frame()
+    return metrics_accessor.summarize().frame()
+
+
 def test_metrics_accessor_repr(report):
     """Metrics accessor __repr__ shows the summary frame and hints."""
-    frame_repr = repr(report.metrics.summarize().frame())
+    frame_repr = repr(_metrics_summary_frame(report.metrics))
     result = repr(report.metrics)
 
     assert result.startswith("Metrics summary:")
@@ -76,7 +82,7 @@ def test_metrics_accessor_repr(report):
 
 def test_metrics_accessor_repr_html(report):
     """Metrics accessor _repr_html_ shows the summary frame and hints."""
-    frame_html = report.metrics.summarize().frame()._repr_html_()
+    frame_html = _metrics_summary_frame(report.metrics)._repr_html_()
     html = report.metrics._repr_html_()
 
     assert html.startswith("<p>Metrics summary:</p>")


### PR DESCRIPTION
Towards #2941.

<details>

<summary>Example output</summary>

# ComparisonReport: LogisticRegression, RidgeClassifier

## Estimators

- ml task: binary-classification

| report name | LogisticRegression | RidgeClassifier | 
| --- |  --- |  --- | 
| estimator name | `LogisticRegression` | `RidgeClassifier` | 
| kind | scikit-learn estimator | scikit-learn estimator | 
| fit time | 0.00299 s | 0.00297 s | 
| predict time (on test set) | 0.000836 s | 0.000445 s | 

## Metrics

```text
                        LogisticRegression  RidgeClassifier
Metric           Label                                     
Score                             0.950000         0.950000
Accuracy                          0.950000         0.950000
Precision        0                0.923077         0.923077
                 1                1.000000         1.000000
Recall           0                1.000000         1.000000
                 1                0.875000         0.875000
ROC AUC                           1.000000         1.000000
Log loss                          0.165920              NaN
Brier score                       0.043655              NaN
Fit time (s)                      0.002987         0.002967
Predict time (s)                  0.000836         0.000445

Get the metrics results and control output format with: `report.metrics.summarize().frame()`.
```

## Checks (fast mode)

```text
Checks summary: 1 issue(s), 2 tip(s), 5 passed, 0 ignored.
Issues:
- [SKD008] Highly correlated input features. Detected in: [LogisticRegression], [RidgeClassifier]. Read more about this here: https://docs.skore.probabl.ai/dev/user_guide/automated_checks.html#skd008-correlated-features.
Tips:
- [SKD006] Coefficient interpretation. Detected in: [LogisticRegression], [RidgeClassifier]. Read more about this here: https://docs.skore.probabl.ai/dev/user_guide/automated_checks.html#skd006-unscaled-coefficients.
- [SKD016] Estimator not tuned. Detected in: [LogisticRegression], [RidgeClassifier]. Read more about this here: https://docs.skore.probabl.ai/dev/user_guide/automated_checks.html#skd016-estimator-not-tuned.
Passed:
- [SKD001] Potential overfitting
- [SKD002] Potential underfitting
- [SKD004] High class imbalance
- [SKD009] Model worse than baseline
- [SKD010] Model slower than baseline
Mute a check with .checks.summarize(ignore=['<code>']).
```

Get the full checks results with: `report.checks.summarize()`.

## Data (Same dataset version)
Computed on the full dataset (n_rows=100, n_columns=6, n_constant_columns=0).

| column | dtype | null_count | n_unique |
| ------ | ----- | ---------- | -------- |
| f_0 | Float64DType | 0 | 100 |
| f_1 | Float64DType | 0 | 100 |
| f_2 | Float64DType | 0 | 100 |
| f_3 | Float64DType | 0 | 100 |
| f_4 | Float64DType | 0 | 100 |
| Target | Int64DType | 0 | 2 |

## Data (Different dataset version)
| report name | n_rows | n_columns |
| --- | --- | --- |
| LogisticRegression | 100 | 6 |
| RidgeClassifier | 100 | 3 |
</details>