### PR TITLE
fix(checks): Use type().__name__ in not applicable reasons

### DIFF
--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -776,12 +776,12 @@ class CheckTrainTestTimeOverlap(Check):
             if not nw.dependencies.is_into_dataframe(report.X_train):
                 raise CheckNotApplicable(
                     "Input data is not a narwhals compatible DataFrame. "
-                    f"Got {type(report.X_train)}."
+                    f"Got {type(report.X_train).__name__}."
                 )
             if not nw.dependencies.is_into_dataframe(report.X_test):
                 raise CheckNotApplicable(
                     "Input data is not a narwhals compatible DataFrame. "
-                    f"Got {type(report.X_test)}."
+                    f"Got {type(report.X_test).__name__}."
                 )
             X_train_nw = nw.from_native(report.X_train)
             X_test_nw = nw.from_native(report.X_test)
@@ -846,7 +846,8 @@ class CheckHyperparamsAtSearchEdge(Check):
         estimator = get_fitted_estimator(report)
         if not isinstance(estimator, BaseSearchCV):
             raise CheckNotApplicable(
-                f"Estimator is not a BaseSearchCV instance. Got {type(estimator)}."
+                "Estimator is not a BaseSearchCV instance. "
+                f"Got {type(estimator).__name__}."
             )
 
         param_combinations = estimator.cv_results_["params"]
@@ -940,7 +941,8 @@ class CheckSearchParamsToTune(Check):
         estimator = get_fitted_estimator(report)
         if not isinstance(estimator, BaseSearchCV):
             raise CheckNotApplicable(
-                f"Estimator is not a BaseSearchCV instance. Got {type(estimator)}."
+                "Estimator is not a BaseSearchCV instance. "
+                f"Got {type(estimator).__name__}."
             )
 
         searched_keys = {


### PR DESCRIPTION
Makes not applicable reasons more readable:

Before:
<img width="960" height="157" alt="image" src="https://github.com/user-attachments/assets/d266d939-ae8e-40ca-a691-0593d4ea7ef9" />


After:
<img width="960" height="130" alt="image" src="https://github.com/user-attachments/assets/2fbbabcb-a1b9-4d61-a4b4-d024c171489b" />
