### PR TITLE
feat(checks): Compute fast checks at report init

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -125,6 +125,14 @@ class _BaseReport(ReportHelpMixin):
             self._not_applicable_codes,
         )
 
+    def _clear_checks_cache(self) -> None:
+        if hasattr(self, "_check_results_cache"):
+            self._check_results_cache.clear()
+        if hasattr(self, "_applicable_codes"):
+            self._applicable_codes.clear()
+        if hasattr(self, "_not_applicable_codes"):
+            self._not_applicable_codes.clear()
+
     def _checks_summary_html_fragment(self) -> str:
         """HTML snippet for the checks summary tab in report reprs."""
         return self.checks.summarize(fast_mode=True)._embedded_repr_html()

--- a/skore/src/skore/_sklearn/_checks/accessor.py
+++ b/skore/src/skore/_sklearn/_checks/accessor.py
@@ -6,6 +6,19 @@ from skore._sklearn._base import _BaseAccessor, _BaseReport
 from skore._sklearn._checks.base import Check, CheckCode, ChecksSummaryDisplay
 
 
+def collect_ignored_codes(
+    ignore: list[CheckCode] | tuple[CheckCode, ...] | None = None,
+) -> set[CheckCode]:
+    ignored_codes: set[CheckCode] = set()
+    if ignore:
+        ignored_codes.update(code.strip().upper() for code in ignore if code.strip())
+    if configuration.ignore_checks:
+        ignored_codes.update(
+            code.strip().upper() for code in configuration.ignore_checks if code.strip()
+        )
+    return ignored_codes
+
+
 class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
     """Accessor for checks-related operations.
 
@@ -55,17 +68,7 @@ class _ChecksAccessor(_BaseAccessor[_BaseReport], DirNamesMixin):
         >>> "SKD002" in filtered.frame()["code"].values
         False
         """
-        ignored_codes: set[CheckCode] = set()
-        if ignore:
-            ignored_codes.update(
-                code.strip().upper() for code in ignore if code.strip()
-            )
-        if configuration.ignore_checks:
-            ignored_codes.update(
-                code.strip().upper()
-                for code in configuration.ignore_checks
-                if code.strip()
-            )
+        ignored_codes = collect_ignored_codes(ignore)
         check_results, applicable_codes, not_applicable_codes = (
             self._parent._get_results(ignored_codes, fast_mode=fast_mode)
         )

--- a/skore/src/skore/_sklearn/_checks/model_checks.py
+++ b/skore/src/skore/_sklearn/_checks/model_checks.py
@@ -102,6 +102,7 @@ def _baseline_estimator_report(
                 splitter=report.splitter,
                 pos_label=report.pos_label,
                 n_jobs=report.n_jobs,
+                run_fast_checks=False,
             )
         except Exception as exc:
             raise CheckNotApplicable("Failed to create baseline report.") from exc
@@ -130,6 +131,7 @@ def _baseline_estimator_report(
             X_test=X_test,
             y_test=y_test,
             pos_label=report.pos_label,
+            run_fast_checks=False,
         )
     except Exception as exc:
         raise CheckNotApplicable("Failed to create baseline report.") from exc
@@ -649,6 +651,7 @@ class CheckGoldenFeature(Check):
                         splitter=report.splitter,
                         pos_label=report.pos_label,
                         n_jobs=report.n_jobs,
+                        run_fast_checks=False,
                     )
                     for sub_report in single_feature_report.reports_:
                         sub_report._metric_registry = metric_registry
@@ -660,6 +663,7 @@ class CheckGoldenFeature(Check):
                         X_test=X_test.select(nw.col(feature_names[i])).to_native(),
                         y_test=y_test,
                         pos_label=report.pos_label,
+                        run_fast_checks=False,
                     )
                     single_feature_report._metric_registry = metric_registry
                 single_feature_scores = collect_scores(

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -256,6 +256,7 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
                 position=position,
                 **kwargs,
             )
+        self._parent._clear_checks_cache()
 
     def remove(self, name: str) -> None:
         """Remove a metric from each underlying estimator report.
@@ -271,6 +272,7 @@ class _MetricsAccessor(_BaseAccessor[ComparisonReport], DirNamesMixin):
         """
         for report in self._parent.reports_.values():
             report.metrics.remove(name)
+        self._parent._clear_checks_cache()
 
     def get(
         self,

--- a/skore/src/skore/_sklearn/_comparison/report.py
+++ b/skore/src/skore/_sklearn/_comparison/report.py
@@ -11,6 +11,7 @@ from numpy.typing import ArrayLike
 
 from skore._externals._pandas_accessors import DirNamesMixin
 from skore._sklearn._base import _BaseReport
+from skore._sklearn._checks.accessor import collect_ignored_codes
 from skore._sklearn._checks.base import CheckCode, CheckExplanation, CheckSource
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._estimator.report import EstimatorReport
@@ -53,6 +54,10 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         parameter is used to parallelize the computation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors.
+
+    run_fast_checks : bool, default=True
+        When `True`, fast checks run at the end of initialization to
+        pre-populate the checks cache.
 
     Attributes
     ----------
@@ -254,6 +259,7 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
         ),
         *,
         n_jobs: int | None = None,
+        run_fast_checks: bool = True,
     ) -> None:
         super().__init__()
         self.reports_, self._report_type, self._pos_label = (
@@ -262,6 +268,9 @@ class ComparisonReport(_BaseReport, DirNamesMixin):
 
         self.n_jobs = n_jobs
         self._ml_task = next(iter(self.reports_.values()))._ml_task  # type: ignore
+
+        if run_fast_checks:
+            self._get_results(collect_ignored_codes(), fast_mode=True)
 
     def _clear_cache(self) -> None:
         """Clear the cache."""

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -203,6 +203,7 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
                 position=position,
                 **kwargs,
             )
+        self._parent._clear_checks_cache()
 
     def remove(self, name: str) -> None:
         """Remove a metric from each underlying estimator report.
@@ -214,6 +215,7 @@ class _MetricsAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
         """
         for report in self._parent.reports_:
             report.metrics.remove(name)
+        self._parent._clear_checks_cache()
 
     def get(
         self,

--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -17,6 +17,7 @@ from skrub._reporting._summarize import summarize_dataframe
 from skore._externals._pandas_accessors import DirNamesMixin
 from skore._externals._sklearn_compat import _safe_indexing, is_clusterer
 from skore._sklearn._base import _BaseReport
+from skore._sklearn._checks.accessor import collect_ignored_codes
 from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
 from skore._sklearn._estimator.report import EstimatorReport
 from skore._sklearn.types import (
@@ -64,6 +65,7 @@ def _generate_estimator_report(
         X_test=_safe_indexing(X, test_indices),
         y_test=_safe_indexing(y, test_indices),
         pos_label=pos_label,
+        run_fast_checks=False,
     )
 
 
@@ -127,6 +129,10 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         parameter is used to parallelize the computation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors.
+
+    run_fast_checks : bool, default=True
+        When `True`, fast checks run at the end of initialization to
+        pre-populate the checks cache.
 
     Attributes
     ----------
@@ -201,6 +207,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         pos_label: PositiveLabel | None = None,
         splitter: int | SKLearnCrossValidator | Generator | None = None,
         n_jobs: int | None = None,
+        run_fast_checks: bool = True,
     ) -> None:
         super().__init__()
         self._check_estimator_and_data(estimator, X, y, data, splitter)
@@ -210,6 +217,9 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
         self.reports_: list[EstimatorReport] = self._fit_estimator_reports()
 
         self._ml_task = self.reports_[0].ml_task
+
+        if run_fast_checks:
+            self._get_results(collect_ignored_codes(), fast_mode=True)
 
     def _check_estimator_and_data(
         self,
@@ -290,6 +300,7 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                     train_data=split["train"],
                     test_data=split["test"],
                     pos_label=self._pos_label,
+                    run_fast_checks=False,
                 )
                 for split in self.learner_.data_op.skb.iter_cv_splits(
                     environment=self._data, cv=self.split_indices

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -285,6 +285,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             raise ValueError(
                 f"{error.msg} Pass those kwargs to add: add({error.metric}, {args_msg})"
             ) from error
+        self._parent._clear_checks_cache()
 
     def remove(self, name: str) -> None:
         """Remove a metric from the registry.
@@ -297,6 +298,7 @@ class _MetricsAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         # `remove` takes the report as input so that the MetricRegistry does not
         # need to have the report as an attribute, which would be a circular reference
         self._parent._metric_registry.remove(report=self._parent, name=name)
+        self._parent._clear_checks_cache()
 
     def get(
         self,

--- a/skore/src/skore/_sklearn/_estimator/report.py
+++ b/skore/src/skore/_sklearn/_estimator/report.py
@@ -23,6 +23,7 @@ from skrub._reporting._summarize import summarize_dataframe
 from skore._externals._pandas_accessors import DirNamesMixin
 from skore._externals._sklearn_compat import _safe_indexing, is_clusterer
 from skore._sklearn._base import _BaseReport
+from skore._sklearn._checks.accessor import collect_ignored_codes
 from skore._sklearn._checks.model_checks import _BUILTIN_CHECKS
 from skore._sklearn.find_ml_task import _find_ml_task
 from skore._sklearn.metrics import MetricRegistry
@@ -147,6 +148,10 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         Binary metrics and displays that support it will expose all classes instead.
         This parameter is rejected for non-binary tasks.
 
+    run_fast_checks : bool, default=True
+        When `True`, fast checks run at the end of initialization to
+        pre-populate the checks cache.
+
     Attributes
     ----------
     estimator_ : estimator object
@@ -264,6 +269,7 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         train_data: dict | None = None,
         test_data: dict | None = None,
         pos_label: PositiveLabel | None = None,
+        run_fast_checks: bool = True,
     ) -> None:
         super().__init__()
         estimator = self._copy_estimator(estimator)
@@ -305,6 +311,9 @@ class EstimatorReport(_BaseReport, DirNamesMixin):
         self._cache_predictions(data_source="test")
 
         self._metric_registry = MetricRegistry(self)
+
+        if run_fast_checks:
+            self._get_results(collect_ignored_codes(), fast_mode=True)
 
         if pos_label is None:
             return

--- a/skore/src/skore/_sklearn/evaluate.py
+++ b/skore/src/skore/_sklearn/evaluate.py
@@ -8,6 +8,7 @@ from typing import Literal, cast
 from numpy.typing import ArrayLike
 
 from skore import configuration
+from skore._sklearn._checks.accessor import collect_ignored_codes
 from skore._sklearn._comparison.report import ComparisonReport
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._estimator.report import EstimatorReport
@@ -234,6 +235,7 @@ def evaluate(
                 splitter=splitter,
                 n_jobs=n_jobs,
             )
+        report.reports_[0]._get_results(collect_ignored_codes(), fast_mode=True)
         return report.reports_[0]
 
     splitter = cast(int | SKLearnCrossValidator | Generator, splitter)

--- a/skore/tests/unit/reports/comparison/test_checks.py
+++ b/skore/tests/unit/reports/comparison/test_checks.py
@@ -3,6 +3,16 @@ import pytest
 from skore._sklearn._checks.base import ChecksSummaryDisplay
 
 
+def test_fast_checks_run_at_init(report):
+    """Fast-mode checks populate sub-report caches during comparison init."""
+    for sub_report in report.reports_.values():
+        assert sub_report._check_results_cache
+    codes = set(report.checks.summarize(fast_mode=True).frame()["code"])
+    assert codes
+    slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
+    assert slow_codes.isdisjoint(codes)
+
+
 def test_collects_component_issues(report, monkeypatch):
     """Check that issues from all component reports are collected."""
     report_names = list(report.reports_)

--- a/skore/tests/unit/reports/cross_validation/test_checks.py
+++ b/skore/tests/unit/reports/cross_validation/test_checks.py
@@ -437,3 +437,19 @@ def test_fast_mode_skips_slow_checks(regression_report):
     codes = set(regression_report.checks.summarize(fast_mode=True).frame()["code"])
     slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
     assert slow_codes.isdisjoint(codes)
+
+
+def test_fast_checks_run_at_init(regression_data):
+    """Fast-mode checks populate the CV report cache at initialization."""
+    X, y = regression_data
+    report = evaluate(LinearRegression(), X, y, splitter=3)
+    assert report._check_results_cache
+    slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
+    assert slow_codes.isdisjoint(report._check_results_cache)
+
+
+def test_cv_fold_subreports_skip_init_fast_checks(regression_report):
+    """Fold EstimatorReports do not run fast checks at initialization."""
+    assert regression_report._check_results_cache
+    for fold_report in regression_report.reports_:
+        assert not hasattr(fold_report, "_check_results_cache")

--- a/skore/tests/unit/reports/estimator/test_checks.py
+++ b/skore/tests/unit/reports/estimator/test_checks.py
@@ -427,7 +427,7 @@ def test_get_space_bound(estimator, param_name, side, expected):
 
 def _prefit_grid_search_report(X, y, search):
     search.fit(X, y)
-    return evaluate(search, X, y, splitter="prefit")
+    return EstimatorReport(search, X_test=X, y_test=y, run_fast_checks=False)
 
 
 @pytest.mark.parametrize(
@@ -1204,3 +1204,49 @@ def test_subclass_check_without_slow_attr_treated_as_fast(regression_report):
     regression_report.checks.add([check])
     codes = set(regression_report.checks.summarize(fast_mode=True).frame()["code"])
     assert "TSTFAST" in codes
+
+
+def test_fast_checks_run_at_init(regression_data):
+    """Fast-mode checks populate the cache during report initialization."""
+    X, y = regression_data
+    report = evaluate(
+        LinearRegression(),
+        pd.DataFrame(X, columns=[str(i) for i in range(X.shape[1])]),
+        pd.Series(y),
+    )
+    assert report._check_results_cache
+    slow_codes = {"SKD009", "SKD010", "SKD011", "SKD012"}
+    assert slow_codes.isdisjoint(report._check_results_cache)
+
+
+def test_run_fast_checks_false_skips_init(regression_data):
+    """run_fast_checks=False defers checks until summarize is called."""
+    X, y = regression_data
+    X_df = pd.DataFrame(X, columns=[str(i) for i in range(X.shape[1])])
+    X_train, X_test, y_train, y_test = train_test_split(
+        X_df, pd.Series(y), random_state=42
+    )
+    report = EstimatorReport(
+        LinearRegression(),
+        X_train=X_train,
+        y_train=y_train,
+        X_test=X_test,
+        y_test=y_test,
+        run_fast_checks=False,
+    )
+    assert not hasattr(report, "_check_results_cache")
+    report.checks.summarize(fast_mode=True)
+    assert report._check_results_cache
+
+
+def test_init_fast_checks_not_rerun_on_summarize(regression_report, monkeypatch):
+    """Cached init fast checks are not recomputed on summarize(fast_mode=True)."""
+    assert regression_report._check_results_cache
+    for check in regression_report._checks_registry:
+        if check.code in regression_report._check_results_cache:
+            monkeypatch.setattr(
+                check,
+                "check_function",
+                lambda report: pytest.fail("re-ran cached check"),
+            )
+    regression_report.checks.summarize(fast_mode=True)


### PR DESCRIPTION
Closes #3059

We clear the checks cache when a custom metrics is added/removed since a lot of the checks should take custom metrics into account.