### PR TITLE
feat(skore/checks): Add a progress bar

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -13,6 +13,7 @@ from skore._project.git import git_commit
 from skore._sklearn._checks._utils import CheckNotApplicable
 from skore._sklearn._checks.base import Check, CheckCode
 from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
+from skore._utils._progress_bar import track
 from skore._utils.repr.base import AccessorHelpMixin, ReportHelpMixin
 
 
@@ -74,15 +75,19 @@ class _BaseReport(ReportHelpMixin):
         if not hasattr(self, "_applicable_codes"):
             self._applicable_codes: set[CheckCode] = set()
 
-        for check in self._checks_registry:
-            if (
-                check.report_type != self._report_type
-                or check.code in self._check_results_cache
-                or check.code in ignored_codes
-            ):
-                continue
-            if fast_mode and getattr(check, "slow", False):
-                continue
+        checks_to_run = [
+            check
+            for check in self._checks_registry
+            if check.report_type == self._report_type
+            and check.code not in self._check_results_cache
+            and check.code not in ignored_codes
+            and not (fast_mode and getattr(check, "slow", False))
+        ]
+        for check in track(
+            checks_to_run,
+            description="Running checks",
+            total=len(checks_to_run),
+        ):
             try:
                 explanation = check.check_function(self)
                 self._applicable_codes.add(check.code)

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -87,6 +87,7 @@ class _BaseReport(ReportHelpMixin):
             checks_to_run,
             description="Running checks",
             total=len(checks_to_run),
+            disable=fast_mode,
         ):
             try:
                 explanation = check.check_function(self)

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -75,6 +75,7 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
                 if code in applicable_codes and code not in ignored_codes
             },
             n_ignored_codes=len(ignored_codes),
+            fast_mode=fast_mode,
         )
 
     def add(
@@ -139,7 +140,6 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
 
     def __repr__(self) -> str:
         return (
-            "Checks summary: (fast mode)\n"
             f"{self.summarize(fast_mode=True)!r}\n"
             "Explore available methods with .help()."
         )

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -69,6 +69,7 @@ class ChecksSummaryDisplay(DisplayHelpMixin):
         self,
         check_results: dict[CheckCode, dict],
         n_ignored_codes: int,
+        fast_mode: bool,
     ) -> None:
         self._check_results = pd.DataFrame(
             [
@@ -84,11 +85,13 @@ class ChecksSummaryDisplay(DisplayHelpMixin):
             columns=["code", "title", "severity", "explanation", "documentation_url"],
         )
         self._n_ignored_codes = n_ignored_codes
+        self._fast_mode = fast_mode
 
     @property
     def _header(self) -> str:
         return (
-            f"Checks summary: {len(self.frame(severity='issue'))} issue(s), "
+            f"Checks summary {'(fast mode)' if self._fast_mode else ''}: "
+            f"{len(self.frame(severity='issue'))} issue(s), "
             f"{len(self.frame(severity='tip'))} tip(s), "
             f"{len(self.frame(severity='passed'))} passed, "
             f"{self._n_ignored_codes} ignored."

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -90,7 +90,7 @@ class ChecksSummaryDisplay(DisplayHelpMixin):
     @property
     def _header(self) -> str:
         return (
-            f"Checks summary {'(fast mode)' if self._fast_mode else ''}: "
+            f"Checks summary{' (fast mode)' if self._fast_mode else ''}: "
             f"{len(self.frame(severity='issue'))} issue(s), "
             f"{len(self.frame(severity='tip'))} tip(s), "
             f"{len(self.frame(severity='passed'))} passed, "

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -462,6 +462,7 @@ class CheckWorseThanBaseline(Check):
     report_type = "estimator"
     docs_url = "skd009-worse-than-baseline"
     severity = "issue"
+    slow = True
 
     def check_function(self, report: _BaseReport) -> str | None:
         report = cast("EstimatorReport", report)
@@ -507,6 +508,7 @@ class CheckSlowerThanBaseline(Check):
     report_type = "estimator"
     docs_url = "skd010-slower-than-baseline"
     severity = "issue"
+    slow = True
 
     def check_function(self, report: _BaseReport) -> str | None:
         report = cast("EstimatorReport", report)

--- a/skore/src/skore/_utils/_progress_bar.py
+++ b/skore/src/skore/_utils/_progress_bar.py
@@ -10,7 +10,7 @@ T = TypeVar("T")
 class ProgressBar:
     """Simplified progress bar based on ``rich.Progress``."""
 
-    def __init__(self, description: str, total: float | None):
+    def __init__(self, description: str, total: float | None, disable: bool = False):
         from skore import THREADABLE, console
         from skore._config import configuration
 
@@ -27,7 +27,7 @@ class ProgressBar:
             expand=False,
             transient=True,
             auto_refresh=THREADABLE,
-            disable=(not configuration.show_progress),
+            disable=(not configuration.show_progress or disable),
         )
 
         self._description = description
@@ -79,12 +79,7 @@ def track(
     if total is None:
         total = float(length_hint(sequence)) or None
 
-    if disable:
-        for value in sequence:
-            yield value
-        return
-
-    with ProgressBar(description=description, total=total) as progress:
+    with ProgressBar(description=description, total=total, disable=disable) as progress:
         for value in sequence:
             yield value
             progress.advance()

--- a/skore/src/skore/_utils/_progress_bar.py
+++ b/skore/src/skore/_utils/_progress_bar.py
@@ -70,11 +70,19 @@ class ProgressBar:
 
 
 def track(
-    sequence: Iterable[Any], description: str, total: float | None = None
+    sequence: Iterable[Any],
+    description: str,
+    total: float | None = None,
+    disable: bool = False,
 ) -> Iterable[Any]:
     """Track progress by iterating over a sequence."""
     if total is None:
         total = float(length_hint(sequence)) or None
+
+    if disable:
+        for value in sequence:
+            yield value
+        return
 
     with ProgressBar(description=description, total=total) as progress:
         for value in sequence:

--- a/skore/src/skore/_utils/_progress_bar.py
+++ b/skore/src/skore/_utils/_progress_bar.py
@@ -27,7 +27,7 @@ class ProgressBar:
             expand=False,
             transient=True,
             auto_refresh=THREADABLE,
-            disable=(not configuration.show_progress or disable),
+            disable=((not configuration.show_progress) or disable),
         )
 
         self._description = description

--- a/skore/tests/unit/utils/test_progress_bar.py
+++ b/skore/tests/unit/utils/test_progress_bar.py
@@ -158,6 +158,15 @@ def test_track(monkeypatch):
     assert progress._progress.tasks[0].finished
 
 
+def test_track_disable(monkeypatch):
+    def RegisteredProgressBar(*args, **kwargs):
+        raise AssertionError("ProgressBar should not be used when disable=True")
+
+    monkeypatch.setattr("skore._utils._progress_bar.ProgressBar", RegisteredProgressBar)
+    results = list(track(range(5), description="track", disable=True))
+    assert results == list(range(5))
+
+
 def test_disable_progress_bar():
     with ProgressBar(description="progress1", total=0) as progress1:
         assert configuration.show_progress is True

--- a/skore/tests/unit/utils/test_progress_bar.py
+++ b/skore/tests/unit/utils/test_progress_bar.py
@@ -158,15 +158,6 @@ def test_track(monkeypatch):
     assert progress._progress.tasks[0].finished
 
 
-def test_track_disable(monkeypatch):
-    def RegisteredProgressBar(*args, **kwargs):
-        raise AssertionError("ProgressBar should not be used when disable=True")
-
-    monkeypatch.setattr("skore._utils._progress_bar.ProgressBar", RegisteredProgressBar)
-    results = list(track(range(5), description="track", disable=True))
-    assert results == list(range(5))
-
-
 def test_disable_progress_bar():
     with ProgressBar(description="progress1", total=0) as progress1:
         assert configuration.show_progress is True


### PR DESCRIPTION
Adds a progress bar on the checks loop and marks SKD009 and SKD010 as slow. 

cc @jeromedockes

I'm looking at how to show checks that were skipped in a new tab, maybe show checks that were ignored there too. Also looking into showing checks that raised `CheckNotApplicable` in a separate tab.

I'm going to tackle all that separately.