### PR TITLE
ci: Dispatch end-to-end event on push@main/pull-request

### DIFF
--- a/.github/workflows/dispatch-end-to-end.yml
+++ b/.github/workflows/dispatch-end-to-end.yml
@@ -1,0 +1,80 @@
+name: dispatch-end-to-end
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  dispatch:
+    if: >-
+      ${{
+        (github.repository == 'probabl-ai/skore') &&
+        (
+          (github.event_name == 'push') ||
+          (
+            github.event.issue.pull_request &&
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+            (
+              startsWith(github.event.comment.body, '/e2e') ||
+              startsWith(github.event.comment.body, '/end-to-end')
+            )
+          )
+        )
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: React to command
+        if: ${{ github.event_name == 'issue_comment' }}
+        run: gh api --method POST "/repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" -f content=rocket
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+
+      - name: Resolve sha
+        id: resolve-sha
+        shell: bash
+        run: |
+          set -eu
+
+          if [ "${EVENT_NAME}" = "issue_comment" ]; then
+            sha=$(gh api "${URL}" --jq .head.sha)
+          else
+            sha="${SHA}"
+          fi
+
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          URL: ${{ github.event.issue.pull_request.url }}
+          SHA: ${{ github.sha }}
+
+      - name: Generate end-to-end-dispatcher-app token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: create-end-to-end-dispatcher-app-token
+        with:
+          client-id: ${{ secrets.END_TO_END_DISPATCHER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.END_TO_END_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: probabl-ai
+          repositories: skore-end-to-end-ci
+
+      - name: Dispatch end-to-end event
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ steps.create-end-to-end-dispatcher-app-token.outputs.token }}
+          repository: probabl-ai/skore-end-to-end-ci
+          event-type: test
+          client-payload: |
+            {
+              "repository": "${{ github.event.repository.name }}",
+              "ref": "${{ steps.resolve-sha.outputs.sha }}"
+            }


### PR DESCRIPTION
Dispatch an end-to-end event to trigger the end-to-end test suite.

The event is automatically dispatched on `push@main` or in a pull-request by commenting manually using:
- `/e2e`,
- `/end-to-end`.

---

The status is directly reported in the PR in live:

<img width="808" height="92" alt="image" src="https://github.com/user-attachments/assets/d916d0c7-c67f-4d09-8fa9-9d26263011a1" />

<img width="811" height="86" alt="image" src="https://github.com/user-attachments/assets/1f19f2f3-1bf1-4482-a0b5-fc02d505b386" />

---

You can click on the status to get an URL pointing to the E2E:

<img width="619" height="263" alt="image" src="https://github.com/user-attachments/assets/2e80a305-22ed-4b1b-940f-1b0af473eba4" />

---

You can click on the URL to get details:

<img width="1576" height="892" alt="image" src="https://github.com/user-attachments/assets/ab83612e-e852-4f88-9146-da7b1b804271" />