### PR TITLE
fix: Ensure X and y are provided to CrossValidationReport

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -87,6 +87,11 @@ def _check_estimator_and_data(
                 "`data` can only be provided when estimator "
                 "is a SkrubLearner. Provide X and y instead."
             )
+        if X is None or y is None:
+            raise TypeError(
+                "X and y must be provided (unless estimator is a "
+                "SkrubLearner and data is provided instead)."
+            )
         estimator = to_learner(estimator)
         data = {"_skrub_X": X, "_skrub_y": y}
     return initialized_with_data_op, estimator, data

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -656,8 +656,8 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         return self._data["_skrub_X"]
 
     @property
-    def y(self) -> ArrayLike | None:
-        return self._data.get("_skrub_y")
+    def y(self) -> ArrayLike:
+        return self._data["_skrub_y"]
 
     @property
     def input_data(self) -> dict:

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -445,3 +445,12 @@ def test_state_has_no_unexpected_data_copy(estimator, splitter):
     # However, this is a heuristic; if this test fails, it may also be because the state
     # size is no longer dominated by the size of X.
     assert state_nbytes_without_data(report) < X.nbytes
+
+
+def test_no_data_error():
+    X, y = make_classification()
+    estimator = DummyClassifier()
+    with pytest.raises(TypeError, match="X and y must be provided"):
+        CrossValidationReport(estimator, splitter=2)
+        CrossValidationReport(estimator, X=X, splitter=2)
+        CrossValidationReport(estimator, y=y, splitter=2)


### PR DESCRIPTION
## What

Applies the same fix as #3076 to `CrossValidationReport`.

When `initialized_with_data_op = False`, `_check_estimator_and_data` never validated that `X` and `y` are both non-`None`. This caused silent failures downstream instead of a clear error at construction time.

For example:
```python
evaluate(model, X, splitter=5)   # y defaults to None → confusing error deep in CV
evaluate(model, y, splitter=5)   # X=y_array, y=None → same issue
CrossValidationReport(model, X=X, splitter=2)  # y missing → same issue
```

## How

Added a guard in `CrossValidationReport._check_estimator_and_data` (non-SkrubLearner branch) that raises `TypeError` when `X is None or y is None`, mirroring the fix in #3076 for `EstimatorReport`.

Added `test_no_data_error` to the `CrossValidationReport` test suite, mirroring the pattern added in #3076.