### PR TITLE
fix(skore-hub): Handle multioutput regression in the Skore Hub

### DIFF
--- a/skore/src/skore/_plugins/hub/report/cross_validation_report.py
+++ b/skore/src/skore/_plugins/hub/report/cross_validation_report.py
@@ -55,6 +55,36 @@ SPLITTERS = {
 }
 
 
+def _regression_target_kdes(
+    y: np.ndarray,
+) -> tuple[list[list[float]], list[tuple[float, float]]]:
+    """Estimate per-target density curves for regression splitting strategy."""
+    sample_count = TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT
+    y = np.asarray(y)
+    if y.ndim == 1:
+        lo, hi = float(y.min()), float(y.max())
+        linspace = np.linspace(lo, hi, num=sample_count)
+        kde = gaussian_kde(y)
+        return [[float(x) for x in kde(linspace)]], [(lo, hi)]
+
+    curves: list[list[float]] = []
+    ranges: list[tuple[float, float]] = []
+    for col in y.T:
+        col_arr = np.asarray(col).ravel()
+        lo, hi = float(col_arr.min()), float(col_arr.max())
+        linspace = np.linspace(lo, hi, num=sample_count)
+        curves.append([float(x) for x in gaussian_kde(col_arr).evaluate(linspace)])
+        ranges.append((lo, hi))
+    return curves, ranges
+
+
+def _flatten_regression_target_kdes(curves: list[list[float]]) -> list[float]:
+    """Flatten per-target density curves for hub payload storage."""
+    if len(curves) == 1:
+        return curves[0]
+    return [value for curve in curves for value in curve]
+
+
 class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
     """
     Payload used to send a cross-validation report to ``hub``.
@@ -93,6 +123,8 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
     def model_post_init(self, _: Any) -> None:  # noqa: D102
         self.__sample_to_class_index: list[int] | None
         self.__classes: list[str] | None
+        self.__target_names: list[str] | None
+        self.__target_ranges: list[list[float]] | None
 
         if "classification" in self.ml_task and (self.report.y is not None):
             class_to_class_indice: defaultdict[Any, int] = defaultdict(
@@ -109,9 +141,24 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
             self.__classes = [str(class_) for class_ in class_to_class_indice]
 
             assert max(self.__sample_to_class_index) == (len(self.__classes) - 1)
+            self.__target_names = None
+            self.__target_ranges = None
+        elif self.ml_task == "multioutput-regression" and (self.report.y is not None):
+            from skore._utils._dataframe import _normalize_y_as_dataframe
+
+            y_df = _normalize_y_as_dataframe(self.report.y)
+            self.__sample_to_class_index = None
+            self.__classes = None
+            self.__target_names = [str(name) for name in y_df.columns]
+            y_arr = np.asarray(self.report.y)
+            self.__target_ranges = [
+                [float(col.min()), float(col.max())] for col in y_arr.T
+            ]
         else:
             self.__sample_to_class_index = None
             self.__classes = None
+            self.__target_names = None
+            self.__target_ranges = None
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
@@ -219,16 +266,12 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
                     train_target_distribution.append(train.get(label, 0))
                     test_target_distribution.append(test.get(label, 0))
             else:
-                y = np.asarray(self.report.y)
-                linspace = np.linspace(
-                    float(y.min()),
-                    float(y.max()),
-                    num=TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT,
+                train_curves, _ = _regression_target_kdes(train_y)
+                test_curves, _ = _regression_target_kdes(test_y)
+                train_target_distribution = _flatten_regression_target_kdes(
+                    train_curves
                 )
-                train_kernel = gaussian_kde(train_y)
-                train_target_distribution = [float(x) for x in train_kernel(linspace)]
-                test_kernel = gaussian_kde(test_y)
-                test_target_distribution = [float(x) for x in test_kernel(linspace)]
+                test_target_distribution = _flatten_regression_target_kdes(test_curves)
 
             train_target_distributions.append(train_target_distribution)
             train_target_distributions_sample_count.append(len(train_y))
@@ -255,6 +298,18 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
     def class_names(self) -> list[str] | None:
         """In classification, the class names of the dataset used in the report."""
         return self.__classes
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def target_names(self) -> list[str] | None:
+        """In multi-output regression, the target names of the dataset."""
+        return self.__target_names
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def target_ranges(self) -> list[list[float]] | None:
+        """In multi-output regression, the per-target value ranges."""
+        return self.__target_ranges
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -198,6 +198,52 @@ class TestCrossValidationReportPayload:
         }
 
     @mark.filterwarnings(
+        (
+            "ignore:scipy.optimize.*The `disp` and `iprint` options of the L-BFGS-B "
+            "solver are deprecated:DeprecationWarning"
+        ),
+    )
+    def test_multioutput_regression_splitting_strategy(self, project, monkeypatch):
+        """Regression for https://github.com/probabl-ai/skore/issues/3021."""
+        monkeypatch.setattr(
+            "skore._plugins.hub.report.cross_validation_report.TARGET_DISTRIBUTION_REPR_SAMPLE_COUNT",
+            10,
+        )
+
+        X, y = make_regression(
+            n_samples=100, n_features=10, n_targets=2, random_state=0
+        )
+
+        report = CrossValidationReport(
+            DummyRegressor(), X, y, splitter=KFold(3, shuffle=False)
+        )
+        payload = CrossValidationReportPayload(
+            project=project, report=report, key="<key>"
+        )
+
+        train_target_distributions = payload.splitting_strategy[
+            "train_target_distributions"
+        ]
+        test_target_distributions = payload.splitting_strategy[
+            "test_target_distributions"
+        ]
+
+        for train_distribution, test_distribution in zip(
+            train_target_distributions, test_target_distributions, strict=True
+        ):
+            assert len(train_distribution) == len(test_distribution) == 20
+            assert all(distribution >= 0 for distribution in train_distribution)
+            assert all(distribution >= 0 for distribution in test_distribution)
+
+        assert payload.ml_task == "multioutput-regression"
+        assert payload.target_names == ["Target 0", "Target 1"]
+        assert payload.target_ranges == [
+            [float(y[:, 0].min()), float(y[:, 0].max())],
+            [float(y[:, 1].min()), float(y[:, 1].max())],
+        ]
+        assert payload.target_range == [float(y.min()), float(y.max())]
+
+    @mark.filterwarnings(
         # ignore deprecation warning due to `scikit-learn` misusing `scipy` arguments,
         # raised by `scipy`
         (
@@ -711,6 +757,8 @@ class TestCrossValidationReportPayload:
             "class_names": ["1", "0"],
             "groups": None,
             "target_range": None,
+            "target_names": None,
+            "target_ranges": None,
         }
 
     @mark.respx(assert_all_called=False)


### PR DESCRIPTION
closes #3021 

Make it possible to send multioutput regression data to the hub for the target distribution