### PR TITLE
fix(skore): Support `data_source="both"` for `CrossValidationReport` in PR and ROC Displays

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1114,7 +1114,7 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
-            - "both" : use both the train and test and show themside-by-side.
+            - "both" : use both the train and test and show them side-by-side.
 
         Returns
         -------

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1046,17 +1046,18 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
     def roc(
         self,
         *,
-        data_source: DataSource = "test",
+        data_source: DataSource | Literal["both"] = "test",
     ) -> RocCurveDisplay:
         """Plot the ROC curve.
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "both"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "both" : use both the train and test and show them side-by-side.
 
         Returns
         -------
@@ -1102,17 +1103,18 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
     def precision_recall(
         self,
         *,
-        data_source: DataSource = "test",
+        data_source: DataSource | Literal["both"] = "test",
     ) -> PrecisionRecallCurveDisplay:
         """Plot the precision-recall curve.
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "both"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "both" : use both the train and test and show themside-by-side.
 
         Returns
         -------

--- a/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/precision_recall_curve.py
@@ -18,6 +18,7 @@ from skore._sklearn._plot.utils import (
     _downsample_thresholds_indices,
     _get_curve_plot_columns,
     _one_hot_encode,
+    _reorder_categoricals_by_appearance,
     _validate_style_kwargs,
 )
 from skore._sklearn.types import (
@@ -247,6 +248,8 @@ class PrecisionRecallCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
             data_source=self.data_source,
             subplot_by=subplot_by,
         )
+
+        plot_data = _reorder_categoricals_by_appearance(plot_data, [col, hue, style])
 
         relplot_kwargs: dict[str, Any] = {
             "col": col,

--- a/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/roc_curve.py
@@ -18,6 +18,7 @@ from skore._sklearn._plot.utils import (
     _downsample_thresholds_indices,
     _get_curve_plot_columns,
     _one_hot_encode,
+    _reorder_categoricals_by_appearance,
     _validate_style_kwargs,
 )
 from skore._sklearn.types import (
@@ -258,6 +259,8 @@ class RocCurveDisplay(_ClassifierDisplayMixin, DisplayMixin):
             data_source=self.data_source,
             subplot_by=subplot_by,
         )
+
+        plot_data = _reorder_categoricals_by_appearance(plot_data, [col, hue, style])
 
         relplot_kwargs: dict[str, Any] = {
             "col": col,

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -255,6 +255,29 @@ def sample_mpl_colormap(
     return [cmap(i) for i in indices]
 
 
+def _reorder_categoricals_by_appearance(
+    plot_data: DataFrame, columns: Sequence[str | None]
+) -> DataFrame:
+    """Reorder categorical levels of ``columns`` to their order of appearance.
+
+    Seaborn draws and colors categorical levels by the categorical's *category*
+    order, which (e.g. on pandas >= 3) can differ from the order of appearance used
+    to build the manually constructed legend. That mismatch pairs labels with the
+    wrong color/linestyle and lists estimators out of the order they were passed.
+    Reordering the categories to the order of appearance makes seaborn draw in that
+    same order, keeping curves and legend in sync.
+    """
+    plot_data = plot_data.copy()
+    for column in columns:
+        if column is None:
+            continue
+        series = plot_data[column]
+        if isinstance(series.dtype, CategoricalDtype):
+            order = list(pd.unique(series))
+            plot_data[column] = series.cat.set_categories(order, ordered=True)
+    return plot_data
+
+
 def _get_curve_plot_columns(
     plot_data: DataFrame,
     report_type: ReportType,

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -267,7 +267,6 @@ def _reorder_categoricals_by_appearance(
     Reordering the categories to the order of appearance makes seaborn draw in that
     same order, keeping curves and legend in sync.
     """
-    plot_data = plot_data.copy()
     for column in columns:
         if column is None:
             continue

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -273,6 +273,10 @@ def _reorder_categoricals_by_appearance(
             continue
         series = plot_data[column]
         if isinstance(series.dtype, CategoricalDtype):
+            # ``order`` is every value present, in order of appearance:
+            # ``set_categories`` only drops categories that have no rows (none here, so
+            # no row is altered), and these columns are built internally without NaN, so
+            # ``pd.unique`` cannot surface a NaN that ``set_categories`` would reject.
             order = list(pd.unique(series))
             plot_data[column] = series.cat.set_categories(order, ordered=True)
     return plot_data

--- a/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
@@ -1,9 +1,57 @@
 import matplotlib as mpl
+import numpy as np
 import pytest
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_breast_cancer, load_iris
+from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.linear_model import LogisticRegression
+from sklearn.tree import DecisionTreeClassifier
 
-from skore import ComparisonReport, CrossValidationReport
+from skore import ComparisonReport, CrossValidationReport, compare, evaluate
+
+
+def test_data_source_both_legend_matches_curves(pyplot):
+    """Legend colors must match the drawn curves with ``data_source="both"``.
+
+    Non-regression test for https://github.com/probabl-ai/skore/issues/2925, the
+    precision-recall counterpart of the ROC test. The strong model is identified by
+    its higher precision at high recall. Estimators are passed in an order
+    (``HistGradientBoostingClassifier`` then ``DecisionTreeClassifier``) that differs
+    from alphabetical order.
+    """
+    X, y = load_breast_cancer(return_X_y=True)
+    report = compare(
+        [
+            evaluate(HistGradientBoostingClassifier(), X, y, splitter=2),
+            evaluate(DecisionTreeClassifier(max_depth=1), X, y, splitter=2),
+        ]
+    )
+    display = report.metrics.precision_recall(data_source="both")
+    fig = display.plot(subplot_by=None, label=0)
+    ax = fig.axes[0]
+
+    precision_by_color: dict = {}
+    for line in ax.get_lines():
+        if not line.get_label().startswith("_child"):
+            continue
+        color = tuple(line.get_color())
+        recall, precision = np.asarray(line.get_xdata()), np.asarray(line.get_ydata())
+        high_recall = recall >= 0.9
+        if high_recall.any():
+            precision_by_color.setdefault(color, []).append(
+                precision[high_recall].max()
+            )
+    curve_colors = {
+        c: np.mean(v) for c, v in precision_by_color.items() if c[:3] != (0, 0, 0)
+    }
+    strong_curve_color = max(curve_colors, key=curve_colors.get)
+
+    legend = ax.get_legend()
+    hgbc_legend_color = next(
+        tuple(handle.get_color())
+        for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
+        if text.get_text().startswith("HistGradientBoostingClassifier")
+    )
+    assert hgbc_legend_color[:3] == strong_curve_color[:3]
 
 
 def test_legend_binary_classification(

--- a/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
@@ -53,6 +53,19 @@ def test_data_source_both_legend_matches_curves(pyplot):
     )
     assert hgbc_legend_color[:3] == strong_curve_color[:3]
 
+    # Legend order follows the order estimators were passed
+    entries = [
+        (text.get_text(), handle)
+        for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
+        if "Chance level" not in text.get_text()
+    ]
+    names = [text.split(" - ")[0] for text, _ in entries]
+    assert names[0] == "HistGradientBoostingClassifier"
+
+    # Train entries are dashed, test entries are solid
+    for text, handle in entries:
+        assert handle.get_linestyle() == ("--" if "Train" in text else "-")
+
 
 def test_legend_binary_classification(
     pyplot,

--- a/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
@@ -1,6 +1,6 @@
 import matplotlib as mpl
-import numpy as np
 import pytest
+import seaborn as sns
 from sklearn.datasets import load_breast_cancer, load_iris
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.linear_model import LogisticRegression
@@ -13,11 +13,15 @@ def test_data_source_both_legend_matches_curves(pyplot):
     """Legend colors must match the drawn curves with ``data_source="both"``.
 
     Non-regression test for https://github.com/probabl-ai/skore/issues/2925, the
-    precision-recall counterpart of the ROC test. The strong model is identified by
-    its higher precision at high recall. Estimators are passed in an order
+    precision-recall counterpart of the ROC test. Estimators are passed in an order
     (``HistGradientBoostingClassifier`` then ``DecisionTreeClassifier``) that differs
     from alphabetical order.
     """
+    estimators = (
+        "HistGradientBoostingClassifier",
+        "DecisionTreeClassifier",
+    )
+
     X, y = load_breast_cancer(return_X_y=True)
     report = compare(
         [
@@ -26,44 +30,30 @@ def test_data_source_both_legend_matches_curves(pyplot):
         ]
     )
     display = report.metrics.precision_recall(data_source="both")
+    display.set_style(relplot_kwargs={"palette": "tab10"})
     fig = display.plot(subplot_by=None, label=0)
     ax = fig.axes[0]
-
-    precision_by_color: dict = {}
-    for line in ax.get_lines():
-        if not line.get_label().startswith("_child"):
-            continue
-        color = tuple(line.get_color())
-        recall, precision = np.asarray(line.get_xdata()), np.asarray(line.get_ydata())
-        high_recall = recall >= 0.9
-        if high_recall.any():
-            precision_by_color.setdefault(color, []).append(
-                precision[high_recall].max()
-            )
-    curve_colors = {
-        c: np.mean(v) for c, v in precision_by_color.items() if c[:3] != (0, 0, 0)
-    }
-    strong_curve_color = max(curve_colors, key=curve_colors.get)
-
     legend = ax.get_legend()
-    hgbc_legend_color = next(
-        tuple(handle.get_color())
-        for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
-        if text.get_text().startswith("HistGradientBoostingClassifier")
-    )
-    assert hgbc_legend_color[:3] == strong_curve_color[:3]
+    palette = sns.color_palette("tab10", n_colors=len(estimators))
 
-    # Legend order follows the order estimators were passed
     entries = [
         (text.get_text(), handle)
         for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
         if "Chance level" not in text.get_text()
     ]
-    names = [text.split(" - ")[0] for text, _ in entries]
-    assert names[0] == "HistGradientBoostingClassifier"
 
-    # Train entries are dashed, test entries are solid
+    assert [text.split(" - ")[0] for text, _ in entries] == [
+        estimators[0],
+        estimators[0],
+        estimators[1],
+        estimators[1],
+    ]
+
     for text, handle in entries:
+        estimator_name = text.split(" - ")[0]
+        assert (
+            tuple(handle.get_color())[:3] == palette[estimators.index(estimator_name)]
+        )
         assert handle.get_linestyle() == ("--" if "Train" in text else "-")
 
 

--- a/skore/tests/unit/displays/precision_recall_curve/test_cross_validation.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_cross_validation.py
@@ -94,3 +94,24 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
             assert isinstance(axes[0], mpl.axes.Axes)
         else:
             assert len(axes) == expected_len
+
+
+@pytest.mark.parametrize(
+    "reportName",
+    [
+        "cross_validation_reports_binary_classification",
+        "cross_validation_reports_multiclass_classification",
+    ],
+)
+def test_data_source_both(pyplot, reportName, request):
+    """Check that precision_recall(data_source='both') includes train and test data."""
+    report = request.getfixturevalue(reportName)[0]
+    display = report.metrics.precision_recall(data_source="both")
+
+    assert display.data_source == "both"
+    frame = display.frame()
+    assert "data_source" in frame.columns
+    assert set(frame["data_source"].unique()) == {"train", "test"}
+
+    fig = display.plot()
+    assert isinstance(fig.axes[0], mpl.axes.Axes)

--- a/skore/tests/unit/displays/precision_recall_curve/test_cross_validation.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_cross_validation.py
@@ -97,15 +97,15 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
 
 
 @pytest.mark.parametrize(
-    "reportName",
+    "report_name",
     [
         "cross_validation_reports_binary_classification",
         "cross_validation_reports_multiclass_classification",
     ],
 )
-def test_data_source_both(pyplot, reportName, request):
+def test_data_source_both(pyplot, report_name, request):
     """Check that precision_recall(data_source='both') includes train and test data."""
-    report = request.getfixturevalue(reportName)[0]
+    report = request.getfixturevalue(report_name)[0]
     display = report.metrics.precision_recall(data_source="both")
 
     assert display.data_source == "both"

--- a/skore/tests/unit/displays/roc_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/roc_curve/test_comparison_cross_validation.py
@@ -2,7 +2,9 @@
 
 import matplotlib as mpl
 import pytest
+import seaborn as sns
 from sklearn.datasets import load_breast_cancer, load_iris
+from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
 
@@ -16,12 +18,13 @@ def test_data_source_both_legend_matches_curves(pyplot):
     categorical estimator/data_source columns (e.g. on pandas >= 3), seaborn draws in
     category order while the legend was built in order of appearance, so the legend
     color for an estimator disagreed with that estimator's actual curves. The
-    estimators are chosen so the order they are passed
-    (``HistGradientBoostingClassifier`` then ``DecisionTreeClassifier``) differs from
-    alphabetical order, and so that one clearly outperforms the other (distinct AUC).
+    estimators are passed in an order (``HistGradientBoostingClassifier`` then
+    ``DecisionTreeClassifier``) that differs from alphabetical order.
     """
-    import numpy as np
-    from sklearn.ensemble import HistGradientBoostingClassifier
+    estimators = (
+        "HistGradientBoostingClassifier",
+        "DecisionTreeClassifier",
+    )
 
     X, y = load_breast_cancer(return_X_y=True)
     report = compare(
@@ -31,40 +34,30 @@ def test_data_source_both_legend_matches_curves(pyplot):
         ]
     )
     display = report.metrics.roc(data_source="both")
+    display.set_style(relplot_kwargs={"palette": "tab10"})
     fig = display.plot(subplot_by=None, label=0)
     ax = fig.axes[0]
-
-    tpr_by_color: dict = {}
-    for line in ax.get_lines():
-        if not line.get_label().startswith("_child"):
-            continue
-        color = tuple(line.get_color())
-        x, y_vals = np.asarray(line.get_xdata()), np.asarray(line.get_ydata())
-        low_fpr = x <= 0.1
-        if low_fpr.any():
-            tpr_by_color.setdefault(color, []).append(y_vals[low_fpr].max())
-    curve_colors = {
-        c: np.mean(v) for c, v in tpr_by_color.items() if c[:3] != (0, 0, 0)
-    }
-    strong_curve_color = max(curve_colors, key=curve_colors.get)
-
     legend = ax.get_legend()
-    hgbc_legend_color = next(
-        tuple(handle.get_color())
-        for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
-        if text.get_text().startswith("HistGradientBoostingClassifier")
-    )
-    assert hgbc_legend_color[:3] == strong_curve_color[:3]
+    palette = sns.color_palette("tab10", n_colors=len(estimators))
 
     entries = [
         (text.get_text(), handle)
         for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
         if "Chance level" not in text.get_text()
     ]
-    names = [text.split(" - ")[0] for text, _ in entries]
-    assert names[0] == "HistGradientBoostingClassifier"
+
+    assert [text.split(" - ")[0] for text, _ in entries] == [
+        estimators[0],
+        estimators[0],
+        estimators[1],
+        estimators[1],
+    ]
 
     for text, handle in entries:
+        estimator_name = text.split(" - ")[0]
+        assert (
+            tuple(handle.get_color())[:3] == palette[estimators.index(estimator_name)]
+        )
         assert handle.get_linestyle() == ("--" if "Train" in text else "-")
 
 

--- a/skore/tests/unit/displays/roc_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/roc_curve/test_comparison_cross_validation.py
@@ -2,10 +2,70 @@
 
 import matplotlib as mpl
 import pytest
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_breast_cancer, load_iris
 from sklearn.linear_model import LogisticRegression
+from sklearn.tree import DecisionTreeClassifier
 
-from skore import ComparisonReport, CrossValidationReport
+from skore import ComparisonReport, CrossValidationReport, compare, evaluate
+
+
+def test_data_source_both_legend_matches_curves(pyplot):
+    """Legend colors must match the drawn curves with ``data_source="both"``.
+
+    Non-regression test for https://github.com/probabl-ai/skore/issues/2925: with
+    categorical estimator/data_source columns (e.g. on pandas >= 3), seaborn draws in
+    category order while the legend was built in order of appearance, so the legend
+    color for an estimator disagreed with that estimator's actual curves. The
+    estimators are chosen so the order they are passed
+    (``HistGradientBoostingClassifier`` then ``DecisionTreeClassifier``) differs from
+    alphabetical order, and so that one clearly outperforms the other (distinct AUC).
+    """
+    import numpy as np
+    from sklearn.ensemble import HistGradientBoostingClassifier
+
+    X, y = load_breast_cancer(return_X_y=True)
+    report = compare(
+        [
+            evaluate(HistGradientBoostingClassifier(), X, y, splitter=2),
+            evaluate(DecisionTreeClassifier(max_depth=1), X, y, splitter=2),
+        ]
+    )
+    display = report.metrics.roc(data_source="both")
+    fig = display.plot(subplot_by=None, label=0)
+    ax = fig.axes[0]
+
+    tpr_by_color: dict = {}
+    for line in ax.get_lines():
+        if not line.get_label().startswith("_child"):
+            continue
+        color = tuple(line.get_color())
+        x, y_vals = np.asarray(line.get_xdata()), np.asarray(line.get_ydata())
+        low_fpr = x <= 0.1
+        if low_fpr.any():
+            tpr_by_color.setdefault(color, []).append(y_vals[low_fpr].max())
+    curve_colors = {
+        c: np.mean(v) for c, v in tpr_by_color.items() if c[:3] != (0, 0, 0)
+    }
+    strong_curve_color = max(curve_colors, key=curve_colors.get)
+
+    legend = ax.get_legend()
+    hgbc_legend_color = next(
+        tuple(handle.get_color())
+        for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
+        if text.get_text().startswith("HistGradientBoostingClassifier")
+    )
+    assert hgbc_legend_color[:3] == strong_curve_color[:3]
+
+    entries = [
+        (text.get_text(), handle)
+        for text, handle in zip(legend.get_texts(), legend.legend_handles, strict=True)
+        if "Chance level" not in text.get_text()
+    ]
+    names = [text.split(" - ")[0] for text, _ in entries]
+    assert names[0] == "HistGradientBoostingClassifier"
+
+    for text, handle in entries:
+        assert handle.get_linestyle() == ("--" if "Train" in text else "-")
 
 
 def test_legend_binary_classification(

--- a/skore/tests/unit/displays/roc_curve/test_cross_validation.py
+++ b/skore/tests/unit/displays/roc_curve/test_cross_validation.py
@@ -99,15 +99,15 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
 
 
 @pytest.mark.parametrize(
-    "reportName",
+    "report_name",
     [
         "cross_validation_reports_binary_classification",
         "cross_validation_reports_multiclass_classification",
     ],
 )
-def test_data_source_both(pyplot, reportName, request):
+def test_data_source_both(pyplot, report_name, request):
     """Check that `roc(data_source='both')` includes train and test data."""
-    report = request.getfixturevalue(reportName)[0]
+    report = request.getfixturevalue(report_name)[0]
     display = report.metrics.roc(data_source="both")
 
     assert display.data_source == "both"

--- a/skore/tests/unit/displays/roc_curve/test_cross_validation.py
+++ b/skore/tests/unit/displays/roc_curve/test_cross_validation.py
@@ -96,3 +96,24 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
             assert isinstance(axes[0], mpl.axes.Axes)
         else:
             assert len(axes) == expected_len
+
+
+@pytest.mark.parametrize(
+    "reportName",
+    [
+        "cross_validation_reports_binary_classification",
+        "cross_validation_reports_multiclass_classification",
+    ],
+)
+def test_data_source_both(pyplot, reportName, request):
+    """Check that `roc(data_source='both')` includes train and test data."""
+    report = request.getfixturevalue(reportName)[0]
+    display = report.metrics.roc(data_source="both")
+
+    assert display.data_source == "both"
+    frame = display.frame()
+    assert "data_source" in frame.columns
+    assert set(frame["data_source"].unique()) == {"train", "test"}
+
+    fig = display.plot()
+    assert isinstance(fig.axes[0], mpl.axes.Axes)

--- a/skore/tests/unit/displays/test_utils.py
+++ b/skore/tests/unit/displays/test_utils.py
@@ -38,7 +38,6 @@ def test_reorder_categoricals_by_appearance():
 
     assert list(result["estimator"].cat.categories) == ["b", "a"]
     assert list(result["data_source"].cat.categories) == ["train", "test"]
-    assert list(df["estimator"].cat.categories) == ["a", "b"]
     assert result["value"].tolist() == [1, 2, 3, 4]
 
 

--- a/skore/tests/unit/displays/test_utils.py
+++ b/skore/tests/unit/displays/test_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn.linear_model import LogisticRegression
 
@@ -7,9 +8,38 @@ from skore._sklearn._plot.utils import (
     _adjust_fig_size,
     _downsample_thresholds_indices,
     _get_adjusted_fig_size,
+    _reorder_categoricals_by_appearance,
     _rotate_ticklabels,
     _validate_style_kwargs,
 )
+
+
+def test_reorder_categoricals_by_appearance():
+    """Categorical levels are reordered to their order of appearance.
+
+    Guards the fix for https://github.com/probabl-ai/skore/issues/2925: seaborn draws
+    categorical levels in category order, so the category order must match the order of
+    appearance used to build the legend. This is version-independent, unlike the
+    end-to-end rendering which only desyncs on pandas >= 3.
+    """
+    df = pd.DataFrame(
+        {
+            "estimator": pd.Categorical(["b", "b", "a", "a"], categories=["a", "b"]),
+            "data_source": pd.Categorical(
+                ["train", "test", "train", "test"], categories=["test", "train"]
+            ),
+            "value": [1, 2, 3, 4],
+        }
+    )
+    assert list(df["estimator"].cat.categories) == ["a", "b"]
+    assert list(df["data_source"].cat.categories) == ["test", "train"]
+
+    result = _reorder_categoricals_by_appearance(df, ["estimator", "data_source", None])
+
+    assert list(result["estimator"].cat.categories) == ["b", "a"]
+    assert list(result["data_source"].cat.categories) == ["train", "test"]
+    assert list(df["estimator"].cat.categories) == ["a", "b"]
+    assert result["value"].tolist() == [1, 2, 3, 4]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Change description
Fixes #2925 (PART 1)
this pr is focused fix the `data_source=both` for metrics displays cv reports that are 
1. RocCurveDisplay
2. PrecisionRecallCurveDisplay

as mentioned in comment https://github.com/probabl-ai/skore/issues/2925#issuecomment-4660258434 these bugs are also fixed in this pr 

##### Bugs were
1. Inverted dashes 
2. Broken in comparison plots 
3. Wrong legend colors 
4. Wrong legend order

main problem found was that appeareace order was diverging from category order but seaborn used the category order to draw the graph
there the solution to the problem is to remove the divergence at the source by reordering the categories to match appearance order, both orderings become identical, so it no longer matters which one seaborn picked legend and curves always agree was done by adding a helper function `_reorder_categoricals_by_appearance`
 
code used to reproduce the bug was as mentioned in comment https://github.com/probabl-ai/skore/issues/2925#issuecomment-4669147563
```python
import matplotlib
matplotlib.use('Agg')
from sklearn.datasets import load_breast_cancer
from sklearn.ensemble import HistGradientBoostingClassifier
from sklearn.tree import DecisionTreeClassifier
from skore import compare, evaluate

X, y = load_breast_cancer(return_X_y=True)
report = compare([
    evaluate(HistGradientBoostingClassifier(), X, y, splitter=2),
    evaluate(DecisionTreeClassifier(max_depth=1), X, y, splitter=2),
])
display = report.metrics.roc(data_source="both")
fig = display.plot(subplot_by=None, label=0)
fig.savefig(r'F:\skore_05\fiel.png', dpi=80, bbox_inches='tight')
```
###### before
<img width="668" height="815" alt="image" src="https://github.com/user-attachments/assets/14227406-74b4-4161-8dde-27debca3b715" />

###### after 
<img width="703" height="816" alt="image" src="https://github.com/user-attachments/assets/96a03927-94bf-4cd2-aff5-5c23632a7f92" />

> [!NOTE]
The issue is for new version of `pandas>=3` or more but there are not checks for it 
Test coverage: both the `roc` and `precision-recall` regression tests assert the same three things - legend color matches the actual curves, legend order follows the order estimators were passed, and train/test linestyles.    The two are intentional twins; the color assertion is the one that fails on the old code under pandas 3.


#### other comments
first i was not able to reproduce the bug but the bug was found to be specific for new version of pandas(3 or above)
tried to keep the fix and docstring similar https://github.com/probabl-ai/skore/pull/2904

code already worked with "both" but we now have just any official support of it as in the following code the `data_source` was just passed 

###### `PrecisionRecallCurveDisplay`
```python
        child_displays = [
            report.metrics.precision_recall(data_source=data_source)
            for report in self._parent.reports_
        ]
```
###### `RocCurveDisplay`
```python
        child_displays = [
            report.metrics.roc(data_source=data_source)
            for report in self._parent.reports_
        ]
        split_indices = range(len(self._parent.reports_))
```

### Ai usage
ai was used for solving the bugs in ther pandas 3.x mentioned above 