### PR TITLE
fix(plugin/hub/cross-validation-report/splitting-strategy): Fix target distribution plot

### DIFF
--- a/skore/src/skore/_plugins/hub/report/cross_validation_report.py
+++ b/skore/src/skore/_plugins/hub/report/cross_validation_report.py
@@ -302,9 +302,10 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
                     train_target_distribution.append(train.get(label, 0))
                     test_target_distribution.append(test.get(label, 0))
             else:
+                y = np.asarray(self.report.y)
                 linspace = np.linspace(
-                    float(train_y.min()),
-                    float(train_y.max()),
+                    float(y.min()),
+                    float(y.max()),
                     num=TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT,
                 )
                 train_kernel = gaussian_kde(train_y)


### PR DESCRIPTION
closes #3020 

the density plots are done over the support of all y not just train_y