### PR TITLE
fix(plugin/hub/cross_validation_report/splitting_strategy): Deal with custom splitter

### DIFF
--- a/skore/src/skore/_plugins/hub/report/cross_validation_report.py
+++ b/skore/src/skore/_plugins/hub/report/cross_validation_report.py
@@ -4,6 +4,7 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Sized
 from functools import cached_property
 from inspect import signature
+from itertools import chain
 from typing import Any, ClassVar, cast
 
 import numpy as np
@@ -42,6 +43,7 @@ from skore._plugins.hub.metric import Metric
 from skore._plugins.hub.report.estimator_report import EstimatorReportPayload
 from skore._plugins.hub.report.report import ReportPayload
 
+SPLITTING_STRATEGY_MAX_INDEX_COUNT = 10_000
 SPLITTING_STRATEGY_REPR_SAMPLE_COUNT = 100
 TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT = 100
 SPLITTERS = {
@@ -175,6 +177,7 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
         if self.report.y is None:
             return {}
 
+        splits: list[list[int] | None] = []
         splitter = self.report.splitter
         target = cast(Sized, self.report.y)
         is_classifier = "classification" in self.ml_task
@@ -239,12 +242,19 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
                 target_repr,
             )
         else:
-            split_generator = self.report.split_indices
+            total_index_count = sum(
+                len(cast(Sized, indices))
+                for indices in chain.from_iterable(self.report.split_indices)
+            )
+
+            if total_index_count > SPLITTING_STRATEGY_MAX_INDEX_COUNT:
+                splits = [None] * len(self.report.split_indices)
+                split_generator = []
+            else:
+                split_generator = self.report.split_indices
 
         # Per split: one list of length N_SAMPLES_REPR, ordered by sample index,
         # with 0 = train fold and 1 = test fold for that split.
-        splits: list[list[int]] = []
-
         for train_idx, test_idx in split_generator:
             split_flags = np.full(len(target), -1, dtype=int)
             split_flags[train_idx] = 0

--- a/skore/src/skore/_plugins/hub/report/cross_validation_report.py
+++ b/skore/src/skore/_plugins/hub/report/cross_validation_report.py
@@ -193,54 +193,60 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
             "random_state": getattr(splitter, "random_state", None),
         }
 
-        rng = np.random.default_rng(0)
-        rng_size = min(len(target), SPLITTING_STRATEGY_REPR_SAMPLE_COUNT)
+        # create a simplified splitter without shuffling and repetitions when possible
+        if simplified_cls := SPLITTERS.get(splitter.__class__.__name__):
+            rng = np.random.default_rng(0)
+            rng_size = min(len(target), SPLITTING_STRATEGY_REPR_SAMPLE_COUNT)
 
-        if len(target) < SPLITTING_STRATEGY_REPR_SAMPLE_COUNT:
-            target_repr = target
-        elif is_classifier:
-            # create an undersampled target to create a simplify representation
-            if not isinstance(target, pd.Series):
-                target = pd.Series(target)
+            if len(target) < SPLITTING_STRATEGY_REPR_SAMPLE_COUNT:
+                target_repr = target
+            elif is_classifier:
+                # create an undersampled target to create a simplify representation
+                if not isinstance(target, pd.Series):
+                    target = pd.Series(target)
 
-            probs = target.value_counts(normalize=True)
-            target_repr = rng.choice(
-                probs.index.to_numpy(),  # classes
-                size=rng_size,
-                p=probs.to_numpy(),  # probabilities
-                replace=True,
+                probs = target.value_counts(normalize=True)
+                target_repr = rng.choice(
+                    probs.index.to_numpy(),  # classes
+                    size=rng_size,
+                    p=probs.to_numpy(),  # probabilities
+                    replace=True,
+                )
+                target_repr.sort()
+            else:  # regression
+                # uniformly sample the target because it will have no impact on the
+                # representation
+                target_repr = rng.choice(
+                    cast(np.ndarray, target), size=rng_size, replace=False
+                )
+
+            simplified_cls_parameters = {}
+
+            for key in signature(simplified_cls.__init__).parameters:
+                if key in splitter_metadata:
+                    simplified_cls_parameters[key] = splitter_metadata[key]
+                elif hasattr(splitter, key):
+                    simplified_cls_parameters[key] = getattr(splitter, key)
+
+            if "shuffle" in simplified_cls_parameters:
+                simplified_cls_parameters["shuffle"] = False
+                simplified_cls_parameters["random_state"] = None
+
+            target = target_repr
+            simplified_splitter = simplified_cls(**simplified_cls_parameters)
+            split_generator = simplified_splitter.split(
+                rng.normal(size=(rng_size, 1)),
+                target_repr,
             )
-            target_repr.sort()
-        else:  # regression
-            # uniformly sample the target because it will have no impact on the
-            # representation
-            target_repr = rng.choice(
-                cast(np.ndarray, target), size=rng_size, replace=False
-            )
-
-        # create a simplified splitter without shuffling and repetitions
-        simplified_cls = SPLITTERS.get(splitter.__class__.__name__, splitter.__class__)
-        simplified_cls_parameters = {}
-
-        for key in signature(simplified_cls.__init__).parameters:
-            if key in splitter_metadata:
-                simplified_cls_parameters[key] = splitter_metadata[key]
-            elif hasattr(splitter, key):
-                simplified_cls_parameters[key] = getattr(splitter, key)
-
-        if "shuffle" in simplified_cls_parameters:
-            simplified_cls_parameters["shuffle"] = False
-            simplified_cls_parameters["random_state"] = None
-
-        simplified_splitter = simplified_cls(**simplified_cls_parameters)
+        else:
+            split_generator = self.report.split_indices
 
         # Per split: one list of length N_SAMPLES_REPR, ordered by sample index,
         # with 0 = train fold and 1 = test fold for that split.
         splits: list[list[int]] = []
-        X = rng.normal(size=(rng_size, 1))
 
-        for train_idx, test_idx in simplified_splitter.split(X, target_repr):
-            split_flags = np.full(rng_size, -1, dtype=int)
+        for train_idx, test_idx in split_generator:
+            split_flags = np.full(len(target), -1, dtype=int)
             split_flags[train_idx] = 0
             split_flags[test_idx] = 1
 

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -15,7 +15,6 @@ from sklearn.model_selection import (
     RepeatedKFold,
     RepeatedStratifiedKFold,
     ShuffleSplit,
-    StratifiedGroupKFold,
     StratifiedKFold,
     StratifiedShuffleSplit,
     TimeSeriesSplit,
@@ -427,17 +426,8 @@ class TestCrossValidationReportPayload:
             "random_state": None,
         }
 
-    @mark.parametrize(
-        ("splitter"),
-        [
-            param(GroupKFold(n_splits=2), id="GroupKFold"),
-            param(StratifiedGroupKFold(n_splits=2), id="StratifiedGroupKFold"),
-        ],
-    )
     def test_splitting_strategy_do_not_call_split_with_groups_aware_splitter(
-        self,
-        project,
-        splitter,
+        self, project
     ):
         # non-regression test for https://github.com/probabl-ai/skore/pull/3018
         X = array([0, 1, 2, 3, 4])

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -346,7 +346,8 @@ class TestCrossValidationReportPayload:
             "splits": expected_splits,
         }
 
-    def test_regression_splitting_do_not_call_get_n_splits(self, project):
+    def test_splitting_do_not_call_get_n_splits(self, project):
+        # non-regression test for https://github.com/probabl-ai/skore/pull/3011
         X = array([0, 1, 2, 3, 4])
         y = array([5, 6, 7, 8, 9])
 
@@ -358,6 +359,36 @@ class TestCrossValidationReportPayload:
                 raise Exception
 
         report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter())
+        payload = CrossValidationReportPayload(
+            project=project, report=report, key="<key>"
+        )
+
+        assert payload.splitting_strategy["splits"] == [[0, 0, 1, 1, 1]]
+        assert payload.splitting_strategy["splitter"] == {
+            "type": "Splitter",
+            "n_splits": 1,
+            "n_repeats": None,
+            "shuffle": False,
+            "random_state": None,
+        }
+
+    def test_splitting_strategy_do_not_call_custom_splitter_constructor(self, project):
+        # non-regression test for https://github.com/probabl-ai/skore/pull/3018
+        X = array([0, 1, 2, 3, 4])
+        y = array([5, 6, 7, 8, 9])
+
+        class Splitter:
+            def __init__(self, arg):
+                # raise TypeError: missing 1 required positional argument: 'arg'
+                pass
+
+            def split(self, X, y=None, groups=None):
+                yield array([0, 1]), array([2, 3, 4])
+
+            def get_n_splits(self, X, y=None, groups=None):
+                raise Exception
+
+        report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter(0))
         payload = CrossValidationReportPayload(
             project=project, report=report, key="<key>"
         )

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -355,9 +355,6 @@ class TestCrossValidationReportPayload:
             def split(self, X, y=None, groups=None):
                 yield array([0, 1]), array([2, 3, 4])
 
-            def get_n_splits(self, X, y=None, groups=None):
-                raise Exception
-
         report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter())
         payload = CrossValidationReportPayload(
             project=project, report=report, key="<key>"
@@ -384,9 +381,6 @@ class TestCrossValidationReportPayload:
 
             def split(self, X, y=None, groups=None):
                 yield array([0, 1]), array([2, 3, 4])
-
-            def get_n_splits(self, X, y=None, groups=None):
-                raise Exception
 
         report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter(0))
         payload = CrossValidationReportPayload(

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -356,9 +356,7 @@ class TestCrossValidationReportPayload:
                 yield array([0, 1]), array([2, 3, 4])
 
         report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter())
-        payload = CrossValidationReportPayload(
-            project=project, report=report, key="<key>"
-        )
+        payload = CrossValidationReportPayload(project=project, report=report, key="-")
 
         assert payload.splitting_strategy["splits"] == [[0, 0, 1, 1, 1]]
         assert payload.splitting_strategy["splitter"] == {
@@ -380,13 +378,17 @@ class TestCrossValidationReportPayload:
                 pass
 
             def split(self, X, y=None, groups=None):
+                nonlocal calls
+                calls += 1
                 yield array([0, 1]), array([2, 3, 4])
 
+        calls = 0
         report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter(0))
-        payload = CrossValidationReportPayload(
-            project=project, report=report, key="<key>"
-        )
+        calls_before_put = calls
+        payload = CrossValidationReportPayload(project=project, report=report, key="-")
 
+        assert calls_before_put > 0
+        assert calls_before_put == calls
         assert payload.splitting_strategy["splits"] == [[0, 0, 1, 1, 1]]
         assert payload.splitting_strategy["splitter"] == {
             "type": "Splitter",

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 
+import skrub
 from joblib import dump, hash
 from numpy import array
 from pydantic import ValidationError
@@ -9,10 +10,12 @@ from sklearn.dummy import DummyRegressor
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import (
+    GroupKFold,
     KFold,
     RepeatedKFold,
     RepeatedStratifiedKFold,
     ShuffleSplit,
+    StratifiedGroupKFold,
     StratifiedKFold,
     StratifiedShuffleSplit,
     TimeSeriesSplit,
@@ -419,6 +422,59 @@ class TestCrossValidationReportPayload:
         assert payload.splitting_strategy["splitter"] == {
             "type": "Splitter",
             "n_splits": 1,
+            "n_repeats": None,
+            "shuffle": False,
+            "random_state": None,
+        }
+
+    @mark.parametrize(
+        ("splitter"),
+        [
+            param(GroupKFold(n_splits=2), id="GroupKFold"),
+            param(StratifiedGroupKFold(n_splits=2), id="StratifiedGroupKFold"),
+        ],
+    )
+    def test_splitting_strategy_do_not_call_split_with_groups_aware_splitter(
+        self,
+        project,
+        splitter,
+    ):
+        # non-regression test for https://github.com/probabl-ai/skore/pull/3018
+        X = array([0, 1, 2, 3, 4])
+        y = array([5, 6, 7, 8, 9])
+        groups = array([0, 0, 1, 1, 2])
+        data = {"X": X, "y": y, "groups": groups}
+
+        splitter = GroupKFold(n_splits=2)
+
+        def split(X, y=None, groups=None):
+            nonlocal calls
+            calls += 1
+            yield from GroupKFold.split(splitter, X, y, groups=groups)
+
+        splitter.split = split
+
+        X_op = skrub.var("X", X).skb.mark_as_X(
+            cv=splitter,
+            split_kwargs={"groups": skrub.var("groups", groups)},
+        )
+        pred = X_op.skb.apply(DummyRegressor(), y=skrub.var("y", y).skb.mark_as_y())
+
+        calls = 0
+        report = CrossValidationReport(pred.skb.make_learner(), data=data)
+        calls_before_payload = calls
+        payload = CrossValidationReportPayload(project=project, report=report, key="-")
+
+        assert isinstance(report.splitter, splitter.__class__)
+        assert calls_before_payload > 0
+        assert calls_before_payload == calls
+        assert payload.splitting_strategy["splits"] == [
+            [0, 0, 1, 1, 1],
+            [1, 1, 0, 0, 0],
+        ]
+        assert payload.splitting_strategy["splitter"] == {
+            "type": "GroupKFold",
+            "n_splits": 2,
             "n_repeats": None,
             "shuffle": False,
             "random_state": None,

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -40,6 +40,9 @@ from skore._plugins.hub.report import (
     CrossValidationReportPayload,
     EstimatorReportPayload,
 )
+from skore._plugins.hub.report.cross_validation_report import (
+    SPLITTING_STRATEGY_MAX_INDEX_COUNT,
+)
 
 
 def serialize(object: EstimatorReport | CrossValidationReport) -> tuple[bytes, str]:
@@ -390,6 +393,29 @@ class TestCrossValidationReportPayload:
         assert calls_before_put > 0
         assert calls_before_put == calls
         assert payload.splitting_strategy["splits"] == [[0, 0, 1, 1, 1]]
+        assert payload.splitting_strategy["splitter"] == {
+            "type": "Splitter",
+            "n_splits": 1,
+            "n_repeats": None,
+            "shuffle": False,
+            "random_state": None,
+        }
+
+    def test_splitting_strategy_do_not_send_more_than_10_000_samples(self, project):
+        # non-regression test for https://github.com/probabl-ai/skore/pull/3018
+        assert SPLITTING_STRATEGY_MAX_INDEX_COUNT < 10_001
+
+        X = array(range(10_001))
+        y = array(range(10_001, 20_002))
+
+        class Splitter:
+            def split(self, X, y=None, groups=None):
+                yield array(X[: (len(X) // 2)]), array(X[(len(X) // 2) :])
+
+        report = CrossValidationReport(DummyRegressor(), X, y, splitter=Splitter())
+        payload = CrossValidationReportPayload(project=project, report=report, key="-")
+
+        assert payload.splitting_strategy["splits"] == [None]
         assert payload.splitting_strategy["splitter"] == {
             "type": "Splitter",
             "n_splits": 1,


### PR DESCRIPTION
Do not try to simplify/recompute splits when splitter is custom.

It addresses especially a bug when `X = rng.normal(size=(rng_size, 1))` changes the type of the parameters passed to the splitter.

```python-traceback
File skore/skore/src/skore/_plugins/hub/report/cross_validation_report.py:278, in CrossValidationReportPayload.splitting_strategy(self)
    275 splits: list[list[int]] = []
    276 X = rng.normal(size=(rng_size, 1))
--> 278 for train_idx, test_idx in simplified_splitter.split(X, target_repr):
    279     split_flags = np.full(rng_size, -1, dtype=int)
    280     split_flags[train_idx] = 0

Cell In[1], line 28, in Splitter.split(self, X, y, groups)
     27 def split(self, X, y=None, groups=None):
---> 28     df = X.assign(row_index=np.arange(X.shape[0]))
     29     for split_date in pd.date_range(X["when"].min(), X["when"].max(), freq="48h"):
     30         train = df[df["when"] <= split_date]["row_index"].to_numpy()

AttributeError: 'numpy.ndarray' object has no attribute 'assign'
```

Following https://github.com/probabl-ai/skore/pull/3011.

---

Second iteration of a bunch of bug-fixes all related with the provided reproducer in https://github.com/probabl-ai/skore/issues/3004 .