### PR TITLE
feat: Support split_kwargs from DataOp for advanced cross-validation

### DIFF
--- a/examples/technical_details/plot_skrub_data_op_cv.py
+++ b/examples/technical_details/plot_skrub_data_op_cv.py
@@ -71,5 +71,5 @@ holdout_report
 
 # %%
 # Explicitly passing a ``splitter`` always overrides the DataOp configuration.
-override_report = evaluate(learner, data={"df": df}, splitter=3)
+override_report = evaluate(learner, data={"df": df}, splitter=2)
 override_report

--- a/examples/technical_details/plot_skrub_data_op_cv.py
+++ b/examples/technical_details/plot_skrub_data_op_cv.py
@@ -26,7 +26,7 @@ from sklearn.dummy import DummyClassifier
 from sklearn.model_selection import LeaveOneGroupOut
 
 df = skrub.datasets.toy_products()
-data = skrub.var("df", df)
+data = skrub.var("df")
 groups = data["seller"]
 X = data[["description", "price"]].skb.mark_as_X(
     cv=LeaveOneGroupOut(), split_kwargs={"groups": groups}

--- a/examples/technical_details/plot_skrub_data_op_cv.py
+++ b/examples/technical_details/plot_skrub_data_op_cv.py
@@ -1,0 +1,75 @@
+"""
+.. _example_skrub_data_op_cv:
+
+===================================
+Using skrub DataOp cross-validation
+===================================
+
+When a skrub :class:`~skrub.DataOp` defines a cross-validation splitter on
+:meth:`~skrub.DataOp.skb.mark_as_X`, :func:`~skore.evaluate` can reuse that
+configuration — including ``split_kwargs`` such as ``groups`` — instead of
+skore's default 80/20 holdout.
+
+This example builds a small grouped cross-validation setup with skrub and
+evaluates it with skore.
+"""
+
+# %%
+# Configure cross-validation on the DataOp
+# ========================================
+#
+# We use the toy products dataset and group products by seller. The goal is to
+# assess generalization to new sellers with
+# :class:`~sklearn.model_selection.LeaveOneGroupOut`.
+import skrub
+from sklearn.dummy import DummyClassifier
+from sklearn.model_selection import LeaveOneGroupOut
+
+df = skrub.datasets.toy_products()
+data = skrub.var("df", df)
+groups = data["seller"]
+X = data[["description", "price"]].skb.mark_as_X(
+    cv=LeaveOneGroupOut(), split_kwargs={"groups": groups}
+)
+y = data["category"].skb.mark_as_y()
+pred = X.skb.apply(DummyClassifier(), y=y)
+learner = pred.skb.make_learner()
+
+# %%
+# Evaluate with skore (no explicit splitter)
+# ==========================================
+#
+# Because ``mark_as_X`` was called with an explicit ``cv`` argument, calling
+# :func:`~skore.evaluate` without a ``splitter`` returns a
+# :class:`~skore.CrossValidationReport` that respects the DataOp grouping.
+from skore import evaluate
+
+report = evaluate(learner, data={"df": df})
+report
+
+# %%
+# There are two sellers, so cross-validation runs in two folds:
+len(report.reports_)
+
+# %%
+# Inspect aggregated metrics with the same API as other skore reports:
+report.metrics.summarize().frame()
+
+# %%
+# Default behavior without an explicit DataOp cv
+# ==============================================
+#
+# If ``mark_as_X`` is called without an explicit ``cv`` argument,
+# :func:`~skore.evaluate` still defaults to a single 80/20 holdout and returns
+# an :class:`~skore.EstimatorReport`.
+simple_learner = skrub.X().skb.apply(DummyClassifier(), y=skrub.y()).skb.make_learner()
+holdout_report = evaluate(
+    simple_learner,
+    data={"X": df[["description", "price"]], "y": df["category"]},
+)
+holdout_report
+
+# %%
+# Explicitly passing a ``splitter`` always overrides the DataOp configuration.
+override_report = evaluate(learner, data={"df": df}, splitter=3)
+override_report

--- a/skore/src/skore/_plugins/mlflow/reports.py
+++ b/skore/src/skore/_plugins/mlflow/reports.py
@@ -204,14 +204,15 @@ def iter_cv(report: CrossValidationReport) -> Generator[NestedLogItem, None, Non
             ),
         )
 
-    yield Params({"cv_splitter.class": report.splitter.__class__.__name__})
+    if report.splitter is not None:
+        yield Params({"cv_splitter.class": report.splitter.__class__.__name__})
 
-    try:
-        n_splits = report.splitter.get_n_splits()
-    except AttributeError:
-        pass
-    else:
-        yield Params({"cv_splitter.n_splits": n_splits})
+        try:
+            n_splits = report.splitter.get_n_splits()
+        except AttributeError:
+            pass
+        else:
+            yield Params({"cv_splitter.n_splits": n_splits})
 
 
 def iter_estimator(report: EstimatorReport) -> Generator[LogItem, None, None]:

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -22,18 +22,14 @@ from skore._sklearn._checks.base import CheckCode
 from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
 from skore._sklearn._estimator.report import EstimatorReport
 from skore._sklearn.types import (
-    _DEFAULT,
     PositiveLabel,
     SKLearnCrossValidator,
-    _DefaultType,
 )
 from skore._utils._fixes import _validate_joblib_parallel_params
 from skore._utils._parallel import delayed
 from skore._utils._progress_bar import track
 from skore._utils._skrub import (
-    eval_X_y,
     is_skrub_learner,
-    resolve_data_op_split_indices,
     to_estimator,
     to_learner,
 )
@@ -72,34 +68,6 @@ def _generate_estimator_report(
         y_test=_safe_indexing(y, test_indices),
         pos_label=pos_label,
     )
-
-
-def _check_estimator_and_data(
-    estimator: EstimatorLike,
-    X: ArrayLike | None,
-    y: ArrayLike | None,
-    data: dict | None,
-) -> tuple[bool, skrub.SkrubLearner, dict]:
-    if is_skrub_learner(estimator):
-        initialized_with_data_op = True
-        if X is not None or y is not None:
-            raise TypeError(
-                "X and y cannot be provided when estimator is a SkrubLearner. "
-                "Provide `data` instead."
-            )
-        if data is None:
-            raise TypeError("data must be provided when estimator is a SkrubLearner")
-        data = eval_X_y(estimator.data_op, data)
-    else:
-        initialized_with_data_op = False
-        if data is not None:
-            raise TypeError(
-                "`data` can only be provided when estimator "
-                "is a SkrubLearner. Provide X and y instead."
-            )
-        estimator = to_learner(estimator)
-        data = {"_skrub_X": X, "_skrub_y": y}
-    return initialized_with_data_op, estimator, data
 
 
 class CrossValidationReport(_BaseReport, DirNamesMixin):
@@ -234,10 +202,26 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         y: ArrayLike | None = None,
         data: dict | None = None,
         pos_label: PositiveLabel | None = None,
-        splitter: int | SKLearnCrossValidator | Generator | _DefaultType | None = None,
+        splitter: int | SKLearnCrossValidator | Generator | None = None,
         n_jobs: int | None = None,
     ) -> None:
         super().__init__()
+        self._check_estimator_and_data(estimator, X, y, data, splitter)
+        self._pos_label = pos_label
+        self.n_jobs = n_jobs
+
+        self.reports_: list[EstimatorReport] = self._fit_estimator_reports()
+
+        self._ml_task = self.reports_[0].ml_task
+
+    def _check_estimator_and_data(
+        self,
+        estimator,
+        X: ArrayLike | None,
+        y: ArrayLike | None,
+        data: dict | None,
+        splitter: int | SKLearnCrossValidator | Generator | None,
+    ) -> None:
         self.estimator = estimator
         if isinstance(estimator, skrub.DataOp):
             if data is None:
@@ -248,34 +232,37 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                 "Clustering models are not supported yet. Please use a"
                 " classification or regression model instead."
             )
-        self._initialized_with_data_op, self.learner_, self._data = (
-            _check_estimator_and_data(clone(estimator), X, y, data)
-        )
-        self._pos_label = pos_label
-        if self._initialized_with_data_op:
-            cv_for_indices = splitter if splitter is not None else _DEFAULT
-            self._split_indices = resolve_data_op_split_indices(
-                self.learner_.data_op,
-                self._data,
-                cv=cv_for_indices,
-            )
-            self._splitter = (
-                None
-                if splitter in (None, _DEFAULT)
-                else check_cv(
-                    splitter, self.y, classifier=is_classifier(self.estimator_)
+        estimator = clone(estimator)
+        if is_skrub_learner(estimator):
+            self._initialized_with_data_op = True
+            if X is not None or y is not None:
+                raise TypeError(
+                    "X and y cannot be provided when estimator is a SkrubLearner. "
+                    "Provide `data` instead."
                 )
-            )
+            if data is None:
+                raise TypeError(
+                    "data must be provided when estimator is a SkrubLearner"
+                )
+            self.learner_ = estimator
+            X_y_cv = skrub.as_data_op(estimator.data_op.skb.find_X_y()).skb.eval(data)
+            X, y = X_y_cv["X"], X_y_cv["y"]
+            self._data = data | {"_skrub_X": X, "_skrub_y": y}
+            if splitter is None and (cv := X_y_cv.get("cv")) is not None:
+                self._splitter = cv
+                self._split_indices = tuple(cv.split(X, y, **X_y_cv["split_kwargs"]))
         else:
-            resolved_splitter = None if splitter is _DEFAULT else splitter
-            self._splitter = check_cv(
-                resolved_splitter, y, classifier=is_classifier(estimator)
-            )
-            self._split_indices = tuple(self._splitter.split(self.X, self.y))
-        self.n_jobs = n_jobs
-
-        self.reports_: list[EstimatorReport] = self._fit_estimator_reports()
-        self._ml_task = self.reports_[0].ml_task
+            self._initialized_with_data_op = False
+            if data is not None:
+                raise TypeError(
+                    "`data` can only be provided when estimator "
+                    "is a SkrubLearner. Provide X and y instead."
+                )
+            self.learner_ = to_learner(estimator)
+            self._data = {"_skrub_X": X, "_skrub_y": y}
+        if getattr(self, "_splitter", None) is None:
+            self._splitter = check_cv(splitter, y, classifier=is_classifier(estimator))
+            self._split_indices = tuple(self._splitter.split(X, y))
 
     def _fit_estimator_reports(self) -> list[EstimatorReport]:
         """Fit the estimator reports.

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -250,7 +250,10 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             self._data = data | {"_skrub_X": X, "_skrub_y": y}
             if splitter is None and (cv := X_y_cv.get("cv")) is not None:
                 self._splitter = cv
-                self._split_indices = tuple(cv.split(X, y, **X_y_cv["split_kwargs"]))
+                split_kwargs = X_y_cv["split_kwargs"]
+                if split_kwargs is None:
+                    split_kwargs = {}
+                self._split_indices = tuple(cv.split(X, y, **split_kwargs))
         else:
             self._initialized_with_data_op = False
             if data is not None:

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -676,7 +676,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         return self._data.copy()
 
     @property
-    def splitter(self) -> SKLearnCrossValidator | None:
+    def splitter(self) -> SKLearnCrossValidator:
         return self._splitter
 
     @property
@@ -753,15 +753,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                     f" (± {timings.loc['Predict time test (s)', 'std']:.3f})"
                 ),
                 "n_folds": len(self.reports_),
-                "splitter_repr": (
-                    repr(self.splitter)
-                    if self.splitter is not None
-                    else (
-                        "from DataOp"
-                        if self._initialized_with_data_op
-                        else f"{len(self.split_indices)} folds"
-                    )
-                ),
+                "splitter_repr": (repr(self.splitter)),
                 "metrics_text": metrics_text,
                 **markdown_data_section(summary, data_label="full"),
             },

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -21,19 +21,28 @@ from skore._sklearn._base import _BaseReport
 from skore._sklearn._checks.base import CheckCode
 from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
 from skore._sklearn._estimator.report import EstimatorReport
-from skore._sklearn.types import PositiveLabel, SKLearnCrossValidator
+from skore._sklearn.types import (
+    _DEFAULT,
+    PositiveLabel,
+    SKLearnCrossValidator,
+    _DefaultType,
+)
 from skore._utils._fixes import _validate_joblib_parallel_params
 from skore._utils._parallel import delayed
 from skore._utils._progress_bar import track
-from skore._utils._skrub import eval_X_y, is_skrub_learner, to_estimator, to_learner
+from skore._utils._skrub import (
+    eval_X_y,
+    is_skrub_learner,
+    resolve_data_op_split_indices,
+    to_estimator,
+    to_learner,
+)
 from skore._utils.repr.data import get_documentation_url
 from skore._utils.repr.html_repr import render_template
 from skore._utils.repr.markdown import markdown_data_section, report_markdown_context
 from skore._utils.repr.utils import repair_estimator_html_for_slotted_host
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from skore._sklearn._checks.accessor import _ChecksAccessor
     from skore._sklearn._cross_validation.data_accessor import _DataAccessor
     from skore._sklearn._cross_validation.inspection_accessor import (
@@ -225,7 +234,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         y: ArrayLike | None = None,
         data: dict | None = None,
         pos_label: PositiveLabel | None = None,
-        splitter: int | SKLearnCrossValidator | Generator | None = None,
+        splitter: int | SKLearnCrossValidator | Generator | _DefaultType | None = None,
         n_jobs: int | None = None,
     ) -> None:
         super().__init__()
@@ -243,8 +252,26 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             _check_estimator_and_data(clone(estimator), X, y, data)
         )
         self._pos_label = pos_label
-        self._splitter = check_cv(splitter, y, classifier=is_classifier(estimator))
-        self._split_indices = tuple(self._splitter.split(self.X, self.y))
+        if self._initialized_with_data_op:
+            cv_for_indices = splitter if splitter is not None else _DEFAULT
+            self._split_indices = resolve_data_op_split_indices(
+                self.learner_.data_op,
+                self._data,
+                cv=cv_for_indices,
+            )
+            self._splitter = (
+                None
+                if splitter in (None, _DEFAULT)
+                else check_cv(
+                    splitter, self.y, classifier=is_classifier(self.estimator_)
+                )
+            )
+        else:
+            resolved_splitter = None if splitter is _DEFAULT else splitter
+            self._splitter = check_cv(
+                resolved_splitter, y, classifier=is_classifier(estimator)
+            )
+            self._split_indices = tuple(self._splitter.split(self.X, self.y))
         self.n_jobs = n_jobs
 
         self.reports_: list[EstimatorReport] = self._fit_estimator_reports()
@@ -659,11 +686,11 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         return self._data.copy()
 
     @property
-    def splitter(self) -> SKLearnCrossValidator:
+    def splitter(self) -> SKLearnCrossValidator | None:
         return self._splitter
 
     @property
-    def split_indices(self) -> tuple[tuple[Iterable[int], Iterable[int]]]:
+    def split_indices(self) -> tuple[tuple[ArrayLike, ArrayLike], ...]:
         return self._split_indices
 
     @property
@@ -739,7 +766,11 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                 "splitter_repr": (
                     repr(self.splitter)
                     if self.splitter is not None
-                    else f"{len(self.split_indices)} folds"
+                    else (
+                        "from DataOp"
+                        if self._initialized_with_data_op
+                        else f"{len(self.split_indices)} folds"
+                    )
                 ),
                 "metrics_text": metrics_text,
                 **markdown_data_section(summary, data_label="full"),

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -11,6 +11,8 @@ from skore._sklearn._comparison.report import ComparisonReport
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._estimator.report import EstimatorReport
 from skore._sklearn.train_test_split import TrainTestSplit
+from skore._sklearn.types import _DEFAULT, _DefaultType
+from skore._utils._skrub import data_op_has_explicit_cv, get_data_op
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -24,7 +26,12 @@ def evaluate(
     y: ArrayLike | None = None,
     data: dict | None = None,
     *,
-    splitter: float | int | str | SKLearnCrossValidator | Generator = 0.2,
+    splitter: float
+    | int
+    | str
+    | SKLearnCrossValidator
+    | Generator
+    | _DefaultType = _DEFAULT,
     pos_label: int | float | bool | str | None = None,
     n_jobs: int | None = None,
 ) -> EstimatorReport | CrossValidationReport | ComparisonReport:
@@ -64,7 +71,11 @@ def evaluate(
         (e.g. ``{"X": X_df, "other_table": df, ...}``).
 
     splitter : float, int, str, or cross-validation object, default=0.2
-        Determines how the data is split:
+        Determines how the data is split. When omitted, a skrub learner whose
+        DataOp was configured with an explicit cross-validation splitter via
+        :meth:`~skrub.DataOp.skb.mark_as_X` uses that splitter (including
+        ``split_kwargs`` such as ``groups``). Otherwise, the default is a
+        single 80/20 train-test split:
 
         - ``float``: perform a single train-test split where the data is shuffled before
           splitting with a fixed seed (``random_state=0``) for reproducibility.
@@ -202,6 +213,20 @@ def evaluate(
         return ComparisonReport(reports, n_jobs=n_jobs)
 
     X = cast(ArrayLike | None, X)
+
+    if splitter is _DEFAULT:
+        data_op = get_data_op(estimator)
+        if data_op is not None and data_op_has_explicit_cv(data_op):
+            return CrossValidationReport(
+                estimator,
+                X,
+                y,
+                data=data,
+                pos_label=pos_label,
+                splitter=_DEFAULT,
+                n_jobs=n_jobs,
+            )
+        splitter = 0.2
 
     if isinstance(splitter, str):
         if splitter != "prefit":

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -223,7 +223,7 @@ def evaluate(
                 y,
                 data=data,
                 pos_label=pos_label,
-                splitter=_DEFAULT,
+                splitter=None,
                 n_jobs=n_jobs,
             )
         splitter = 0.2
@@ -260,6 +260,8 @@ def evaluate(
                 n_jobs=n_jobs,
             )
         return report.reports_[0]
+
+    splitter = cast(int | SKLearnCrossValidator | Generator, splitter)
 
     return CrossValidationReport(
         estimator,

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from collections.abc import Generator
+from typing import cast
 
 from numpy.typing import ArrayLike
 
@@ -11,13 +12,13 @@ from skore._sklearn._comparison.report import ComparisonReport
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._estimator.report import EstimatorReport
 from skore._sklearn.train_test_split import TrainTestSplit
-from skore._sklearn.types import _DEFAULT, _DefaultType
+from skore._sklearn.types import (
+    _DEFAULT,
+    EstimatorLike,
+    SKLearnCrossValidator,
+    _DefaultType,
+)
 from skore._utils._skrub import data_op_has_explicit_cv, get_data_op
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from skore._sklearn.types import EstimatorLike, SKLearnCrossValidator
 
 
 def evaluate(

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -1,11 +1,19 @@
 import functools
-from typing import TypeGuard
+from typing import TYPE_CHECKING, TypeGuard
 
+import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
 from skrub import DataOp, SkrubLearner
 
-from skore._sklearn.types import EstimatorLike
+from skore._sklearn.types import _DEFAULT, EstimatorLike, _DefaultType
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from numpy.typing import ArrayLike
+
+    from skore._sklearn.types import SKLearnCrossValidator
 
 
 def eval_X_y(data_op: DataOp, env: dict) -> dict:
@@ -27,6 +35,37 @@ def eval_X_y(data_op: DataOp, env: dict) -> dict:
 def is_skrub_learner(obj: EstimatorLike) -> TypeGuard[SkrubLearner]:
     """Detect if obj is a skrub learner (SkrubLearner, ParamSearch, OptunaSearch)."""
     return hasattr(obj, "__skrub_to_Xy_pipeline__")
+
+
+def get_data_op(estimator: EstimatorLike) -> DataOp | None:
+    """Return the DataOp backing a skrub learner, if any."""
+    if isinstance(estimator, DataOp):
+        return estimator
+    if is_skrub_learner(estimator):
+        return estimator.data_op
+    return None
+
+
+def data_op_has_explicit_cv(data_op: DataOp) -> bool:
+    """Return whether ``mark_as_X`` was called with an explicit ``cv`` argument."""
+    return "cv" in data_op.skb.find_X_y()
+
+
+def resolve_data_op_split_indices(
+    data_op: DataOp,
+    environment: dict,
+    *,
+    cv: int | SKLearnCrossValidator | Generator | _DefaultType | None = _DEFAULT,
+) -> tuple[tuple[ArrayLike, ArrayLike], ...]:
+    """Resolve cross-validation split indices from a skrub DataOp."""
+    cv_arg = None if cv is _DEFAULT else cv
+    return tuple(
+        (
+            np.asarray(split["row_indices_train"]),
+            np.asarray(split["row_indices_test"]),
+        )
+        for split in data_op.skb.iter_cv_splits(environment=environment, cv=cv_arg)
+    )
 
 
 class _LearnerAdapter(BaseEstimator):

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from typing import TYPE_CHECKING, TypeGuard
 

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, TypeGuard
+from typing import TypeGuard
 
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
 from skrub import DataOp, SkrubLearner
 
 from skore._sklearn.types import EstimatorLike
-
-if TYPE_CHECKING:
-    pass
 
 
 def eval_X_y(data_op: DataOp, env: dict) -> dict:
@@ -45,7 +42,7 @@ def get_data_op(estimator: EstimatorLike) -> DataOp | None:
 
 def data_op_has_explicit_cv(data_op: DataOp) -> bool:
     """Return whether ``mark_as_X`` was called with an explicit ``cv`` argument."""
-    return "cv" in data_op.skb.find_X_y()
+    return data_op.skb.find_X_y().get("cv") is None
 
 
 class _LearnerAdapter(BaseEstimator):

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -42,7 +42,7 @@ def get_data_op(estimator: EstimatorLike) -> DataOp | None:
 
 def data_op_has_explicit_cv(data_op: DataOp) -> bool:
     """Return whether ``mark_as_X`` was called with an explicit ``cv`` argument."""
-    return data_op.skb.find_X_y().get("cv") is None
+    return data_op.skb.find_X_y().get("cv") is not None
 
 
 class _LearnerAdapter(BaseEstimator):

--- a/skore/src/skore/_utils/_skrub.py
+++ b/skore/src/skore/_utils/_skrub.py
@@ -3,19 +3,14 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING, TypeGuard
 
-import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
 from skrub import DataOp, SkrubLearner
 
-from skore._sklearn.types import _DEFAULT, EstimatorLike, _DefaultType
+from skore._sklearn.types import EstimatorLike
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from numpy.typing import ArrayLike
-
-    from skore._sklearn.types import SKLearnCrossValidator
+    pass
 
 
 def eval_X_y(data_op: DataOp, env: dict) -> dict:
@@ -51,23 +46,6 @@ def get_data_op(estimator: EstimatorLike) -> DataOp | None:
 def data_op_has_explicit_cv(data_op: DataOp) -> bool:
     """Return whether ``mark_as_X`` was called with an explicit ``cv`` argument."""
     return "cv" in data_op.skb.find_X_y()
-
-
-def resolve_data_op_split_indices(
-    data_op: DataOp,
-    environment: dict,
-    *,
-    cv: int | SKLearnCrossValidator | Generator | _DefaultType | None = _DEFAULT,
-) -> tuple[tuple[ArrayLike, ArrayLike], ...]:
-    """Resolve cross-validation split indices from a skrub DataOp."""
-    cv_arg = None if cv is _DEFAULT else cv
-    return tuple(
-        (
-            np.asarray(split["row_indices_train"]),
-            np.asarray(split["row_indices_test"]),
-        )
-        for split in data_op.skb.iter_cv_splits(environment=environment, cv=cv_arg)
-    )
 
 
 class _LearnerAdapter(BaseEstimator):

--- a/skore/tests/unit/dispatch/test_evaluate.py
+++ b/skore/tests/unit/dispatch/test_evaluate.py
@@ -1,7 +1,9 @@
+import numpy as np
 import pytest
 import skrub
+from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LinearRegression, LogisticRegression
-from sklearn.model_selection import KFold, StratifiedKFold
+from sklearn.model_selection import KFold, LeaveOneGroupOut, StratifiedKFold
 
 from skore import ComparisonReport, CrossValidationReport, EstimatorReport, evaluate
 
@@ -252,3 +254,62 @@ def test_evaluate_learner(binary_classification_data):
     learner = skrub.X().skb.apply(LogisticRegression(), y=skrub.y()).skb.make_learner()
     report = evaluate(learner, data={"X": X, "y": y}, splitter=Splitter())
     assert len(report.reports_) == 5
+
+
+def test_evaluate_skrub_learner_default_holdout_without_explicit_cv(
+    binary_classification_data,
+):
+    """Skrub learners without an explicit DataOp cv keep the 0.2 holdout default."""
+    X, y = binary_classification_data
+    learner = skrub.X().skb.apply(LogisticRegression(), y=skrub.y()).skb.make_learner()
+    report = evaluate(learner, data={"X": X, "y": y})
+    assert isinstance(report, EstimatorReport)
+    assert len(report.X_test) == round(0.2 * len(X))
+
+
+def test_evaluate_skrub_learner_uses_data_op_cv_with_split_kwargs():
+    """Reproduce issue #2884: grouped CV from mark_as_X split_kwargs."""
+    df = skrub.datasets.toy_products()
+    data = skrub.var("df", df)
+    groups = data["seller"]
+    X = data[["description", "price"]].skb.mark_as_X(
+        cv=LeaveOneGroupOut(), split_kwargs={"groups": groups}
+    )
+    y = data["category"].skb.mark_as_y()
+    pred = X.skb.apply(DummyClassifier(), y=y)
+    learner = pred.skb.make_learner()
+
+    report = evaluate(learner, data={"df": df})
+    assert isinstance(report, CrossValidationReport)
+    assert len(report.reports_) == 2
+
+    expected_indices = tuple(
+        (split["row_indices_train"], split["row_indices_test"])
+        for split in pred.skb.iter_cv_splits(environment={"df": df}, cv=None)
+    )
+    assert len(report.split_indices) == len(expected_indices)
+    for (train_a, test_a), (train_b, test_b) in zip(
+        report.split_indices, expected_indices, strict=True
+    ):
+        np.testing.assert_array_equal(train_a, train_b)
+        np.testing.assert_array_equal(test_a, test_b)
+
+    skrub_cv = pred.skb.cross_validate({"df": df})
+    skore_accuracy = report.metrics.accuracy(aggregate="mean").iloc[0, 0]
+    assert skore_accuracy == pytest.approx(skrub_cv["test_score"].mean())
+
+
+def test_evaluate_skrub_learner_explicit_splitter_overrides_data_op_cv():
+    """An explicit splitter argument overrides the DataOp cv configuration."""
+    df = skrub.datasets.toy_products()
+    data = skrub.var("df", df)
+    groups = data["seller"]
+    X = data[["description", "price"]].skb.mark_as_X(
+        cv=LeaveOneGroupOut(), split_kwargs={"groups": groups}
+    )
+    y = data["category"].skb.mark_as_y()
+    learner = X.skb.apply(DummyClassifier(), y=y).skb.make_learner()
+
+    report = evaluate(learner, data={"df": df}, splitter=3)
+    assert isinstance(report, CrossValidationReport)
+    assert len(report.reports_) == 3

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -12,7 +12,7 @@ from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LinearRegression, LogisticRegression
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import LeaveOneGroupOut, train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.utils.validation import check_is_fitted
 
@@ -317,6 +317,56 @@ def test_report_with_data_op():
     assert list(report.metrics.accuracy(aggregate="mean").columns) == [
         ("SkrubLearner", "mean")
     ]
+
+
+def test_cross_validation_report_split_indices_from_data_op_cv():
+    """CrossValidationReport derives split indices from skrub iter_cv_splits."""
+    df = skrub.datasets.toy_products()
+    data = skrub.var("df", df)
+    groups = data["seller"]
+    X = data[["description", "price"]].skb.mark_as_X(
+        cv=LeaveOneGroupOut(), split_kwargs={"groups": groups}
+    )
+    y = data["category"].skb.mark_as_y()
+    pred = X.skb.apply(DummyClassifier(), y=y)
+    environment = {"df": df}
+
+    expected_indices = tuple(
+        (split["row_indices_train"], split["row_indices_test"])
+        for split in pred.skb.iter_cv_splits(environment=environment, cv=None)
+    )
+    report = CrossValidationReport(pred.skb.make_learner(), data=environment)
+
+    assert len(report.split_indices) == len(expected_indices)
+    for (train_a, test_a), (train_b, test_b) in zip(
+        report.split_indices, expected_indices, strict=True
+    ):
+        np.testing.assert_array_equal(train_a, train_b)
+        np.testing.assert_array_equal(test_a, test_b)
+
+
+def test_get_from_dict_with_grouped_data_op_cv():
+    """Serialization roundtrip preserves grouped CV folds from a DataOp."""
+    df = skrub.datasets.toy_products()
+    data = skrub.var("df", df)
+    groups = data["seller"]
+    X = data[["description", "price"]].skb.mark_as_X(
+        cv=LeaveOneGroupOut(), split_kwargs={"groups": groups}
+    )
+    y = data["category"].skb.mark_as_y()
+    pred = X.skb.apply(DummyClassifier(), y=y)
+
+    report = CrossValidationReport(pred, data={"df": df})
+    expected_accuracy = report.metrics.accuracy()
+    expected_preds = report.get_predictions(data_source="test")
+    state = report.to_dict()
+
+    restored = CrossValidationReport.from_dict(state)
+    restored.clear_cache()
+    assert restored.metrics.accuracy().equals(expected_accuracy)
+    preds = restored.get_predictions(data_source="test")
+    for pred_fold, expected_pred in zip(preds, expected_preds, strict=True):
+        np.testing.assert_array_equal(pred_fold, expected_pred)
 
 
 def test_create_estimator_report_with_data_op():


### PR DESCRIPTION
closes #2884 

Support more advanced cross-validation by leveraging `split_kwargs` from skrub `DataOp`.