### PR TITLE
feat(summarize): Gather failed metrics instead of raising

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -88,7 +88,11 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
             test_summary = self.summarize(data_source="test", metric=metric)
 
             combined = train_summary.rows + test_summary.rows
-            return MetricsSummaryDisplay(rows=combined, report_type="cross-validation")
+            return MetricsSummaryDisplay(
+                rows=combined,
+                report_type="cross-validation",
+                errors=train_summary.errors + test_summary.errors,
+            )
 
         parallel = Parallel(
             **_validate_joblib_parallel_params(
@@ -347,7 +351,9 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
                 for row in metric_rows
             )
 
-        return MetricsSummaryDisplay(rows=rows, report_type="cross-validation")
+        return MetricsSummaryDisplay(
+            rows=rows, report_type="cross-validation", errors=[]
+        )
 
     @available_if(_check_estimator_report_has_method("metrics", "score"))
     def score(

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -29,6 +29,7 @@ from skore._sklearn.metrics import (
     Mape,
     Metric,
     MetricLike,
+    MetricRow,
     MissingKwargsError,
     Precision,
     PredictTime,
@@ -118,8 +119,11 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
             train_summary = self.summarize(data_source="train", metric=metric)
             test_summary = self.summarize(data_source="test", metric=metric)
 
-            combined = train_summary.rows + test_summary.rows
-            return MetricsSummaryDisplay(rows=combined, report_type="estimator")
+            return MetricsSummaryDisplay(
+                rows=train_summary.rows + test_summary.rows,
+                report_type="estimator",
+                errors=train_summary.errors + test_summary.errors,
+            )
 
         registry = self._parent._metric_registry
         if isinstance(metric, str):
@@ -140,12 +144,28 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
                 parsed_metrics = list(registry.values())
 
         rows: list[MetricsSummaryRow] = []
+        errors = []
         for parsed_metric in parsed_metrics:
-            metric_rows = parsed_metric.rows(
-                report=self._parent,
-                data_source=data_source,
-                **parsed_metric.kwargs,
-            )
+            try:
+                metric_rows = parsed_metric.rows(
+                    report=self._parent,
+                    data_source=data_source,
+                    **parsed_metric.kwargs,
+                )
+            except Exception as exception:
+                metric_rows = [
+                    MetricRow(
+                        metric_verbose_name=parsed_metric.verbose_name,
+                        fingerprint=None,
+                        greater_is_better=parsed_metric.greater_is_better,
+                        label=None,
+                        average=None,
+                        output=None,
+                        score=float("nan"),
+                    )
+                ]
+                errors.append((parsed_metric, exception))
+
             rows.extend(
                 row
                 | {
@@ -156,7 +176,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
                 for row in metric_rows
             )
 
-        return MetricsSummaryDisplay(rows=rows, report_type="estimator")
+        return MetricsSummaryDisplay(rows=rows, report_type="estimator", errors=errors)
 
     def _metric(
         self, metric_name: str, *, data_source: DataSource, **kwargs: Any
@@ -177,7 +197,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
                 report=self._parent, data_source=data_source, **kwargs
             )
         ]
-        return MetricsSummaryDisplay(rows=rows, report_type="estimator")
+        return MetricsSummaryDisplay(rows=rows, report_type="estimator", errors=[])
 
     def available(self) -> list[str]:
         """List available metric names in the registry.

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 from typing import Any, Literal, NotRequired, TypedDict, cast
 
@@ -409,6 +410,15 @@ class MetricsSummaryDisplay(DisplayMixin):
         frame : pandas.DataFrame
             The report metrics as a dataframe.
         """
+        if self.errors:
+            warnings.warn(
+                "\n".join(
+                    f"Metric {metric.name!r} has failed: {error!r}"
+                    for metric, error in self.errors
+                ),
+                stacklevel=2,
+            )
+
         if self.report_type == "estimator":
             return MetricsSummaryDisplay._frame_estimator(
                 self.data,

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -105,7 +105,8 @@ class MetricsSummaryDisplay(DisplayMixin):
         self.rows = rows
         self.report_type = report_type
         # Remove duplicates while preserving order
-        self.errors = list(dict.fromkeys(errors))
+        # Use repr because Metrics and Exceptions are not comparable
+        self.errors = list({repr(x): x for x in errors}.values())
 
     @property
     def data(self):

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -342,13 +342,6 @@ class MetricsSummaryDisplay(DisplayMixin):
         )
         favorability_col = df.pop("Favorability")
 
-        # TODO: Have one `if aggregate is None` block
-        if isinstance(aggregate, (list, tuple)):
-            aggregate = list(aggregate)
-        elif aggregate is not None:
-            aggregate = cast(Literal["mean", "std"], aggregate)
-            aggregate = [aggregate]
-
         if aggregate is None:
             metric_order = df.index.get_level_values("Metric").unique()
             df = (
@@ -356,20 +349,6 @@ class MetricsSummaryDisplay(DisplayMixin):
                 .unstack("split")
                 .reindex(metric_order, level="Metric")
             )
-        else:
-            df = df.reset_index().pivot_table(
-                index=df.index.names,
-                columns=None,
-                aggfunc=aggregate,
-                sort=False,
-            )
-
-        if aggregate is not None:
-            df = df.drop(
-                [col for col in df.columns if col[1] == "split"], axis="columns"
-            )
-
-        if aggregate is None:
             df.columns = pd.MultiIndex.from_product(
                 [
                     [estimator_name],
@@ -377,6 +356,20 @@ class MetricsSummaryDisplay(DisplayMixin):
                 ]
             )
         else:
+            if isinstance(aggregate, (list, tuple)):
+                aggregate = list(aggregate)
+            else:
+                aggregate = [cast(Literal["mean", "std"], aggregate)]
+
+            df = df.reset_index().pivot_table(
+                index=df.index.names,
+                columns=None,
+                aggfunc=aggregate,
+                sort=False,
+            )
+            df = df.drop(
+                [col for col in df.columns if col[1] == "split"], axis="columns"
+            )
             df.columns = df.columns.swaplevel(0, 1)
 
         if favorability:

--- a/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/metrics_summary_display.py
@@ -7,6 +7,7 @@ import pandas as pd
 from matplotlib.figure import Figure
 
 from skore._sklearn._plot.base import DisplayMixin
+from skore._sklearn.metrics import Metric
 from skore._sklearn.types import (
     Aggregate,
     DataSource,
@@ -99,9 +100,12 @@ class MetricsSummaryDisplay(DisplayMixin):
         self,
         rows: list[MetricsSummaryRow],
         report_type: ReportType,
+        errors: list[tuple[Metric, Exception]],
     ):
         self.rows = rows
         self.report_type = report_type
+        # Remove duplicates while preserving order
+        self.errors = list(dict.fromkeys(errors))
 
     @property
     def data(self):
@@ -190,7 +194,11 @@ class MetricsSummaryDisplay(DisplayMixin):
                 [cast(MetricsSummaryRow, row | extra_data) for row in display.rows]
             )
 
-        return MetricsSummaryDisplay(rows, report_type=report_type)
+        return MetricsSummaryDisplay(
+            rows,
+            report_type=report_type,
+            errors=sum([display.errors for display in child_displays], start=[]),
+        )
 
     @staticmethod
     def _flatten_index(df: pd.DataFrame) -> pd.DataFrame:
@@ -334,23 +342,39 @@ class MetricsSummaryDisplay(DisplayMixin):
         )
         favorability_col = df.pop("Favorability")
 
+        # TODO: Have one `if aggregate is None` block
         if isinstance(aggregate, (list, tuple)):
             aggregate = list(aggregate)
         elif aggregate is not None:
             aggregate = cast(Literal["mean", "std"], aggregate)
             aggregate = [aggregate]
 
-        df = df.reset_index().pivot_table(
-            index=df.index.names,
-            columns="split" if aggregate is None else None,
-            values=estimator_name,
-            aggfunc="first" if aggregate is None else aggregate,
-            sort=False,
-        )
+        if aggregate is None:
+            metric_order = df.index.get_level_values("Metric").unique()
+            df = (
+                df.set_index("split", append=True)
+                .unstack("split")
+                .reindex(metric_order, level="Metric")
+            )
+        else:
+            df = df.reset_index().pivot_table(
+                index=df.index.names,
+                columns=None,
+                aggfunc=aggregate,
+                sort=False,
+            )
+
+        if aggregate is not None:
+            df = df.drop(
+                [col for col in df.columns if col[1] == "split"], axis="columns"
+            )
 
         if aggregate is None:
             df.columns = pd.MultiIndex.from_product(
-                [[estimator_name], [f"Split #{i}" for i in df.columns]]
+                [
+                    [estimator_name],
+                    [f"Split #{i}" for i in df.columns.get_level_values("split")],
+                ]
             )
         else:
             df.columns = df.columns.swaplevel(0, 1)
@@ -464,16 +488,32 @@ class MetricsSummaryDisplay(DisplayMixin):
             return df
 
     def _repr_html_(self) -> str:
-        return (
-            f"{self.frame()._repr_html_()}"
-            '<p role="note">Use <code>.frame()</code> to control the format'
-            " of the output.</p>"
+        lines = [
+            self.frame()._repr_html_(),
+            (
+                '<p role="note">Use <code>.frame()</code> to control the format'
+                " of the output.</p>"
+            ),
+        ]
+        lines.extend(
+            f'<p role="note">Metric {metric.name!r} has failed: {error!r}</p>'
+            for metric, error in self.errors
         )
+        return "".join(lines)
 
     def __repr__(self) -> str:
-        return f"{self.frame()!r}\nUse .frame() to control the format of the output."
+        lines = [
+            f"{self.frame()!r}",
+            "Use .frame() to control the format of the output.",
+        ]
+        lines.extend(
+            f"Metric {metric.name!r} has failed: {error!r}"
+            for metric, error in self.errors
+        )
+
+        return "\n".join(lines)
 
     @DisplayMixin.style_plot
     def plot(self) -> Figure:
         """Plot the metrics summary (not implemented)."""
-        raise NotImplementedError
+        raise NotImplementedError()

--- a/skore/tests/unit/displays/metrics_summary/test_common.py
+++ b/skore/tests/unit/displays/metrics_summary/test_common.py
@@ -61,6 +61,7 @@ def display_fail(request):
     return display
 
 
+@pytest.mark.filterwarnings(r"ignore:Metric 'fail\d' has failed:UserWarning")
 def test_repr_failure(display_fail):
     """Check that __repr__ shows failed metrics."""
     repr_str = repr(display_fail)
@@ -87,6 +88,7 @@ def test_repr_failure(display_fail):
     assert repr_str.count("'fail2'") == 1
 
 
+@pytest.mark.filterwarnings(r"ignore:Metric 'fail\d' has failed:UserWarning")
 def test_repr_html_failure(display_fail):
     """Check that _repr_html_ shows failed metrics."""
     repr_html = display_fail._repr_html_()

--- a/skore/tests/unit/displays/metrics_summary/test_common.py
+++ b/skore/tests/unit/displays/metrics_summary/test_common.py
@@ -1,6 +1,8 @@
 """Tests for MetricsSummaryDisplay repr."""
 
-from skore import EstimatorReport
+import pytest
+
+from skore import CrossValidationReport, EstimatorReport
 
 
 def test_repr_includes_frame_and_hint(forest_binary_classification_with_test):
@@ -31,3 +33,80 @@ def test_repr_html_includes_frame_and_hint(forest_binary_classification_with_tes
     mime_html = display._repr_mimebundle_()["text/html"]
     assert "data:image/png;base64," not in mime_html
     assert "Use <code>.plot()</code> to control the view" not in mime_html
+
+
+@pytest.fixture(params=["estimator", "cross-validation"])
+def display_fail(request):
+    estimator, X_test, y_test = request.getfixturevalue(
+        "forest_binary_classification_with_test"
+    )
+
+    if request.param == "estimator":
+        report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    elif request.param == "cross-validation":
+        report = CrossValidationReport(estimator, X=X_test, y=y_test)
+    else:
+        raise ValueError(request.param)
+
+    def fail1(estimator, X, y):
+        raise Exception("Fail 1")
+
+    def fail2(estimator, X, y):
+        raise Exception("Fail 2")
+
+    report.metrics.add(fail1)
+    report.metrics.add(fail2)
+
+    display = report.metrics.summarize()
+    return display
+
+
+def test_repr_failure(display_fail):
+    """Check that __repr__ shows failed metrics."""
+    repr_str = repr(display_fail)
+    assert repr_str.startswith(repr(display_fail.frame()))
+
+    # NaN is not filtered out of the dataframe
+    assert "Fail" in repr(display_fail.frame())
+    assert "Fail" in repr(display_fail.frame(aggregate=None))
+
+    assert "Use .frame() to control the format of the output." in repr_str
+    assert (
+        "Use .plot() to plot the data"
+        not in display_fail._repr_mimebundle_()["text/plain"]
+    )
+
+    # fail2 was added last, so it appears first in the DataFrame
+    assert repr_str.endswith(
+        "\nMetric 'fail2' has failed: Exception('Fail 2')"
+        "\nMetric 'fail1' has failed: Exception('Fail 1')"
+    )
+
+    # Error messages are not duplicated (for CV)
+    assert repr_str.count("'fail1'") == 1
+    assert repr_str.count("'fail2'") == 1
+
+
+def test_repr_html_failure(display_fail):
+    """Check that _repr_html_ shows failed metrics."""
+    repr_html = display_fail._repr_html_()
+    assert repr_html.startswith(display_fail.frame()._repr_html_())
+
+    # NaN is not filtered out of the dataframe
+    assert "Fail" in display_fail.frame()._repr_html_()
+    assert "Fail" in display_fail.frame(aggregate=None)._repr_html_()
+
+    assert "Use <code>.frame()</code> to control the format of the output." in repr_html
+    mime_html = display_fail._repr_mimebundle_()["text/html"]
+    assert "data:image/png;base64," not in mime_html
+    assert "Use <code>.plot()</code> to control the view" not in mime_html
+
+    # fail2 was added last, so it appears first in the DataFrame
+    assert repr_html.endswith(
+        "<p role=\"note\">Metric 'fail2' has failed: Exception('Fail 2')</p>"
+        "<p role=\"note\">Metric 'fail1' has failed: Exception('Fail 1')</p>"
+    )
+
+    # Error messages are not duplicated (for CV)
+    assert repr_html.count("'fail1'") == 1
+    assert repr_html.count("'fail2'") == 1

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -485,9 +485,6 @@ class TestEdgeCases:
         scorer = make_scorer(accuracy_score, response_method="predict")
         report.metrics.add(scorer)
 
-        with pytest.raises(ValueError, match="(?i)train|data"):
-            report.metrics.summarize(metric="accuracy_score", data_source="train")
-
     def test_duplicate_name_raises(self, binary_classification_report):
         """Adding with duplicate name raises and keeps the original metric."""
         report = binary_classification_report
@@ -853,11 +850,11 @@ class TestSerialization:
         report2 = pickle.loads(pickle.dumps(report))
         assert report2._metric_registry["<lambda>"].function is None
 
-        err_msg = "Metric '<lambda>' has no scoring function."
-        with pytest.raises(ValueError, match=err_msg):
-            report2.metrics.summarize()
+        # Computation fails
+        display = report2.metrics.summarize()
+        assert "Metric '<lambda>' has no scoring function." in repr(display.errors)
 
-        # if we cache beforehand, then it works:
+        # If we cache beforehand, then it works:
         report.metrics.summarize()
         report3 = pickle.loads(pickle.dumps(report))
         report3.metrics.summarize()

--- a/skore/tests/unit/reports/test_common.py
+++ b/skore/tests/unit/reports/test_common.py
@@ -62,3 +62,22 @@ def test_metrics_add_scorer(report):
 
     display = report.metrics.summarize()
     assert "Mean Squared Error" in display.data["metric_verbose_name"].values
+
+
+def test_metrics_failure(report):
+    """If a metric fails, `summarize` still returns."""
+
+    def fail(estimator, X, y):
+        raise Exception()
+
+    report.metrics.add(fail)
+
+    display = report.metrics.summarize()
+
+    assert "Fail" in set(display.data["metric_verbose_name"])
+    assert (
+        display.data[display.data["metric_verbose_name"] == "Fail"]["score"]
+        .isna()
+        .all()
+    )
+    assert "Fail" in repr(display.frame())

--- a/skore/tests/unit/reports/test_common.py
+++ b/skore/tests/unit/reports/test_common.py
@@ -68,7 +68,7 @@ def test_metrics_failure(report):
     """If a metric fails, `summarize` still returns."""
 
     def fail(estimator, X, y):
-        raise Exception()
+        raise Exception("test error")
 
     report.metrics.add(fail)
 
@@ -80,4 +80,8 @@ def test_metrics_failure(report):
         .isna()
         .all()
     )
-    assert "Fail" in repr(display.frame())
+
+    err_msg = r"Metric 'fail' has failed: Exception\('test error'\)"
+    with pytest.warns(UserWarning, match=err_msg):
+        frame = display.frame()
+    assert "Fail" in repr(frame)


### PR DESCRIPTION
Closes #3085 

Adds a new attribute `errors` to `MetricSummaryDisplay` which lists all the metric errors so they can be displayed in the `repr`.
Failed metrics remain in the output DataFrame with their value set to `NaN`.

<details>

<summary>Manual tests to showcase the new behavior</summary>

`EstimatorReport`
```py
from sklearn.ensemble import RandomForestClassifier

import skore
import sklearn

X, y = sklearn.datasets.make_classification(n_samples=1000, return_X_y=True)

model = RandomForestClassifier()
report = skore.evaluate(model, X, y)

def fail(e,x,y):
    raise Exception("hey")

report.metrics.add(fail)

report.metrics.summarize()
#                         RandomForestClassifier
# Metric           Label
# Fail                                       NaN
# Accuracy                              0.945000
# Precision        0                    0.953704
#                  1                    0.934783
# Recall           0                    0.944954
#                  1                    0.945055
# ROC AUC                               0.987801
# Log loss                              0.174793
# Brier score                           0.048785
# Fit time (s)                          0.159072
# Predict time (s)                      0.004261
# Use .frame() to control the format of the output.
```

---

`EstimatorReport`, computing metrics on train set with no train set
```py
from sklearn.ensemble import RandomForestClassifier

import skore
import sklearn

X, y = sklearn.datasets.make_classification(n_samples=1000, return_X_y=True)

model = RandomForestClassifier().fit(X, y)
report = skore.EstimatorReport(model, X_test=X, y_test=y)

def fail(e,x,y):
   raise Exception("hey")

report.metrics.add(fail)

report.metrics.summarize(data_source="train")
# Empty DataFrame
# Columns: []
# Index: [Fail, Accuracy, Precision, Recall, ROC AUC, Log loss, Brier score, Fit time (s), Predict time (s)]
# Use .frame() to control the format of the output.
# Metric 'fail' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'accuracy' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'precision' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'recall' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'roc_auc' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'log_loss' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'brier_score' has failed: ValueError('No train data were provided when creating the report.')

report.metrics.summarize(data_source="both")
#                         RandomForestClassifier (test)
# Metric           Label
# Accuracy                                     1.000000
# Precision        0                           1.000000
#                  1                           1.000000
# Recall           0                           1.000000
#                  1                           1.000000
# ROC AUC                                      1.000000
# Log loss                                     0.056284
# Brier score                                  0.007994
# Predict time (s)                             0.007835
# Use .frame() to control the format of the output.
# Metric 'fail' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'accuracy' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'precision' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'recall' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'roc_auc' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'log_loss' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'brier_score' has failed: ValueError('No train data were provided when creating the report.')
# Metric 'fail' has failed: Exception('hey')
```


---

`CrossValidationReport`
```py
from sklearn.ensemble import RandomForestClassifier

import skore
import sklearn

X, y = sklearn.datasets.make_classification(n_samples=1000, return_X_y=True)

model = RandomForestClassifier()
report = skore.evaluate(model, X, y, splitter=3)

def fail(e,x,y):
    raise Exception("hey")

report.metrics.add(fail)

report.metrics.summarize()
#                        RandomForestClassifier
#                                          mean       std
# Metric           Label
# Fail                                      NaN       NaN
# Accuracy                             0.965993  0.006297
# Precision        0                   0.953693  0.019897
#                  1                   0.979622  0.008645
# Recall           0                   0.980004  0.009135
#                  1                   0.951964  0.021756
# ROC AUC                              0.989542  0.003003
# Log loss                             0.159800  0.054424
# Brier score                          0.030923  0.002292
# Fit time (s)                         0.137264  0.009510
# Predict time (s)                     0.004770  0.000060
# Use .frame() to control the format of the output.
# Metric 'fail' has failed: Exception('hey')
```

---

`ComparisonReport[CV]` where only one of the reports has the failing metric
```py
from sklearn.ensemble import RandomForestClassifier

import skore
import sklearn
import copy

X, y = sklearn.datasets.make_classification(n_samples=1000, return_X_y=True)

model = RandomForestClassifier()
report = skore.evaluate(model, X, y, splitter=3)

def fail(e,x,y):
    raise Exception("hey")

report_with_fail = copy.copy(report)

report_with_fail.metrics.add(fail)

skore.compare([report, report_with_fail]).metrics.summarize()
#                                            mean                                               std
# Estimator              RandomForestClassifier_1 RandomForestClassifier_2 RandomForestClassifier_1 RandomForestClassifier_2
# Metric           Label
# Fail                                        NaN                      NaN                      NaN                      NaN
# Accuracy                               0.926993                 0.926993                 0.009725                 0.009725
# Precision        0                     0.921393                 0.921393                 0.015023                 0.015023
#                  1                     0.933412                 0.933412                 0.019590                 0.019590
# Recall           0                     0.933975                 0.933975                 0.020880                 0.020880
#                  1                     0.919979                 0.919979                 0.017444                 0.017444
# ROC AUC                                0.968959                 0.968959                 0.010729                 0.010729
# Log loss                               0.249354                 0.249354                 0.075652                 0.075652
# Brier score                            0.059976                 0.059976                 0.006762                 0.006762
# Fit time (s)                           0.144223                 0.144223                 0.005398                 0.005398
# Predict time (s)                       0.004864                 0.004864                 0.000194                 0.000194
# Use .frame() to control the format of the output.
# Metric 'fail' has failed: Exception('hey')
```

</details>
