### PR TITLE
feat(checks): Show skipped/ignored checks in summary

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -43,21 +43,22 @@ class _BaseReport(ReportHelpMixin):
         ignored_codes: set[CheckCode],
         *,
         fast_mode: bool = False,
-    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode]]:
+    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode], set[CheckCode]]:
         """Aggregate EstimatorReport checks.
 
         Overwritten in CrossValidation and Comparison reports.
 
-        Returns ``(check_results, applicable_codes, not_applicable_codes)``.
+        Returns ``(check_results, applicable_codes, not_applicable_codes,
+        skipped_codes)``.
         """
-        return {}, set(), set()
+        return {}, set(), set(), set()
 
     def _get_results(
         self,
         ignored_codes: set[CheckCode],
         *,
         fast_mode: bool = False,
-    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode]]:
+    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode], set[CheckCode]]:
         """Get the check results from the cache or compute them.
 
         Parameters
@@ -70,10 +71,12 @@ class _BaseReport(ReportHelpMixin):
             (their `check_function` is never invoked). Cached slow results
             are still surfaced.
 
-        Returns ``(check_results, applicable_codes, not_applicable_codes)``
+        Returns ``(check_results, applicable_codes, not_applicable_codes,
+        skipped_codes)``
         where ``applicable_codes`` contains the codes of the checks that ran
-        without raising :class:`CheckNotApplicable`, and
-        ``not_applicable_codes`` contains those that raised it.
+        without raising :class:`CheckNotApplicable`, ``not_applicable_codes``
+        contains those that raised it, and ``skipped_codes`` contains slow checks
+        not run because of ``fast_mode``.
         """
         if not hasattr(self, "_check_results_cache"):
             self._check_results_cache: dict[CheckCode, dict] = {}
@@ -81,6 +84,16 @@ class _BaseReport(ReportHelpMixin):
             self._applicable_codes: set[CheckCode] = set()
         if not hasattr(self, "_not_applicable_codes"):
             self._not_applicable_codes: set[CheckCode] = set()
+
+        skipped_codes = {
+            check.code
+            for check in self._checks_registry
+            if self._report_type in check.report_types
+            and check.code not in ignored_codes
+            and fast_mode
+            and check.slow
+            and check.code not in self._check_results_cache
+        }
 
         checks_to_run = [
             check
@@ -110,19 +123,21 @@ class _BaseReport(ReportHelpMixin):
             }
 
         if "comparison" in self._report_type:
-            agg_check_results, agg_applicable, agg_not_applicable = (
+            agg_check_results, agg_applicable, agg_not_applicable, agg_skipped = (
                 self._aggregate_checks(ignored_codes, fast_mode=fast_mode)
             )
             return (
                 self._check_results_cache | agg_check_results,
                 self._applicable_codes | agg_applicable,
                 self._not_applicable_codes | agg_not_applicable,
+                skipped_codes | agg_skipped,
             )
 
         return (
             self._check_results_cache,
             self._applicable_codes,
             self._not_applicable_codes,
+            skipped_codes,
         )
 
     def _checks_summary_html_fragment(self) -> str:

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from skore._project.git import git_commit
 from skore._sklearn._checks._utils import CheckNotApplicable
-from skore._sklearn._checks.base import Check, CheckCode
+from skore._sklearn._checks.base import Check, CheckCode, CheckResult, CheckSection
 from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
 from skore._utils._progress_bar import track
 from skore._utils.repr.base import (
@@ -43,57 +43,22 @@ class _BaseReport(ReportHelpMixin):
         ignored_codes: set[CheckCode],
         *,
         fast_mode: bool = False,
-    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode], set[CheckCode]]:
+    ) -> dict[CheckCode, CheckResult]:
         """Aggregate EstimatorReport checks.
 
         Overwritten in CrossValidation and Comparison reports.
-
-        Returns ``(check_results, applicable_codes, not_applicable_codes,
-        skipped_codes)``.
         """
-        return {}, set(), set(), set()
+        return {}
 
-    def _get_results(
+    def _run_checks(
         self,
         ignored_codes: set[CheckCode],
         *,
         fast_mode: bool = False,
-    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode], set[CheckCode]]:
-        """Get the check results from the cache or compute them.
-
-        Parameters
-        ----------
-        ignored_codes : set of CheckCode
-            Check codes to exclude from the results, e.g. ``{"SKD001"}``.
-
-        fast_mode : bool, default=False
-            When True, skip slow checks that are not already in the cache
-            (their `check_function` is never invoked). Cached slow results
-            are still surfaced.
-
-        Returns ``(check_results, applicable_codes, not_applicable_codes,
-        skipped_codes)``
-        where ``applicable_codes`` contains the codes of the checks that ran
-        without raising :class:`CheckNotApplicable`, ``not_applicable_codes``
-        contains those that raised it, and ``skipped_codes`` contains slow checks
-        not run because of ``fast_mode``.
-        """
+    ) -> None:
+        """Run uncached checks and store results in ``_check_results_cache``."""
         if not hasattr(self, "_check_results_cache"):
-            self._check_results_cache: dict[CheckCode, dict] = {}
-        if not hasattr(self, "_applicable_codes"):
-            self._applicable_codes: set[CheckCode] = set()
-        if not hasattr(self, "_not_applicable_codes"):
-            self._not_applicable_codes: set[CheckCode] = set()
-
-        skipped_codes = {
-            check.code
-            for check in self._checks_registry
-            if self._report_type in check.report_types
-            and check.code not in ignored_codes
-            and fast_mode
-            and check.slow
-            and check.code not in self._check_results_cache
-        }
+            self._check_results_cache: dict[CheckCode, CheckResult] = {}
 
         checks_to_run = [
             check
@@ -111,34 +76,75 @@ class _BaseReport(ReportHelpMixin):
         ):
             try:
                 explanation = check.check_function(self)
-                self._applicable_codes.add(check.code)
+                section: CheckSection = (
+                    getattr(check, "severity", "issue") if explanation else "passed"
+                )
             except CheckNotApplicable as exc:
                 explanation = exc.args[0] if exc.args else None
-                self._not_applicable_codes.add(check.code)
+                section = "not_applicable"
             self._check_results_cache[check.code] = {
                 "title": check.title,
                 "docs_url": check.docs_url,
                 "explanation": explanation,
-                "severity": getattr(check, "severity", "issue"),
+                "section": section,
             }
 
-        if "comparison" in self._report_type:
-            agg_check_results, agg_applicable, agg_not_applicable, agg_skipped = (
-                self._aggregate_checks(ignored_codes, fast_mode=fast_mode)
-            )
-            return (
-                self._check_results_cache | agg_check_results,
-                self._applicable_codes | agg_applicable,
-                self._not_applicable_codes | agg_not_applicable,
-                skipped_codes | agg_skipped,
-            )
+    def _build_checks_summary(
+        self,
+        ignored_codes: set[CheckCode],
+        *,
+        fast_mode: bool = False,
+    ) -> dict[CheckCode, CheckResult]:
+        summary: dict[CheckCode, CheckResult] = {}
+        for check in self._checks_registry:
+            if self._report_type not in check.report_types:
+                continue
+            code = check.code
+            if code in ignored_codes:
+                summary[code] = {
+                    "title": check.title,
+                    "docs_url": check.docs_url,
+                    "explanation": None,
+                    "section": "ignored",
+                }
+            elif fast_mode and check.slow and code not in self._check_results_cache:
+                summary[code] = {
+                    "title": check.title,
+                    "docs_url": check.docs_url,
+                    "explanation": None,
+                    "section": "skipped",
+                }
+            elif code in self._check_results_cache:
+                summary[code] = self._check_results_cache[code]
+        return summary
 
-        return (
-            self._check_results_cache,
-            self._applicable_codes,
-            self._not_applicable_codes,
-            skipped_codes,
-        )
+    def _get_results(
+        self,
+        ignored_codes: set[CheckCode],
+        *,
+        fast_mode: bool = False,
+    ) -> dict[CheckCode, CheckResult]:
+        """Build the per-call checks summary.
+
+        Parameters
+        ----------
+        ignored_codes : set of CheckCode
+            Check codes to exclude from execution, e.g. ``{"SKD001"}``.
+
+        fast_mode : bool, default=False
+            When True, skip slow checks that are not already in the cache
+            (their `check_function` is never invoked). Cached slow results
+            are still surfaced.
+
+        Returns
+        -------
+        dict of CheckCode to CheckResult
+            Summary of every applicable check with its display section.
+        """
+        self._run_checks(ignored_codes, fast_mode=fast_mode)
+        if "comparison" in self._report_type:
+            return self._aggregate_checks(ignored_codes, fast_mode=fast_mode)
+        return self._build_checks_summary(ignored_codes, fast_mode=fast_mode)
 
     def _checks_summary_html_fragment(self) -> str:
         """HTML snippet for the checks summary tab in report reprs."""

--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -46,17 +46,34 @@ class _BaseReport(ReportHelpMixin):
     ) -> dict[CheckCode, CheckResult]:
         """Aggregate EstimatorReport checks.
 
-        Overwritten in CrossValidation and Comparison reports.
+        Overwritten in Comparison reports.
         """
         return {}
 
-    def _run_checks(
+    def _get_checks_results(
         self,
         ignored_codes: set[CheckCode],
         *,
         fast_mode: bool = False,
-    ) -> None:
-        """Run uncached checks and store results in ``_check_results_cache``."""
+    ) -> dict[CheckCode, CheckResult]:
+        """Run uncached checks and return the checks summary.
+
+        Parameters
+        ----------
+        ignored_codes : set of CheckCode
+            Check codes to exclude from execution, e.g. ``{"SKD001"}``.
+
+        fast_mode : bool, default=False
+            When True, skip slow checks that are not already in the cache
+            (their `check_function` is never invoked). Cached slow results
+            are still surfaced.
+
+        Returns
+        -------
+        dict of CheckCode to CheckResult
+            Summary of every check applicable to the report type with its display
+            section.
+        """
         if not hasattr(self, "_check_results_cache"):
             self._check_results_cache: dict[CheckCode, CheckResult] = {}
 
@@ -89,12 +106,9 @@ class _BaseReport(ReportHelpMixin):
                 "section": section,
             }
 
-    def _build_checks_summary(
-        self,
-        ignored_codes: set[CheckCode],
-        *,
-        fast_mode: bool = False,
-    ) -> dict[CheckCode, CheckResult]:
+        if "comparison" in self._report_type:
+            return self._aggregate_checks(ignored_codes, fast_mode=fast_mode)
+
         summary: dict[CheckCode, CheckResult] = {}
         for check in self._checks_registry:
             if self._report_type not in check.report_types:
@@ -117,34 +131,6 @@ class _BaseReport(ReportHelpMixin):
             elif code in self._check_results_cache:
                 summary[code] = self._check_results_cache[code]
         return summary
-
-    def _get_results(
-        self,
-        ignored_codes: set[CheckCode],
-        *,
-        fast_mode: bool = False,
-    ) -> dict[CheckCode, CheckResult]:
-        """Build the per-call checks summary.
-
-        Parameters
-        ----------
-        ignored_codes : set of CheckCode
-            Check codes to exclude from execution, e.g. ``{"SKD001"}``.
-
-        fast_mode : bool, default=False
-            When True, skip slow checks that are not already in the cache
-            (their `check_function` is never invoked). Cached slow results
-            are still surfaced.
-
-        Returns
-        -------
-        dict of CheckCode to CheckResult
-            Summary of every applicable check with its display section.
-        """
-        self._run_checks(ignored_codes, fast_mode=fast_mode)
-        if "comparison" in self._report_type:
-            return self._aggregate_checks(ignored_codes, fast_mode=fast_mode)
-        return self._build_checks_summary(ignored_codes, fast_mode=fast_mode)
 
     def _checks_summary_html_fragment(self) -> str:
         """HTML snippet for the checks summary tab in report reprs."""

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -72,24 +72,21 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         registry_by_code = {
             check.code: check for check in self._parent._checks_registry
         }
-        skipped_message = "Skipped in fast mode (not cached)."
-        ignored_message = "Muted via ignore or ignore_checks."
         skipped_checks = {}
         for code in skipped_codes:
-            if code in check_results:
-                skipped_checks[code] = check_results[code]
-            elif check := registry_by_code.get(code):
-                skipped_checks[code] = {
-                    "title": check.title,
-                    "docs_url": check.docs_url,
-                    "explanation": skipped_message,
-                    "severity": getattr(check, "severity", "issue"),
-                }
+            result = check_results.get(code, {})
+            check = registry_by_code.get(code)
+            skipped_checks[code] = {
+                "title": result.get("title") or (check.title if check else code),
+                "docs_url": result.get("docs_url")
+                or (check.docs_url if check else None),
+                "severity": result.get("severity")
+                or (getattr(check, "severity", "issue") if check else "issue"),
+            }
         ignored_checks = {
             code: {
                 "title": check.title,
                 "docs_url": check.docs_url,
-                "explanation": ignored_message,
                 "severity": getattr(check, "severity", "issue"),
             }
             for code in ignored_codes

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -36,9 +36,9 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         Returns
         -------
         ChecksSummaryDisplay
-            A display object with an HTML representation organized as four
-            tabs (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``). The
-            full list of results is accessible via the
+            A display object with an HTML representation organized as five
+            tabs (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``,
+            ``Skipped & Ignored``). The full list of results is accessible via the
             :meth:`~ChecksSummaryDisplay.frame` method.
 
         Examples
@@ -52,8 +52,8 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         >>> "SKD002" in summary.frame()["code"].values
         True
         >>> filtered = report.checks.summarize(ignore=["SKD002"])
-        >>> "SKD002" in filtered.frame()["code"].values
-        False
+        >>> "SKD002" in filtered.frame(section="ignored")["code"].values
+        True
         """
         ignored_codes: set[CheckCode] = set()
         if ignore:
@@ -66,18 +66,48 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
                 for code in configuration.ignore_checks
                 if code.strip()
             )
-        check_results, applicable_codes, not_applicable_codes = (
+        check_results, applicable_codes, not_applicable_codes, skipped_codes = (
             self._parent._get_results(ignored_codes, fast_mode=fast_mode)
         )
+        registry_checks = [
+            check
+            for check in self._parent._checks_registry
+            if self._parent._report_type in check.report_types
+        ]
+        skipped_message = "Skipped in fast mode (not cached)."
+        ignored_message = "Muted via ignore or ignore_checks."
+        skipped_checks = {
+            code: check_results.get(code)
+            or {
+                "title": check.title,
+                "docs_url": check.docs_url,
+                "explanation": skipped_message,
+                "severity": getattr(check, "severity", "issue"),
+            }
+            for check in registry_checks
+            if (code := check.code) in skipped_codes
+        }
+        ignored_checks = {
+            check.code: {
+                "title": check.title,
+                "docs_url": check.docs_url,
+                "explanation": ignored_message,
+                "severity": getattr(check, "severity", "issue"),
+            }
+            for check in registry_checks
+            if check.code in ignored_codes
+        }
         return ChecksSummaryDisplay(
             check_results={
                 code: check_result
                 for code, check_result in check_results.items()
                 if (code in applicable_codes or code in not_applicable_codes)
                 and code not in ignored_codes
+                and code not in skipped_codes
             },
             not_applicable_codes=not_applicable_codes,
-            n_ignored_codes=len(ignored_codes),
+            skipped_checks=skipped_checks,
+            ignored_checks=ignored_checks,
             fast_mode=fast_mode,
         )
 

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -36,10 +36,10 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         Returns
         -------
         ChecksSummaryDisplay
-            A display object with an HTML representation organized as five
+            A display object with an HTML representation organized as six
             tabs (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``,
-            ``Skipped & Ignored``). The full list of results is accessible via the
-            :meth:`~ChecksSummaryDisplay.frame` method.
+            ``Skipped (fast mode)``, ``Ignored``). The full list of results is
+            accessible via the :meth:`~ChecksSummaryDisplay.frame` method.
 
         Examples
         --------

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -36,7 +36,7 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         Returns
         -------
         ChecksSummaryDisplay
-            A display object with an HTML representation organized as six
+            A display object with an HTML representation organized in
             tabs (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``,
             ``Skipped``, ``Ignored``). The full list of results is
             accessible via the :meth:`~ChecksSummaryDisplay.frame` method.

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -69,33 +69,31 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         check_results, applicable_codes, not_applicable_codes, skipped_codes = (
             self._parent._get_results(ignored_codes, fast_mode=fast_mode)
         )
-        registry_checks = [
-            check
-            for check in self._parent._checks_registry
-            if self._parent._report_type in check.report_types
-        ]
+        registry_by_code = {
+            check.code: check for check in self._parent._checks_registry
+        }
         skipped_message = "Skipped in fast mode (not cached)."
         ignored_message = "Muted via ignore or ignore_checks."
-        skipped_checks = {
-            code: check_results.get(code)
-            or {
-                "title": check.title,
-                "docs_url": check.docs_url,
-                "explanation": skipped_message,
-                "severity": getattr(check, "severity", "issue"),
-            }
-            for check in registry_checks
-            if (code := check.code) in skipped_codes
-        }
+        skipped_checks = {}
+        for code in skipped_codes:
+            if code in check_results:
+                skipped_checks[code] = check_results[code]
+            elif check := registry_by_code.get(code):
+                skipped_checks[code] = {
+                    "title": check.title,
+                    "docs_url": check.docs_url,
+                    "explanation": skipped_message,
+                    "severity": getattr(check, "severity", "issue"),
+                }
         ignored_checks = {
-            check.code: {
+            code: {
                 "title": check.title,
                 "docs_url": check.docs_url,
                 "explanation": ignored_message,
                 "severity": getattr(check, "severity", "issue"),
             }
-            for check in registry_checks
-            if check.code in ignored_codes
+            for code in ignored_codes
+            if (check := registry_by_code.get(code))
         }
         return ChecksSummaryDisplay(
             check_results={

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -38,7 +38,7 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         ChecksSummaryDisplay
             A display object with an HTML representation organized as six
             tabs (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``,
-            ``Skipped (fast mode)``, ``Ignored``). The full list of results is
+            ``Skipped``, ``Ignored``). The full list of results is
             accessible via the :meth:`~ChecksSummaryDisplay.frame` method.
 
         Examples
@@ -67,7 +67,7 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
                 if code.strip()
             )
         return ChecksSummaryDisplay(
-            self._parent._get_results(ignored_codes, fast_mode=fast_mode),
+            self._parent._get_checks_results(ignored_codes, fast_mode=fast_mode),
             fast_mode=fast_mode,
         )
 

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -66,43 +66,8 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
                 for code in configuration.ignore_checks
                 if code.strip()
             )
-        check_results, applicable_codes, not_applicable_codes, skipped_codes = (
-            self._parent._get_results(ignored_codes, fast_mode=fast_mode)
-        )
-        registry_by_code = {
-            check.code: check for check in self._parent._checks_registry
-        }
-        skipped_checks = {}
-        for code in skipped_codes:
-            result = check_results.get(code, {})
-            check = registry_by_code.get(code)
-            skipped_checks[code] = {
-                "title": result.get("title") or (check.title if check else code),
-                "docs_url": result.get("docs_url")
-                or (check.docs_url if check else None),
-                "severity": result.get("severity")
-                or (getattr(check, "severity", "issue") if check else "issue"),
-            }
-        ignored_checks = {
-            code: {
-                "title": check.title,
-                "docs_url": check.docs_url,
-                "severity": getattr(check, "severity", "issue"),
-            }
-            for code in ignored_codes
-            if (check := registry_by_code.get(code))
-        }
         return ChecksSummaryDisplay(
-            check_results={
-                code: check_result
-                for code, check_result in check_results.items()
-                if (code in applicable_codes or code in not_applicable_codes)
-                and code not in ignored_codes
-                and code not in skipped_codes
-            },
-            not_applicable_codes=not_applicable_codes,
-            skipped_checks=skipped_checks,
-            ignored_checks=ignored_checks,
+            self._parent._get_results(ignored_codes, fast_mode=fast_mode),
             fast_mode=fast_mode,
         )
 
@@ -172,10 +137,6 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         ]
         if hasattr(self._parent, "_check_results_cache"):
             self._parent._check_results_cache.pop(code, None)
-        if hasattr(self._parent, "_applicable_codes"):
-            self._parent._applicable_codes.discard(code)
-        if hasattr(self._parent, "_not_applicable_codes"):
-            self._parent._not_applicable_codes.discard(code)
 
     def __repr__(self) -> str:
         return (

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -28,6 +28,9 @@ class GroupedExplanation(TypedDict):
     explanation: CheckExplanation
 
 
+_SKIPPED_EXPLANATION = "Skipped in fast mode (not cached)."
+_IGNORED_EXPLANATION = "Muted via ignore or ignore_checks."
+
 _TAB_SPECS: list[
     tuple[str, Literal["issue", "tip", "passed", "not_applicable"], str, str]
 ] = [
@@ -59,6 +62,39 @@ _TAB_SPECS: list[
         ),
     ),
 ]
+
+_SKIPPED_IGNORED_TAB_LABEL = "Skipped & Ignored"
+_SKIPPED_IGNORED_TAB_HELP = (
+    "Checks that were not run because of fast mode or were muted by the user."
+)
+_SKIPPED_IGNORED_TAB_EMPTY = "No checks were skipped or ignored."
+_SKIPPED_IGNORED_BLOCKS: list[tuple[str, Literal["skipped", "ignored"], str]] = [
+    ("Skipped", "skipped", "No checks were skipped in fast mode."),
+    ("Ignored", "ignored", "No checks were muted."),
+]
+
+
+def _rows_from_frame(df: pd.DataFrame) -> list[dict]:
+    return [
+        {
+            "code": row.code,
+            "title": row.title,
+            "explanation": (
+                row.explanation
+                if pd.notna(row.explanation) and isinstance(row.explanation, str)
+                else None
+            ),
+            "grouped_explanations": (
+                _group_explanations(row.explanation)
+                if isinstance(row.explanation, dict)
+                else None
+            ),
+            "documentation_url": (
+                row.documentation_url if pd.notna(row.documentation_url) else None
+            ),
+        }
+        for row in df.itertuples()
+    ]
 
 
 def _group_explanations(
@@ -93,10 +129,10 @@ class ChecksSummaryDisplay(DisplayMixin):
     :meth:`~skore.EstimatorReport.checks.summarize`. This class should not be
     instantiated directly.
 
-    The display object has an HTML representation organized in four tabs
-    (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``). The full list of
-    check results is accessible via the :meth:`~ChecksSummaryDisplay.frame`
-    method.
+    The display object has an HTML representation organized in five tabs
+    (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``, ``Skipped & Ignored``).
+    The full list of check results is accessible via the
+    :meth:`~ChecksSummaryDisplay.frame` method.
 
     Parameters
     ----------
@@ -111,32 +147,55 @@ class ChecksSummaryDisplay(DisplayMixin):
     not_applicable_codes : set of str
         Check codes that raised :class:`~skore.CheckNotApplicable`.
 
-    n_ignored_codes : int
-        Number of the checks that were muted via ``ignore=`` or the global
-        ``ignore_checks`` configuration.
+    skipped_checks : dict of str to dict
+        Check metadata for checks skipped in fast mode, keyed by check code.
+
+    ignored_checks : dict of str to dict
+        Check metadata for checks muted via ``ignore=`` or ``ignore_checks``.
     """
 
     def __init__(
         self,
         check_results: dict[CheckCode, dict],
         not_applicable_codes: set[CheckCode],
-        n_ignored_codes: int,
+        skipped_checks: dict[CheckCode, dict],
+        ignored_checks: dict[CheckCode, dict],
         fast_mode: bool,
     ) -> None:
+        rows = [
+            {
+                "code": code,
+                "title": check_result["title"],
+                "section": _check_section(code, check_result, not_applicable_codes),
+                "explanation": check_result["explanation"],
+                "documentation_url": _get_issue_documentation_url(check_result),
+            }
+            for code, check_result in check_results.items()
+        ]
+        rows.extend(
+            {
+                "code": code,
+                "title": check_result["title"],
+                "section": "skipped",
+                "explanation": check_result.get("explanation", _SKIPPED_EXPLANATION),
+                "documentation_url": _get_issue_documentation_url(check_result),
+            }
+            for code, check_result in skipped_checks.items()
+        )
+        rows.extend(
+            {
+                "code": code,
+                "title": check_result["title"],
+                "section": "ignored",
+                "explanation": check_result.get("explanation", _IGNORED_EXPLANATION),
+                "documentation_url": _get_issue_documentation_url(check_result),
+            }
+            for code, check_result in ignored_checks.items()
+        )
         self._check_results = pd.DataFrame(
-            [
-                {
-                    "code": code,
-                    "title": check_result["title"],
-                    "section": _check_section(code, check_result, not_applicable_codes),
-                    "explanation": check_result["explanation"],
-                    "documentation_url": _get_issue_documentation_url(check_result),
-                }
-                for code, check_result in check_results.items()
-            ],
+            rows,
             columns=["code", "title", "section", "explanation", "documentation_url"],
         )
-        self._n_ignored_codes = n_ignored_codes
         self._fast_mode = fast_mode
 
     @property
@@ -147,22 +206,34 @@ class ChecksSummaryDisplay(DisplayMixin):
             f"{len(self.frame(section='tip'))} tip(s), "
             f"{len(self.frame(section='passed'))} passed, "
             f"{len(self.frame(section='not_applicable'))} not applicable, "
-            f"{self._n_ignored_codes} ignored."
+            f"{len(self.frame(section='skipped'))} skipped, "
+            f"{len(self.frame(section='ignored'))} ignored."
         )
 
     def frame(
         self,
-        section: Literal["issue", "tip", "passed", "not_applicable", "all"] = "all",
+        section: Literal[
+            "issue",
+            "tip",
+            "passed",
+            "not_applicable",
+            "skipped",
+            "ignored",
+            "all",
+        ] = "all",
     ) -> pd.DataFrame:
         """Return check results as a DataFrame.
 
         Parameters
         ----------
-        section : {"issue", "tip", "passed", "not_applicable", "all"}, default="all"
+        section : {"issue", "tip", "passed", "not_applicable", "skipped", \
+                "ignored", "all"}, default="all"
             Which results to include. ``"issue"`` / ``"tip"`` return only
             the matching findings; ``"passed"`` returns the checks that ran
             without reporting anything; ``"not_applicable"`` returns checks
-            that could not run; ``"all"`` returns every check result.
+            that could not run; ``"skipped"`` returns checks not run in fast
+            mode; ``"ignored"`` returns muted checks; ``"all"`` returns every
+            check result.
 
         Returns
         -------
@@ -177,15 +248,15 @@ class ChecksSummaryDisplay(DisplayMixin):
             omitted from the dict).
         """
         match section:
-            case "issue" | "tip" | "passed" | "not_applicable":
+            case "issue" | "tip" | "passed" | "not_applicable" | "skipped" | "ignored":
                 return self._check_results.query("section == @section")
             case "all":
                 return self._check_results.copy()
             case _:
                 raise ValueError(f"Invalid section: {section}")
 
-    def _build_tabs(self) -> list[dict]:
-        tabs = []
+    def _build_tabs(self) -> list[dict[str, object]]:
+        tabs: list[dict[str, object]] = []
         for label, section, empty_message, help_text in _TAB_SPECS:
             df = self.frame(section=section)
             tabs.append(
@@ -193,31 +264,27 @@ class ChecksSummaryDisplay(DisplayMixin):
                     "label": label,
                     "empty_message": empty_message,
                     "help_text": help_text,
-                    "rows": [
-                        {
-                            "code": row.code,
-                            "title": row.title,
-                            "explanation": (
-                                row.explanation
-                                if pd.notna(row.explanation)
-                                and isinstance(row.explanation, str)
-                                else None
-                            ),
-                            "grouped_explanations": (
-                                _group_explanations(row.explanation)
-                                if isinstance(row.explanation, dict)
-                                else None
-                            ),
-                            "documentation_url": (
-                                row.documentation_url
-                                if pd.notna(row.documentation_url)
-                                else None
-                            ),
-                        }
-                        for row in df.itertuples()
-                    ],
+                    "rows": _rows_from_frame(df),
                 }
             )
+        skipped_df = self.frame(section="skipped")
+        ignored_df = self.frame(section="ignored")
+        tabs.append(
+            {
+                "label": _SKIPPED_IGNORED_TAB_LABEL,
+                "empty_message": _SKIPPED_IGNORED_TAB_EMPTY,
+                "help_text": _SKIPPED_IGNORED_TAB_HELP,
+                "row_count": len(skipped_df) + len(ignored_df),
+                "blocks": [
+                    {
+                        "label": label,
+                        "empty_message": empty_message,
+                        "rows": _rows_from_frame(self.frame(section=section)),
+                    }
+                    for label, section, empty_message in _SKIPPED_IGNORED_BLOCKS
+                ],
+            }
+        )
         return tabs
 
     def _html_context(self, *, show_header: bool, nested: bool) -> dict:
@@ -245,42 +312,56 @@ class ChecksSummaryDisplay(DisplayMixin):
 
     def __repr__(self) -> str:
         """Return a plain-text summary of check results."""
-        if self._check_results.empty:
-            return self._header + "\nAll checks were ignored."
         lines = [self._header]
         for label, section, _, _ in _TAB_SPECS:
             df = self.frame(section=section)
             if df.empty:
                 continue
             lines.append(f"{label}:")
-            if section == "passed":
-                lines.extend(f"- [{row.code}] {row.title}" for row in df.itertuples())
-            else:
-                for row in df.itertuples():
-                    msg = f"- [{row.code}] {row.title}"
-                    explanation = row.explanation
-                    if isinstance(explanation, dict):
-                        if pd.notna(row.documentation_url):
-                            msg += (
-                                f". Read more about this here: {row.documentation_url}."
-                            )
-                        else:
-                            msg += "."
-                        lines.append(msg)
-                        lines.extend(
-                            f"  - [{entry['source']}] {entry['explanation']}"
-                            for entry in _group_explanations(explanation)
-                        )
-                    else:
-                        if pd.notna(explanation):
-                            msg += f". {explanation}"
-                        if pd.notna(row.documentation_url):
-                            msg += (
-                                f" Read more about this here: {row.documentation_url}."
-                            )
-                        lines.append(msg)
+            lines.extend(self._repr_section_lines(df, section))
+        skipped_df = self.frame(section="skipped")
+        ignored_df = self.frame(section="ignored")
+        if not skipped_df.empty or not ignored_df.empty:
+            lines.append(f"{_SKIPPED_IGNORED_TAB_LABEL}:")
+            if not skipped_df.empty:
+                lines.append("Skipped:")
+                lines.extend(self._repr_section_lines(skipped_df, "skipped"))
+            if not ignored_df.empty:
+                lines.append("Ignored:")
+                lines.extend(self._repr_section_lines(ignored_df, "ignored"))
         lines.append("Mute a check with .checks.summarize(ignore=['<code>']).")
         return "\n".join(lines)
+
+    def _repr_section_lines(
+        self,
+        df: pd.DataFrame,
+        section: Literal[
+            "issue", "tip", "passed", "skipped", "ignored", "not_applicable"
+        ],
+    ) -> list[str]:
+        if section == "passed":
+            return [f"- [{row.code}] {row.title}" for row in df.itertuples()]
+        lines = []
+        for row in df.itertuples():
+            msg = f"- [{row.code}] {row.title}"
+            explanation = row.explanation
+            if isinstance(explanation, dict):
+                if pd.notna(row.documentation_url):
+                    msg += f". Read more about this here: {row.documentation_url}."
+                else:
+                    msg += "."
+                lines.append(msg)
+                lines.extend(
+                    f"  - [{entry['source']}] {entry['explanation']}"
+                    for entry in _group_explanations(explanation)
+                )
+            else:
+                if pd.notna(explanation):
+                    msg += f". {explanation}"
+                if pd.notna(row.documentation_url):
+                    msg += f" Read more about this here: {row.documentation_url}."
+                lines.append(msg)
+        return lines
 
 
 @runtime_checkable

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -28,7 +28,7 @@ CheckSection = Literal["issue", "tip", "passed", "not_applicable", "skipped", "i
 class CheckResult(TypedDict):
     title: str
     docs_url: str | None
-    explanation: str | dict[CheckSource, CheckExplanation] | None
+    explanation: CheckExplanation | dict[CheckSource, CheckExplanation] | None
     section: CheckSection
 
 

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -22,6 +22,15 @@ CheckSource = str
 CheckSources = str
 CheckExplanation = str
 
+CheckSection = Literal["issue", "tip", "passed", "not_applicable", "skipped", "ignored"]
+
+
+class CheckResult(TypedDict):
+    title: str
+    docs_url: str | None
+    explanation: str | dict[CheckSource, CheckExplanation] | None
+    section: CheckSection
+
 
 class GroupedExplanation(TypedDict):
     source: CheckSources
@@ -120,18 +129,6 @@ def _group_explanations(
     ]
 
 
-def _check_section(
-    code: CheckCode,
-    check_result: dict,
-    not_applicable_codes: set[CheckCode],
-) -> Literal["issue", "tip", "passed", "not_applicable"]:
-    if code in not_applicable_codes:
-        return "not_applicable"
-    if pd.notna(check_result.get("explanation")):
-        return check_result["severity"]
-    return "passed"
-
-
 class ChecksSummaryDisplay(DisplayMixin):
     """Display for the checks summary.
 
@@ -146,64 +143,30 @@ class ChecksSummaryDisplay(DisplayMixin):
 
     Parameters
     ----------
-    check_results : dict of str to dict
-        Results of applicable checks keyed by check code
-        (e.g. ``"SKD001"``). Each value is a dict with keys ``"title"``,
-        ``"explanation"``, ``"severity"`` (``"issue"`` or ``"tip"``), and
-        optionally ``"docs_url"``. ``"explanation"`` is a string for single-report
-        summaries, or a dict mapping source names to messages for aggregated
-        comparison summaries.
-
-    not_applicable_codes : set of str
-        Check codes that raised :class:`~skore.CheckNotApplicable`.
-
-    skipped_checks : dict of str to dict
-        Check metadata for checks skipped in fast mode, keyed by check code.
-
-    ignored_checks : dict of str to dict
-        Check metadata for checks muted via ``ignore=`` or ``ignore_checks``.
+    check_results : dict of str to CheckResult
+        Summary of all checks keyed by check code (e.g. ``"SKD001"``).
+        Each value has keys ``"title"``, ``"explanation"``, ``"section"``,
+        and optionally ``"docs_url"``. The ``"section"`` value is one of
+        ``"issue"``, ``"tip"``, ``"passed"``, ``"not_applicable"``,
+        ``"skipped"``, or ``"ignored"``.
     """
 
     def __init__(
         self,
-        check_results: dict[CheckCode, dict],
-        not_applicable_codes: set[CheckCode],
-        skipped_checks: dict[CheckCode, dict],
-        ignored_checks: dict[CheckCode, dict],
+        check_results: dict[CheckCode, CheckResult],
         fast_mode: bool,
     ) -> None:
-        rows = [
-            {
-                "code": code,
-                "title": check_result["title"],
-                "section": _check_section(code, check_result, not_applicable_codes),
-                "explanation": check_result["explanation"],
-                "documentation_url": _get_issue_documentation_url(check_result),
-            }
-            for code, check_result in check_results.items()
-        ]
-        rows.extend(
-            {
-                "code": code,
-                "title": check_result["title"],
-                "section": "skipped",
-                "explanation": None,
-                "documentation_url": _get_issue_documentation_url(check_result),
-            }
-            for code, check_result in skipped_checks.items()
-        )
-        rows.extend(
-            {
-                "code": code,
-                "title": check_result["title"],
-                "section": "ignored",
-                "explanation": None,
-                "documentation_url": _get_issue_documentation_url(check_result),
-            }
-            for code, check_result in ignored_checks.items()
-        )
         self._check_results = pd.DataFrame(
-            rows,
+            [
+                {
+                    "code": code,
+                    "title": check_result["title"],
+                    "section": check_result["section"],
+                    "explanation": check_result["explanation"],
+                    "documentation_url": _get_issue_documentation_url(check_result),
+                }
+                for code, check_result in check_results.items()
+            ],
             columns=["code", "title", "section", "explanation", "documentation_url"],
         )
         self._fast_mode = fast_mode
@@ -439,7 +402,7 @@ class Check(Protocol):
         """
 
 
-def _get_issue_documentation_url(issue: dict) -> str | None:
+def _get_issue_documentation_url(issue: CheckResult | dict) -> str | None:
     docs_url = issue.get("docs_url")
     if docs_url is None:
         return None

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -28,9 +28,6 @@ class GroupedExplanation(TypedDict):
     explanation: CheckExplanation
 
 
-_SKIPPED_EXPLANATION = "Skipped in fast mode (not cached)."
-_IGNORED_EXPLANATION = "Muted via ignore or ignore_checks."
-
 _TAB_SPECS: list[
     tuple[str, Literal["issue", "tip", "passed", "not_applicable"], str, str]
 ] = [
@@ -69,9 +66,22 @@ _SKIPPED_IGNORED_TAB_HELP = (
 )
 _SKIPPED_IGNORED_TAB_EMPTY = "No checks were skipped or ignored."
 _SKIPPED_IGNORED_BLOCKS: list[tuple[str, Literal["skipped", "ignored"], str]] = [
-    ("Skipped", "skipped", "No checks were skipped in fast mode."),
+    ("Skipped (fast mode)", "skipped", "No checks were skipped in fast mode."),
     ("Ignored", "ignored", "No checks were muted."),
 ]
+
+
+def _rows_title_only_from_frame(df: pd.DataFrame) -> list[dict]:
+    return [
+        {
+            "code": row.code,
+            "title": row.title,
+            "documentation_url": (
+                row.documentation_url if pd.notna(row.documentation_url) else None
+            ),
+        }
+        for row in df.itertuples()
+    ]
 
 
 def _rows_from_frame(df: pd.DataFrame) -> list[dict]:
@@ -177,7 +187,7 @@ class ChecksSummaryDisplay(DisplayMixin):
                 "code": code,
                 "title": check_result["title"],
                 "section": "skipped",
-                "explanation": check_result.get("explanation", _SKIPPED_EXPLANATION),
+                "explanation": None,
                 "documentation_url": _get_issue_documentation_url(check_result),
             }
             for code, check_result in skipped_checks.items()
@@ -187,7 +197,7 @@ class ChecksSummaryDisplay(DisplayMixin):
                 "code": code,
                 "title": check_result["title"],
                 "section": "ignored",
-                "explanation": check_result.get("explanation", _IGNORED_EXPLANATION),
+                "explanation": None,
                 "documentation_url": _get_issue_documentation_url(check_result),
             }
             for code, check_result in ignored_checks.items()
@@ -241,7 +251,7 @@ class ChecksSummaryDisplay(DisplayMixin):
             A DataFrame with one row per check and columns ``"code"``,
             ``"title"``, ``"section"``, ``"explanation"``, and
             ``"documentation_url"``. The ``"explanation"`` column is ``None``
-            for checks that passed without reporting anything. For
+            for checks that passed, were skipped, or were ignored. For
             issue/tip/not-applicable rows it is a string for single-report
             results, or a dict mapping source names to messages for aggregated
             comparison results (entries with a ``None`` explanation are
@@ -279,7 +289,9 @@ class ChecksSummaryDisplay(DisplayMixin):
                     {
                         "label": label,
                         "empty_message": empty_message,
-                        "rows": _rows_from_frame(self.frame(section=section)),
+                        "rows": _rows_title_only_from_frame(
+                            self.frame(section=section)
+                        ),
                     }
                     for label, section, empty_message in _SKIPPED_IGNORED_BLOCKS
                 ],
@@ -323,12 +335,12 @@ class ChecksSummaryDisplay(DisplayMixin):
         ignored_df = self.frame(section="ignored")
         if not skipped_df.empty or not ignored_df.empty:
             lines.append(f"{_SKIPPED_IGNORED_TAB_LABEL}:")
-            if not skipped_df.empty:
-                lines.append("Skipped:")
-                lines.extend(self._repr_section_lines(skipped_df, "skipped"))
-            if not ignored_df.empty:
-                lines.append("Ignored:")
-                lines.extend(self._repr_section_lines(ignored_df, "ignored"))
+            for block_label, block_section, _ in _SKIPPED_IGNORED_BLOCKS:
+                df = self.frame(section=block_section)
+                if df.empty:
+                    continue
+                lines.append(f"{block_label}:")
+                lines.extend(f"- [{row.code}] {row.title}" for row in df.itertuples())
         lines.append("Mute a check with .checks.summarize(ignore=['<code>']).")
         return "\n".join(lines)
 

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -37,9 +37,7 @@ class GroupedExplanation(TypedDict):
     explanation: CheckExplanation
 
 
-_TAB_SPECS: list[
-    tuple[str, Literal["issue", "tip", "passed", "not_applicable"], str, str]
-] = [
+_TAB_SPECS: list[tuple[str, CheckSection, str, str]] = [
     (
         "Issues",  # Title of the tab
         "issue",  # Severity of the checks collected in the tab
@@ -67,53 +65,19 @@ _TAB_SPECS: list[
             "or model capabilities were missing."
         ),
     ),
+    (
+        "Skipped",
+        "skipped",
+        "No checks were skipped in fast mode.",
+        "Slow checks not run because fast mode is on.",
+    ),
+    (
+        "Ignored",
+        "ignored",
+        "No checks were muted.",
+        "Checks excluded via ignore.",
+    ),
 ]
-
-_SKIPPED_IGNORED_TAB_LABEL = "Skipped & Ignored"
-_SKIPPED_IGNORED_TAB_HELP = (
-    "Checks that were not run because of fast mode or were muted by the user."
-)
-_SKIPPED_IGNORED_TAB_EMPTY = "No checks were skipped or ignored."
-_SKIPPED_IGNORED_BLOCKS: list[tuple[str, Literal["skipped", "ignored"], str]] = [
-    ("Skipped (fast mode)", "skipped", "No checks were skipped in fast mode."),
-    ("Ignored", "ignored", "No checks were muted."),
-]
-
-
-def _rows_title_only_from_frame(df: pd.DataFrame) -> list[dict]:
-    return [
-        {
-            "code": row.code,
-            "title": row.title,
-            "documentation_url": (
-                row.documentation_url if pd.notna(row.documentation_url) else None
-            ),
-        }
-        for row in df.itertuples()
-    ]
-
-
-def _rows_from_frame(df: pd.DataFrame) -> list[dict]:
-    return [
-        {
-            "code": row.code,
-            "title": row.title,
-            "explanation": (
-                row.explanation
-                if pd.notna(row.explanation) and isinstance(row.explanation, str)
-                else None
-            ),
-            "grouped_explanations": (
-                _group_explanations(row.explanation)
-                if isinstance(row.explanation, dict)
-                else None
-            ),
-            "documentation_url": (
-                row.documentation_url if pd.notna(row.documentation_url) else None
-            ),
-        }
-        for row in df.itertuples()
-    ]
 
 
 def _group_explanations(
@@ -136,14 +100,15 @@ class ChecksSummaryDisplay(DisplayMixin):
     :meth:`~skore.EstimatorReport.checks.summarize`. This class should not be
     instantiated directly.
 
-    The display object has an HTML representation organized in five tabs
-    (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``, ``Skipped & Ignored``).
+    The display object has an HTML representation organized in six tabs
+    (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``, ``Skipped``,
+    ``Ignored``).
     The full list of check results is accessible via the
     :meth:`~ChecksSummaryDisplay.frame` method.
 
     Parameters
     ----------
-    check_results : dict of str to CheckResult
+    check_results : dict of CheckCode to CheckResult
         Summary of all checks keyed by check code (e.g. ``"SKD001"``).
         Each value has keys ``"title"``, ``"explanation"``, ``"section"``,
         and optionally ``"docs_url"``. The ``"section"`` value is one of
@@ -237,29 +202,31 @@ class ChecksSummaryDisplay(DisplayMixin):
                     "label": label,
                     "empty_message": empty_message,
                     "help_text": help_text,
-                    "rows": _rows_from_frame(df),
+                    "rows": [
+                        {
+                            "code": row.code,
+                            "title": row.title,
+                            "explanation": (
+                                row.explanation
+                                if pd.notna(row.explanation)
+                                and isinstance(row.explanation, str)
+                                else None
+                            ),
+                            "grouped_explanations": (
+                                _group_explanations(row.explanation)
+                                if isinstance(row.explanation, dict)
+                                else None
+                            ),
+                            "documentation_url": (
+                                row.documentation_url
+                                if pd.notna(row.documentation_url)
+                                else None
+                            ),
+                        }
+                        for row in df.itertuples()
+                    ],
                 }
             )
-        skipped_df = self.frame(section="skipped")
-        ignored_df = self.frame(section="ignored")
-        tabs.append(
-            {
-                "label": _SKIPPED_IGNORED_TAB_LABEL,
-                "empty_message": _SKIPPED_IGNORED_TAB_EMPTY,
-                "help_text": _SKIPPED_IGNORED_TAB_HELP,
-                "row_count": len(skipped_df) + len(ignored_df),
-                "blocks": [
-                    {
-                        "label": label,
-                        "empty_message": empty_message,
-                        "rows": _rows_title_only_from_frame(
-                            self.frame(section=section)
-                        ),
-                    }
-                    for label, section, empty_message in _SKIPPED_IGNORED_BLOCKS
-                ],
-            }
-        )
         return tabs
 
     def _html_context(self, *, show_header: bool, nested: bool) -> dict:
@@ -293,50 +260,34 @@ class ChecksSummaryDisplay(DisplayMixin):
             if df.empty:
                 continue
             lines.append(f"{label}:")
-            lines.extend(self._repr_section_lines(df, section))
-        skipped_df = self.frame(section="skipped")
-        ignored_df = self.frame(section="ignored")
-        if not skipped_df.empty or not ignored_df.empty:
-            lines.append(f"{_SKIPPED_IGNORED_TAB_LABEL}:")
-            for block_label, block_section, _ in _SKIPPED_IGNORED_BLOCKS:
-                df = self.frame(section=block_section)
-                if df.empty:
-                    continue
-                lines.append(f"{block_label}:")
+            if section == ("passed", "skipped", "ignored"):
                 lines.extend(f"- [{row.code}] {row.title}" for row in df.itertuples())
+            else:
+                for row in df.itertuples():
+                    msg = f"- [{row.code}] {row.title}"
+                    explanation = row.explanation
+                    if isinstance(explanation, dict):
+                        if pd.notna(row.documentation_url):
+                            msg += (
+                                f". Read more about this here: {row.documentation_url}."
+                            )
+                        else:
+                            msg += "."
+                        lines.append(msg)
+                        lines.extend(
+                            f"  - [{entry['source']}] {entry['explanation']}"
+                            for entry in _group_explanations(explanation)
+                        )
+                    else:
+                        if pd.notna(explanation):
+                            msg += f". {explanation}"
+                        if pd.notna(row.documentation_url):
+                            msg += (
+                                f" Read more about this here: {row.documentation_url}."
+                            )
+                        lines.append(msg)
         lines.append("Mute a check with .checks.summarize(ignore=['<code>']).")
         return "\n".join(lines)
-
-    def _repr_section_lines(
-        self,
-        df: pd.DataFrame,
-        section: Literal[
-            "issue", "tip", "passed", "skipped", "ignored", "not_applicable"
-        ],
-    ) -> list[str]:
-        if section == "passed":
-            return [f"- [{row.code}] {row.title}" for row in df.itertuples()]
-        lines = []
-        for row in df.itertuples():
-            msg = f"- [{row.code}] {row.title}"
-            explanation = row.explanation
-            if isinstance(explanation, dict):
-                if pd.notna(row.documentation_url):
-                    msg += f". Read more about this here: {row.documentation_url}."
-                else:
-                    msg += "."
-                lines.append(msg)
-                lines.extend(
-                    f"  - [{entry['source']}] {entry['explanation']}"
-                    for entry in _group_explanations(explanation)
-                )
-            else:
-                if pd.notna(explanation):
-                    msg += f". {explanation}"
-                if pd.notna(row.documentation_url):
-                    msg += f" Read more about this here: {row.documentation_url}."
-                lines.append(msg)
-        return lines
 
 
 @runtime_checkable
@@ -402,7 +353,7 @@ class Check(Protocol):
         """
 
 
-def _get_issue_documentation_url(issue: CheckResult | dict) -> str | None:
+def _get_issue_documentation_url(issue: CheckResult) -> str | None:
     docs_url = issue.get("docs_url")
     if docs_url is None:
         return None

--- a/skore/src/skore/_sklearn/_checks/base.py
+++ b/skore/src/skore/_sklearn/_checks/base.py
@@ -100,7 +100,7 @@ class ChecksSummaryDisplay(DisplayMixin):
     :meth:`~skore.EstimatorReport.checks.summarize`. This class should not be
     instantiated directly.
 
-    The display object has an HTML representation organized in six tabs
+    The display object has an HTML representation organized in tabs
     (``Issues``, ``Tips``, ``Passed``, ``Not Applicable``, ``Skipped``,
     ``Ignored``).
     The full list of check results is accessible via the
@@ -148,18 +148,7 @@ class ChecksSummaryDisplay(DisplayMixin):
             f"{len(self.frame(section='ignored'))} ignored."
         )
 
-    def frame(
-        self,
-        section: Literal[
-            "issue",
-            "tip",
-            "passed",
-            "not_applicable",
-            "skipped",
-            "ignored",
-            "all",
-        ] = "all",
-    ) -> pd.DataFrame:
+    def frame(self, section: CheckSection | Literal["all"] = "all") -> pd.DataFrame:
         """Return check results as a DataFrame.
 
         Parameters
@@ -260,7 +249,7 @@ class ChecksSummaryDisplay(DisplayMixin):
             if df.empty:
                 continue
             lines.append(f"{label}:")
-            if section == ("passed", "skipped", "ignored"):
+            if section in ("passed", "skipped", "ignored"):
                 lines.extend(f"- [{row.code}] {row.title}" for row in df.itertuples())
             else:
                 for row in df.itertuples():

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -11,7 +11,12 @@ from numpy.typing import ArrayLike
 
 from skore._externals._pandas_accessors import DirNamesMixin
 from skore._sklearn._base import _BaseReport
-from skore._sklearn._checks.base import CheckCode, CheckExplanation, CheckSource
+from skore._sklearn._checks.base import (
+    CheckCode,
+    CheckExplanation,
+    CheckResult,
+    CheckSource,
+)
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._estimator.report import EstimatorReport
 from skore._sklearn.types import PositiveLabel
@@ -505,69 +510,85 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         ignored_codes: set[CheckCode],
         *,
         fast_mode: bool = False,
-    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode], set[CheckCode]]:
-        comparison_results: dict[CheckCode, dict] = {}
+    ) -> dict[CheckCode, CheckResult]:
+        comparison_summary: dict[CheckCode, CheckResult] = {}
         explanation_by_code: dict[CheckCode, dict[CheckSource, CheckExplanation]] = (
             defaultdict(dict)
         )
         na_explanation_by_code: dict[CheckCode, dict[CheckSource, CheckExplanation]] = (
             defaultdict(dict)
         )
-        all_applicable_codes: set[CheckCode] = set()
-        all_not_applicable_codes: set[CheckCode] = set()
-        all_skipped_codes: set[CheckCode] = set()
+        finding_section_by_code: dict[CheckCode, Literal["issue", "tip"]] = {}
+        ran_on_any: set[CheckCode] = set()
+        na_on_any: set[CheckCode] = set()
+        skipped_on_any: set[CheckCode] = set()
         for report_name, report in self.reports_.items():
             report.checks.add(self._checks_registry)
-            (
-                report_results,
-                applicable_codes,
-                not_applicable_codes,
-                skipped_codes,
-            ) = report._get_results(ignored_codes, fast_mode=fast_mode)
-            all_applicable_codes |= applicable_codes
-            all_not_applicable_codes |= not_applicable_codes
-            all_skipped_codes |= skipped_codes
+            sub_summary = report._get_results(ignored_codes, fast_mode=fast_mode)
 
-            for code, result in report_results.items():
-                comparison_results.setdefault(
+            for code, result in sub_summary.items():
+                comparison_summary.setdefault(
                     code,
                     {
                         "title": result["title"],
                         "docs_url": result.get("docs_url"),
                         "explanation": None,
-                        "severity": result.get("severity"),
+                        "section": result["section"],
                     },
                 )
-                if code in applicable_codes and result["explanation"] is not None:
-                    explanation_by_code[code][report_name] = result["explanation"]
-                elif code in not_applicable_codes and result["explanation"] is not None:
-                    na_explanation_by_code[code][report_name] = result["explanation"]
+                section = result["section"]
+                if section in ("issue", "tip"):
+                    ran_on_any.add(code)
+                    finding_section_by_code[code] = section
+                    explanation = result["explanation"]
+                    if isinstance(explanation, str):
+                        explanation_by_code[code][report_name] = explanation
+                elif section == "passed":
+                    ran_on_any.add(code)
+                elif section == "not_applicable":
+                    na_on_any.add(code)
+                    explanation = result["explanation"]
+                    if isinstance(explanation, str):
+                        na_explanation_by_code[code][report_name] = explanation
+                elif section == "skipped":
+                    skipped_on_any.add(code)
 
-            for code in skipped_codes:
-                check = next(c for c in report._checks_registry if c.code == code)
-                comparison_results.setdefault(
-                    code,
-                    {
-                        "title": check.title,
-                        "docs_url": check.docs_url,
-                        "explanation": None,
-                        "severity": getattr(check, "severity", "issue"),
-                    },
-                )
-
-        all_not_applicable_codes -= all_applicable_codes
-        all_skipped_codes -= all_applicable_codes
+        global_na_codes = na_on_any - ran_on_any
+        global_skipped_codes = skipped_on_any - ran_on_any
 
         for code, per_estimator in explanation_by_code.items():
-            comparison_results[code]["explanation"] = dict(per_estimator)
-        for code in all_not_applicable_codes:
-            comparison_results[code]["explanation"] = dict(na_explanation_by_code[code])
-        return (
-            comparison_results,
-            all_applicable_codes,
-            all_not_applicable_codes,
-            all_skipped_codes,
-        )
+            comparison_summary[code] = {
+                **comparison_summary[code],
+                "explanation": dict(per_estimator),
+                "section": finding_section_by_code[code],
+            }
+        for code in global_na_codes:
+            comparison_summary[code] = {
+                **comparison_summary[code],
+                "explanation": dict(na_explanation_by_code[code]),
+                "section": "not_applicable",
+            }
+        for code in global_skipped_codes:
+            comparison_summary[code] = {
+                **comparison_summary[code],
+                "explanation": None,
+                "section": "skipped",
+            }
+        for code in ran_on_any:
+            if code not in explanation_by_code:
+                comparison_summary[code] = {
+                    **comparison_summary[code],
+                    "explanation": None,
+                    "section": "passed",
+                }
+        for code in ignored_codes:
+            if code in comparison_summary:
+                comparison_summary[code] = {
+                    **comparison_summary[code],
+                    "explanation": None,
+                    "section": "ignored",
+                }
+        return comparison_summary
 
     def _get_help_title(self) -> str:
         return "Tools to compare estimators"

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -505,7 +505,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         ignored_codes: set[CheckCode],
         *,
         fast_mode: bool = False,
-    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode]]:
+    ) -> tuple[dict[CheckCode, dict], set[CheckCode], set[CheckCode], set[CheckCode]]:
         comparison_results: dict[CheckCode, dict] = {}
         explanation_by_code: dict[CheckCode, dict[CheckSource, CheckExplanation]] = (
             defaultdict(dict)
@@ -513,15 +513,24 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         na_explanation_by_code: dict[CheckCode, dict[CheckSource, CheckExplanation]] = (
             defaultdict(dict)
         )
+        skipped_explanation_by_code: dict[
+            CheckCode, dict[CheckSource, CheckExplanation]
+        ] = defaultdict(dict)
         all_applicable_codes: set[CheckCode] = set()
         all_not_applicable_codes: set[CheckCode] = set()
+        all_skipped_codes: set[CheckCode] = set()
+        skipped_message = "Skipped in fast mode (not cached)."
         for report_name, report in self.reports_.items():
             report.checks.add(self._checks_registry)
-            report_results, applicable_codes, not_applicable_codes = (
-                report._get_results(ignored_codes, fast_mode=fast_mode)
-            )
+            (
+                report_results,
+                applicable_codes,
+                not_applicable_codes,
+                skipped_codes,
+            ) = report._get_results(ignored_codes, fast_mode=fast_mode)
             all_applicable_codes |= applicable_codes
             all_not_applicable_codes |= not_applicable_codes
+            all_skipped_codes |= skipped_codes
 
             for code, result in report_results.items():
                 comparison_results.setdefault(
@@ -538,13 +547,36 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
                 elif code in not_applicable_codes and result["explanation"] is not None:
                     na_explanation_by_code[code][report_name] = result["explanation"]
 
+            for code in skipped_codes:
+                check = next(c for c in report._checks_registry if c.code == code)
+                comparison_results.setdefault(
+                    code,
+                    {
+                        "title": check.title,
+                        "docs_url": check.docs_url,
+                        "explanation": None,
+                        "severity": getattr(check, "severity", "issue"),
+                    },
+                )
+                skipped_explanation_by_code[code][report_name] = skipped_message
+
         all_not_applicable_codes -= all_applicable_codes
+        all_skipped_codes -= all_applicable_codes
 
         for code, per_estimator in explanation_by_code.items():
             comparison_results[code]["explanation"] = dict(per_estimator)
         for code in all_not_applicable_codes:
             comparison_results[code]["explanation"] = dict(na_explanation_by_code[code])
-        return comparison_results, all_applicable_codes, all_not_applicable_codes
+        for code in all_skipped_codes:
+            comparison_results[code]["explanation"] = dict(
+                skipped_explanation_by_code[code]
+            )
+        return (
+            comparison_results,
+            all_applicable_codes,
+            all_not_applicable_codes,
+            all_skipped_codes,
+        )
 
     def _get_help_title(self) -> str:
         return "Tools to compare estimators"

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -524,7 +524,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         skipped_on_any: set[CheckCode] = set()
         for report_name, report in self.reports_.items():
             report.checks.add(self._checks_registry)
-            sub_summary = report._get_results(ignored_codes, fast_mode=fast_mode)
+            sub_summary = report._get_checks_results(ignored_codes, fast_mode=fast_mode)
 
             for code, result in sub_summary.items():
                 comparison_summary.setdefault(

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -513,13 +513,9 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         na_explanation_by_code: dict[CheckCode, dict[CheckSource, CheckExplanation]] = (
             defaultdict(dict)
         )
-        skipped_explanation_by_code: dict[
-            CheckCode, dict[CheckSource, CheckExplanation]
-        ] = defaultdict(dict)
         all_applicable_codes: set[CheckCode] = set()
         all_not_applicable_codes: set[CheckCode] = set()
         all_skipped_codes: set[CheckCode] = set()
-        skipped_message = "Skipped in fast mode (not cached)."
         for report_name, report in self.reports_.items():
             report.checks.add(self._checks_registry)
             (
@@ -558,7 +554,6 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
                         "severity": getattr(check, "severity", "issue"),
                     },
                 )
-                skipped_explanation_by_code[code][report_name] = skipped_message
 
         all_not_applicable_codes -= all_applicable_codes
         all_skipped_codes -= all_applicable_codes
@@ -567,10 +562,6 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
             comparison_results[code]["explanation"] = dict(per_estimator)
         for code in all_not_applicable_codes:
             comparison_results[code]["explanation"] = dict(na_explanation_by_code[code])
-        for code in all_skipped_codes:
-            comparison_results[code]["explanation"] = dict(
-                skipped_explanation_by_code[code]
-            )
         return (
             comparison_results,
             all_applicable_codes,

--- a/skore/src/skore/_utils/_testing.py
+++ b/skore/src/skore/_utils/_testing.py
@@ -90,8 +90,8 @@ class MockReport(_BaseReport):
 
     _ACCESSOR_CONFIG: dict[str, dict[str, str]] = {}
 
-    def _run_checks(self):
-        return {}, set()
+    def _get_checks_results(self, ignored_codes, *, fast_mode=False):
+        return {}
 
     def __init__(
         self,

--- a/skore/src/skore/_utils/repr/common/css/report.css
+++ b/skore/src/skore/_utils/repr/common/css/report.css
@@ -355,6 +355,7 @@
     margin: 0;
     font-size: 12px;
     font-style: italic;
+    opacity: 0.85;
 }
 
 .comparison-report-select-row {

--- a/skore/src/skore/_utils/repr/common/css/report.css
+++ b/skore/src/skore/_utils/repr/common/css/report.css
@@ -355,6 +355,16 @@
     margin: 0;
     font-size: 12px;
     font-style: italic;
+}
+
+.report-checks-summary-block + .report-checks-summary-block {
+    margin-top: 0.75em;
+}
+
+.report-checks-summary-block-title {
+    margin: 0 0 0.35em;
+    font-size: 12px;
+}
     opacity: 0.85;
 }
 

--- a/skore/src/skore/_utils/repr/common/css/report.css
+++ b/skore/src/skore/_utils/repr/common/css/report.css
@@ -357,17 +357,6 @@
     font-style: italic;
 }
 
-.report-checks-summary-block + .report-checks-summary-block {
-    margin-top: 0.75em;
-}
-
-.report-checks-summary-block-title {
-    margin: 0 0 0.35em;
-    font-size: 12px;
-}
-    opacity: 0.85;
-}
-
 .comparison-report-select-row {
     display: flex;
     align-items: center;

--- a/skore/src/skore/_utils/repr/display/_checks_summary_tabset.html.j2
+++ b/skore/src/skore/_utils/repr/display/_checks_summary_tabset.html.j2
@@ -1,11 +1,7 @@
-{# Issues / Tips / Passed / Not Applicable / Skipped & Ignored tabset. Expects: container_id, tabs. #}
+{# Issues / Tips / Passed / Not Applicable / Skipped / Ignored tabset. Expects: container_id, tabs. #}
 {% set report_tabs = [] %}
 {% for tab in tabs %}
-    {% if tab.blocks is defined %}
-        {% set _ = report_tabs.append({"label": tab.label ~ " (" ~ tab.row_count ~ ")", "help_variant": "text", "help_text": tab.help_text}) %}
-    {% else %}
-        {% set _ = report_tabs.append({"label": tab.label ~ " (" ~ tab.rows|length ~ ")", "help_variant": "text", "help_text": tab.help_text}) %}
-    {% endif %}
+    {% set _ = report_tabs.append({"label": tab.label ~ " (" ~ tab.rows|length ~ ")", "help_variant": "text", "help_text": tab.help_text}) %}
 {% endfor %}
 <div class="report-tabset">
     {% include "common/_report_tabset_chrome.html.j2" %}
@@ -13,28 +9,7 @@
         {% for tab in tabs %}
         <div class="report-tab-panel">
             <div class="report-section report-checks-summary-detail">
-                {% if tab.blocks is defined %}
-                    {% if tab.row_count %}
-                    {% for block in tab.blocks %}
-                    <div class="report-checks-summary-block">
-                        <p class="report-checks-summary-block-title"><strong>{{ block.label }}</strong></p>
-                        {% if block.rows %}
-                        <ul class="report-checks-summary-list">
-                            {% for row in block.rows %}
-                            <li>
-                                {% if row.documentation_url %}[<a href="{{ row.documentation_url }}" target="_blank" rel="noopener noreferrer" class="report-hint-note-link">{{ row.code }}</a>]{% else %}[{{ row.code }}]{% endif %} <strong>{{ row.title }}.</strong>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                        {% else %}
-                        <p class="report-checks-summary-empty">{{ block.empty_message }}</p>
-                        {% endif %}
-                    </div>
-                    {% endfor %}
-                    {% else %}
-                    <p class="report-checks-summary-empty">{{ tab.empty_message }}</p>
-                    {% endif %}
-                {% elif tab.rows %}
+                {% if tab.rows %}
                 <ul class="report-checks-summary-list">
                     {% for row in tab.rows %}
                     <li>

--- a/skore/src/skore/_utils/repr/display/_checks_summary_tabset.html.j2
+++ b/skore/src/skore/_utils/repr/display/_checks_summary_tabset.html.j2
@@ -1,7 +1,11 @@
-{# Issues / Tips / Passed / Not Applicable tabset. Expects: container_id, tabs. #}
+{# Issues / Tips / Passed / Not Applicable / Skipped & Ignored tabset. Expects: container_id, tabs. #}
 {% set report_tabs = [] %}
 {% for tab in tabs %}
-    {% set _ = report_tabs.append({"label": tab.label ~ " (" ~ tab.rows|length ~ ")", "help_variant": "text", "help_text": tab.help_text}) %}
+    {% if tab.blocks is defined %}
+        {% set _ = report_tabs.append({"label": tab.label ~ " (" ~ tab.row_count ~ ")", "help_variant": "text", "help_text": tab.help_text}) %}
+    {% else %}
+        {% set _ = report_tabs.append({"label": tab.label ~ " (" ~ tab.rows|length ~ ")", "help_variant": "text", "help_text": tab.help_text}) %}
+    {% endif %}
 {% endfor %}
 <div class="report-tabset">
     {% include "common/_report_tabset_chrome.html.j2" %}
@@ -9,7 +13,35 @@
         {% for tab in tabs %}
         <div class="report-tab-panel">
             <div class="report-section report-checks-summary-detail">
-                {% if tab.rows %}
+                {% if tab.blocks is defined %}
+                    {% if tab.row_count %}
+                    {% for block in tab.blocks %}
+                    <div class="report-checks-summary-block">
+                        <p class="report-checks-summary-block-title"><strong>{{ block.label }}</strong></p>
+                        {% if block.rows %}
+                        <ul class="report-checks-summary-list">
+                            {% for row in block.rows %}
+                            <li>
+                                {% if row.documentation_url %}[<a href="{{ row.documentation_url }}" target="_blank" rel="noopener noreferrer" class="report-hint-note-link">{{ row.code }}</a>]{% else %}[{{ row.code }}]{% endif %} <strong>{{ row.title }}.</strong>
+                                {%- if row.grouped_explanations %}
+                                <ul class="report-checks-summary-sublist">
+                                    {% for entry in row.grouped_explanations %}
+                                    <li>[{{ entry.source }}] {{ entry.explanation }}</li>
+                                    {% endfor %}
+                                </ul>
+                                {%- elif row.explanation %} {{ row.explanation }}{% endif %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        {% else %}
+                        <p class="report-checks-summary-empty">{{ block.empty_message }}</p>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                    {% else %}
+                    <p class="report-checks-summary-empty">{{ tab.empty_message }}</p>
+                    {% endif %}
+                {% elif tab.rows %}
                 <ul class="report-checks-summary-list">
                     {% for row in tab.rows %}
                     <li>

--- a/skore/src/skore/_utils/repr/display/_checks_summary_tabset.html.j2
+++ b/skore/src/skore/_utils/repr/display/_checks_summary_tabset.html.j2
@@ -23,13 +23,6 @@
                             {% for row in block.rows %}
                             <li>
                                 {% if row.documentation_url %}[<a href="{{ row.documentation_url }}" target="_blank" rel="noopener noreferrer" class="report-hint-note-link">{{ row.code }}</a>]{% else %}[{{ row.code }}]{% endif %} <strong>{{ row.title }}.</strong>
-                                {%- if row.grouped_explanations %}
-                                <ul class="report-checks-summary-sublist">
-                                    {% for entry in row.grouped_explanations %}
-                                    <li>[{{ entry.source }}] {{ entry.explanation }}</li>
-                                    {% endfor %}
-                                </ul>
-                                {%- elif row.explanation %} {{ row.explanation }}{% endif %}
                             </li>
                             {% endfor %}
                         </ul>

--- a/skore/tests/unit/reports/comparison/test_checks.py
+++ b/skore/tests/unit/reports/comparison/test_checks.py
@@ -24,14 +24,11 @@ def test_collects_component_issues(report, monkeypatch):
         monkeypatch.setattr(
             sub_report,
             "_get_results",
-            lambda ignored_codes, *, fast_mode=False, iss=issues: (
-                iss,
-                set(iss),
-                set(),
-                set(),
-            ),
+            lambda ignored_codes, *, fast_mode=False, iss=issues: {
+                code: {**result, "section": "issue"} for code, result in iss.items()
+            },
         )
-    for attr in ("_check_results_cache", "_applicable_codes", "_not_applicable_codes"):
+    for attr in ("_check_results_cache",):
         if hasattr(report, attr):
             delattr(report, attr)
 

--- a/skore/tests/unit/reports/comparison/test_checks.py
+++ b/skore/tests/unit/reports/comparison/test_checks.py
@@ -57,3 +57,29 @@ def test_reuses_component_cached_results(report, monkeypatch):
                 )
 
     report.checks.summarize()
+
+
+def test_fast_mode_surfaces_skipped_slow_checks(
+    comparison_estimator_reports_regression,
+):
+    """fast_mode surfaces slow checks skipped on all estimators."""
+    summary = comparison_estimator_reports_regression.checks.summarize(fast_mode=True)
+    skipped = summary.frame(section="skipped").set_index("code")
+    slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
+    assert slow_codes <= set(skipped.index)
+    for code in slow_codes:
+        assert isinstance(skipped.loc[code, "explanation"], dict)
+        assert set(skipped.loc[code, "explanation"]) == set(
+            comparison_estimator_reports_regression.reports_
+        )
+
+
+def test_ignore_surfaces_muted_checks(comparison_estimator_reports_regression):
+    """Ignored checks appear in the ignored section for comparison reports."""
+    summary = comparison_estimator_reports_regression.checks.summarize(
+        ignore=["SKD001"], fast_mode=True
+    )
+    ignored = summary.frame(section="ignored").set_index("code")
+    assert "SKD001" in ignored.index
+    assert ignored.loc["SKD001", "explanation"] == "Muted via ignore or ignore_checks."
+    assert "SKD001" not in set(summary.frame(section="issue")["code"])

--- a/skore/tests/unit/reports/comparison/test_checks.py
+++ b/skore/tests/unit/reports/comparison/test_checks.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from skore._sklearn._checks.base import ChecksSummaryDisplay
@@ -67,11 +68,7 @@ def test_fast_mode_surfaces_skipped_slow_checks(
     skipped = summary.frame(section="skipped").set_index("code")
     slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
     assert slow_codes <= set(skipped.index)
-    for code in slow_codes:
-        assert isinstance(skipped.loc[code, "explanation"], dict)
-        assert set(skipped.loc[code, "explanation"]) == set(
-            comparison_estimator_reports_regression.reports_
-        )
+    assert skipped["explanation"].isna().all()
 
 
 def test_ignore_surfaces_muted_checks(comparison_estimator_reports_regression):
@@ -81,5 +78,5 @@ def test_ignore_surfaces_muted_checks(comparison_estimator_reports_regression):
     )
     ignored = summary.frame(section="ignored").set_index("code")
     assert "SKD001" in ignored.index
-    assert ignored.loc["SKD001", "explanation"] == "Muted via ignore or ignore_checks."
+    assert pd.isna(ignored.loc["SKD001", "explanation"])
     assert "SKD001" not in set(summary.frame(section="issue")["code"])

--- a/skore/tests/unit/reports/comparison/test_checks.py
+++ b/skore/tests/unit/reports/comparison/test_checks.py
@@ -23,7 +23,7 @@ def test_collects_component_issues(report, monkeypatch):
     ):
         monkeypatch.setattr(
             sub_report,
-            "_get_results",
+            "_get_checks_results",
             lambda ignored_codes, *, fast_mode=False, iss=issues: {
                 code: {**result, "section": "issue"} for code, result in iss.items()
             },

--- a/skore/tests/unit/reports/comparison/test_checks.py
+++ b/skore/tests/unit/reports/comparison/test_checks.py
@@ -27,6 +27,7 @@ def test_collects_component_issues(report, monkeypatch):
                 iss,
                 set(iss),
                 set(),
+                set(),
             ),
         )
     for attr in ("_check_results_cache", "_applicable_codes", "_not_applicable_codes"):

--- a/skore/tests/unit/reports/cross_validation/test_checks.py
+++ b/skore/tests/unit/reports/cross_validation/test_checks.py
@@ -434,6 +434,8 @@ def test_add_checks_estimator_level_not_on_cv_summary(regression_report):
 
 def test_fast_mode_skips_slow_checks(regression_report):
     """fast_mode=True skips slow uncached checks."""
-    codes = set(regression_report.checks.summarize(fast_mode=True).frame()["code"])
+    summary = regression_report.checks.summarize(fast_mode=True)
     slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
-    assert slow_codes.isdisjoint(codes)
+    assert slow_codes.isdisjoint(set(summary.frame(section="issue")["code"]))
+    assert slow_codes.isdisjoint(set(summary.frame(section="passed")["code"]))
+    assert slow_codes <= set(summary.frame(section="skipped")["code"])

--- a/skore/tests/unit/reports/cross_validation/test_checks.py
+++ b/skore/tests/unit/reports/cross_validation/test_checks.py
@@ -438,4 +438,4 @@ def test_fast_mode_skips_slow_checks(regression_report):
     slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
     assert slow_codes.isdisjoint(set(summary.frame(section="issue")["code"]))
     assert slow_codes.isdisjoint(set(summary.frame(section="passed")["code"]))
-    assert slow_codes <= set(summary.frame(section="skipped")["code"])
+    assert slow_codes == set(summary.frame(section="skipped")["code"])

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -53,15 +53,6 @@ def regression_report(request, regression_data):
 
 
 def mock_issue(report, ignored_codes, *, fast_mode=False):
-    if "SKD001" in ignored_codes:
-        return {
-            "SKD001": {
-                "title": "Mock title",
-                "docs_url": "skd001-overfitting",
-                "explanation": None,
-                "section": "ignored",
-            }
-        }
     return {
         "SKD001": {
             "title": "Mock title",
@@ -744,14 +735,11 @@ def test_skd016_pipeline_walks_steps(regression_data):
     assert "Ridge" not in explanation
 
 
-def test_ignore_checks(monkeypatch, regression_report):
+def test_ignore_checks(regression_report):
     """Check that checks are ignored when ignore is passed."""
-    monkeypatch.setattr(EstimatorReport, "_get_results", mock_issue)
-    assert (
-        regression_report.checks.summarize(ignore=["SKD001"])
-        .frame(section="issue")
-        .empty
-    )
+    result = regression_report.checks.summarize(ignore=["SKD001"])
+    assert "SKD001" in set(result.frame(section="ignored")["code"])
+    assert "SKD001" not in set(result.frame(section="issue")["code"])
 
 
 def test_exception_when_train_data_missing(regression_train_test_split):
@@ -799,7 +787,7 @@ def test_no_issues(monkeypatch, regression_report):
     """Check that no issues are detected when checks pass."""
     monkeypatch.setattr(
         EstimatorReport,
-        "_get_results",
+        "_get_checks_results",
         lambda report, ignored_codes, *, fast_mode=False: {},
     )
     assert regression_report.checks.summarize().frame(section="issue").empty
@@ -807,7 +795,7 @@ def test_no_issues(monkeypatch, regression_report):
 
 def test_checks_summary_repr(monkeypatch, regression_report):
     """Check that the checks summary has a repr."""
-    monkeypatch.setattr(EstimatorReport, "_get_results", mock_issue)
+    monkeypatch.setattr(EstimatorReport, "_get_checks_results", mock_issue)
     results = regression_report.checks.summarize()
     assert isinstance(results, ChecksSummaryDisplay)
     elements = [
@@ -827,11 +815,10 @@ def test_checks_summary_repr(monkeypatch, regression_report):
     assert "report-hint-note-line" in bundle["text/html"]
 
 
-def test_global_ignore(monkeypatch, regression_report):
+def test_global_ignore(regression_report):
     """Check that checks are ignored when global ignore is set."""
-    monkeypatch.setattr(EstimatorReport, "_get_results", mock_issue)
-    assert "SKD001" in set(
-        regression_report.checks.summarize().frame(section="issue")["code"]
+    assert "SKD001" not in set(
+        regression_report.checks.summarize().frame(section="ignored")["code"]
     )
     with configuration(ignore_checks=["SKD001"]):
         summary = regression_report.checks.summarize()
@@ -1074,7 +1061,7 @@ def test_html_tabs(regression_report):
 
 def test_checks_summary_html_note_lines(monkeypatch, regression_report):
     """HTML note shows fast-mode info and mute hint on separate lines."""
-    monkeypatch.setattr(EstimatorReport, "_get_results", mock_issue)
+    monkeypatch.setattr(EstimatorReport, "_get_checks_results", mock_issue)
     html_fast = regression_report.checks.summarize(fast_mode=True)._repr_html_()
     assert "Fast mode is on" in html_fast
     assert "Mute a check by passing" in html_fast
@@ -1181,7 +1168,7 @@ def test_html_repr_shows_cached_slow(regression_report):
 
 def test_html_repr_fragments_includes_checks_detail(monkeypatch, regression_report):
     """The HTML repr fragments include per-check detail from fast-mode summary."""
-    monkeypatch.setattr(EstimatorReport, "_get_results", mock_issue)
+    monkeypatch.setattr(EstimatorReport, "_get_checks_results", mock_issue)
     checks_html = regression_report._html_repr_fragments()["checks_summary"]
     assert "report-checks-summary-list" in checks_html
     assert "Issues (1)" in checks_html

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -1068,7 +1068,8 @@ def test_html_tabs(regression_report):
     assert "Tips (" in html
     assert "Passed (" in html
     assert "Not Applicable (" in html
-    assert "Skipped &amp; Ignored (" in html
+    assert "Skipped (" in html
+    assert "Ignored (" in html
 
 
 def test_checks_summary_html_note_lines(monkeypatch, regression_report):

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -1026,7 +1026,7 @@ def test_ignored_checks_appear_in_ignored_section(regression_report):
     result = regression_report.checks.summarize(ignore=["TST001"])
     ignored = result.frame(section="ignored").set_index("code")
     assert "TST001" in ignored.index
-    assert ignored.loc["TST001", "explanation"] == "Muted via ignore or ignore_checks."
+    assert pd.isna(ignored.loc["TST001", "explanation"])
     assert "TST001" not in set(result.frame(section="passed")["code"])
     assert "TST001" not in set(result.frame(section="issue")["code"])
 
@@ -1138,7 +1138,7 @@ def test_summarize_fast_mode_skips_uncached_slow_checks(regression_report):
     assert "TSTSLOW" not in set(result.frame(section="issue")["code"])
     skipped = result.frame(section="skipped").set_index("code")
     assert "TSTSLOW" in skipped.index
-    assert skipped.loc["TSTSLOW", "explanation"] == "Skipped in fast mode (not cached)."
+    assert pd.isna(skipped.loc["TSTSLOW", "explanation"])
     assert slow_check.calls == 0
 
 

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -53,19 +53,23 @@ def regression_report(request, regression_data):
 
 
 def mock_issue(report, ignored_codes, *, fast_mode=False):
-    return (
-        {
+    if "SKD001" in ignored_codes:
+        return {
             "SKD001": {
                 "title": "Mock title",
                 "docs_url": "skd001-overfitting",
-                "explanation": "Mock overfitting detected.",
-                "severity": "issue",
+                "explanation": None,
+                "section": "ignored",
             }
-        },
-        {"SKD001"},
-        set(),
-        set(),
-    )
+        }
+    return {
+        "SKD001": {
+            "title": "Mock title",
+            "docs_url": "skd001-overfitting",
+            "explanation": "Mock overfitting detected.",
+            "section": "issue",
+        }
+    }
 
 
 class MockCheck(Check):
@@ -796,12 +800,7 @@ def test_no_issues(monkeypatch, regression_report):
     monkeypatch.setattr(
         EstimatorReport,
         "_get_results",
-        lambda report, ignored_codes, *, fast_mode=False: (
-            {},
-            {"SKD001", "SKD002"},
-            set(),
-            set(),
-        ),
+        lambda report, ignored_codes, *, fast_mode=False: {},
     )
     assert regression_report.checks.summarize().frame(section="issue").empty
 
@@ -835,14 +834,14 @@ def test_global_ignore(monkeypatch, regression_report):
         regression_report.checks.summarize().frame(section="issue")["code"]
     )
     with configuration(ignore_checks=["SKD001"]):
-        assert "SKD001" not in set(
-            regression_report.checks.summarize().frame(section="issue")["code"]
-        )
+        summary = regression_report.checks.summarize()
+        assert "SKD001" not in set(summary.frame(section="issue")["code"])
+        assert "SKD001" in set(summary.frame(section="ignored")["code"])
 
 
 def test_documentation_url_points_to_existing_rst():
     """Check that the URL in _get_issue_documentation_url maps to a real RST file."""
-    url = urlparse(_get_issue_documentation_url(mock_issue(None, set())[0]["SKD001"]))
+    url = urlparse(_get_issue_documentation_url(mock_issue(None, set())["SKD001"]))
     # url.path is e.g. "/dev/user_guide/automated_checks.html"
     # strip version prefix and convert .html -> .rst
     rst_rel_path = "/".join(url.path.split("/")[2:]).replace(".html", ".rst")
@@ -935,12 +934,10 @@ def test_remove_clears_cache(regression_report):
     regression_report.checks.add([MockCheck(has_issue=True)])
     regression_report.checks.summarize()
     assert "TST001" in regression_report._check_results_cache
-    assert "TST001" in regression_report._applicable_codes
+    assert regression_report._check_results_cache["TST001"]["section"] == "issue"
 
     regression_report.checks.remove("TST001")
     assert "TST001" not in regression_report._check_results_cache
-    assert "TST001" not in regression_report._applicable_codes
-    assert "TST001" not in regression_report._not_applicable_codes
 
 
 def test_remove_is_case_insensitive(regression_report):

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -64,6 +64,7 @@ def mock_issue(report, ignored_codes, *, fast_mode=False):
         },
         {"SKD001"},
         set(),
+        set(),
     )
 
 
@@ -799,6 +800,7 @@ def test_no_issues(monkeypatch, regression_report):
             {},
             {"SKD001", "SKD002"},
             set(),
+            set(),
         ),
     )
     assert regression_report.checks.summarize().frame(section="issue").empty
@@ -1018,10 +1020,13 @@ def test_passed_contains_applicable_checks_with_no_finding(regression_report):
     assert "TST001" not in set(result.frame(section="tip")["code"])
 
 
-def test_passed_excludes_ignored(regression_report):
-    """Ignored codes are not listed as passed."""
+def test_ignored_checks_appear_in_ignored_section(regression_report):
+    """Ignored codes appear under the ignored section."""
     regression_report.checks.add([MockCheck(has_issue=False)])
     result = regression_report.checks.summarize(ignore=["TST001"])
+    ignored = result.frame(section="ignored").set_index("code")
+    assert "TST001" in ignored.index
+    assert ignored.loc["TST001", "explanation"] == "Muted via ignore or ignore_checks."
     assert "TST001" not in set(result.frame(section="passed")["code"])
     assert "TST001" not in set(result.frame(section="issue")["code"])
 
@@ -1047,13 +1052,14 @@ def test_frame_section_filter(regression_report):
 
 
 def test_header_reports_all_counts(regression_report):
-    """The header reports issue, tip, passed, not applicable and ignored counts."""
+    """The header reports issue, tip, passed, NA, skipped and ignored counts."""
     regression_report.checks.add([MockCheck(has_issue=True), TipCheck()])
     result = regression_report.checks.summarize(ignore=["SKD001"])
     assert "issue(s)" in result._header
     assert "tip(s)" in result._header
     assert "passed" in result._header
     assert "not applicable" in result._header
+    assert "skipped" in result._header
     assert "1 ignored" in result._header
 
 
@@ -1065,6 +1071,7 @@ def test_html_tabs(regression_report):
     assert "Tips (" in html
     assert "Passed (" in html
     assert "Not Applicable (" in html
+    assert "Skipped &amp; Ignored (" in html
 
 
 def test_checks_summary_html_note_lines(monkeypatch, regression_report):
@@ -1127,8 +1134,11 @@ def test_summarize_fast_mode_skips_uncached_slow_checks(regression_report):
     """fast_mode=True skips slow checks that are not cached."""
     slow_check = SlowMockCheck()
     regression_report.checks.add([slow_check])
-    codes = set(regression_report.checks.summarize(fast_mode=True).frame()["code"])
-    assert "TSTSLOW" not in codes
+    result = regression_report.checks.summarize(fast_mode=True)
+    assert "TSTSLOW" not in set(result.frame(section="issue")["code"])
+    skipped = result.frame(section="skipped").set_index("code")
+    assert "TSTSLOW" in skipped.index
+    assert skipped.loc["TSTSLOW", "explanation"] == "Skipped in fast mode (not cached)."
     assert slow_check.calls == 0
 
 

--- a/skore/tests/unit/reports/test_checks_summary_display.py
+++ b/skore/tests/unit/reports/test_checks_summary_display.py
@@ -1,31 +1,18 @@
 from skore._sklearn._checks.base import ChecksSummaryDisplay
 
 
-def display(
-    check_results,
-    *,
-    not_applicable_codes=frozenset(),
-    skipped_checks=None,
-    ignored_checks=None,
-    fast_mode=False,
-):
-    return ChecksSummaryDisplay(
-        check_results=check_results,
-        not_applicable_codes=set(not_applicable_codes),
-        skipped_checks={} if skipped_checks is None else skipped_checks,
-        ignored_checks={} if ignored_checks is None else ignored_checks,
-        fast_mode=fast_mode,
-    )
+def display(check_results, *, fast_mode=False):
+    return ChecksSummaryDisplay(check_results, fast_mode=fast_mode)
 
 
-def display_html(*args, **kwargs):
-    return display(*args, **kwargs)._repr_html_()
+def display_html(check_results, *, fast_mode=False):
+    return display(check_results, fast_mode=fast_mode)._repr_html_()
 
 
 _MOCK_ISSUE = {
     "title": "Mock issue",
     "docs_url": "skd001-mock",
-    "severity": "issue",
+    "section": "issue",
 }
 
 
@@ -58,11 +45,10 @@ def test_repr_html_groups_not_applicable_explanations():
             "SKDNA": {
                 "title": "Not applicable check",
                 "docs_url": "skdna-mock",
-                "severity": "issue",
+                "section": "not_applicable",
                 "explanation": {"Ridge": "Reason A.", "Lasso": "Reason B."},
             }
-        },
-        not_applicable_codes={"SKDNA"},
+        }
     )
     assert "Not Applicable (1)" in html
     assert ">SKDNA</a>] <strong>Not applicable check.</strong>" in html
@@ -90,20 +76,19 @@ def test_repr_html_merges_estimators_with_same_explanation():
 def test_repr_html_skipped_and_ignored_blocks():
     """HTML repr shows skipped and ignored checks as code and title only."""
     html = display_html(
-        {},
-        skipped_checks={
+        {
             "SKDSLOW": {
                 "title": "Slow check",
                 "docs_url": "skdslow",
-                "severity": "issue",
-            }
-        },
-        ignored_checks={
+                "section": "skipped",
+                "explanation": None,
+            },
             "SKDIGN": {
                 "title": "Ignored check",
                 "docs_url": "skdign",
-                "severity": "issue",
-            }
+                "section": "ignored",
+                "explanation": None,
+            },
         },
         fast_mode=True,
     )
@@ -120,21 +105,20 @@ def test_repr_html_skipped_and_ignored_blocks():
 def test_frame_skipped_and_ignored_sections():
     """frame(section=...) exposes skipped and ignored rows."""
     summary = display(
-        {},
-        skipped_checks={
+        {
             "SKDSLOW": {
                 "title": "Slow check",
                 "docs_url": "skdslow",
-                "severity": "issue",
-            }
-        },
-        ignored_checks={
+                "section": "skipped",
+                "explanation": None,
+            },
             "SKDIGN": {
                 "title": "Ignored check",
                 "docs_url": "skdign",
-                "severity": "issue",
-            }
-        },
+                "section": "ignored",
+                "explanation": None,
+            },
+        }
     )
     assert set(summary.frame(section="skipped")["code"]) == {"SKDSLOW"}
     assert set(summary.frame(section="ignored")["code"]) == {"SKDIGN"}

--- a/skore/tests/unit/reports/test_checks_summary_display.py
+++ b/skore/tests/unit/reports/test_checks_summary_display.py
@@ -73,7 +73,7 @@ def test_repr_html_merges_estimators_with_same_explanation():
     assert html.count("Same reason.") == 1
 
 
-def test_repr_html_skipped_and_ignored_blocks():
+def test_repr_html_skipped_and_ignored_tabs():
     """HTML repr shows skipped and ignored checks as code and title only."""
     html = display_html(
         {
@@ -92,10 +92,8 @@ def test_repr_html_skipped_and_ignored_blocks():
         },
         fast_mode=True,
     )
-    assert "Skipped &amp; Ignored (2)" in html or "Skipped & Ignored (2)" in html
-    assert "report-checks-summary-block-title" in html
-    assert "<strong>Skipped (fast mode)</strong>" in html
-    assert "<strong>Ignored</strong>" in html
+    assert "Skipped (1)" in html
+    assert "Ignored (1)" in html
     assert ">SKDSLOW</a>] <strong>Slow check.</strong>" in html
     assert ">SKDIGN</a>] <strong>Ignored check.</strong>" in html
     assert "Skipped in fast mode" not in html

--- a/skore/tests/unit/reports/test_checks_summary_display.py
+++ b/skore/tests/unit/reports/test_checks_summary_display.py
@@ -1,12 +1,8 @@
 from skore._sklearn._checks.base import ChecksSummaryDisplay
 
 
-def display(check_results, *, fast_mode=False):
-    return ChecksSummaryDisplay(check_results, fast_mode=fast_mode)
-
-
-def display_html(check_results, *, fast_mode=False):
-    return display(check_results, fast_mode=fast_mode)._repr_html_()
+def display_html(check_results, fast_mode=False):
+    return ChecksSummaryDisplay(check_results, fast_mode=fast_mode)._repr_html_()
 
 
 _MOCK_ISSUE = {
@@ -71,54 +67,3 @@ def test_repr_html_merges_estimators_with_same_explanation():
     assert ">SKD001</a>] <strong>Mock issue.</strong>" in html
     assert "<li>[Ridge, Lasso] Same reason.</li>" in html
     assert html.count("Same reason.") == 1
-
-
-def test_repr_html_skipped_and_ignored_tabs():
-    """HTML repr shows skipped and ignored checks as code and title only."""
-    html = display_html(
-        {
-            "SKDSLOW": {
-                "title": "Slow check",
-                "docs_url": "skdslow",
-                "section": "skipped",
-                "explanation": None,
-            },
-            "SKDIGN": {
-                "title": "Ignored check",
-                "docs_url": "skdign",
-                "section": "ignored",
-                "explanation": None,
-            },
-        },
-        fast_mode=True,
-    )
-    assert "Skipped (1)" in html
-    assert "Ignored (1)" in html
-    assert ">SKDSLOW</a>] <strong>Slow check.</strong>" in html
-    assert ">SKDIGN</a>] <strong>Ignored check.</strong>" in html
-    assert "Skipped in fast mode" not in html
-    assert "Muted via ignore" not in html
-
-
-def test_frame_skipped_and_ignored_sections():
-    """frame(section=...) exposes skipped and ignored rows."""
-    summary = display(
-        {
-            "SKDSLOW": {
-                "title": "Slow check",
-                "docs_url": "skdslow",
-                "section": "skipped",
-                "explanation": None,
-            },
-            "SKDIGN": {
-                "title": "Ignored check",
-                "docs_url": "skdign",
-                "section": "ignored",
-                "explanation": None,
-            },
-        }
-    )
-    assert set(summary.frame(section="skipped")["code"]) == {"SKDSLOW"}
-    assert set(summary.frame(section="ignored")["code"]) == {"SKDIGN"}
-    assert summary.frame(section="skipped")["explanation"].isna().all()
-    assert summary.frame(section="ignored")["explanation"].isna().all()

--- a/skore/tests/unit/reports/test_checks_summary_display.py
+++ b/skore/tests/unit/reports/test_checks_summary_display.py
@@ -1,18 +1,25 @@
 from skore._sklearn._checks.base import ChecksSummaryDisplay
 
 
-def display_html(
+def display(
     check_results,
     *,
     not_applicable_codes=frozenset(),
+    skipped_checks=None,
+    ignored_checks=None,
     fast_mode=False,
 ):
     return ChecksSummaryDisplay(
         check_results=check_results,
         not_applicable_codes=set(not_applicable_codes),
-        n_ignored_codes=0,
+        skipped_checks={} if skipped_checks is None else skipped_checks,
+        ignored_checks={} if ignored_checks is None else ignored_checks,
         fast_mode=fast_mode,
-    )._repr_html_()
+    )
+
+
+def display_html(*args, **kwargs):
+    return display(*args, **kwargs)._repr_html_()
 
 
 _MOCK_ISSUE = {
@@ -78,3 +85,60 @@ def test_repr_html_merges_estimators_with_same_explanation():
     assert ">SKD001</a>] <strong>Mock issue.</strong>" in html
     assert "<li>[Ridge, Lasso] Same reason.</li>" in html
     assert html.count("Same reason.") == 1
+
+
+def test_repr_html_skipped_and_ignored_blocks():
+    """HTML repr shows skipped and ignored checks in separate blocks."""
+    html = display_html(
+        {},
+        skipped_checks={
+            "SKDSLOW": {
+                "title": "Slow check",
+                "docs_url": "skdslow",
+                "explanation": "Skipped in fast mode (not cached).",
+                "severity": "issue",
+            }
+        },
+        ignored_checks={
+            "SKDIGN": {
+                "title": "Ignored check",
+                "docs_url": "skdign",
+                "explanation": "Muted via ignore or ignore_checks.",
+                "severity": "issue",
+            }
+        },
+        fast_mode=True,
+    )
+    assert "Skipped &amp; Ignored (2)" in html or "Skipped & Ignored (2)" in html
+    assert "report-checks-summary-block-title" in html
+    assert "<strong>Skipped</strong>" in html
+    assert "<strong>Ignored</strong>" in html
+    assert ">SKDSLOW</a>" in html
+    assert "Skipped in fast mode (not cached)." in html
+    assert ">SKDIGN</a>" in html
+    assert "Muted via ignore or ignore_checks." in html
+
+
+def test_frame_skipped_and_ignored_sections():
+    """frame(section=...) exposes skipped and ignored rows."""
+    summary = display(
+        {},
+        skipped_checks={
+            "SKDSLOW": {
+                "title": "Slow check",
+                "docs_url": "skdslow",
+                "explanation": "Skipped in fast mode (not cached).",
+                "severity": "issue",
+            }
+        },
+        ignored_checks={
+            "SKDIGN": {
+                "title": "Ignored check",
+                "docs_url": "skdign",
+                "explanation": "Muted via ignore or ignore_checks.",
+                "severity": "issue",
+            }
+        },
+    )
+    assert set(summary.frame(section="skipped")["code"]) == {"SKDSLOW"}
+    assert set(summary.frame(section="ignored")["code"]) == {"SKDIGN"}

--- a/skore/tests/unit/reports/test_checks_summary_display.py
+++ b/skore/tests/unit/reports/test_checks_summary_display.py
@@ -88,14 +88,13 @@ def test_repr_html_merges_estimators_with_same_explanation():
 
 
 def test_repr_html_skipped_and_ignored_blocks():
-    """HTML repr shows skipped and ignored checks in separate blocks."""
+    """HTML repr shows skipped and ignored checks as code and title only."""
     html = display_html(
         {},
         skipped_checks={
             "SKDSLOW": {
                 "title": "Slow check",
                 "docs_url": "skdslow",
-                "explanation": "Skipped in fast mode (not cached).",
                 "severity": "issue",
             }
         },
@@ -103,7 +102,6 @@ def test_repr_html_skipped_and_ignored_blocks():
             "SKDIGN": {
                 "title": "Ignored check",
                 "docs_url": "skdign",
-                "explanation": "Muted via ignore or ignore_checks.",
                 "severity": "issue",
             }
         },
@@ -111,12 +109,12 @@ def test_repr_html_skipped_and_ignored_blocks():
     )
     assert "Skipped &amp; Ignored (2)" in html or "Skipped & Ignored (2)" in html
     assert "report-checks-summary-block-title" in html
-    assert "<strong>Skipped</strong>" in html
+    assert "<strong>Skipped (fast mode)</strong>" in html
     assert "<strong>Ignored</strong>" in html
-    assert ">SKDSLOW</a>" in html
-    assert "Skipped in fast mode (not cached)." in html
-    assert ">SKDIGN</a>" in html
-    assert "Muted via ignore or ignore_checks." in html
+    assert ">SKDSLOW</a>] <strong>Slow check.</strong>" in html
+    assert ">SKDIGN</a>] <strong>Ignored check.</strong>" in html
+    assert "Skipped in fast mode" not in html
+    assert "Muted via ignore" not in html
 
 
 def test_frame_skipped_and_ignored_sections():
@@ -127,7 +125,6 @@ def test_frame_skipped_and_ignored_sections():
             "SKDSLOW": {
                 "title": "Slow check",
                 "docs_url": "skdslow",
-                "explanation": "Skipped in fast mode (not cached).",
                 "severity": "issue",
             }
         },
@@ -135,10 +132,11 @@ def test_frame_skipped_and_ignored_sections():
             "SKDIGN": {
                 "title": "Ignored check",
                 "docs_url": "skdign",
-                "explanation": "Muted via ignore or ignore_checks.",
                 "severity": "issue",
             }
         },
     )
     assert set(summary.frame(section="skipped")["code"]) == {"SKDSLOW"}
     assert set(summary.frame(section="ignored")["code"]) == {"SKDIGN"}
+    assert summary.frame(section="skipped")["explanation"].isna().all()
+    assert summary.frame(section="ignored")["explanation"].isna().all()

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -41,13 +41,18 @@ can be skipped with `fast_mode=True`:
     report.checks.summarize(fast_mode=True)
 
 In fast mode, slow checks that are not yet in the cache are not run; cached
-slow results from a previous call are still surfaced. The HTML representation
-of a report uses fast mode so it never triggers an expensive computation.
+slow results from a previous call are still surfaced. Skipped checks appear in
+the ``Skipped & Ignored`` tab of the summary. The HTML representation of a
+report uses fast mode so it never triggers an expensive computation.
+
+Muted checks appear in the same tab under ``Ignored``. You can also query them
+with :meth:`~skore.ChecksSummaryDisplay.frame` using ``section="ignored"`` or
+``section="skipped"``.
 
 For comparison reports, :meth:`~skore.ComparisonReport.checks.summarize` builds a global
 summary from each compared report. Results are grouped by check code; the HTML summary
-lists each check once with per-estimator sub-entries for issues, tips, and not-applicable
-reasons.
+lists each check once with per-estimator sub-entries for issues, tips, not-applicable
+reasons, and fast-mode skips.
 
 
 .. _skd001-overfitting:

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -41,13 +41,14 @@ can be skipped with `fast_mode=True`:
     report.checks.summarize(fast_mode=True)
 
 In fast mode, slow checks that are not yet in the cache are not run; cached
-slow results from a previous call are still surfaced. Skipped checks appear in
-the ``Skipped & Ignored`` tab of the summary. The HTML representation of a
-report uses fast mode so it never triggers an expensive computation.
+slow results from a previous call are still surfaced. They are listed by code and
+title under ``Skipped (fast mode)`` in the ``Skipped & Ignored`` tab. The HTML
+representation of a report uses fast mode so it never triggers an expensive
+computation.
 
-Muted checks appear in the same tab under ``Ignored``. You can also query them
-with :meth:`~skore.ChecksSummaryDisplay.frame` using ``section="ignored"`` or
-``section="skipped"``.
+Muted checks are listed the same way under ``Ignored`` in that tab. You can also
+query them with :meth:`~skore.ChecksSummaryDisplay.frame` using
+``section="ignored"`` or ``section="skipped"``.
 
 For comparison reports, :meth:`~skore.ComparisonReport.checks.summarize` builds a global
 summary from each compared report. Results are grouped by check code; the HTML summary

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -40,16 +40,6 @@ can be skipped with `fast_mode=True`:
 
     report.checks.summarize(fast_mode=True)
 
-In fast mode, slow checks that are not yet in the cache are not run; cached
-slow results from a previous call are still surfaced. They are listed by code and
-title under ``Skipped (fast mode)`` in the ``Skipped & Ignored`` tab. The HTML
-representation of a report uses fast mode so it never triggers an expensive
-computation.
-
-Muted checks are listed the same way under ``Ignored`` in that tab. You can also
-query them with :meth:`~skore.ChecksSummaryDisplay.frame` using
-``section="ignored"`` or ``section="skipped"``.
-
 For comparison reports, :meth:`~skore.ComparisonReport.checks.summarize` builds a global
 summary from each compared report. Results are grouped by check code; the HTML summary
 lists each check once with per-estimator sub-entries for issues, tips, not-applicable


### PR DESCRIPTION
Closes #3052 by adding a Skipped and an Ignored section to the checks results.

Also includes a small refactor of how check results are collected and transferred:
Checks are now summarized as a single `dict[CheckCode, CheckResult]` with an explicit `section` per check (issue/tip/passed/not_applicable/skipped/ignored), produced by `_get_checks_results` and passed straight into `ChecksSummaryDisplay`, replacing the old parallel findings/applicable/NA structures.