### PR TITLE
feat: Make custom metrics available as methods

### DIFF
--- a/examples/model_evaluation/plot_custom_metrics.py
+++ b/examples/model_evaluation/plot_custom_metrics.py
@@ -69,7 +69,14 @@ report.metrics.add(make_scorer(specificity))
 report.metrics.summarize().frame()
 
 # %%
-# ``specificity`` now appears alongside the built-in metrics.
+# ``specificity`` now appears alongside the built-in metrics. It can also be computed
+# individually using the :meth:`~skore.EstimatorReport.metrics.get` method:
+report.metrics.get("specificity")
+
+# %%
+# Further, if the metric name is a valid identifier, the metric is also exposed as a
+# method:
+report.metrics.specificity()
 
 # %%
 # Passing extra keyword arguments

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -205,7 +205,7 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
     ) -> pd.DataFrame:
         """Metric summary.
 
-        Used for displaying the report.
+        Used for displaying the accessor.
         """
         return self.summarize().frame()
 

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -10,6 +10,7 @@ from skore._project.git import git_commit
 from skore._sklearn._checks._utils import CheckNotApplicable
 from skore._sklearn._checks.base import Check, CheckCode
 from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
+from skore._sklearn.types import DataSource
 from skore._utils._progress_bar import track
 from skore._utils.repr.base import (
     AccessorHelpMixin,
@@ -18,6 +19,8 @@ from skore._utils.repr.base import (
 )
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from skore._sklearn._checks.accessor import _ChecksAccessor
 
 
@@ -193,3 +196,30 @@ class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
     def __dir__(self) -> list[str]:
         """Add custom metrics to __dir__ for tab-completion."""
         return list(set(super().__dir__()).union(self.available()))
+
+    def _formatted_summary_frame(
+        self,
+        *,
+        data_source: DataSource = "test",
+        metric: str | list[str] | None = None,
+    ) -> pd.DataFrame:
+        """Metric summary.
+
+        Used for displaying the report.
+        """
+        return self.summarize().frame()
+
+    def __repr__(self) -> str:
+        return (
+            "Metrics summary:\n"
+            f"{self._formatted_summary_frame()!r}\n"
+            "Explore available methods with .help()."
+        )
+
+    def _repr_html_(self) -> str:
+        return (
+            "<p>Metrics summary:</p>"
+            f"{self._formatted_summary_frame()._repr_html_()}"
+            '<p role="note">Explore available methods with '
+            "<code>.help()</code>.</p>"
+        )

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from functools import partial
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 from uuid import uuid4
@@ -172,3 +173,23 @@ class _BaseAccessor(AccessorHelpMixin, Generic[ParentT]):
 
     def _repr_mimebundle_(self, **kwargs):
         return {"text/plain": repr(self), "text/html": self._repr_html_()}
+
+
+class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):
+    """Base class for metrics accessor."""
+
+    def __getattr__(self, name):
+        """Define custom metric methods dynamically.
+
+        If attribute ``name`` is defined statically, this method will not be called.
+        """
+        if name in self.available():
+            return partial(lambda *args, **kwargs: self.get(name, *args, **kwargs))
+
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'"
+        )
+
+    def __dir__(self) -> list[str]:
+        """Add custom metrics to __dir__ for tab-completion."""
+        return list(set(super().__dir__()).union(self.available()))

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -119,6 +119,10 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         data_source: DataSource = "test",
         metric: str | list[str] | None = None,
     ) -> pd.DataFrame:
+        """Metric summary.
+
+        Used for displaying the report.
+        """
         frame = self.summarize(data_source=data_source, metric=metric).frame()
         frame = frame.rename_axis(
             None
@@ -1054,23 +1058,8 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         )
 
     ####################################################################################
-    # Methods related to the help tree
+    # Methods related to displays
     ####################################################################################
-
-    def __repr__(self) -> str:
-        return (
-            "Metrics summary:\n"
-            f"{self._formatted_summary_frame()!r}\n"
-            "Explore available methods with .help()."
-        )
-
-    def _repr_html_(self) -> str:
-        return (
-            "<p>Metrics summary:</p>"
-            f"{self._formatted_summary_frame()._repr_html_()}"
-            '<p role="note">Explore available methods with '
-            "<code>.help()</code>.</p>"
-        )
 
     @available_if(
         _check_supported_ml_task(

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -10,7 +10,7 @@ from numpy.typing import ArrayLike
 from sklearn.utils.metaestimators import available_if
 
 from skore._externals._pandas_accessors import DirNamesMixin
-from skore._sklearn._base import _BaseAccessor
+from skore._sklearn._base import BaseMetricsAccessor
 from skore._sklearn._comparison.report import ComparisonReport
 from skore._sklearn._plot.metrics import (
     ConfusionMatrixDisplay,
@@ -31,7 +31,7 @@ from skore._utils._progress_bar import track
 DataSource = Literal["test", "train", "both"]
 
 
-class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
+class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
     """Accessor for metrics-related operations.
 
     You can access this accessor using the `metrics` attribute.
@@ -246,6 +246,10 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
         Metric              Label
         ...
         Mean Absolute Error                    ...                   ...
+        >>> report.metrics.mean_absolute_error()
+        Estimator             LogisticRegression_1  LogisticRegression_2
+        Metric
+        Mean Absolute Error                   ...                   ...
         """
         for report in self._parent.reports_.values():
             report.metrics.add(

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1025,23 +1025,8 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
         ).frame(aggregate=aggregate, flat_index=flat_index)
 
     ####################################################################################
-    # Methods related to the help tree
+    # Methods related to displays
     ####################################################################################
-
-    def __repr__(self) -> str:
-        return (
-            "Metrics summary:\n"
-            f"{self.summarize().frame()!r}\n"
-            "Explore available methods with .help()."
-        )
-
-    def _repr_html_(self) -> str:
-        return (
-            "<p>Metrics summary:</p>"
-            f"{self.summarize().frame()._repr_html_()}"
-            '<p role="note">Explore available methods with '
-            "<code>.help()</code>.</p>"
-        )
 
     @available_if(_check_estimator_report_has_method("metrics", "roc"))
     def roc(

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike
 from sklearn.utils.metaestimators import available_if
 
 from skore._externals._pandas_accessors import DirNamesMixin
-from skore._sklearn._base import _BaseAccessor
+from skore._sklearn._base import BaseMetricsAccessor
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._plot import (
     ConfusionMatrixDisplay,
@@ -29,7 +29,7 @@ from skore._utils._progress_bar import track
 DataSource = Literal["test", "train"]
 
 
-class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
+class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin):
     """Accessor for metrics-related operations.
 
     You can access this accessor using the `metrics` attribute.
@@ -193,6 +193,11 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
         Metric
         ...
         Mean Absolute Error      ...       ...
+        >>> report.metrics.mean_absolute_error()
+                             LogisticRegression
+                                          mean   std
+        Metric
+        Mean Absolute Error            0.05...   ...
         """
         for report in self._parent.reports_:
             report.metrics.add(

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -8,7 +8,7 @@ from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.utils.metaestimators import available_if
 
 from skore._externals._pandas_accessors import DirNamesMixin
-from skore._sklearn._base import _BaseAccessor
+from skore._sklearn._base import BaseMetricsAccessor
 from skore._sklearn._estimator.report import EstimatorReport
 from skore._sklearn._plot import (
     ConfusionMatrixDisplay,
@@ -19,7 +19,6 @@ from skore._sklearn._plot import (
 )
 from skore._sklearn._plot.metrics.metrics_summary_display import MetricsSummaryRow
 from skore._sklearn.metrics import (
-    BUILTIN_METRICS,
     R2,
     Accuracy,
     Brier,
@@ -42,27 +41,11 @@ from skore._utils._accessor import _check_supported_ml_task
 from skore._utils._cache_key import make_cache_key
 
 
-class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
+class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
     """Accessor for metrics-related operations.
 
     You can access this accessor using the `metrics` attribute.
     """
-
-    def __getattribute__(self, name):
-        """Hide some metric methods conditionally.
-
-        When the registry is initialized, the report is analyzed to filter metrics
-        depending on the report's characteristics (e.g. the ML task and the estimator's
-        prediction methods).
-        """
-        if (
-            name in {m.name for m in BUILTIN_METRICS}
-            and name not in self._parent._metric_registry
-        ):
-            raise AttributeError(
-                f"'{self.__class__.__name__}' object has no attribute '{name}'"
-            )
-        return super().__getattribute__(name)
 
     def summarize(
         self,
@@ -268,6 +251,8 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         Metric
                                            ...
         Mean Absolute Error                ...
+        >>> report.metrics.mean_absolute_error()
+        0.05...
         """
         try:
             self._parent._metric_registry.add(
@@ -419,6 +404,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         }
         return {k: v for k, v in times.items() if v is not None}
 
+    @available_if(lambda self: Score.available(self._parent))
     def score(
         self,
         *,
@@ -455,6 +441,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         """
         return Score().pretty(report=self._parent, data_source=data_source)
 
+    @available_if(lambda self: Accuracy.available(self._parent))
     def accuracy(
         self,
         *,
@@ -488,6 +475,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         """
         return Accuracy().pretty(report=self._parent, data_source=data_source)
 
+    @available_if(lambda self: Precision.available(self._parent))
     def precision(
         self,
         *,
@@ -547,6 +535,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             report=self._parent, data_source=data_source, average=average
         )
 
+    @available_if(lambda self: Recall.available(self._parent))
     def recall(
         self,
         *,
@@ -612,6 +601,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             report=self._parent, data_source=data_source, average=average
         )
 
+    @available_if(lambda self: Brier.available(self._parent))
     def brier_score(
         self,
         *,
@@ -645,6 +635,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         """
         return Brier().pretty(report=self._parent, data_source=data_source)
 
+    @available_if(lambda self: RocAuc.available(self._parent))
     def roc_auc(
         self,
         *,
@@ -718,6 +709,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             multi_class=multi_class,
         )
 
+    @available_if(lambda self: LogLoss.available(self._parent))
     def log_loss(
         self,
         *,
@@ -751,6 +743,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         """
         return LogLoss().pretty(report=self._parent, data_source=data_source)
 
+    @available_if(lambda self: R2.available(self._parent))
     def r2(
         self,
         *,
@@ -799,6 +792,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             report=self._parent, data_source=data_source, multioutput=multioutput
         )
 
+    @available_if(lambda self: Rmse.available(self._parent))
     def rmse(
         self,
         *,
@@ -847,6 +841,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             report=self._parent, data_source=data_source, multioutput=multioutput
         )
 
+    @available_if(lambda self: Mae.available(self._parent))
     def mae(
         self,
         *,
@@ -895,6 +890,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             report=self._parent, data_source=data_source, multioutput=multioutput
         )
 
+    @available_if(lambda self: Mape.available(self._parent))
     def mape(
         self,
         *,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -937,25 +937,6 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
         )
 
     ####################################################################################
-    # Methods related to the help tree
-    ####################################################################################
-
-    def __repr__(self) -> str:
-        return (
-            "Metrics summary:\n"
-            f"{self.summarize().frame()!r}\n"
-            "Explore available methods with .help()."
-        )
-
-    def _repr_html_(self) -> str:
-        return (
-            "<p>Metrics summary:</p>"
-            f"{self.summarize().frame()._repr_html_()}"
-            '<p role="note">Explore available methods with '
-            "<code>.help()</code>.</p>"
-        )
-
-    ####################################################################################
     # Methods related to displays
     ####################################################################################
 

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -320,10 +320,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
         >>> report.metrics.get("precision")
         {0: 0.90..., 1: 0.98...}
         """
-        try:
-            metric = self._parent._metric_registry[name]
-        except KeyError:
-            raise KeyError(f"{name!r} not found in the registered metrics") from None
+        metric = self._parent._metric_registry[name]
         return metric.pretty(report=self._parent, data_source=data_source, **kwargs)
 
     def fit_time(self, *, cast: bool = True) -> float | None:

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -156,7 +156,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
     def _metric(
         self, metric_name: str, *, data_source: DataSource, **kwargs: Any
     ) -> MetricsSummaryDisplay:
-        """Compute a single metric, forwarding *kwargs* to the score function."""
+        """Compute a single metric, forwarding ``kwargs`` to the score function."""
         metric = self._parent._metric_registry[metric_name]
         rows = [
             cast(
@@ -242,7 +242,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
         >>> from skore import evaluate
         >>> X, y = load_breast_cancer(return_X_y=True)
         >>> classifier = LogisticRegression(max_iter=10_000)
-        >>> report = evaluate(classifier, X, y, splitter=0.2, pos_label=1)
+        >>> report = evaluate(classifier, X, y, pos_label=1)
         >>> report.metrics.add(
         ...     make_scorer(mean_absolute_error, response_method="predict")
         ... )

--- a/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
@@ -327,9 +327,6 @@ def test_get_custom(comparison_cross_validation_reports_binary_classification):
     }
 
 
-# report.metrics.<custom>
-
-
 def test_custom_metric_as_method(
     comparison_cross_validation_reports_binary_classification,
 ):

--- a/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
@@ -325,3 +325,30 @@ def test_get_custom(comparison_cross_validation_reports_binary_classification):
         ("std", "DummyClassifier_1"): {"Hello": 0.0},
         ("std", "DummyClassifier_2"): {"Hello": 0.0},
     }
+
+
+# report.metrics.<custom>
+
+
+def test_custom_metric_as_method(
+    comparison_cross_validation_reports_binary_classification,
+):
+    """Custom metrics are accessible as methods."""
+    report = comparison_cross_validation_reports_binary_classification
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()
+
+    report.metrics.add(lambda estimator, X, y: 1, name="hello")
+
+    assert report.metrics.hello().to_dict() == {
+        ("mean", "DummyClassifier_1"): {"Hello": 1.0},
+        ("mean", "DummyClassifier_2"): {"Hello": 1.0},
+        ("std", "DummyClassifier_1"): {"Hello": 0.0},
+        ("std", "DummyClassifier_2"): {"Hello": 0.0},
+    }
+
+    report.metrics.remove("hello")
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -353,9 +353,6 @@ def test_get_custom(comparison_estimator_reports_binary_classification):
     }
 
 
-# report.metrics.<custom>
-
-
 def test_custom_metric_as_method(comparison_estimator_reports_binary_classification):
     """Custom metrics are accessible as methods."""
     report = comparison_estimator_reports_binary_classification

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -351,3 +351,26 @@ def test_get_custom(comparison_estimator_reports_binary_classification):
         "DummyClassifier_1": {"Hello": 1},
         "DummyClassifier_2": {"Hello": 1},
     }
+
+
+# report.metrics.<custom>
+
+
+def test_custom_metric_as_method(comparison_estimator_reports_binary_classification):
+    """Custom metrics are accessible as methods."""
+    report = comparison_estimator_reports_binary_classification
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()
+
+    report.metrics.add(lambda estimator, X, y: 1, name="hello")
+
+    assert report.metrics.hello().to_dict() == {
+        "DummyClassifier_1": {"Hello": 1},
+        "DummyClassifier_2": {"Hello": 1},
+    }
+
+    report.metrics.remove("hello")
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()

--- a/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.datasets import make_classification
+from sklearn.dummy import DummyClassifier
 from sklearn.svm import SVC
 
 from skore import CrossValidationReport
@@ -236,3 +237,29 @@ def test_get_custom(forest_binary_classification_data):
         ("RandomForestClassifier", "mean"): {"Hello": 1.0},
         ("RandomForestClassifier", "std"): {"Hello": 0.0},
     }
+
+
+# report.metrics.<custom>
+
+
+def test_custom_metric_as_method(forest_binary_classification_data):
+    """Custom metrics are accessible as methods."""
+    _, X, y = forest_binary_classification_data
+    report = CrossValidationReport(
+        DummyClassifier(strategy="uniform"), X, y, splitter=2
+    )
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()
+
+    report.metrics.add(lambda estimator, X, y: 1, name="hello")
+
+    assert report.metrics.hello().to_dict() == {
+        ("DummyClassifier", "mean"): {"Hello": 1.0},
+        ("DummyClassifier", "std"): {"Hello": 0.0},
+    }
+
+    report.metrics.remove("hello")
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()

--- a/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
@@ -213,9 +213,9 @@ def test_precision_recall_pos_label_overwrite(
 # report.metrics.get
 
 
-def test_get(forest_binary_classification_data):
+def test_get(binary_classification_data):
     """``get`` works."""
-    _, X, y = forest_binary_classification_data
+    X, y = binary_classification_data
     report = CrossValidationReport(
         DummyClassifier(strategy="uniform"), X, y, splitter=2
     )
@@ -225,9 +225,9 @@ def test_get(forest_binary_classification_data):
         report.metrics.get("non-existing metric")
 
 
-def test_get_custom(forest_binary_classification_data):
+def test_get_custom(binary_classification_data):
     """``get`` works for custom metrics."""
-    _, X, y = forest_binary_classification_data
+    X, y = binary_classification_data
     report = CrossValidationReport(
         DummyClassifier(strategy="uniform"), X, y, splitter=2
     )
@@ -243,12 +243,9 @@ def test_get_custom(forest_binary_classification_data):
     }
 
 
-# report.metrics.<custom>
-
-
-def test_custom_metric_as_method(forest_binary_classification_data):
+def test_custom_metric_as_method(binary_classification_data):
     """Custom metrics are accessible as methods."""
-    _, X, y = forest_binary_classification_data
+    X, y = binary_classification_data
     report = CrossValidationReport(
         DummyClassifier(strategy="uniform"), X, y, splitter=2
     )

--- a/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_numeric.py
@@ -215,8 +215,10 @@ def test_precision_recall_pos_label_overwrite(
 
 def test_get(forest_binary_classification_data):
     """``get`` works."""
-    estimator, X, y = forest_binary_classification_data
-    report = CrossValidationReport(estimator, X, y, splitter=2)
+    _, X, y = forest_binary_classification_data
+    report = CrossValidationReport(
+        DummyClassifier(strategy="uniform"), X, y, splitter=2
+    )
 
     assert isinstance(report.metrics.get("precision"), pd.DataFrame)
     with pytest.raises(KeyError):
@@ -225,8 +227,10 @@ def test_get(forest_binary_classification_data):
 
 def test_get_custom(forest_binary_classification_data):
     """``get`` works for custom metrics."""
-    estimator, X, y = forest_binary_classification_data
-    report = CrossValidationReport(estimator, X, y, splitter=2)
+    _, X, y = forest_binary_classification_data
+    report = CrossValidationReport(
+        DummyClassifier(strategy="uniform"), X, y, splitter=2
+    )
 
     with pytest.raises(KeyError):
         report.metrics.get("hello")
@@ -234,8 +238,8 @@ def test_get_custom(forest_binary_classification_data):
     report.metrics.add(lambda estimator, X, y: 1, name="hello")
 
     assert report.metrics.get("hello").to_dict() == {
-        ("RandomForestClassifier", "mean"): {"Hello": 1.0},
-        ("RandomForestClassifier", "std"): {"Hello": 0.0},
+        ("DummyClassifier", "mean"): {"Hello": 1.0},
+        ("DummyClassifier", "std"): {"Hello": 0.0},
     }
 
 

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -257,3 +257,34 @@ def test_get_custom(binary_classification_report):
     report.metrics.add(lambda estimator, X, y: 1, name="hello")
 
     assert report.metrics.get("hello") == 1
+
+
+# report.metrics.<custom>
+
+
+def test_custom_metric_as_method(binary_classification_report):
+    """Custom metrics are accessible as methods."""
+    report = binary_classification_report
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()
+
+    report.metrics.add(lambda estimator, X, y: 1, name="hello")
+
+    assert report.metrics.hello() == 1
+
+    report.metrics.remove("hello")
+
+    with pytest.raises(AttributeError):
+        report.metrics.hello()
+
+
+def test_custom_metric_as_method_neg(binary_classification_report):
+    """Custom metrics which are `neg_` sklearn methods are accessible as methods."""
+    report = binary_classification_report
+
+    report.metrics.add("neg_mean_squared_error")
+    assert report.metrics.neg_mean_squared_error() == 0
+
+    report.metrics.add("mean_squared_error")
+    assert report.metrics.mean_squared_error() == 0

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -259,9 +259,6 @@ def test_get_custom(binary_classification_report):
     assert report.metrics.get("hello") == 1
 
 
-# report.metrics.<custom>
-
-
 def test_custom_metric_as_method(binary_classification_report):
     """Custom metrics are accessible as methods."""
     report = binary_classification_report
@@ -285,6 +282,9 @@ def test_custom_metric_as_method_neg(binary_classification_report):
 
     report.metrics.add("neg_mean_squared_error")
     assert report.metrics.neg_mean_squared_error() == 0
+
+    with pytest.raises(AttributeError):
+        report.metrics.mean_squared_error()
 
     report.metrics.add("mean_squared_error")
     assert report.metrics.mean_squared_error() == 0

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -182,9 +182,8 @@ class TestRemove:
     def test_remove_unknown_metric_raises(self, binary_classification_report):
         """Removing a name that was never added raises KeyError."""
         report = binary_classification_report
-        with pytest.raises(KeyError) as exc_info:
+        with pytest.raises(KeyError, match="no_such_metric"):
             report.metrics.remove("no_such_metric")
-        assert exc_info.value.args[0] == "no_such_metric"
 
     def test_remove_builtin_metric(self, binary_classification_report):
         """Built-in metrics can be removed from the registry."""


### PR DESCRIPTION
Closes https://github.com/probabl-ai/skore-hub/issues/941

The main changes are in the first commit, the rest is some cleanups I did along the way; I can split them into other PRs if need be.

Overrides `__getattr__` so that the metrics registry is checked when `report.metrics.<thing>` is accessed (except if the method is defined statically). I replaced `__getattribute__` with `__getattr__` because `__getattribute__` is more low-level and harder to manipulate safely. This made it harder to both add new methods and hide non-applicable ones, so I put back `available_if`s and made `__getattr__`'s only responsibility to add new methods. This works out nicely because every `_MetricsAccessor` class now shares the same behaviour and I could refactor it to a `BaseMetricsAccessor`.

As discussed IRL, re-defining the builtin metrics using this mechanism is deferred because the UX would be really bare-bones (no documentation).
