### PR TITLE
feat: Remove multi-dataset X from evaluate

### DIFF
--- a/examples/technical_details/plot_skore_api.py
+++ b/examples/technical_details/plot_skore_api.py
@@ -149,7 +149,7 @@ comparison_report = evaluate(
     y,
     splitter=0.2,
 )
-comparison_report.help()
+comparison_report
 
 # %%
 comparison_report.metrics.summarize().frame()

--- a/examples/technical_details/plot_skore_api.py
+++ b/examples/technical_details/plot_skore_api.py
@@ -152,7 +152,7 @@ comparison_report = evaluate(
 comparison_report.help()
 
 # %%
-_ = comparison_report.metrics.summarize().plot()
+comparison_report.metrics.summarize().frame()
 
 # %%
 # To compare evaluations on different feature matrices, call
@@ -168,7 +168,7 @@ comparison_report = compare([report_logistic, report_forest])
 comparison_report.help()
 
 # %%
-_ = comparison_report.metrics.summarize().plot()
+comparison_report.metrics.summarize().frame()
 
 # %%
 # Summary

--- a/examples/technical_details/plot_skore_api.py
+++ b/examples/technical_details/plot_skore_api.py
@@ -45,8 +45,9 @@ produce a visualization return a **Display** object with ``plot()``, ``frame()``
 # :class:`~skore.EstimatorReport`. The accessors and display API shown below
 # are the same for the other report types.
 from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
-from skore import evaluate
+from skore import compare, evaluate
 from skrub import tabular_pipeline
 
 X, y = load_breast_cancer(return_X_y=True, as_frame=True)
@@ -131,10 +132,43 @@ _ = cv_report.inspection.coefficients().plot(select_k=10, sorting_order="descend
 # Third report type: comparison
 # =============================
 #
-# ``inspection`` accessors (no ``data`` accessor on
-# :class:`~skore.ComparisonReport`). To compare evaluations on different
-# feature matrices, use :func:`~skore.evaluate` then :func:`~skore.compare`.
-# The display API is unchanged.
+# Skore makes it possible to compare several estimators side by side with a
+# :class:`~skore.ComparisonReport`. Pass a list or dict of estimators to
+# :func:`~skore.evaluate` along with a single ``X`` and ``y``; each model is
+# evaluated on the same data. The resulting report exposes the same
+# ``metrics`` and ``inspection`` accessors as the other report types (there is
+# no ``data`` accessor, because compared models may rely on different inputs).
+# Methods on these accessors still return **Display** objects, so the display
+# API is unchanged.
+comparison_report = evaluate(
+    [
+        tabular_pipeline(LogisticRegression()),
+        tabular_pipeline(RandomForestClassifier()),
+    ],
+    X,
+    y,
+    splitter=0.2,
+)
+comparison_report.help()
+
+# %%
+_ = comparison_report.metrics.summarize().plot()
+
+# %%
+# To compare evaluations on different feature matrices, call
+# :func:`~skore.evaluate` once per matrix, then pass the resulting reports to
+# :func:`~skore.compare`:
+X_1 = X.iloc[:, :15]
+X_2 = X.iloc[:, 15:]
+report_logistic = evaluate(tabular_pipeline(LogisticRegression()), X_1, y, splitter=0.2)
+report_forest = evaluate(
+    tabular_pipeline(RandomForestClassifier()), X_2, y, splitter=0.2
+)
+comparison_report = compare([report_logistic, report_forest])
+comparison_report.help()
+
+# %%
+_ = comparison_report.metrics.summarize().plot()
 
 # %%
 # Summary

--- a/examples/technical_details/plot_skore_api.py
+++ b/examples/technical_details/plot_skore_api.py
@@ -131,10 +131,10 @@ _ = cv_report.inspection.coefficients().plot(select_k=10, sorting_order="descend
 # Third report type: comparison
 # =============================
 #
-# Passing a **list or dict of estimators** to :func:`~skore.evaluate` returns a
-# :class:`~skore.ComparisonReport`. It exposes the same ``metrics`` and
-# ``inspection`` accessors (no ``data`` accessor, since compared models can
-# use different datasets). The display API is unchanged.
+# ``inspection`` accessors (no ``data`` accessor on
+# :class:`~skore.ComparisonReport`). To compare evaluations on different
+# feature matrices, use :func:`~skore.evaluate` then :func:`~skore.compare`.
+# The display API is unchanged.
 
 # %%
 # Summary

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -23,7 +23,7 @@ from skore._utils._skrub import data_op_has_explicit_cv, get_data_op
 
 def evaluate(
     estimator: EstimatorLike | list[EstimatorLike] | dict[str, EstimatorLike],
-    X: ArrayLike | list[ArrayLike | None] | dict[str, ArrayLike] | None = None,
+    X: ArrayLike | None = None,
     y: ArrayLike | None = None,
     data: dict | None = None,
     *,
@@ -53,15 +53,12 @@ def evaluate(
         - a skrub :class:`~skrub.SkrubLearner` extracted from a :class:`~skrub.DataOp`
           by calling :meth:`~skrub.DataOp.skb.make_learner`.
 
-    X : array-like, list of array-like, dict of array-like, or None
-        Feature matrix. When ``estimator`` is a list, ``X`` can be a list of
-        feature matrices (one per estimator) to compare models with different
-        preprocessing pipelines. When ``estimator`` is a dict, ``X`` can be a
-        dict with the same keys, mapping each name to its feature matrix, or
-        a single matrix broadcast to every estimator. When comparing prefit
-        estimators and no test features are needed, pass ``X=None``. A list of
-        ``X`` is not supported when ``estimator`` is a dict; use a dict aligned on
-        names or a single matrix.
+    X : array-like or None
+        Feature matrix shared by all estimators when comparing several models.
+        When comparing prefit estimators and no test features are needed,
+        pass ``X=None``. To compare estimators evaluated on different feature
+        matrices, call :func:`~skore.evaluate` once per estimator, then
+        :func:`~skore.compare`.
 
     y : array-like of shape (n_samples,), or None
         Target vector.
@@ -148,10 +145,11 @@ def evaluate(
     >>> list(report.reports_)
     ['m1', 'm2']
     """
-    if not isinstance(estimator, (list, dict)) and isinstance(X, (list, dict)):
+    if isinstance(X, (list, dict)):
         raise TypeError(
-            "X must be a single array-like (or None) when estimator is not a list"
-            " or dict."
+            "X must be a single array-like or None. To compare estimators "
+            "evaluated on different feature matrices, call evaluate() once per "
+            "model, then use skore.compare()."
         )
 
     if X is None and y is None and data is None:
@@ -163,33 +161,11 @@ def evaluate(
         if isinstance(estimator, dict):
             names = list(estimator.keys())
             estimators = list(estimator.values())
-            if isinstance(X, list):
-                raise TypeError(
-                    "When estimator is a dict, X cannot be a list. Pass a single "
-                    "array-like broadcast to all estimators, or a "
-                    "dict[str, array-like] with the same keys as estimator."
-                )
-            if isinstance(X, dict):
-                if set(X) != set(names):
-                    raise ValueError(
-                        "When estimator and X are both dicts, they must have the "
-                        f"same keys; got estimator keys {sorted(names)!r}"
-                        f" and X keys {sorted(X)!r}."
-                    )
-
-                Xs = [X[name] for name in names]
-            else:
-                Xs = [cast(ArrayLike, X)] * len(estimators)
-        else:  # isinstance(estimator, list)
+        else:
             names = None
             estimators = estimator
-            if isinstance(X, dict):
-                raise TypeError(
-                    "When estimator is a list, X cannot be a dict. Pass a single "
-                    "array-like broadcast to all estimators, or a list of "
-                    "array-like with one matrix per estimator."
-                )
-            Xs = cast(list, X if isinstance(X, list) else [X] * len(estimators))
+
+        Xs = [cast(ArrayLike, X)] * len(estimators)
 
         reports = cast(
             list[EstimatorReport] | list[CrossValidationReport],
@@ -212,8 +188,6 @@ def evaluate(
                 dict(zip(names, reports, strict=True)), n_jobs=n_jobs
             )
         return ComparisonReport(reports, n_jobs=n_jobs)
-
-    X = cast(ArrayLike | None, X)
 
     if splitter is _DEFAULT:
         data_op = get_data_op(estimator)

--- a/skore/tests/unit/dispatch/test_evaluate.py
+++ b/skore/tests/unit/dispatch/test_evaluate.py
@@ -83,18 +83,12 @@ def test_multiple_estimators_cv(regression_data):
     assert isinstance(report, ComparisonReport)
 
 
-def test_list_X_raises(regression_data):
-    """Passing list X raises TypeError."""
+def test_list_or_dict_X_raises(regression_data):
+    """Passing list or dict X raises TypeError."""
     X, y = regression_data
-    with pytest.raises(TypeError, match="single array-like or None"):
-        evaluate(LinearRegression(), [X], y)
-
-
-def test_dict_X_raises(regression_data):
-    """Passing dict X raises TypeError."""
-    X, y = regression_data
-    with pytest.raises(TypeError, match="single array-like or None"):
-        evaluate(LinearRegression(), {"a": X}, y)
+    for invalid_x in ([X], {"a": X}):
+        with pytest.raises(TypeError, match="single array-like or None"):
+            evaluate(LinearRegression(), invalid_x, y)
 
 
 def test_multiple_estimators_dict(regression_data):

--- a/skore/tests/unit/dispatch/test_evaluate.py
+++ b/skore/tests/unit/dispatch/test_evaluate.py
@@ -83,23 +83,18 @@ def test_multiple_estimators_cv(regression_data):
     assert isinstance(report, ComparisonReport)
 
 
-def test_multiple_estimators_multiple_X(regression_data):
-    """A list of estimators with a list of X returns a ComparisonReport."""
+def test_list_X_raises(regression_data):
+    """Passing list X raises TypeError."""
     X, y = regression_data
-    report = evaluate([LinearRegression(), LinearRegression()], [X, X], y, splitter=0.2)
-    assert isinstance(report, ComparisonReport)
+    with pytest.raises(TypeError, match="single array-like or None"):
+        evaluate(LinearRegression(), [X], y)
 
 
-def test_list_estimator_dict_X_raises(regression_data):
-    """List estimators with a dict X raises TypeError."""
+def test_dict_X_raises(regression_data):
+    """Passing dict X raises TypeError."""
     X, y = regression_data
-    with pytest.raises(TypeError, match="cannot be a dict"):
-        evaluate(
-            [LinearRegression(), LinearRegression()],
-            {"a": X, "b": X},
-            y,
-            splitter=0.2,
-        )
+    with pytest.raises(TypeError, match="single array-like or None"):
+        evaluate(LinearRegression(), {"a": X}, y)
 
 
 def test_multiple_estimators_dict(regression_data):
@@ -130,44 +125,6 @@ def test_multiple_estimators_dict_cv(regression_data):
     assert set(report.reports_) == {"a", "b"}
 
 
-def test_multiple_estimators_dict_per_estimator_X(regression_data):
-    """A dict of estimators with a dict of X (same keys) returns a ComparisonReport."""
-    X, y = regression_data
-    report = evaluate(
-        {"a": LinearRegression(), "b": LinearRegression()},
-        {"a": X, "b": X},
-        y,
-        splitter=0.2,
-    )
-    assert isinstance(report, ComparisonReport)
-    assert set(report.reports_) == {"a", "b"}
-
-
-def test_dict_estimator_list_X_raises(regression_data):
-    """Dict estimators with a list X raises TypeError."""
-    X, y = regression_data
-    with pytest.raises(TypeError, match="X cannot be a list"):
-        evaluate(
-            {"a": LinearRegression(), "b": LinearRegression()},
-            [X, X],
-            y,
-            splitter=0.2,
-        )
-
-
-def test_dict_estimator_mismatched_X_keys_raises(regression_data):
-    """Dict estimators with dict X whose keys differ from estimator raises
-    ValueError."""
-    X, y = regression_data
-    with pytest.raises(ValueError, match="same keys"):
-        evaluate(
-            {"a": LinearRegression(), "b": LinearRegression()},
-            {"a": X, "c": X},
-            y,
-            splitter=0.2,
-        )
-
-
 def test_dict_estimators_prefit(regression_data):
     """A dict of fitted estimators with splitter='prefit' returns ComparisonReport."""
     X, y = regression_data
@@ -183,20 +140,6 @@ def test_empty_dict_raises(regression_data):
     X, y = regression_data
     with pytest.raises(ValueError, match="Expected.*reports to compare"):
         evaluate({}, X, y)
-
-
-def test_single_estimator_list_X_raises(regression_data):
-    """A single estimator with list X raises TypeError."""
-    X, y = regression_data
-    with pytest.raises(TypeError, match="single array-like"):
-        evaluate(LinearRegression(), [X], y)
-
-
-def test_single_estimator_dict_X_raises(regression_data):
-    """A single estimator with dict X raises TypeError."""
-    X, y = regression_data
-    with pytest.raises(TypeError, match="single array-like"):
-        evaluate(LinearRegression(), {"a": X}, y)
 
 
 def test_invalid_splitter_string(regression_data):

--- a/skore/tests/unit/reports/comparison/test_report.py
+++ b/skore/tests/unit/reports/comparison/test_report.py
@@ -17,6 +17,7 @@ from skore import (
     ComparisonReport,
     CrossValidationReport,
     EstimatorReport,
+    compare,
     evaluate,
 )
 from skore._externals._sklearn_compat import convert_container
@@ -484,7 +485,10 @@ def test_to_markdown_pos_label():
 def test_to_markdown_different_datasets():
     X1, y = make_classification(n_samples=100, n_features=20, random_state=0)
     X2, _ = make_classification(n_samples=100, n_features=10, random_state=1)
-    report = evaluate([LinearRegression(), LinearRegression()], [X1, X2], y)
+    model = LinearRegression()
+    r1 = evaluate(model, X1, y)
+    r2 = evaluate(model, X2, y)
+    report = compare([r1, r2])
     markdown = report.to_markdown()
     assert "## Data" in markdown
     assert "| report name | n_rows | n_columns |" in markdown


### PR DESCRIPTION
Closes #3077

<!--
🙌 Thanks for contributing a pull request!

If this is your first contribution, take a look at our contribution guidelines:
https://docs.skore.probabl.ai/stable/contributing.html
-->
#### Change description

This PR removes the option to pass a **list** or **dict** as `X` in `skore.evaluate()`.

Before, you could do something like `evaluate([model1, model2], [X1, X2], y)` to give each model its own dataset. I am removing that because preprocessing should live in the model/pipeline, and it’s clearer to evaluate separately and then compare.

**What still works:**
- `evaluate(model, X, y)` 
- `evaluate([m1, m2], X, y)`

**What to do instead if you had different X per model:**
```python
r1 = evaluate(model, X_raw, y, splitter=0.2)
r2 = evaluate(model, X_engineered, y, splitter=0.2)
compare({"raw": r1, "engineered": r2})
```
<!--
Please describe what your contribution changes for skore.

Here is some inspiration for what to write here:
- Are you adding a new feature? Fixing a bug?
- Can you give an example of your change in action, e.g. a snippet of code or a plot?
- Is your change likely to break users' code?
- Are there any other details the reviewer should be aware of, such as API design choices, performance characteristics or edge cases?

Please reference issues/PRs when possible, e.g. "Fixes #1234", "Closes #3456", "See also #7890".
More information [here](https://github.com/blog/1506-closing-issues-via-pull-requests).
-->

#### Contribution checklist
<!--
Below are some of the criteria that the review will include.
Feel free to use it as a checklist to ensure that your contribution is high-quality.
-->

- [x] Unit tests were added or updated (if necessary)
- [x] Documentation was added or updated (if necessary)
- [x] The code passes our style conventions (you can check this by running pre-commit on your code
with `pre-commit run --all-files`)
- [x] All the tests pass (please test locally before pushing)
- [ ] The documentation builds and renders properly (if it does, our bot will add a comment linking
to a preview of the documentation to review it visually)
- [x] All the commits in the PR are signed (more information
[here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
- [x] The pull request title respects the Conventional Commits convention (more information
[here](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests))

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure you understand our [automated contributions policy](https://docs.skore.probabl.ai/stable/contributing.html#automated-contributions-policy)
-->
AI tools were involved for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

<!-- Any other comments can go here. Thanks again for contributing! -->
I used AI to understand the code and find places where changes were necessary, and to check my code before testing. 