### PR TITLE
ci: Dispatch end-to-end event in merge-queue

### DIFF
--- a/.github/workflows/dispatch-end-to-end.yml
+++ b/.github/workflows/dispatch-end-to-end.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 permissions: {}
 


### PR DESCRIPTION
Mandatory if we want to add `test-end-to-end` in status checks that are required.
