### PR TITLE
feat: Add reprs to all Displays

### DIFF
--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -8,8 +8,8 @@ from uuid import uuid4
 import pandas as pd
 
 from skore._externals._sklearn_compat import parse_version
+from skore._sklearn._plot.base import DisplayMixin
 from skore._sklearn.types import ReportType
-from skore._utils.repr.base import DisplayHelpMixin
 from skore._utils.repr.html_repr import render_template
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ _TAB_SPECS: list[tuple[str, Literal["issue", "tip", "passed"], str, str]] = [
 ]
 
 
-class ChecksSummaryDisplay(DisplayHelpMixin):
+class ChecksSummaryDisplay(DisplayMixin):
     """Display for the checks summary.
 
     An instance of this class will be created by
@@ -163,9 +163,6 @@ class ChecksSummaryDisplay(DisplayHelpMixin):
                 "tabs": tabs,
             },
         )
-
-    def _repr_mimebundle_(self, **kwargs: object) -> dict[str, str]:
-        return {"text/plain": self.__repr__(), "text/html": self._repr_html_()}
 
     def __repr__(self) -> str:
         """Return a plain-text summary of check results."""

--- a/skore/src/skore/_sklearn/_plot/base.py
+++ b/skore/src/skore/_sklearn/_plot/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, runtime_checkable
 
 import matplotlib.pyplot as plt
 
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
         from matplotlib.typing import RcKeyType as MatplotlibRcKeyType
     except ImportError:
         MatplotlibRcKeyType = str  # type: ignore[misc]
-    from typing import cast
 import pandas as pd
 from matplotlib.figure import Figure
 

--- a/skore/src/skore/_sklearn/_plot/base.py
+++ b/skore/src/skore/_sklearn/_plot/base.py
@@ -11,12 +11,15 @@ if TYPE_CHECKING:
         from matplotlib.typing import RcKeyType as MatplotlibRcKeyType
     except ImportError:
         MatplotlibRcKeyType = str  # type: ignore[misc]
+    from typing import cast
 import pandas as pd
 from matplotlib.figure import Figure
 
 from skore import configuration
+from skore._plugins import switch_plt_backend
 from skore._sklearn.types import PlotBackend
 from skore._utils.repr.base import DisplayHelpMixin
+from skore._utils.repr.utils import figure_to_html
 
 ########################################################################################
 # Display protocol
@@ -239,3 +242,21 @@ class StyleDisplayMixin:
 
 class DisplayMixin(DisplayHelpMixin, PlotBackendMixin, StyleDisplayMixin):
     """Mixin inheriting help, plotting, and style functionality."""
+
+    def _repr_html_(self) -> str:
+        with switch_plt_backend(), plt.ioff():
+            plot_html = figure_to_html(cast(Display, self).plot())
+        return (
+            f"{plot_html}"
+            '<p role="note">Use <code>.plot()</code> to control the view and '
+            "<code>.frame()</code> to access the plotted data.</p>"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{cast(Display, self).frame()!r}\n"
+            f"Use .plot() to plot the data and .frame() to access the full data."
+        )
+
+    def _repr_mimebundle_(self, **kwargs):
+        return {"text/plain": repr(self), "text/html": self._repr_html_()}

--- a/skore/src/skore/_sklearn/_plot/data/table_report.py
+++ b/skore/src/skore/_sklearn/_plot/data/table_report.py
@@ -22,7 +22,6 @@ from skore._sklearn._plot.utils import (
     _rotate_ticklabels,
     _validate_style_kwargs,
 )
-from skore._utils.repr import ReprHTMLMixin
 
 
 def _truncate_top_k_categories(
@@ -160,7 +159,7 @@ def _resize_categorical_axis(
     _adjust_fig_size(figure, ax, target_width, target_height)
 
 
-class TableReportDisplay(ReprHTMLMixin, DisplayMixin):
+class TableReportDisplay(DisplayMixin):
     """Summarize and plot dataset columns.
 
     Parameters
@@ -675,12 +674,8 @@ class TableReportDisplay(ReprHTMLMixin, DisplayMixin):
         else:
             raise ValueError(f"Invalid kind: {kind!r}")
 
-    def _html_repr(self) -> str:
-        """Show the HTML representation of the report."""
-        return to_html(self.summary, standalone=False, column_filters=None)
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}(...)>"
+    def _repr_html_(self) -> str:
+        return f"{to_html(self.summary, standalone=False, column_filters=None)}"
 
     # ignore the type signature because we override kwargs by specifying the name of
     # the parameters for the user.

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -402,9 +402,6 @@ class MetricsSummaryDisplay(DisplayMixin):
     def __repr__(self) -> str:
         return f"{self.frame()!r}\nUse .frame() to control the format of the output."
 
-    def _repr_mimebundle_(self, **kwargs):
-        return {"text/plain": repr(self), "text/html": self._repr_html_()}
-
     @DisplayMixin.style_plot
     def plot(self) -> Figure:
         """Plot the metrics summary (not implemented)."""

--- a/skore/src/skore/_utils/repr/utils.py
+++ b/skore/src/skore/_utils/repr/utils.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 import re
+from io import BytesIO
+
+from matplotlib.figure import Figure
 
 # Strip script bodies when counting <div> so strings like "</div>" in JS do not skew.
 _HTML_SCRIPT_RE = re.compile(
@@ -31,3 +35,12 @@ def repair_estimator_html_for_slotted_host(html: str) -> str:
     if deficit > 0:
         return f"{html}{'</div>' * deficit}"
     return html
+
+
+def figure_to_html(figure: Figure) -> str:
+    """Return an HTML ``<img>`` tag embedding a matplotlib figure as base64 PNG."""
+    buffer = BytesIO()
+    figure.savefig(buffer, format="png", bbox_inches="tight")
+    buffer.seek(0)
+    encoded = base64.b64encode(buffer.read()).decode("ascii")
+    return f'<img src="data:image/png;base64,{encoded}">'

--- a/skore/tests/unit/displays/conftest.py
+++ b/skore/tests/unit/displays/conftest.py
@@ -264,3 +264,11 @@ def comparison_cross_validation_reports_multioutput_regression(
 ):
     report_1, report_2 = cross_validation_reports_multioutput_regression
     return ComparisonReport([report_1, report_2])
+
+
+@pytest.fixture
+def repr_coefficients_display(logistic_binary_classification_with_test):
+    estimator, X_test, y_test = logistic_binary_classification_with_test
+    return EstimatorReport(
+        estimator, X_test=X_test, y_test=y_test
+    ).inspection.coefficients()

--- a/skore/tests/unit/displays/metrics_summary/test_common.py
+++ b/skore/tests/unit/displays/metrics_summary/test_common.py
@@ -13,6 +13,9 @@ def test_repr_includes_frame_and_hint(forest_binary_classification_with_test):
     repr_str = repr(display)
     assert repr_str.startswith(repr(display.frame()))
     assert repr_str.endswith("Use .frame() to control the format of the output.")
+    assert (
+        "Use .plot() to plot the data" not in display._repr_mimebundle_()["text/plain"]
+    )
 
 
 def test_repr_html_includes_frame_and_hint(forest_binary_classification_with_test):
@@ -25,3 +28,6 @@ def test_repr_html_includes_frame_and_hint(forest_binary_classification_with_tes
     html = display._repr_html_()
     assert html.startswith(display.frame()._repr_html_())
     assert "Use <code>.frame()</code> to control the format of the output." in html
+    mime_html = display._repr_mimebundle_()["text/html"]
+    assert "data:image/png;base64," not in mime_html
+    assert "Use <code>.plot()</code> to control the view" not in mime_html

--- a/skore/tests/unit/displays/table_report/test_common.py
+++ b/skore/tests/unit/displays/table_report/test_common.py
@@ -111,7 +111,11 @@ def test_corr_plot(pyplot, estimator_report):
 
 
 def test_repr(display):
-    assert repr(display) == "<TableReportDisplay(...)>"
+    repr_str = repr(display)
+    assert repr(display.frame()) in repr_str
+    assert repr_str.endswith(
+        "Use .plot() to plot the data and .frame() to access the full data."
+    )
 
 
 def test_compute_contingency_table_error():

--- a/skore/tests/unit/displays/test_common.py
+++ b/skore/tests/unit/displays/test_common.py
@@ -3,8 +3,20 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
 
+import skore
 from skore import EstimatorReport
-from skore._sklearn._plot.base import Display
+from skore._sklearn._plot.base import Display, DisplayMixin
+
+DISPLAY_CLASSES = [
+    getattr(skore, name)
+    for name in skore.__all__
+    if name.endswith("Display") and name != "Display"
+]
+
+
+@pytest.mark.parametrize("display_cls", DISPLAY_CLASSES)
+def test_display_inherits_display_mixin(display_cls):
+    assert issubclass(display_cls, DisplayMixin)
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/displays/test_repr.py
+++ b/skore/tests/unit/displays/test_repr.py
@@ -1,0 +1,26 @@
+"""Tests for DisplayMixin default repr."""
+
+
+def test_default_repr_includes_frame_and_hint(repr_coefficients_display):
+    display = repr_coefficients_display
+    repr_str = repr(display)
+    assert repr(display.frame()) in repr_str
+    assert repr_str.endswith(
+        "Use .plot() to plot the data and .frame() to access the full data."
+    )
+
+
+def test_default_repr_html_includes_plot_and_hint(pyplot, repr_coefficients_display):
+    display = repr_coefficients_display
+    html = display._repr_html_()
+    assert "data:image/png;base64," in html
+    assert "Use <code>.plot()</code> to control the view and" in html
+    assert "<code>.frame()</code> to access the plotted data." in html
+
+
+def test_default_repr_mimebundle(pyplot, repr_coefficients_display):
+    bundle = repr_coefficients_display._repr_mimebundle_()
+    assert bundle == {
+        "text/plain": repr(repr_coefficients_display),
+        "text/html": repr_coefficients_display._repr_html_(),
+    }

--- a/skore/tests/unit/utils/repr/test_utils.py
+++ b/skore/tests/unit/utils/repr/test_utils.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import re
 
 import pytest
 import skrub
+from matplotlib.figure import Figure
 from sklearn.base import BaseEstimator, MetaEstimatorMixin
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
@@ -13,7 +15,10 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
 
 from skore._utils.repr.markdown import _markdown_estimator_kind
-from skore._utils.repr.utils import repair_estimator_html_for_slotted_host
+from skore._utils.repr.utils import (
+    figure_to_html,
+    repair_estimator_html_for_slotted_host,
+)
 
 _SCRIPT_STRIP = re.compile(
     r"<script\b[^>]*>.*?</script\s*[^>]*>", re.DOTALL | re.IGNORECASE
@@ -65,6 +70,18 @@ class TestRepairEstimatorHtmlForSlottedHost:
         combined = repaired + following
         o, c = _div_open_close_counts(combined)
         assert o == c
+
+
+def test_figure_to_html_returns_base64_img(pyplot):
+
+    fig = Figure()
+    ax = fig.subplots()
+    ax.plot([0, 1], [0, 1])
+    html = figure_to_html(fig)
+    prefix = '<img src="data:image/png;base64,'
+    assert html.startswith(prefix)
+    png_bytes = base64.b64decode(html[len(prefix) : -2])
+    assert png_bytes.startswith(b"\x89PNG")
 
 
 def _bare_meta_estimator() -> BaseEstimator:


### PR DESCRIPTION
Closes #2941

Implements default `__repr__` and `_repr_html_` in `DisplayMixin` so that all displays get reprs. `MetricsSummaryDisplay`, `ChecksSummaryDisplay` and `TableReportDisplay` override them to define their custom ones. 

The text repr is the default ouput of the `.frame` with a hint to use `.plot` to plot and `.frame` for access to full data. 
The html repr is the default output of `.plot` with a hint to use `.plot` to control the view and `.frame` to access the raw data.