### PR TITLE
fix(skore/evaluate): Do not call `get_n_splits(None)`

### DIFF
--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -220,7 +220,7 @@ def evaluate(
     if isinstance(splitter, float):
         splitter = TrainTestSplit(test_size=splitter)
 
-    if hasattr(splitter, "get_n_splits") and splitter.get_n_splits(X, y) == 1:
+    if isinstance(splitter, TrainTestSplit):
         # It's easier to make a 1-split CrossValidationReport
         # and extract an EstimatorReport from it,
         # than to make an EstimatorReport from scratch

--- a/skore/tests/unit/dispatch/test_evaluate.py
+++ b/skore/tests/unit/dispatch/test_evaluate.py
@@ -1,4 +1,5 @@
 import pytest
+import skrub
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import KFold, StratifiedKFold
 
@@ -233,3 +234,21 @@ def test_no_data_raises():
         match="Provide data through X and y or through data to evaluate your estimator",
     ):
         evaluate(LinearRegression())
+
+
+def test_evaluate_learner(binary_classification_data):
+    class Splitter:
+        """A splitter with get_n_splits that requires X and y"""
+
+        def split(self, X, y, groups=None):
+            return KFold().split(X, y)
+
+        def get_n_splits(self, X, y, groups=None):
+            if X is None or y is None:
+                raise TypeError("X and y cannot be None")
+            return KFold().get_n_splits(X, y)
+
+    X, y = binary_classification_data
+    learner = skrub.X().skb.apply(LogisticRegression(), y=skrub.y()).skb.make_learner()
+    report = evaluate(learner, data={"X": X, "y": y}, splitter=Splitter())
+    assert len(report.reports_) == 5


### PR DESCRIPTION
avoid calling get_n_splits(None, None)

also, if the splitter number of splits depends on data it could be unexpected that it stops returning crossvalidation report when the number of splits happens to be 1

now it only gets unwrapped if splitter was a float or a skore TrainTestSplit