### PR TITLE
fix(plugin/hub/cross_validation_report/splitting_strategy): Deal with `len(split) == 1`

### DIFF
--- a/skore/src/skore/_plugins/hub/report/cross_validation_report.py
+++ b/skore/src/skore/_plugins/hub/report/cross_validation_report.py
@@ -61,23 +61,28 @@ def _regression_target_kdes(
     y: np.ndarray,
 ) -> tuple[list[list[float]], list[tuple[float, float]]]:
     """Estimate per-target density curves for regression splitting strategy."""
-    sample_count = TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT
-    y = np.asarray(y)
-    if y.ndim == 1:
-        lo, hi = float(y.min()), float(y.max())
-        linspace = np.linspace(lo, hi, num=sample_count)
-        kde = gaussian_kde(y)
-        return [[float(x) for x in kde(linspace)]], [(lo, hi)]
 
-    curves: list[list[float]] = []
-    ranges: list[tuple[float, float]] = []
-    for col in y.T:
-        col_arr = np.asarray(col).ravel()
+    def _target_distribution(
+        col_arr: np.ndarray,
+    ) -> tuple[list[float], tuple[float, float]]:
+        col_arr = np.asarray(col_arr).ravel()
         lo, hi = float(col_arr.min()), float(col_arr.max())
-        linspace = np.linspace(lo, hi, num=sample_count)
-        curves.append([float(x) for x in gaussian_kde(col_arr).evaluate(linspace)])
-        ranges.append((lo, hi))
-    return curves, ranges
+        linspace = np.linspace(lo, hi, num=TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT)
+
+        if len(col_arr) > 1:
+            curve = [float(x) for x in gaussian_kde(col_arr).evaluate(linspace)]
+        else:
+            # Fallback when `y` is not compatible with `gaussian_kde`
+            distribution = np.zeros(TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT, dtype=float)
+            distribution[np.abs(linspace - col_arr[0]).argmin()] = 1.0
+            curve = [float(x) for x in distribution]
+
+        return curve, (lo, hi)
+
+    y = np.asarray(y)
+    columns: Iterable[np.ndarray] = [y] if y.ndim == 1 else y.T
+    curves, ranges = zip(*map(_target_distribution, columns), strict=True)
+    return list(curves), list(ranges)
 
 
 def _flatten_regression_target_kdes(curves: list[list[float]]) -> list[float]:
@@ -391,9 +396,9 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
                 name=f"{row['metric_name']}_{suffix}",
                 verbose_name=f"{row['metric_verbose_name']} - {suffix.upper()}",
                 data_source=row["data_source"],
-                greater_is_better=row["greater_is_better"]
-                if suffix == "mean"
-                else False,
+                greater_is_better=(
+                    row["greater_is_better"] if suffix == "mean" else False
+                ),
                 value=row[suffix],
             )
             for row in aggregated.to_dict("records")

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -470,6 +470,36 @@ class TestCrossValidationReportPayload:
             "random_state": None,
         }
 
+    def test_splitting_strategy_with_singleton_split(self, project):
+        # non-regression test for https://github.com/probabl-ai/skore/pull/3017
+        X = array([0, 1, 2, 3, 4])
+        y = array([5, 6, 7, 8, 9])
+
+        class Splitter:
+            def split(self, X, y=None, groups=None):
+                yield array([0]), array([1, 2, 3, 4])
+
+            def get_n_splits(self, X, y=None, groups=None):
+                return 1
+
+        report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter())
+        payload = CrossValidationReportPayload(
+            project=project, report=report, key="<key>"
+        )
+
+        splitting_strategy = payload.splitting_strategy
+
+        assert splitting_strategy["test_target_distributions_sample_counts"] == [4]
+        assert splitting_strategy["train_target_distributions_sample_counts"] == [1]
+        assert splitting_strategy["splits"] == [[0, 1, 1, 1, 1]]
+        assert splitting_strategy["splitter"] == {
+            "type": "Splitter",
+            "n_splits": 1,
+            "n_repeats": None,
+            "shuffle": False,
+            "random_state": None,
+        }
+
     @mark.respx(assert_all_called=False)
     def test_class_names(self, payload):
         assert payload.class_names == ["1", "0"]

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -477,7 +477,7 @@ class TestCrossValidationReportPayload:
 
         class Splitter:
             def split(self, X, y=None, groups=None):
-                yield array([0]), array([1, 2, 3, 4])
+                yield array([0, 1, 2, 3]), array([4])
 
             def get_n_splits(self, X, y=None, groups=None):
                 return 1
@@ -489,9 +489,9 @@ class TestCrossValidationReportPayload:
 
         splitting_strategy = payload.splitting_strategy
 
-        assert splitting_strategy["test_target_distributions_sample_counts"] == [4]
-        assert splitting_strategy["train_target_distributions_sample_counts"] == [1]
-        assert splitting_strategy["splits"] == [[0, 1, 1, 1, 1]]
+        assert splitting_strategy["test_target_distributions_sample_counts"] == [1]
+        assert splitting_strategy["train_target_distributions_sample_counts"] == [4]
+        assert splitting_strategy["splits"] == [[0, 0, 0, 0, 1]]
         assert splitting_strategy["splitter"] == {
             "type": "Splitter",
             "n_splits": 1,


### PR DESCRIPTION
Deal with splits not compatible with `gaussian_kde`, with only one element `len(y) == 1`.

```python-traceback
File skore/skore/src/skore/_plugins/hub/report/cross_validation_report.py:318, in CrossValidationReportPayload.splitting_strategy(self)
    316     train_kernel = gaussian_kde(train_y)
    317     train_target_distribution = [float(x) for x in train_kernel(linspace)]
--> 318     test_kernel = gaussian_kde(test_y)
    319     test_target_distribution = [float(x) for x in test_kernel(linspace)]
    321 train_target_distributions.append(train_target_distribution)

File scipy/stats/_kde.py:212, in gaussian_kde.__init__(self, dataset, bw_method, weights)
    210 self.dataset = atleast_2d(asarray(dataset))
    211 if not self.dataset.size > 1:
--> 212     raise ValueError("`dataset` input should have multiple elements.")
    214 self.d, self.n = self.dataset.shape
    216 if weights is not None:

ValueError: `dataset` input should have multiple elements.

```

Following https://github.com/probabl-ai/skore/pull/3018, and closes https://github.com/probabl-ai/skore/issues/3004.

---

Third and last iteration of a bunch of bug-fixes all related with the provided reproducer in https://github.com/probabl-ai/skore/issues/3004 .
