### PR TITLE
chore(checks): Miscellaneous fixes and improvements

### DIFF
--- a/skore/src/skore/_sklearn/_checks/_utils.py
+++ b/skore/src/skore/_sklearn/_checks/_utils.py
@@ -154,7 +154,10 @@ def split_preprocessor_estimator(estimator):
     steps and final predictor.
     """
     if isinstance(estimator, Pipeline):
-        return estimator[:-1], estimator[-1]
+        if len(estimator.steps) > 1:
+            return estimator[:-1], estimator[-1]
+        else:
+            return None, estimator[0]
     return None, estimator
 
 

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -331,14 +331,14 @@ class CheckCoefficientsInterpretation(Check):
     def check_function(self, report: _BaseReport) -> str | None:
         """Assess whether linear-model coefficients are comparable and interpretable."""
         report = cast("EstimatorReport", report)
-        _, predictor = split_preprocessor_estimator(report.learner_)
+        _, predictor = split_preprocessor_estimator(report.estimator_)
         X = get_preprocessed_X(report, data_source="both")
 
         if X is None or not hasattr(predictor, "coef_"):
             raise CheckNotApplicable()
 
         stds = X.std(axis=0)
-        if not np.allclose(stds, stds.iloc[0]):
+        if not np.allclose(stds, stds.iloc[0], atol=0.05):
             return (
                 "Features are not on the same scale: coefficient magnitudes "
                 "are not directly comparable as feature importance."
@@ -368,7 +368,7 @@ class CheckMDIHighCardinalityBias(Check):
     def check_function(self, report: _BaseReport) -> str | None:
         """Detect high-cardinality features that may bias MDI importances."""
         report = cast("EstimatorReport", report)
-        _, predictor = split_preprocessor_estimator(report.learner_)
+        _, predictor = split_preprocessor_estimator(report.estimator_)
         X = get_preprocessed_X(report, data_source="train")
 
         if X is None or not hasattr(predictor, "feature_importances_"):
@@ -439,6 +439,7 @@ class CheckCorrelatedFeatures(Check):
                 "above 0.9. Highly correlated features can destabilize "
                 "linear model coefficients and feature-importance estimates, "
                 "and may cause collinearity-induced numerical issues."
+                "Dropping redundant features may also improve model performance."
             )
         return None
 
@@ -662,6 +663,7 @@ class CheckUselessFeatures(Check):
             return (
                 f"Feature(s) {useless} have permutation importance overlapping "
                 "with zero and could likely be dropped without degrading "
+                "performance. Dropping redundant features may also improve model "
                 "performance."
             )
         return None

--- a/skore/src/skore/_sklearn/_checks/tunable_hyperparameters.py
+++ b/skore/src/skore/_sklearn/_checks/tunable_hyperparameters.py
@@ -15,17 +15,31 @@ EQUIVALENT_PARAM_GROUPS: list[tuple[ParameterName, ...]] = [
 
 
 # Init params that don't change the learned model in a hyperparameter-tuning
-# sense: reproducibility, parallelism, logging, memory, class re-weighting.
-# Setting any of these should NOT count as "the estimator has been tuned".
+# sense. Limited to params that exist on estimators in HYPERPARAMETERS_TO_TUNE
+# (the only classes SKD016 evaluates). Setting any of these should NOT count as
+# "the estimator has been tuned".
 INFRASTRUCTURE_PARAMS: set[ParameterName] = {
-    "random_state",
-    "n_jobs",
-    "verbose",
-    "warm_start",
+    "algorithm",
+    "cache_size",
     "class_weight",
     "copy",
     "copy_X",
-    "cache_size",
+    "dtype",
+    "early_stopping",
+    "keep_empty_features",
+    "leaf_size",
+    "max_iter",
+    "missing_values",
+    "n_iter_no_change",
+    "n_jobs",
+    "oob_score",
+    "precompute",
+    "random_state",
+    "sparse_output",
+    "tol",
+    "validation_fraction",
+    "verbose",
+    "warm_start",
 }
 
 

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -572,6 +572,15 @@ def test_skd016_ignores_infrastructure(regression_data):
     assert "alpha" in tips.loc["SKD016", "explanation"]
 
 
+def test_skd016_ignores_budget_params(regression_data):
+    """Raising max_iter alone still triggers SKD016."""
+    X, y = regression_data
+    report = evaluate(Ridge(max_iter=200), X, y)
+    tips = report.checks.summarize().frame(severity="tip").set_index("code")
+    assert "SKD016" in tips.index
+    assert "alpha" in tips.loc["SKD016", "explanation"]
+
+
 def test_skd016_not_applicable_unknown_estimator(regression_data):
     """SKD016 raises CheckNotApplicable for estimators not in the table."""
     X, y = regression_data

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -165,9 +165,7 @@ def test_skd006_pipeline_coefficient_interpretation(
     """SKD006 tip reflects preprocessed feature scale in a pipeline."""
     X, y = regression_data
     report = evaluate(pipeline, X, y)
-    tips = (
-        report.checks.summarize(fast_mode=True).frame(severity="tip").set_index("code")
-    )
+    tips = report.checks.summarize().frame(severity="tip").set_index("code")
     assert "SKD006" in tips.index
     assert expected_message in tips.loc["SKD006", "explanation"]
 

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -146,10 +146,43 @@ def test_skd006_detects_coefficient_interpretation(regression_data):
     assert "Features appear to be standardized" in tips.loc["SKD006", "explanation"]
 
 
-def test_skd007_mdi_bias_with_high_cardinality(regression_data):
+@pytest.mark.parametrize(
+    "pipeline, expected_message",
+    [
+        (
+            Pipeline([("model", LinearRegression())]),
+            "Features are not on the same scale",
+        ),
+        (
+            Pipeline([("scaler", StandardScaler()), ("model", LinearRegression())]),
+            "Features appear to be standardized",
+        ),
+    ],
+)
+def test_skd006_pipeline_coefficient_interpretation(
+    regression_data, pipeline, expected_message
+):
+    """SKD006 tip reflects preprocessed feature scale in a pipeline."""
+    X, y = regression_data
+    report = evaluate(pipeline, X, y)
+    tips = (
+        report.checks.summarize(fast_mode=True).frame(severity="tip").set_index("code")
+    )
+    assert "SKD006" in tips.index
+    assert expected_message in tips.loc["SKD006", "explanation"]
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        RandomForestRegressor(n_estimators=5, random_state=0),
+        Pipeline([("rf", RandomForestRegressor(n_estimators=5, random_state=0))]),
+    ],
+)
+def test_skd007_mdi_bias_with_high_cardinality(regression_data, estimator):
     """SKD007 tip is emitted with continuous features and tree importances."""
     X, y = regression_data
-    report = evaluate(RandomForestRegressor(n_estimators=5, random_state=0), X, y)
+    report = evaluate(estimator, X, y)
     tips = report.checks.summarize().frame(severity="tip").set_index("code")
     assert "SKD007" in tips.index
     assert (

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -626,10 +626,10 @@ The check runs on plain estimators and :class:`~sklearn.pipeline.Pipeline`
 object.
 
 For every step whose class is in the recommendation table, `skore` lists the
-init params that differ from their scikit-learn default. Infrastructure params
-that do not affect the learned model (``random_state``, ``n_jobs``, ``verbose``,
-``warm_start``, ``class_weight``, ``copy`` / ``copy_X``, ``cache_size``) are
-ignored. When every remaining param of a step is still at its default, the
+initialization parameters that differ from their scikit-learn default.
+Infrastructure parameters that do not affect the learned model
+(e.g. ``random_state``, ``n_jobs``, ``verbose``, ...) are ignored. When every
+remaining parameter of a step is still at its default value, the
 check reports a tip suggesting the recommended tuning axes for that class.
 
 Why it matters


### PR DESCRIPTION
Fixes #3066 and Fixes #3067. 

- use `estimator_` instead of `learner_` to fix SKD006 & SKD007 with pipeline inputs.
- improve language in SKD016 userguide entry
- include more params in the `INFRASTRUCTURE_PARAMS` list, including `max_iter`.
- mention potential gains of dropping features in correlated and useless features checks.