### PR TITLE
feat!: Stop deep-copying reports every time

### DIFF
--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import copy
 import html
 import uuid
-import warnings
 from dataclasses import asdict
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
@@ -114,9 +112,8 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         - a skrub :class:`~skrub.SkrubLearner` extracted from a :class:`~skrub.DataOp`
           by calling :meth:`~skrub.DataOp.skb.make_learner`.
 
-        The estimator passed will not be modified in-place: it is deep-copied, and if
-        it is not already fitted, the copy is cloned before being fitted on the
-        training data.
+        If the estimator is not fitted, it is cloned and then fitted on the training
+        data.
 
     X_train : {array-like, sparse matrix} of shape (n_samples, n_features) or \
             None
@@ -237,22 +234,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
             estimator_.fit(data)
         return estimator_, fit_time()
 
-    @classmethod
-    def _copy_estimator(cls, estimator: EstimatorLike) -> EstimatorLike:
-        """Copy the estimator."""
-        try:
-            return copy.deepcopy(estimator)
-        except Exception as e:
-            warnings.warn(
-                "Deepcopy failed; using estimator as-is. "
-                "Be aware that modifying the estimator outside of "
-                f"{cls.__name__} will modify the internal estimator. "
-                "Consider using a FrozenEstimator from scikit-learn to prevent this. "
-                f"Original error: {e}",
-                stacklevel=1,
-            )
-        return estimator
-
     def __init__(
         self,
         estimator: EstimatorLike,
@@ -266,7 +247,6 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         pos_label: PositiveLabel | None = None,
     ) -> None:
         super().__init__()
-        estimator = self._copy_estimator(estimator)
         self.estimator = estimator
 
         if isinstance(estimator, skrub.DataOp):

--- a/skore/src/skore/_utils/_testing.py
+++ b/skore/src/skore/_utils/_testing.py
@@ -73,7 +73,7 @@ class MockEstimator(ClassifierMixin, BaseEstimator):
 
     def __sklearn_clone__(self):
         self.n_call += 1
-        return self
+        return super().__sklearn_clone__()
 
     def predict(self, X):
         return np.ones(X.shape[0])

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -164,13 +164,7 @@ def test_pickle(tmp_path, logistic_binary_classification_data):
     joblib.dump(report, tmp_path / "report.joblib")
 
 
-@pytest.mark.parametrize(
-    "error",
-    [
-        ValueError("No more fitting"),
-        KeyboardInterrupt(),
-    ],
-)
+@pytest.mark.parametrize("error", [ValueError("No more fitting"), KeyboardInterrupt()])
 @pytest.mark.parametrize("n_jobs", [None, 1, 2])
 def test_interrupted_propagates_error(binary_classification_data, error, n_jobs):
     """Check that when a split fails during cross-validation, the error propagates."""

--- a/skore/tests/unit/reports/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_numeric.py
@@ -42,31 +42,6 @@ def test_interaction_cache_metrics(linear_regression_multioutput_with_test):
     )
 
 
-@pytest.mark.parametrize("prefit_estimator", [True, False])
-def test_has_side_effects(prefit_estimator):
-    """Re-fitting the estimator outside the EstimatorReport
-    should not have an effect on the EstimatorReport's internal estimator."""
-    X, y = make_classification(n_classes=2, random_state=42)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-
-    estimator = LogisticRegression()
-    if prefit_estimator:
-        estimator.fit(X_train, y_train)
-
-    report = EstimatorReport(
-        estimator,
-        X_train=X_train,
-        X_test=X_test,
-        y_train=y_train,
-        y_test=y_test,
-    )
-
-    predictions_before = report.estimator_.predict_proba(X_test)
-    estimator.fit(X_test, y_test)
-    predictions_after = report.estimator_.predict_proba(X_test)
-    np.testing.assert_array_equal(predictions_before, predictions_after)
-
-
 @pytest.mark.parametrize("metric", ["brier_score", "log_loss"])
 def test_brier_log_loss_requires_probabilities(metric):
     """Check that the Brier score and the Log loss is not defined for estimator

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -773,7 +773,7 @@ def test_not_applicable_reason_in_summarize(regression_train_test_split):
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     na = report.checks.summarize().frame(section="not_applicable").set_index("code")
     assert "SKD001" in na.index
-    assert na.loc["SKD001", "explanation"] == ("Train data is unavailable.")
+    assert na.loc["SKD001", "explanation"] == "Train data is unavailable."
 
 
 def test_exception_when_baseline_report_creation_fails(regression_data, monkeypatch):

--- a/skore/tests/unit/reports/estimator/test_report.py
+++ b/skore/tests/unit/reports/estimator/test_report.py
@@ -320,20 +320,6 @@ def test_clustering():
         EstimatorReport(KMeans(), X_test=None, y_test=None)
 
 
-def test_has_no_deep_copy():
-    """Check that we raise a warning if the deep copy failed."""
-    X, y = make_classification(n_classes=2, random_state=42)
-
-    estimator = LogisticRegression()
-
-    # Make it so deepcopy does not work
-    estimator.__reduce_ex__ = None
-    estimator.__reduce__ = None
-
-    with pytest.warns(UserWarning, match="Deepcopy failed"):
-        EstimatorReport(estimator, X_train=X, y_train=y, X_test=X, y_test=y)
-
-
 class _DummyClassifierBadRepr(DummyClassifier):
     def _repr_html_(self):
         raise TypeError("error")

--- a/skore/tests/unit/utils/test_testing.py
+++ b/skore/tests/unit/utils/test_testing.py
@@ -29,7 +29,7 @@ def test_mock_estimator_sklearn_clone_increments_n_call():
     est = MockEstimator(error=RuntimeError("test"), n_call=0)
     assert est.n_call == 0
     out = est.__sklearn_clone__()
-    assert out is est
+    assert isinstance(out, MockEstimator)
     assert est.n_call == 1
 
 


### PR DESCRIPTION
Closes https://github.com/probabl-ai/skore/issues/3075

Performance test:

```py
import statistics
from sklearn.ensemble import RandomForestRegressor
from time import perf_counter

from skore import evaluate
import sklearn

X, y = sklearn.datasets.make_classification(n_samples=10_000, return_X_y=True)

model = RandomForestRegressor()
model.fit(X, y)

n = 5
results = []
for _ in range(n):
    start = perf_counter()
    evaluate(model, X, y)
    end = perf_counter()
    results.append(end - start)

mean = statistics.mean(results)
stdev = statistics.stdev(results, xbar=mean)

print(f"{mean:.2f} +/- {stdev:.2f} ({n} runs)")
```

Results:

- without this PR: 10.41 +/- 0.07 seconds (5 runs)
- with this PR: 6.95 +/- 0.30 (5 runs)

Note: this test uses a RandomForest estimator which is the kind of case where deep-copying is costly (the estimator contains 100 decision trees, each containing ~1000 nodes/floats)
