### PR TITLE
fix: Ensure y_test is provided to estimator report

### DIFF
--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -87,9 +87,9 @@ def _check_estimator_and_data(
                 "Provide X_train, y_train, X_test, y_test instead."
             )
         estimator = to_learner(estimator)
-        if X_test is None:
+        if X_test is None or y_test is None:
             raise TypeError(
-                "X_test must be provided (unless estimator is a "
+                "Test data must be provided (unless estimator is a "
                 "SkrubLearner and test_data is provided instead)."
             )
         test_data = {"_skrub_X": X_test, "_skrub_y": y_test}

--- a/skore/tests/unit/reports/comparison/estimator/test_report.py
+++ b/skore/tests/unit/reports/comparison/estimator/test_report.py
@@ -39,14 +39,6 @@ def test_different_test_data(
             ]
         )
 
-    # If there is an X_test but no y_test, it should not raise an error
-    ComparisonReport(
-        [
-            EstimatorReport(estimator, fit=False, X_test=X_test, y_test=None),
-            EstimatorReport(estimator, fit=False, X_test=X_test, y_test=None),
-        ]
-    )
-
 
 def test_init_different_ml_usecases(
     estimator_reports_binary_classification, estimator_reports_regression

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -616,3 +616,5 @@ def test_no_data_error():
     estimator = DummyClassifier().fit(X, y)
     with pytest.raises(TypeError, match="Test data must be provided"):
         EstimatorReport(estimator)
+        EstimatorReport(estimator, X_test=X)
+        EstimatorReport(estimator, y_test=y)

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -614,5 +614,5 @@ def test_no_data_error():
     with pytest.raises(TypeError, match="test_data must be provided"):
         EstimatorReport(learner)
     estimator = DummyClassifier().fit(X, y)
-    with pytest.raises(TypeError, match="X_test must be provided"):
+    with pytest.raises(TypeError, match="Test data must be provided"):
         EstimatorReport(estimator)


### PR DESCRIPTION
Follow-up to #2992. 

I realized while working on #3074 that `y_test` is not mandatory for non skrub estimators, despite our philosophy of requiring test data to create a report.

For instance, this snippet works on main:
```python
from skore import evaluate
from sklearn.datasets import make_regression
import pandas as pd
from skrub import tabular_pipeline
from sklearn.linear_model import RidgeCV

X, y = make_regression(n_samples=1_000, n_features=10, noise=0.1)
X, y = pd.DataFrame(X, columns=[f"f_{i}" for i in range(X.shape[1])]), pd.Series(y)

model = tabular_pipeline(RidgeCV())
model.fit(X, y)
report_ridge = evaluate(model, X, splitter="prefit")
```
But any other action, such as displaying the metrics summary or the report's repr, fails.