### PR TITLE
fix(plugin/hub/cross_validation_report/splitting_strategy): Use `len(split_indices)`

### DIFF
--- a/skore/src/skore/_plugins/hub/report/cross_validation_report.py
+++ b/skore/src/skore/_plugins/hub/report/cross_validation_report.py
@@ -216,7 +216,8 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
         is_classifier = "classification" in self.ml_task
 
         n_repeats = getattr(splitter, "n_repeats", None)
-        n_splits = splitter.get_n_splits() // (n_repeats or 1)
+        n_splits = len(self.report.split_indices) // (n_repeats or 1)
+
         splitter_metadata = {
             "type": splitter.__class__.__name__,
             "n_splits": n_splits,

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -1,9 +1,11 @@
 from io import BytesIO
 
 from joblib import dump, hash
+from numpy import array
 from pydantic import ValidationError
 from pytest import fixture, mark, param, raises
 from sklearn.datasets import make_classification, make_regression
+from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import (
     KFold,
@@ -289,7 +291,6 @@ class TestCrossValidationReportPayload:
         splitter,
         metadata,
         expected_splits,
-        monkeypatch,
     ):
         X, y = make_classification(random_state=42, n_samples=8, n_classes=2)
         estimator = LogisticRegression(random_state=42)
@@ -327,6 +328,31 @@ class TestCrossValidationReportPayload:
         assert payload.splitting_strategy == {
             "splitter": metadata,
             "splits": expected_splits,
+        }
+
+    def test_regression_splitting_do_not_call_get_n_splits(self, project):
+        X = array([0, 1, 2, 3, 4])
+        y = array([5, 6, 7, 8, 9])
+
+        class Splitter:
+            def split(self, X, y=None, groups=None):
+                yield array([0, 1]), array([2, 3, 4])
+
+            def get_n_splits(self, X, y=None, groups=None):
+                raise Exception
+
+        report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter())
+        payload = CrossValidationReportPayload(
+            project=project, report=report, key="<key>"
+        )
+
+        assert payload.splitting_strategy["splits"] == [[0, 0, 1, 1, 1]]
+        assert payload.splitting_strategy["splitter"] == {
+            "type": "Splitter",
+            "n_splits": 1,
+            "n_repeats": None,
+            "shuffle": False,
+            "random_state": None,
         }
 
     @mark.respx(assert_all_called=False)


### PR DESCRIPTION
 Use `len(report.split_indices)` instead of `splitter.get_n_splits()`, where `report.split_indices` is already computed and always available.
 
We can't control the way `splitter.get_n_splits()` must be called: with or without parameters?

```python-traceback
File skore/skore/src/skore/_plugins/hub/report/cross_validation_report.py:219, in CrossValidationReportPayload.splitting_strategy(self)
    216 is_classifier = "classification" in self.ml_task
    218 n_repeats = getattr(splitter, "n_repeats", None)
--> 219 n_splits = splitter.get_n_splits() // (n_repeats or 1)
    220 splitter_metadata = {
    221     "type": splitter.__class__.__name__,
    222     "n_splits": n_splits,
   (...)    228     "random_state": getattr(splitter, "random_state", None),
    229 }
    231 rng = np.random.default_rng(0)

TypeError: Splitter.get_n_splits() missing 1 required positional argument: 'X'
```

---

First iteration of a bunch of bug-fixes all related with the provided reproducer in #3004 .
