### PR TITLE
refactor: Auto-close figures after every test

### DIFF
--- a/skore/conftest.py
+++ b/skore/conftest.py
@@ -1,0 +1,13 @@
+"""Top-level conftest applying to both `tests/` and doctests under `src/`."""
+
+import matplotlib.pyplot as plt
+
+
+def pytest_runtest_teardown(item):
+    """Close any matplotlib figures left open by the test.
+
+    Guards against silent figure accumulation across the suite (which used to
+    trip matplotlib's `figure.max_open_warning`). Applied via a hook rather
+    than an autouse fixture so it also covers doctests.
+    """
+    plt.close("all")

--- a/skore/conftest.py
+++ b/skore/conftest.py
@@ -1,9 +1,9 @@
 """Top-level conftest applying to both `tests/` and doctests under `src/`."""
 
 import matplotlib
-import matplotlib.pyplot as plt
+import matplotlib.pyplot
 
-from skore import configuration
+import skore
 
 
 def pytest_configure(config):
@@ -15,7 +15,7 @@ def pytest_configure(config):
 
     # Disable progress bars during tests to avoid rich interfering with
     # doctest stdout capture.
-    configuration.show_progress = False
+    skore.configuration.show_progress = False
 
 
 def pytest_runtest_teardown(item):
@@ -25,4 +25,4 @@ def pytest_runtest_teardown(item):
     trip matplotlib's `figure.max_open_warning`). Applied via a hook rather
     than an autouse fixture so it also covers doctests.
     """
-    plt.close("all")
+    matplotlib.pyplot.close("all")

--- a/skore/conftest.py
+++ b/skore/conftest.py
@@ -1,6 +1,21 @@
 """Top-level conftest applying to both `tests/` and doctests under `src/`."""
 
+import matplotlib
 import matplotlib.pyplot as plt
+
+from skore import configuration
+
+
+def pytest_configure(config):
+    """Set up global test configuration.
+
+    Some of these could be set in fixtures, but doctests do not run fixtures.
+    """
+    matplotlib.use("agg")
+
+    # Disable progress bars during tests to avoid rich interfering with
+    # doctest stdout capture.
+    configuration.show_progress = False
 
 
 def pytest_runtest_teardown(item):

--- a/skore/tests/conftest.py
+++ b/skore/tests/conftest.py
@@ -1,6 +1,5 @@
 from datetime import UTC, datetime
 
-import matplotlib
 import numpy as np
 import pytest
 from sklearn.base import BaseEstimator, ClassifierMixin, clone
@@ -20,22 +19,9 @@ from skore import (
     ComparisonReport,
     CrossValidationReport,
     EstimatorReport,
-    configuration,
 )
 from skore._config import LocalConfiguration
 from skore._externals._sklearn_compat import validate_data
-
-
-def pytest_configure(config):
-    """Set up global test configuration.
-
-    Some of these could be set in fixtures, but doctests do not run fixtures.
-    """
-    matplotlib.use("agg")
-
-    # Disable progress bars during tests to avoid rich interfering with
-    # doctest stdout capture.
-    configuration.show_progress = False
 
 
 @pytest.fixture(autouse=True)

--- a/skore/tests/conftest.py
+++ b/skore/tests/conftest.py
@@ -85,24 +85,6 @@ def MockDatetime(mock_now):
     return MockDatetime
 
 
-@pytest.fixture(scope="session")
-def pyplot():
-    """Setup and teardown fixture for matplotlib.
-
-    This fixture closes the figures before and after running the functions.
-
-    Returns
-    -------
-    pyplot : module
-        The ``matplotlib.pyplot`` module.
-    """
-    from matplotlib import pyplot
-
-    pyplot.close("all")
-    yield pyplot
-    pyplot.close("all")
-
-
 @pytest.fixture
 def binary_classification_data():
     return make_classification(random_state=42, n_features=4)

--- a/skore/tests/unit/displays/calibration_curve/conftest.py
+++ b/skore/tests/unit/displays/calibration_curve/conftest.py
@@ -1,12 +1,9 @@
-import matplotlib as mpl
 import pytest
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     display = report.inspection.calibration_curve()
@@ -16,7 +13,7 @@ def estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_binary_classification_figure_axes(
-    pyplot, cross_validation_reports_binary_classification
+    cross_validation_reports_binary_classification,
 ):
     report = cross_validation_reports_binary_classification[0]
     display = report.inspection.calibration_curve()
@@ -26,7 +23,7 @@ def cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_binary_classification_figure_axes(
-    pyplot, comparison_estimator_reports_binary_classification
+    comparison_estimator_reports_binary_classification,
 ):
     report = comparison_estimator_reports_binary_classification
     display = report.inspection.calibration_curve()
@@ -36,7 +33,7 @@ def comparison_estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_binary_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_binary_classification
+    comparison_cross_validation_reports_binary_classification,
 ):
     report = comparison_cross_validation_reports_binary_classification
     display = report.inspection.calibration_curve()
@@ -46,7 +43,7 @@ def comparison_cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def estimator_reports_multiclass_classification_figure_axes(
-    pyplot, estimator_reports_multiclass_classification
+    estimator_reports_multiclass_classification,
 ):
     report = estimator_reports_multiclass_classification[0]
     display = report.inspection.calibration_curve()
@@ -56,7 +53,7 @@ def estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, cross_validation_reports_multiclass_classification
+    cross_validation_reports_multiclass_classification,
 ):
     report = cross_validation_reports_multiclass_classification[0]
     display = report.inspection.calibration_curve()
@@ -66,7 +63,7 @@ def cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_estimator_reports_multiclass_classification
+    comparison_estimator_reports_multiclass_classification,
 ):
     report = comparison_estimator_reports_multiclass_classification
     display = report.inspection.calibration_curve()
@@ -76,7 +73,7 @@ def comparison_estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_multiclass_classification
+    comparison_cross_validation_reports_multiclass_classification,
 ):
     report = comparison_cross_validation_reports_multiclass_classification
     display = report.inspection.calibration_curve()

--- a/skore/tests/unit/displays/calibration_curve/test_common.py
+++ b/skore/tests/unit/displays/calibration_curve/test_common.py
@@ -11,7 +11,7 @@ from skore import CalibrationDisplay
 )
 @pytest.mark.parametrize("task", ["binary_classification", "multiclass_classification"])
 class TestCalibrationDisplay:
-    def test_class_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_class_attributes(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -52,7 +52,7 @@ class TestCalibrationDisplay:
         }
         assert set(display.frame().columns) == expected
 
-    def test_plot_structure(self, pyplot, fixture_prefix, task, request):
+    def test_plot_structure(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -61,7 +61,7 @@ class TestCalibrationDisplay:
         assert ax.get_xlabel() == "Mean predicted probability"
         assert ax.get_ylabel() == "Fraction of positives"
 
-    def test_title(self, pyplot, fixture_prefix, task, request):
+    def test_title(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -73,7 +73,7 @@ class TestCalibrationDisplay:
             estimator_name = display.calibration_report["estimator"].iloc[0]
             assert estimator_name in title
 
-    def test_kwargs(self, pyplot, fixture_prefix, task, request):
+    def test_kwargs(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]

--- a/skore/tests/unit/displays/coefficients/conftest.py
+++ b/skore/tests/unit/displays/coefficients/conftest.py
@@ -1,11 +1,8 @@
-import matplotlib as mpl
 import pytest
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 
 from skore import ComparisonReport, CrossValidationReport, EstimatorReport
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture(scope="module")
@@ -15,7 +12,7 @@ def estimator_type():
 
 @pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     display = report.inspection.coefficients()
@@ -26,7 +23,7 @@ def estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def estimator_reports_multiclass_classification_figure_axes(
-    pyplot, estimator_reports_multiclass_classification
+    estimator_reports_multiclass_classification,
 ):
     report = estimator_reports_multiclass_classification[0]
     display = report.inspection.coefficients()
@@ -36,7 +33,7 @@ def estimator_reports_multiclass_classification_figure_axes(
 
 
 @pytest.fixture(scope="module")
-def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regression):
+def estimator_reports_regression_figure_axes(estimator_reports_regression):
     report = estimator_reports_regression[0]
     display = report.inspection.coefficients()
     fig = display.plot()
@@ -46,7 +43,7 @@ def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regressio
 
 @pytest.fixture(scope="module")
 def estimator_reports_multioutput_regression_figure_axes(
-    pyplot, estimator_reports_multioutput_regression
+    estimator_reports_multioutput_regression,
 ):
     report = estimator_reports_multioutput_regression[0]
     display = report.inspection.coefficients()
@@ -57,7 +54,7 @@ def estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_binary_classification_figure_axes(
-    pyplot, cross_validation_reports_binary_classification
+    cross_validation_reports_binary_classification,
 ):
     report = cross_validation_reports_binary_classification[0]
     display = report.inspection.coefficients()
@@ -68,7 +65,7 @@ def cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, cross_validation_reports_multiclass_classification
+    cross_validation_reports_multiclass_classification,
 ):
     report = cross_validation_reports_multiclass_classification[0]
     display = report.inspection.coefficients()
@@ -79,7 +76,7 @@ def cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_regression_figure_axes(
-    pyplot, cross_validation_reports_regression
+    cross_validation_reports_regression,
 ):
     report = cross_validation_reports_regression[0]
     display = report.inspection.coefficients()
@@ -90,7 +87,7 @@ def cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot, cross_validation_reports_multioutput_regression
+    cross_validation_reports_multioutput_regression,
 ):
     report = cross_validation_reports_multioutput_regression[0]
     display = report.inspection.coefficients()
@@ -101,7 +98,7 @@ def cross_validation_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_binary_classification_figure_axes(
-    pyplot, comparison_estimator_reports_binary_classification
+    comparison_estimator_reports_binary_classification,
 ):
     report = comparison_estimator_reports_binary_classification
     display = report.inspection.coefficients()
@@ -112,7 +109,7 @@ def comparison_estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_estimator_reports_multiclass_classification
+    comparison_estimator_reports_multiclass_classification,
 ):
     report = comparison_estimator_reports_multiclass_classification
     display = report.inspection.coefficients()
@@ -123,7 +120,7 @@ def comparison_estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_regression_figure_axes(
-    pyplot, comparison_estimator_reports_regression
+    comparison_estimator_reports_regression,
 ):
     report = comparison_estimator_reports_regression
     display = report.inspection.coefficients()
@@ -134,7 +131,7 @@ def comparison_estimator_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multioutput_regression_figure_axes(
-    pyplot, comparison_estimator_reports_multioutput_regression
+    comparison_estimator_reports_multioutput_regression,
 ):
     report = comparison_estimator_reports_multioutput_regression
     display = report.inspection.coefficients()
@@ -145,7 +142,6 @@ def comparison_estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_binary_classification_figure_axes(
-    pyplot,
     comparison_cross_validation_reports_binary_classification,
 ):
     report = comparison_cross_validation_reports_binary_classification
@@ -157,7 +153,6 @@ def comparison_cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot,
     comparison_cross_validation_reports_multiclass_classification,
 ):
     report = comparison_cross_validation_reports_multiclass_classification
@@ -169,7 +164,6 @@ def comparison_cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_regression_figure_axes(
-    pyplot,
     comparison_cross_validation_reports_regression,
 ):
     report = comparison_cross_validation_reports_regression
@@ -181,7 +175,6 @@ def comparison_cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot,
     comparison_cross_validation_reports_multioutput_regression,
 ):
     report = comparison_cross_validation_reports_multioutput_regression

--- a/skore/tests/unit/displays/coefficients/test_common.py
+++ b/skore/tests/unit/displays/coefficients/test_common.py
@@ -23,7 +23,7 @@ from skore import CoefficientsDisplay
     ],
 )
 class TestCoefficientsDisplay:
-    def test_class_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_class_attributes(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -96,7 +96,7 @@ class TestCoefficientsDisplay:
         }
         assert set(display.coefficients.columns) == expected
 
-    def test_plot_structure(self, pyplot, fixture_prefix, task, request):
+    def test_plot_structure(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -105,7 +105,7 @@ class TestCoefficientsDisplay:
         assert ax.get_xlabel() == "Magnitude of coefficient"
         assert ax.get_ylabel() == ""
 
-    def test_title(self, pyplot, fixture_prefix, task, request):
+    def test_title(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -117,7 +117,7 @@ class TestCoefficientsDisplay:
             estimator_name = display.coefficients["estimator"].iloc[0]
             assert estimator_name in title
 
-    def test_kwargs(pyplot, fixture_prefix, task, request):
+    def test_kwargs(self, fixture_prefix, task, request):
         """Check that custom `barplot_kwargs` are applied to the plots."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):

--- a/skore/tests/unit/displays/coefficients/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/coefficients/test_comparison_cross_validation.py
@@ -23,7 +23,7 @@ import pytest
         ),
     ],
 )
-def test_invalid_subplot_by(pyplot, fixture_name, valid_values, request):
+def test_invalid_subplot_by(fixture_name, valid_values, request):
     report = request.getfixturevalue(fixture_name)
     display = report.inspection.coefficients()
     err_msg = (
@@ -77,7 +77,6 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     ],
 )
 def test_subplot_by_none_multiclass_or_multioutput(
-    pyplot,
     request,
     fixture_name,
 ):
@@ -108,7 +107,7 @@ def test_subplot_by_none_multiclass_or_multioutput(
         ),
     ],
 )
-def test_different_features(pyplot, fixture_name, subplot_by, request):
+def test_different_features(fixture_name, subplot_by, request):
     """Check that we get a proper report even if the estimators do not have the same
     input features."""
     report = request.getfixturevalue(fixture_name)

--- a/skore/tests/unit/displays/coefficients/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/coefficients/test_comparison_estimator.py
@@ -23,7 +23,7 @@ import pytest
         ),
     ],
 )
-def test_invalid_subplot_by(pyplot, fixture_name, valid_values, request):
+def test_invalid_subplot_by(fixture_name, valid_values, request):
     report = request.getfixturevalue(fixture_name)
     display = report.inspection.coefficients()
     err_msg = (
@@ -55,7 +55,7 @@ def test_invalid_subplot_by(pyplot, fixture_name, valid_values, request):
         ),
     ],
 )
-def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
+def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     report = request.getfixturevalue(fixture_name)
     display = report.inspection.coefficients()
     for subplot_by, expected_len in subplot_by_tuples:
@@ -76,7 +76,6 @@ def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
     ],
 )
 def test_subplot_by_none_multiclass_or_multioutput(
-    pyplot,
     request,
     fixture_name,
 ):
@@ -107,7 +106,7 @@ def test_subplot_by_none_multiclass_or_multioutput(
         ),
     ],
 )
-def test_different_features(pyplot, fixture_name, subplot_by, request):
+def test_different_features(fixture_name, subplot_by, request):
     """Check that we get a proper report even if the estimators do not have the same
     input features."""
     report = request.getfixturevalue(fixture_name)

--- a/skore/tests/unit/displays/coefficients/test_cross_validation.py
+++ b/skore/tests/unit/displays/coefficients/test_cross_validation.py
@@ -29,7 +29,7 @@ import pytest
         ),
     ],
 )
-def test_invalid_subplot_by(pyplot, fixture_name, subplot_by, err_msg, request):
+def test_invalid_subplot_by(fixture_name, subplot_by, err_msg, request):
     reports = request.getfixturevalue(fixture_name)
     report = reports[0]
     display = report.inspection.coefficients()
@@ -58,7 +58,7 @@ def test_invalid_subplot_by(pyplot, fixture_name, subplot_by, err_msg, request):
         ),
     ],
 )
-def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
+def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     """Check that we can pass non default values to `subplot_by`."""
     reports = request.getfixturevalue(fixture_name)
     report = reports[0]

--- a/skore/tests/unit/displays/coefficients/test_estimator.py
+++ b/skore/tests/unit/displays/coefficients/test_estimator.py
@@ -33,7 +33,7 @@ from skore import EstimatorReport
         ),
     ],
 )
-def test_invalid_subplot_by(pyplot, fixture_name, subplot_by, err_msg, request):
+def test_invalid_subplot_by(fixture_name, subplot_by, err_msg, request):
     reports = request.getfixturevalue(fixture_name)
     report = reports[0]
     display = report.inspection.coefficients()
@@ -62,7 +62,7 @@ def test_invalid_subplot_by(pyplot, fixture_name, subplot_by, err_msg, request):
         ),
     ],
 )
-def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
+def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     """Check that we can pass non default values to `subplot_by`."""
     reports = request.getfixturevalue(fixture_name)
     report = reports[0]

--- a/skore/tests/unit/displays/coefficients/test_select_k.py
+++ b/skore/tests/unit/displays/coefficients/test_select_k.py
@@ -24,7 +24,7 @@ def test_negative(comparison_estimator_reports_binary_classification):
 
 
 def test_different_features(
-    pyplot, comparison_estimator_reports_binary_classification_different_features
+    comparison_estimator_reports_binary_classification_different_features,
 ):
     """`select_k` works for plotting when the estimators have different features."""
     report = comparison_estimator_reports_binary_classification_different_features

--- a/skore/tests/unit/displays/coefficients/test_sorting_order.py
+++ b/skore/tests/unit/displays/coefficients/test_sorting_order.py
@@ -50,7 +50,6 @@ def test_frame_sorts_per_estimator(
     ],
 )
 def test_plot_different_features(
-    pyplot,
     comparison_estimator_reports_binary_classification,
     sorting_order,
     expected_features,

--- a/skore/tests/unit/displays/confusion_matrix/conftest.py
+++ b/skore/tests/unit/displays/confusion_matrix/conftest.py
@@ -1,7 +1,4 @@
-import matplotlib as mpl
 import pytest
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture(scope="module")
@@ -11,7 +8,7 @@ def estimator_type():
 
 @pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     display = report.metrics.confusion_matrix()
@@ -22,7 +19,7 @@ def estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def estimator_reports_multiclass_classification_figure_axes(
-    pyplot, estimator_reports_multiclass_classification
+    estimator_reports_multiclass_classification,
 ):
     report = estimator_reports_multiclass_classification[0]
     display = report.metrics.confusion_matrix()
@@ -33,7 +30,7 @@ def estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_binary_classification_figure_axes(
-    pyplot, cross_validation_reports_binary_classification
+    cross_validation_reports_binary_classification,
 ):
     report = cross_validation_reports_binary_classification[0]
     display = report.metrics.confusion_matrix()
@@ -44,7 +41,7 @@ def cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, cross_validation_reports_multiclass_classification
+    cross_validation_reports_multiclass_classification,
 ):
     report = cross_validation_reports_multiclass_classification[0]
     display = report.metrics.confusion_matrix()
@@ -55,7 +52,7 @@ def cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_binary_classification_figure_axes(
-    pyplot, comparison_estimator_reports_binary_classification
+    comparison_estimator_reports_binary_classification,
 ):
     report = comparison_estimator_reports_binary_classification
     display = report.metrics.confusion_matrix()
@@ -66,7 +63,7 @@ def comparison_estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_estimator_reports_multiclass_classification
+    comparison_estimator_reports_multiclass_classification,
 ):
     report = comparison_estimator_reports_multiclass_classification
     display = report.metrics.confusion_matrix()
@@ -77,7 +74,7 @@ def comparison_estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_binary_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_binary_classification
+    comparison_cross_validation_reports_binary_classification,
 ):
     report = comparison_cross_validation_reports_binary_classification
     display = report.metrics.confusion_matrix()
@@ -88,7 +85,7 @@ def comparison_cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_multiclass_classification
+    comparison_cross_validation_reports_multiclass_classification,
 ):
     report = comparison_cross_validation_reports_multiclass_classification
     display = report.metrics.confusion_matrix()

--- a/skore/tests/unit/displays/confusion_matrix/test_common.py
+++ b/skore/tests/unit/displays/confusion_matrix/test_common.py
@@ -44,7 +44,7 @@ def _iter_groups(frame):
 )
 class TestConfusionMatrixDisplay:
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_class_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_class_attributes(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
             report = report[0]
@@ -180,7 +180,7 @@ class TestConfusionMatrixDisplay:
         assert display.confusion_matrix_thresholded.shape[0] == expected_rows
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_facet_grid_kwargs(self, pyplot, fixture_prefix, task, request):
+    def test_facet_grid_kwargs(self, fixture_prefix, task, request):
         """Check that we can override default facet grid kwargs."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -196,7 +196,7 @@ class TestConfusionMatrixDisplay:
         assert fig.get_figheight() == 8
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_heatmap_kwargs(self, pyplot, fixture_prefix, task, request):
+    def test_heatmap_kwargs(self, fixture_prefix, task, request):
         """Check that heatmap kwargs are applied correctly and can be changed."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -214,7 +214,7 @@ class TestConfusionMatrixDisplay:
         assert ax.collections[0].get_cmap().name == "Reds"
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_plot_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_plot_attributes(self, fixture_prefix, task, request):
         """Check that the plot has correct attributes and labels."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -243,7 +243,7 @@ class TestConfusionMatrixDisplay:
             assert yticklabels == ["0", "1", "2"]
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_threshold_in_title(self, pyplot, fixture_prefix, task, request):
+    def test_threshold_in_title(self, fixture_prefix, task, request):
         """Check title for both default and thresholded plots."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -266,7 +266,7 @@ class TestConfusionMatrixDisplay:
         assert expected_label_line in title
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_thresholded_plot_ticklabels(self, pyplot, fixture_prefix, task, request):
+    def test_thresholded_plot_ticklabels(self, fixture_prefix, task, request):
         """Check that thresholded plot uses OvR tick labels with positive class star."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -295,7 +295,7 @@ class TestConfusionMatrixDisplay:
         assert frame_all.shape[0] == display.confusion_matrix_thresholded.shape[0]
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_normalization(self, pyplot, fixture_prefix, task, request):
+    def test_normalization(self, fixture_prefix, task, request):
         """Check normalization on both predict-based and thresholded frames."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -377,7 +377,7 @@ def test_data_source_both_is_not_supported(binary_classification_data):
         report.metrics.confusion_matrix(data_source="both")
 
 
-def test_plot_threshold_requires_label(pyplot, binary_classification_data):
+def test_plot_threshold_requires_label(binary_classification_data):
     """Check that plot raises when threshold_value is set but label is None."""
     X, y = binary_classification_data
     report = evaluate(LogisticRegression(), X, y, splitter=0.2)
@@ -401,7 +401,7 @@ def test_frame_threshold_label_none_returns_all_labels(binary_classification_dat
 
 @pytest.mark.parametrize("threshold_value", [None, 0.5])
 def test_multiclass_plot_with_numeric_label(
-    pyplot, multiclass_classification_data, threshold_value
+    multiclass_classification_data, threshold_value
 ):
     """Check that numeric labels can select predict-based and thresholded OvR plots."""
     X, y = multiclass_classification_data
@@ -417,7 +417,7 @@ def test_multiclass_plot_with_numeric_label(
     assert yticklabels == ["not 1", "1*"]
 
 
-def test_plot_threshold_all_not_supported(pyplot, binary_classification_data):
+def test_plot_threshold_all_not_supported(binary_classification_data):
     """Check that plot raises when threshold_value='all'."""
     X, y = binary_classification_data
     report = evaluate(LogisticRegression(), X, y, splitter=0.2)
@@ -476,7 +476,7 @@ def test_confusion_matrix_thresholded_not_available_comparison(
         display.frame(threshold_value=0.5)
 
 
-def test_missing_class_in_split(pyplot, binary_classification_data):
+def test_missing_class_in_split(binary_classification_data):
     """Check that the confusion matrix is correct when a class is missing in a split."""
     X = np.array([[0], [1], [0], [0]])
     y = np.array([0, 1, 0, 0])

--- a/skore/tests/unit/displays/confusion_matrix/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/confusion_matrix/test_comparison_cross_validation.py
@@ -13,7 +13,7 @@ from skore import ComparisonReport, CrossValidationReport
         "comparison_cross_validation_reports_multiclass_classification",
     ],
 )
-def test_subplot_by(pyplot, subplot_by, fixture_name, request):
+def test_subplot_by(subplot_by, fixture_name, request):
     """Check that the subplot_by parameter works correctly for comparison reports."""
     report = request.getfixturevalue(fixture_name)
     display = report.metrics.confusion_matrix()
@@ -32,7 +32,6 @@ def test_subplot_by(pyplot, subplot_by, fixture_name, request):
 
 
 def test_split_aggregation(
-    pyplot,
     comparison_cross_validation_reports_binary_classification,
     comparison_cross_validation_reports_binary_classification_figure_axes,
 ):
@@ -70,7 +69,7 @@ def test_estimator_names_in_confusion_matrix(
     assert set(estimator_names) == set(report.reports_.keys())
 
 
-def test_pos_label(pyplot, forest_binary_classification_data):
+def test_pos_label(forest_binary_classification_data):
     """Check that the report_pos_label parameter works correctly."""
     estimator, X, y = forest_binary_classification_data
     labels = np.array(["A", "B"], dtype=object)

--- a/skore/tests/unit/displays/confusion_matrix/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/confusion_matrix/test_comparison_estimator.py
@@ -14,7 +14,7 @@ from skore import ComparisonReport, EstimatorReport
         "comparison_estimator_reports_multiclass_classification",
     ],
 )
-def test_subplot_by(pyplot, subplot_by, fixture_name, request):
+def test_subplot_by(subplot_by, fixture_name, request):
     """Check that the subplot_by parameter works correctly for comparison reports."""
     report = request.getfixturevalue(fixture_name)
     display = report.metrics.confusion_matrix()
@@ -32,7 +32,7 @@ def test_subplot_by(pyplot, subplot_by, fixture_name, request):
         assert len(axes) == len(report.reports_)
 
 
-def test_pos_label(pyplot, binary_classification_train_test_split):
+def test_pos_label(binary_classification_train_test_split):
     """Check that the report_pos_label parameter works correctly."""
     X_train, X_test, y_train, y_test = binary_classification_train_test_split
     labels = np.array(["A", "B"], dtype=object)

--- a/skore/tests/unit/displays/confusion_matrix/test_cross_validation.py
+++ b/skore/tests/unit/displays/confusion_matrix/test_cross_validation.py
@@ -25,7 +25,7 @@ def test_multiple_thresholds_different_confusion_matrices(
     assert not np.array_equal(frame_low["value"].values, frame_high["value"].values)
 
 
-def test_split_aggregation(pyplot, forest_binary_classification_data):
+def test_split_aggregation(forest_binary_classification_data):
     """Check that confusion matrix values are aggregated across splits."""
     (estimator, X, y), cv = forest_binary_classification_data, 3
     report = CrossValidationReport(estimator, X=X, y=y, splitter=cv)
@@ -57,7 +57,7 @@ def test_split_aggregation(pyplot, forest_binary_classification_data):
         "forest_multiclass_classification_data",
     ],
 )
-def test_subplot_by(pyplot, subplot_by, fixture_name, request):
+def test_subplot_by(subplot_by, fixture_name, request):
     estimator, X, y = request.getfixturevalue(fixture_name)
     report = CrossValidationReport(estimator, X=X, y=y, splitter=3)
     display = report.metrics.confusion_matrix()
@@ -78,7 +78,7 @@ def test_subplot_by(pyplot, subplot_by, fixture_name, request):
         assert isinstance(axes[0], mpl.axes.Axes)
 
 
-def test_pos_label(pyplot, forest_binary_classification_data):
+def test_pos_label(forest_binary_classification_data):
     """Check that the report_pos_label parameter works correctly."""
     (estimator, X, y), cv = forest_binary_classification_data, 3
     labels = np.array(["A", "B"], dtype=object)

--- a/skore/tests/unit/displays/confusion_matrix/test_estimator.py
+++ b/skore/tests/unit/displays/confusion_matrix/test_estimator.py
@@ -36,7 +36,7 @@ def test_multiple_thresholds_different_confusion_matrices(
         "forest_multiclass_classification_with_train_test",
     ],
 )
-def test_subplot_by(pyplot, subplot_by, fixture_name, request):
+def test_subplot_by(subplot_by, fixture_name, request):
     estimator, X_train, X_test, y_train, y_test = request.getfixturevalue(fixture_name)
     report = EstimatorReport(
         estimator, X_train=X_train, y_train=y_train, X_test=X_test, y_test=y_test
@@ -55,7 +55,7 @@ def test_subplot_by(pyplot, subplot_by, fixture_name, request):
         assert isinstance(axes[0], mpl.axes.Axes)
 
 
-def test_pos_label(pyplot, forest_binary_classification_with_train_test):
+def test_pos_label(forest_binary_classification_with_train_test):
     """Check that the report_pos_label parameter works correctly."""
     estimator, X_train, X_test, y_train, y_test = (
         forest_binary_classification_with_train_test

--- a/skore/tests/unit/displays/impurity_decrease/conftest.py
+++ b/skore/tests/unit/displays/impurity_decrease/conftest.py
@@ -1,7 +1,4 @@
-import matplotlib as mpl
 import pytest
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture(scope="module")
@@ -11,7 +8,7 @@ def estimator_type():
 
 @pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     display = report.inspection.impurity_decrease()
@@ -22,7 +19,7 @@ def estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def estimator_reports_multiclass_classification_figure_axes(
-    pyplot, estimator_reports_multiclass_classification
+    estimator_reports_multiclass_classification,
 ):
     report = estimator_reports_multiclass_classification[0]
     display = report.inspection.impurity_decrease()
@@ -32,7 +29,7 @@ def estimator_reports_multiclass_classification_figure_axes(
 
 
 @pytest.fixture(scope="module")
-def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regression):
+def estimator_reports_regression_figure_axes(estimator_reports_regression):
     report = estimator_reports_regression[0]
     display = report.inspection.impurity_decrease()
     fig = display.plot()
@@ -42,7 +39,7 @@ def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regressio
 
 @pytest.fixture(scope="module")
 def estimator_reports_multioutput_regression_figure_axes(
-    pyplot, estimator_reports_multioutput_regression
+    estimator_reports_multioutput_regression,
 ):
     report = estimator_reports_multioutput_regression[0]
     display = report.inspection.impurity_decrease()
@@ -53,7 +50,7 @@ def estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_binary_classification_figure_axes(
-    pyplot, cross_validation_reports_binary_classification
+    cross_validation_reports_binary_classification,
 ):
     report = cross_validation_reports_binary_classification[0]
     display = report.inspection.impurity_decrease()
@@ -64,7 +61,7 @@ def cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, cross_validation_reports_multiclass_classification
+    cross_validation_reports_multiclass_classification,
 ):
     report = cross_validation_reports_multiclass_classification[0]
     display = report.inspection.impurity_decrease()
@@ -75,7 +72,7 @@ def cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_regression_figure_axes(
-    pyplot, cross_validation_reports_regression
+    cross_validation_reports_regression,
 ):
     report = cross_validation_reports_regression[0]
     display = report.inspection.impurity_decrease()
@@ -86,7 +83,7 @@ def cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot, cross_validation_reports_multioutput_regression
+    cross_validation_reports_multioutput_regression,
 ):
     report = cross_validation_reports_multioutput_regression[0]
     display = report.inspection.impurity_decrease()
@@ -97,7 +94,7 @@ def cross_validation_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_binary_classification_figure_axes(
-    pyplot, comparison_estimator_reports_binary_classification
+    comparison_estimator_reports_binary_classification,
 ):
     report = comparison_estimator_reports_binary_classification
     display = report.inspection.impurity_decrease()
@@ -108,7 +105,7 @@ def comparison_estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_estimator_reports_multiclass_classification
+    comparison_estimator_reports_multiclass_classification,
 ):
     report = comparison_estimator_reports_multiclass_classification
     display = report.inspection.impurity_decrease()
@@ -119,7 +116,7 @@ def comparison_estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_regression_figure_axes(
-    pyplot, comparison_estimator_reports_regression
+    comparison_estimator_reports_regression,
 ):
     report = comparison_estimator_reports_regression
     display = report.inspection.impurity_decrease()
@@ -130,7 +127,7 @@ def comparison_estimator_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multioutput_regression_figure_axes(
-    pyplot, comparison_estimator_reports_multioutput_regression
+    comparison_estimator_reports_multioutput_regression,
 ):
     report = comparison_estimator_reports_multioutput_regression
     display = report.inspection.impurity_decrease()
@@ -141,7 +138,7 @@ def comparison_estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_binary_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_binary_classification
+    comparison_cross_validation_reports_binary_classification,
 ):
     report = comparison_cross_validation_reports_binary_classification
     display = report.inspection.impurity_decrease()
@@ -152,7 +149,7 @@ def comparison_cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_multiclass_classification
+    comparison_cross_validation_reports_multiclass_classification,
 ):
     report = comparison_cross_validation_reports_multiclass_classification
     display = report.inspection.impurity_decrease()
@@ -163,7 +160,7 @@ def comparison_cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_regression_figure_axes(
-    pyplot, comparison_cross_validation_reports_regression
+    comparison_cross_validation_reports_regression,
 ):
     report = comparison_cross_validation_reports_regression
     display = report.inspection.impurity_decrease()
@@ -174,7 +171,7 @@ def comparison_cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot, comparison_cross_validation_reports_multioutput_regression
+    comparison_cross_validation_reports_multioutput_regression,
 ):
     report = comparison_cross_validation_reports_multioutput_regression
     display = report.inspection.impurity_decrease()

--- a/skore/tests/unit/displays/impurity_decrease/test_common.py
+++ b/skore/tests/unit/displays/impurity_decrease/test_common.py
@@ -15,7 +15,7 @@ from skore import ImpurityDecreaseDisplay
 )
 @pytest.mark.parametrize("task", ["binary_classification", "regression"])
 class TestImpurityDecreaseDisplay:
-    def test_class_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_class_attributes(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -77,7 +77,7 @@ class TestImpurityDecreaseDisplay:
         expected = {"estimator", "split", "feature", "importance"}
         assert set(display.importances.columns) == expected
 
-    def test_plot_structure(self, pyplot, fixture_prefix, task, request):
+    def test_plot_structure(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -86,7 +86,7 @@ class TestImpurityDecreaseDisplay:
         assert ax.get_xlabel() == "Mean decrease in impurity"
         assert ax.get_ylabel() == ""
 
-    def test_title(self, pyplot, fixture_prefix, task, request):
+    def test_title(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -98,7 +98,7 @@ class TestImpurityDecreaseDisplay:
             estimator_name = display.importances["estimator"].iloc[0]
             assert estimator_name in title
 
-    def test_kwargs(self, pyplot, fixture_prefix, task, request):
+    def test_kwargs(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -175,7 +175,7 @@ class TestImpurityDecreaseDisplay:
 @pytest.mark.parametrize(
     "task", ["multiclass_classification", "multioutput_regression"]
 )
-def test_multiclass_and_multioutput(pyplot, fixture_prefix, task, request):
+def test_multiclass_and_multioutput(fixture_prefix, task, request):
     report = request.getfixturevalue(f"{fixture_prefix}_{task}")
     if isinstance(report, tuple):
         report = report[0]

--- a/skore/tests/unit/displays/impurity_decrease/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/impurity_decrease/test_comparison_cross_validation.py
@@ -8,7 +8,7 @@ from skore import ComparisonReport, CrossValidationReport, ImpurityDecreaseDispl
 from skore._externals._sklearn_compat import convert_container
 
 
-def test_with_pipeline(pyplot, forest_binary_classification_data):
+def test_with_pipeline(forest_binary_classification_data):
     estimator, X, y = forest_binary_classification_data
     columns_names = [f"Feature #{i}" for i in range(X.shape[1])]
     X = convert_container(X, "pandas", column_names=columns_names)

--- a/skore/tests/unit/displays/impurity_decrease/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/impurity_decrease/test_comparison_estimator.py
@@ -8,7 +8,7 @@ from skore import ComparisonReport, EstimatorReport, ImpurityDecreaseDisplay
 from skore._externals._sklearn_compat import convert_container
 
 
-def test_with_pipeline(pyplot, forest_binary_classification_data):
+def test_with_pipeline(forest_binary_classification_data):
     estimator, X, y = forest_binary_classification_data
     estimator = clone(estimator)
 

--- a/skore/tests/unit/displays/impurity_decrease/test_cross_validation.py
+++ b/skore/tests/unit/displays/impurity_decrease/test_cross_validation.py
@@ -8,7 +8,7 @@ from skore import CrossValidationReport, ImpurityDecreaseDisplay
 from skore._externals._sklearn_compat import convert_container
 
 
-def test_with_pipeline(pyplot, forest_binary_classification_data):
+def test_with_pipeline(forest_binary_classification_data):
     estimator, X, y = forest_binary_classification_data
     estimator = clone(estimator)
 

--- a/skore/tests/unit/displays/impurity_decrease/test_estimator.py
+++ b/skore/tests/unit/displays/impurity_decrease/test_estimator.py
@@ -8,7 +8,7 @@ from skore import EstimatorReport, ImpurityDecreaseDisplay
 from skore._externals._sklearn_compat import convert_container
 
 
-def test_with_pipeline(pyplot, forest_binary_classification_with_train_test):
+def test_with_pipeline(forest_binary_classification_with_train_test):
     estimator, X_train, X_test, y_train, y_test = (
         forest_binary_classification_with_train_test
     )

--- a/skore/tests/unit/displays/impurity_decrease/test_select_k.py
+++ b/skore/tests/unit/displays/impurity_decrease/test_select_k.py
@@ -24,7 +24,7 @@ def test_negative(comparison_estimator_reports_binary_classification):
         assert group["feature"].nunique() == 2
 
 
-def test_plot_with_select_k(pyplot, comparison_estimator_reports_binary_classification):
+def test_plot_with_select_k(comparison_estimator_reports_binary_classification):
     """`select_k` works for plotting."""
     report = comparison_estimator_reports_binary_classification
     display = report.inspection.impurity_decrease()

--- a/skore/tests/unit/displays/impurity_decrease/test_sorting_order.py
+++ b/skore/tests/unit/displays/impurity_decrease/test_sorting_order.py
@@ -26,7 +26,7 @@ def test_frame_sorts_per_estimator(
 
 @pytest.mark.parametrize("sorting_order", ["descending", "ascending"])
 def test_plot_with_sorting_order(
-    pyplot, comparison_estimator_reports_binary_classification, sorting_order
+    comparison_estimator_reports_binary_classification, sorting_order
 ):
     """`sorting_order` works for plotting."""
     report = comparison_estimator_reports_binary_classification

--- a/skore/tests/unit/displays/permutation_importance/conftest.py
+++ b/skore/tests/unit/displays/permutation_importance/conftest.py
@@ -1,12 +1,9 @@
-import matplotlib as mpl
 import pytest
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import make_scorer, precision_score, r2_score
 from sklearn.model_selection import train_test_split
 
 from skore import ComparisonReport, CrossValidationReport, EstimatorReport
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture(scope="module")
@@ -16,7 +13,7 @@ def estimator_type():
 
 @pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -27,7 +24,7 @@ def estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def estimator_reports_multiclass_classification_figure_axes(
-    pyplot, estimator_reports_multiclass_classification
+    estimator_reports_multiclass_classification,
 ):
     report = estimator_reports_multiclass_classification[0]
     metric = make_scorer(precision_score, average=None)
@@ -40,7 +37,7 @@ def estimator_reports_multiclass_classification_figure_axes(
 
 
 @pytest.fixture(scope="module")
-def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regression):
+def estimator_reports_regression_figure_axes(estimator_reports_regression):
     report = estimator_reports_regression[0]
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
     fig = display.plot()
@@ -50,7 +47,7 @@ def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regressio
 
 @pytest.fixture(scope="module")
 def estimator_reports_multioutput_regression_figure_axes(
-    pyplot, estimator_reports_multioutput_regression
+    estimator_reports_multioutput_regression,
 ):
     report = estimator_reports_multioutput_regression[0]
     metric = make_scorer(r2_score, multioutput="raw_values")
@@ -64,7 +61,7 @@ def estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_binary_classification_figure_axes(
-    pyplot, cross_validation_reports_binary_classification
+    cross_validation_reports_binary_classification,
 ):
     report = cross_validation_reports_binary_classification[0]
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -75,7 +72,7 @@ def cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, cross_validation_reports_multiclass_classification
+    cross_validation_reports_multiclass_classification,
 ):
     report = cross_validation_reports_multiclass_classification[0]
     metric = make_scorer(precision_score, average=None)
@@ -89,7 +86,7 @@ def cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_regression_figure_axes(
-    pyplot, cross_validation_reports_regression
+    cross_validation_reports_regression,
 ):
     report = cross_validation_reports_regression[0]
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -100,7 +97,7 @@ def cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot, cross_validation_reports_multioutput_regression
+    cross_validation_reports_multioutput_regression,
 ):
     report = cross_validation_reports_multioutput_regression[0]
     metric = make_scorer(r2_score, multioutput="raw_values")
@@ -114,7 +111,7 @@ def cross_validation_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_binary_classification_figure_axes(
-    pyplot, comparison_estimator_reports_binary_classification
+    comparison_estimator_reports_binary_classification,
 ):
     report = comparison_estimator_reports_binary_classification
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -125,7 +122,7 @@ def comparison_estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_estimator_reports_multiclass_classification
+    comparison_estimator_reports_multiclass_classification,
 ):
     metric = make_scorer(precision_score, average=None)
     report = comparison_estimator_reports_multiclass_classification
@@ -139,7 +136,7 @@ def comparison_estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_regression_figure_axes(
-    pyplot, comparison_estimator_reports_regression
+    comparison_estimator_reports_regression,
 ):
     display = comparison_estimator_reports_regression.inspection.permutation_importance(
         n_repeats=2, seed=0
@@ -151,7 +148,7 @@ def comparison_estimator_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multioutput_regression_figure_axes(
-    pyplot, comparison_estimator_reports_multioutput_regression
+    comparison_estimator_reports_multioutput_regression,
 ):
     report = comparison_estimator_reports_multioutput_regression
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -162,7 +159,7 @@ def comparison_estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_binary_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_binary_classification
+    comparison_cross_validation_reports_binary_classification,
 ):
     report = comparison_cross_validation_reports_binary_classification
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -173,7 +170,7 @@ def comparison_cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_multiclass_classification
+    comparison_cross_validation_reports_multiclass_classification,
 ):
     report = comparison_cross_validation_reports_multiclass_classification
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -184,7 +181,7 @@ def comparison_cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_regression_figure_axes(
-    pyplot, comparison_cross_validation_reports_regression
+    comparison_cross_validation_reports_regression,
 ):
     report = comparison_cross_validation_reports_regression
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -195,7 +192,7 @@ def comparison_cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot, comparison_cross_validation_reports_multioutput_regression
+    comparison_cross_validation_reports_multioutput_regression,
 ):
     report = comparison_cross_validation_reports_multioutput_regression
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)

--- a/skore/tests/unit/displays/permutation_importance/test_common.py
+++ b/skore/tests/unit/displays/permutation_importance/test_common.py
@@ -22,7 +22,7 @@ from skore import PermutationImportanceDisplay
     ],
 )
 class TestPermutationImportanceDisplay:
-    def test_class_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_class_attributes(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -65,13 +65,13 @@ class TestPermutationImportanceDisplay:
             expected.add("estimator")
         assert set(frame.columns) == expected
 
-    def test_plot_structure(self, pyplot, fixture_prefix, task, request):
+    def test_plot_structure(self, fixture_prefix, task, request):
         _, axes = request.getfixturevalue(f"{fixture_prefix}_{task}_figure_axes")
         ax = axes[0]
         assert "Decrease in" in ax.get_xlabel()
         assert ax.get_ylabel() == ""
 
-    def test_title(self, pyplot, fixture_prefix, task, request):
+    def test_title(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -87,7 +87,7 @@ class TestPermutationImportanceDisplay:
         else:
             assert "averaged over splits" not in title
 
-    def test_set_style(self, pyplot, fixture_prefix, task, request):
+    def test_set_style(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]

--- a/skore/tests/unit/displays/permutation_importance/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/permutation_importance/test_comparison_cross_validation.py
@@ -12,7 +12,7 @@ from sklearn.metrics import make_scorer, precision_score, r2_score
         "multioutput_regression",
     ],
 )
-def test_invalid_subplot_by(pyplot, task, request):
+def test_invalid_subplot_by(task, request):
     report = request.getfixturevalue(f"comparison_cross_validation_reports_{task}")
     display = report.inspection.permutation_importance(seed=0, n_repeats=2)
     err_msg = "The column 'invalid' is not available for subplotting."
@@ -38,7 +38,7 @@ def test_invalid_subplot_by(pyplot, task, request):
         (None, 1),
     ],
 )
-def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
+def test_valid_subplot_by(task, subplot_by, expected_len, request):
     report = request.getfixturevalue(f"comparison_cross_validation_reports_{task}")
     display = report.inspection.permutation_importance(seed=0, n_repeats=2)
     fig = display.plot(subplot_by=subplot_by)
@@ -58,7 +58,7 @@ def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
         "multioutput_regression",
     ],
 )
-def test_different_features(pyplot, task, request):
+def test_different_features(task, request):
     report = request.getfixturevalue(
         f"comparison_cross_validation_reports_{task}_different_features"
     )
@@ -96,7 +96,7 @@ def test_different_features(pyplot, task, request):
     ],
 )
 def test_subplot_by_non_averaged_metrics(
-    pyplot, task, metric, metric_name, subplot_by, expected_len, request
+    task, metric, metric_name, subplot_by, expected_len, request
 ):
     report = request.getfixturevalue(f"comparison_cross_validation_reports_{task}")
     display = report.inspection.permutation_importance(

--- a/skore/tests/unit/displays/permutation_importance/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/permutation_importance/test_comparison_estimator.py
@@ -12,7 +12,7 @@ from sklearn.metrics import make_scorer, precision_score, r2_score
         "multioutput_regression",
     ],
 )
-def test_invalid_subplot_by(pyplot, task, request):
+def test_invalid_subplot_by(task, request):
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.inspection.permutation_importance(seed=0, n_repeats=2)
     err_msg = "The column 'invalid' is not available for subplotting."
@@ -37,7 +37,7 @@ def test_invalid_subplot_by(pyplot, task, request):
         (None, 1),
     ],
 )
-def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
+def test_valid_subplot_by(task, subplot_by, expected_len, request):
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.inspection.permutation_importance(seed=0, n_repeats=2)
     fig = display.plot(subplot_by=subplot_by)
@@ -57,7 +57,7 @@ def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
         "multioutput_regression",
     ],
 )
-def test_different_features(pyplot, task, request):
+def test_different_features(task, request):
     report = request.getfixturevalue(
         f"comparison_estimator_reports_{task}_different_features"
     )
@@ -94,7 +94,7 @@ def test_different_features(pyplot, task, request):
     ],
 )
 def test_subplot_by_non_averaged_metrics(
-    pyplot, task, metric, metric_name, subplot_by, expected_len, request
+    task, metric, metric_name, subplot_by, expected_len, request
 ):
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.inspection.permutation_importance(

--- a/skore/tests/unit/displays/permutation_importance/test_cross_validation.py
+++ b/skore/tests/unit/displays/permutation_importance/test_cross_validation.py
@@ -12,7 +12,7 @@ from sklearn.metrics import make_scorer, precision_score, r2_score
         "multioutput_regression",
     ],
 )
-def test_invalid_subplot_by(pyplot, task, request):
+def test_invalid_subplot_by(task, request):
     report = request.getfixturevalue(f"cross_validation_reports_{task}")[0]
     err_msg = "The column 'invalid' is not available for subplotting."
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -37,7 +37,7 @@ def test_invalid_subplot_by(pyplot, task, request):
         ("auto", 1),
     ],
 )
-def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
+def test_valid_subplot_by(task, subplot_by, expected_len, request):
     report = request.getfixturevalue(f"cross_validation_reports_{task}")[0]
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
     fig = display.plot(subplot_by=subplot_by)
@@ -68,7 +68,7 @@ def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
     ],
 )
 def test_subplot_by_non_averaged_metrics(
-    pyplot, task, metric, metric_name, subplot_by, expected_len, request
+    task, metric, metric_name, subplot_by, expected_len, request
 ):
     report = request.getfixturevalue(f"cross_validation_reports_{task}")[0]
     display = report.inspection.permutation_importance(

--- a/skore/tests/unit/displays/permutation_importance/test_estimator.py
+++ b/skore/tests/unit/displays/permutation_importance/test_estimator.py
@@ -21,7 +21,7 @@ from skore._utils._testing import custom_r2_score
         "multioutput_regression",
     ],
 )
-def test_invalid_subplot_by(pyplot, task, request):
+def test_invalid_subplot_by(task, request):
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     err_msg = "The column 'invalid' is not available for subplotting."
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
@@ -45,7 +45,7 @@ def test_invalid_subplot_by(pyplot, task, request):
         ("auto", 1),
     ],
 )
-def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
+def test_valid_subplot_by(task, subplot_by, expected_len, request):
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     display = report.inspection.permutation_importance(n_repeats=2, seed=0)
     fig = display.plot(subplot_by=subplot_by)
@@ -76,7 +76,7 @@ def test_valid_subplot_by(pyplot, task, subplot_by, expected_len, request):
     ],
 )
 def test_subplot_by_non_averaged_metrics(
-    pyplot, task, metric, metric_name, subplot_by, expected_len, request
+    task, metric, metric_name, subplot_by, expected_len, request
 ):
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     display = report.inspection.permutation_importance(
@@ -95,7 +95,7 @@ def test_subplot_by_non_averaged_metrics(
         display.plot(subplot_by="invalid")
 
 
-def test_multiple_metrics_require_metric_param(pyplot, estimator_reports_regression):
+def test_multiple_metrics_require_metric_param(estimator_reports_regression):
     report = estimator_reports_regression[0]
     display = report.inspection.permutation_importance(
         n_repeats=2, seed=0, metric=["r2", "neg_mean_squared_error"]
@@ -123,7 +123,7 @@ def test_frame_metric_filter(estimator_reports_regression):
     assert set(display.frame(metric=["r2"])["metric"]) == {"r2"}
 
 
-def test_callable_metric_name(pyplot, estimator_reports_regression):
+def test_callable_metric_name(estimator_reports_regression):
     report = estimator_reports_regression[0]
     display = report.inspection.permutation_importance(
         n_repeats=2, seed=0, metric=custom_r2_score
@@ -192,7 +192,7 @@ def test_frame_mixed_averaged_and_non_averaged_metrics(
 
 
 def test_plot_mixed_averaged_and_non_averaged_metrics(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     metrics = {

--- a/skore/tests/unit/displays/permutation_importance/test_select_k.py
+++ b/skore/tests/unit/displays/permutation_importance/test_select_k.py
@@ -29,7 +29,6 @@ def test_negative(comparison_estimator_reports_binary_classification):
 
 
 def test_different_features(
-    pyplot,
     comparison_estimator_reports_binary_classification_different_features,
 ):
     """`select_k` works for plotting when the estimators have different features."""

--- a/skore/tests/unit/displays/permutation_importance/test_sorting_order.py
+++ b/skore/tests/unit/displays/permutation_importance/test_sorting_order.py
@@ -26,7 +26,7 @@ def test_frame_sorts_per_estimator(
 
 @pytest.mark.parametrize("sorting_order", ["descending", "ascending"])
 def test_plot_with_sorting_order(
-    pyplot, comparison_estimator_reports_binary_classification, sorting_order
+    comparison_estimator_reports_binary_classification, sorting_order
 ):
     """`sorting_order` works for plotting."""
     report = comparison_estimator_reports_binary_classification

--- a/skore/tests/unit/displays/precision_recall_curve/conftest.py
+++ b/skore/tests/unit/displays/precision_recall_curve/conftest.py
@@ -1,12 +1,9 @@
-import matplotlib as mpl
 import pytest
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     display = report.metrics.precision_recall()
@@ -17,7 +14,7 @@ def estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def estimator_reports_multiclass_classification_figure_axes(
-    pyplot, estimator_reports_multiclass_classification
+    estimator_reports_multiclass_classification,
 ):
     report = estimator_reports_multiclass_classification[0]
     display = report.metrics.precision_recall()
@@ -28,7 +25,7 @@ def estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_binary_classification_figure_axes(
-    pyplot, cross_validation_reports_binary_classification
+    cross_validation_reports_binary_classification,
 ):
     report = cross_validation_reports_binary_classification[0]
     display = report.metrics.precision_recall()
@@ -39,7 +36,7 @@ def cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, cross_validation_reports_multiclass_classification
+    cross_validation_reports_multiclass_classification,
 ):
     report = cross_validation_reports_multiclass_classification[0]
     display = report.metrics.precision_recall()
@@ -50,7 +47,7 @@ def cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_binary_classification_figure_axes(
-    pyplot, comparison_estimator_reports_binary_classification
+    comparison_estimator_reports_binary_classification,
 ):
     report = comparison_estimator_reports_binary_classification
     display = report.metrics.precision_recall()
@@ -61,7 +58,7 @@ def comparison_estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_estimator_reports_multiclass_classification
+    comparison_estimator_reports_multiclass_classification,
 ):
     report = comparison_estimator_reports_multiclass_classification
     display = report.metrics.precision_recall()
@@ -72,7 +69,7 @@ def comparison_estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_binary_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_binary_classification
+    comparison_cross_validation_reports_binary_classification,
 ):
     report = comparison_cross_validation_reports_binary_classification
     display = report.metrics.precision_recall()
@@ -83,7 +80,7 @@ def comparison_cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_multiclass_classification
+    comparison_cross_validation_reports_multiclass_classification,
 ):
     report = comparison_cross_validation_reports_multiclass_classification
     display = report.metrics.precision_recall()

--- a/skore/tests/unit/displays/precision_recall_curve/test_common.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_common.py
@@ -19,7 +19,7 @@ from skore._utils._testing import check_frame_structure
 )
 class TestPrecisionRecallCurveDisplay:
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_class_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_class_attributes(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
             report = report[0]
@@ -90,7 +90,7 @@ class TestPrecisionRecallCurveDisplay:
         ]
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_relplot_kwargs(self, pyplot, fixture_prefix, task, request):
+    def test_relplot_kwargs(self, fixture_prefix, task, request):
         """Check that heatmap kwargs are applied correctly and can be changed."""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -112,7 +112,7 @@ class TestPrecisionRecallCurveDisplay:
         assert actual_colors == set(palette)
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_plot_structure(self, pyplot, fixture_prefix, task, request):
+    def test_plot_structure(self, fixture_prefix, task, request):
         """Check that the plot has correct structure"""
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
@@ -132,7 +132,7 @@ class TestPrecisionRecallCurveDisplay:
         assert ax.get_xlim() == ax.get_ylim() == (-0.01, 1.01)
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_title(self, pyplot, fixture_prefix, task, request):
+    def test_title(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
             report = report[0]

--- a/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_comparison_cross_validation.py
@@ -9,7 +9,7 @@ from sklearn.tree import DecisionTreeClassifier
 from skore import ComparisonReport, CrossValidationReport, compare, evaluate
 
 
-def test_data_source_both_legend_matches_curves(pyplot):
+def test_data_source_both_legend_matches_curves():
     """Legend colors must match the drawn curves with ``data_source="both"``.
 
     Non-regression test for https://github.com/probabl-ai/skore/issues/2925, the
@@ -58,7 +58,6 @@ def test_data_source_both_legend_matches_curves(pyplot):
 
 
 def test_legend_binary_classification(
-    pyplot,
     comparison_cross_validation_reports_binary_classification,
     comparison_cross_validation_reports_binary_classification_figure_axes,
 ):
@@ -88,7 +87,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     comparison_cross_validation_reports_multiclass_classification,
     comparison_cross_validation_reports_multiclass_classification_figure_axes,
 ):
@@ -118,7 +116,7 @@ def test_legend_multiclass_classification(
             )
 
 
-def test_multiclass_str_labels_precision_recall_plot(pyplot):
+def test_multiclass_str_labels_precision_recall_plot():
     """Regression test for issue #2183 with multiclass comparison reports.
 
     Using string labels backed by numpy.str_ should not break

--- a/skore/tests/unit/displays/precision_recall_curve/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_comparison_estimator.py
@@ -3,7 +3,6 @@ import pytest
 
 
 def test_legend_binary_classification(
-    pyplot,
     comparison_estimator_reports_binary_classification,
     comparison_estimator_reports_binary_classification_figure_axes,
 ):
@@ -30,7 +29,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     comparison_estimator_reports_multiclass_classification,
     comparison_estimator_reports_multiclass_classification_figure_axes,
 ):
@@ -135,7 +133,7 @@ def test_subplot_by_data_source(fixture_name, request):
         "comparison_estimator_reports_multiclass_classification",
     ],
 )
-def test_source_both(pyplot, fixture_name, request):
+def test_source_both(fixture_name, request):
     """Check the behaviour of the plot when data_source='both'."""
     report = request.getfixturevalue(fixture_name)
     display = report.metrics.precision_recall(data_source="both")

--- a/skore/tests/unit/displays/precision_recall_curve/test_cross_validation.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_cross_validation.py
@@ -3,7 +3,6 @@ import pytest
 
 
 def test_legend_binary_classification(
-    pyplot,
     cross_validation_reports_binary_classification,
     cross_validation_reports_binary_classification_figure_axes,
 ):
@@ -26,7 +25,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     cross_validation_reports_multiclass_classification,
     cross_validation_reports_multiclass_classification_figure_axes,
 ):
@@ -103,7 +101,7 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
         "cross_validation_reports_multiclass_classification",
     ],
 )
-def test_data_source_both(pyplot, report_name, request):
+def test_data_source_both(report_name, request):
     """Check that precision_recall(data_source='both') includes train and test data."""
     report = request.getfixturevalue(report_name)[0]
     display = report.metrics.precision_recall(data_source="both")

--- a/skore/tests/unit/displays/precision_recall_curve/test_estimator.py
+++ b/skore/tests/unit/displays/precision_recall_curve/test_estimator.py
@@ -3,7 +3,6 @@ import pytest
 
 
 def test_legend_binary_classification(
-    pyplot,
     estimator_reports_binary_classification,
     estimator_reports_binary_classification_figure_axes,
 ):
@@ -25,7 +24,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     estimator_reports_multiclass_classification,
     estimator_reports_multiclass_classification_figure_axes,
 ):
@@ -98,7 +96,7 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
         "estimator_reports_multiclass_classification",
     ],
 )
-def test_source_both(pyplot, fixture_name, request):
+def test_source_both(fixture_name, request):
     """Check the behaviour of the plot when data_source='both'."""
     report = request.getfixturevalue(fixture_name)[0]
     display = report.metrics.precision_recall(data_source="both")

--- a/skore/tests/unit/displays/prediction_error/conftest.py
+++ b/skore/tests/unit/displays/prediction_error/conftest.py
@@ -1,11 +1,8 @@
-import matplotlib as mpl
 import pytest
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture
-def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regression):
+def estimator_reports_regression_figure_axes(estimator_reports_regression):
     report = estimator_reports_regression[0]
     display = report.metrics.prediction_error()
     fig = display.plot()
@@ -15,7 +12,7 @@ def estimator_reports_regression_figure_axes(pyplot, estimator_reports_regressio
 
 @pytest.fixture
 def cross_validation_reports_regression_figure_axes(
-    pyplot, cross_validation_reports_regression
+    cross_validation_reports_regression,
 ):
     report = cross_validation_reports_regression[0]
     display = report.metrics.prediction_error()
@@ -26,7 +23,7 @@ def cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture
 def comparison_estimator_reports_regression_figure_axes(
-    pyplot, comparison_estimator_reports_regression
+    comparison_estimator_reports_regression,
 ):
     report = comparison_estimator_reports_regression
     display = report.metrics.prediction_error()
@@ -37,7 +34,7 @@ def comparison_estimator_reports_regression_figure_axes(
 
 @pytest.fixture
 def comparison_cross_validation_reports_regression_figure_axes(
-    pyplot, comparison_cross_validation_reports_regression
+    comparison_cross_validation_reports_regression,
 ):
     report = comparison_cross_validation_reports_regression
     display = report.metrics.prediction_error()
@@ -48,7 +45,7 @@ def comparison_cross_validation_reports_regression_figure_axes(
 
 @pytest.fixture
 def estimator_reports_multioutput_regression_figure_axes(
-    pyplot, estimator_reports_multioutput_regression
+    estimator_reports_multioutput_regression,
 ):
     report = estimator_reports_multioutput_regression[0]
     display = report.metrics.prediction_error()
@@ -59,7 +56,7 @@ def estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture
 def cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot, cross_validation_reports_multioutput_regression
+    cross_validation_reports_multioutput_regression,
 ):
     report = cross_validation_reports_multioutput_regression[0]
     display = report.metrics.prediction_error()
@@ -70,7 +67,7 @@ def cross_validation_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture
 def comparison_estimator_reports_multioutput_regression_figure_axes(
-    pyplot, comparison_estimator_reports_multioutput_regression
+    comparison_estimator_reports_multioutput_regression,
 ):
     report = comparison_estimator_reports_multioutput_regression
     display = report.metrics.prediction_error()
@@ -81,7 +78,7 @@ def comparison_estimator_reports_multioutput_regression_figure_axes(
 
 @pytest.fixture
 def comparison_cross_validation_reports_multioutput_regression_figure_axes(
-    pyplot, comparison_cross_validation_reports_multioutput_regression
+    comparison_cross_validation_reports_multioutput_regression,
 ):
     report = comparison_cross_validation_reports_multioutput_regression
     display = report.metrics.prediction_error()

--- a/skore/tests/unit/displays/prediction_error/test_common.py
+++ b/skore/tests/unit/displays/prediction_error/test_common.py
@@ -74,7 +74,7 @@ class TestPredictionErrorDisplay:
             "residuals",
         ]
 
-    def test_relplot_kwargs(self, pyplot, fixture_prefix, request, task):
+    def test_relplot_kwargs(self, fixture_prefix, request, task):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -99,7 +99,7 @@ class TestPredictionErrorDisplay:
             ax.collections[0].get_facecolor()[0][:3], [1.0, 0.0, 0.0]
         )
 
-    def test_plot_structure(self, pyplot, fixture_prefix, request, task):
+    def test_plot_structure(self, fixture_prefix, request, task):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -110,7 +110,7 @@ class TestPredictionErrorDisplay:
         assert ax.get_xlabel() == "Predicted values"
         assert ax.get_ylabel() == "Residuals (actual - predicted)"
 
-    def test_title(self, pyplot, fixture_prefix, request, task):
+    def test_title(self, fixture_prefix, request, task):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
@@ -130,7 +130,7 @@ class TestPredictionErrorDisplay:
             assert "Data source" not in title
 
     @pytest.mark.parametrize("subsample", [20, 0.25, None])
-    def test_subsample(pyplot, fixture_prefix, request, task, subsample):
+    def test_subsample(self, fixture_prefix, request, task, subsample):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]

--- a/skore/tests/unit/displays/prediction_error/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_cross_validation.py
@@ -6,7 +6,7 @@ import pytest
     "task, legend_prefix",
     [("regression", "Split"), ("multioutput_regression", "Output")],
 )
-def test_legend(pyplot, task, legend_prefix, request):
+def test_legend(task, legend_prefix, request):
     """Check the legend of the prediction error plot with comparison crossvalidation."""
     figure, _ = request.getfixturevalue(
         f"comparison_cross_validation_reports_{task}_figure_axes"
@@ -24,7 +24,7 @@ def test_legend(pyplot, task, legend_prefix, request):
     "task, legend_prefix",
     [("regression", "Split"), ("multioutput_regression", "Output")],
 )
-def test_legend_actual_vs_predicted(pyplot, task, legend_prefix, request):
+def test_legend_actual_vs_predicted(task, legend_prefix, request):
     """Check the legend when kind is actual_vs_predicted."""
     report = request.getfixturevalue(f"comparison_cross_validation_reports_{task}")
     display = report.metrics.prediction_error()
@@ -49,7 +49,7 @@ def test_legend_actual_vs_predicted(pyplot, task, legend_prefix, request):
         ("multioutput_regression", ["auto", "output", "estimator"]),
     ],
 )
-def test_invalid_subplot_by(pyplot, task, valid_values, request):
+def test_invalid_subplot_by(task, valid_values, request):
     """Check that we raise a proper error message when passing an inappropriate
     value for the `subplot_by` argument.
     """
@@ -78,7 +78,7 @@ def test_invalid_subplot_by(pyplot, task, valid_values, request):
         ),
     ],
 )
-def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
+def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     """Check that we can pass valid values to `subplot_by`."""
     report = request.getfixturevalue(fixture_name)
     display = report.metrics.prediction_error()

--- a/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
@@ -5,7 +5,7 @@ import pytest
     "task, n_legend_entries",
     [("regression", 1), ("multioutput_regression", 3)],
 )
-def test_legend(pyplot, task, n_legend_entries, request):
+def test_legend(task, n_legend_entries, request):
     """Check the legend of the prediction error plot with comparison of estimators."""
     figure, _ = request.getfixturevalue(
         f"comparison_estimator_reports_{task}_figure_axes"
@@ -24,7 +24,7 @@ def test_legend(pyplot, task, n_legend_entries, request):
     "task, n_legend_entries",
     [("regression", 1), ("multioutput_regression", 3)],
 )
-def test_legend_actual_vs_predicted(pyplot, task, n_legend_entries, request):
+def test_legend_actual_vs_predicted(task, n_legend_entries, request):
     """Check the legend when kind is actual_vs_predicted."""
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.metrics.prediction_error()
@@ -45,7 +45,7 @@ def test_legend_actual_vs_predicted(pyplot, task, n_legend_entries, request):
         ("multioutput_regression", ["auto", "output", "estimator"]),
     ],
 )
-def test_invalid_subplot_by(pyplot, task, valid_values, request):
+def test_invalid_subplot_by(task, valid_values, request):
     """Check that we raise a proper error message when passing an inappropriate
     value for the `subplot_by` argument.
     """
@@ -71,7 +71,7 @@ def test_invalid_subplot_by(pyplot, task, valid_values, request):
         ),
     ],
 )
-def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
+def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     """Check that we can pass valid values to `subplot_by`."""
     report = request.getfixturevalue(fixture_name)
     display = report.metrics.prediction_error()
@@ -82,7 +82,7 @@ def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
 
 
 @pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
-def test_subplot_by_data_source(pyplot, task, request):
+def test_subplot_by_data_source(task, request):
     """Check the behaviour when `subplot_by` is `data_source`."""
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.metrics.prediction_error(data_source="both")
@@ -106,7 +106,7 @@ def test_subplot_by_data_source(pyplot, task, request):
 
 
 @pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
-def test_source_both(pyplot, task, request):
+def test_source_both(task, request):
     """Check the behaviour of the plot when data_source='both'."""
     report = request.getfixturevalue(f"comparison_estimator_reports_{task}")
     display = report.metrics.prediction_error(data_source="both")

--- a/skore/tests/unit/displays/prediction_error/test_cross_validation.py
+++ b/skore/tests/unit/displays/prediction_error/test_cross_validation.py
@@ -6,7 +6,7 @@ import pytest
     "task, legend_prefix",
     [("regression", "Split"), ("multioutput_regression", "Output")],
 )
-def test_legend(pyplot, task, legend_prefix, request):
+def test_legend(task, legend_prefix, request):
     """Check the legend of the prediction error plot with cross-validation."""
     figure, _ = request.getfixturevalue(f"cross_validation_reports_{task}_figure_axes")
     legend = figure.axes[len(figure.axes) // 2].get_legend()
@@ -22,7 +22,7 @@ def test_legend(pyplot, task, legend_prefix, request):
     "task, legend_prefix",
     [("regression", "Split"), ("multioutput_regression", "Output")],
 )
-def test_legend_actual_vs_predicted(pyplot, task, legend_prefix, request):
+def test_legend_actual_vs_predicted(task, legend_prefix, request):
     """Check the legend when kind is actual_vs_predicted."""
     report = request.getfixturevalue(f"cross_validation_reports_{task}")[0]
     display = report.metrics.prediction_error()
@@ -43,7 +43,7 @@ def test_legend_actual_vs_predicted(pyplot, task, legend_prefix, request):
         ("multioutput_regression", ["auto", "output", "split", "None"]),
     ],
 )
-def test_invalid_subplot_by(pyplot, task, valid_values, request):
+def test_invalid_subplot_by(task, valid_values, request):
     """Check that we raise a proper error message when passing an inappropriate
     value for the `subplot_by` argument.
     """
@@ -69,7 +69,7 @@ def test_invalid_subplot_by(pyplot, task, valid_values, request):
         ),
     ],
 )
-def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
+def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     """Check that we can pass valid values to `subplot_by`."""
     report = request.getfixturevalue(fixture_name)[0]
     display = report.metrics.prediction_error()

--- a/skore/tests/unit/displays/prediction_error/test_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_estimator.py
@@ -10,7 +10,7 @@ from skore._utils._testing import check_cache_unchanged
     "task, n_legend_entries",
     [("regression", 1), ("multioutput_regression", 3)],
 )
-def test_legend(pyplot, task, n_legend_entries, request):
+def test_legend(task, n_legend_entries, request):
     """Check the legend of the prediction error plot."""
     figure, _ = request.getfixturevalue(f"estimator_reports_{task}_figure_axes")
     legend = figure.axes[len(figure.axes) // 2].get_legend()
@@ -27,7 +27,7 @@ def test_legend(pyplot, task, n_legend_entries, request):
     "task, n_legend_entries",
     [("regression", 1), ("multioutput_regression", 3)],
 )
-def test_legend_actual_vs_predicted(pyplot, task, n_legend_entries, request):
+def test_legend_actual_vs_predicted(task, n_legend_entries, request):
     """Check the legend when kind is actual_vs_predicted."""
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     display = report.metrics.prediction_error()
@@ -48,7 +48,7 @@ def test_legend_actual_vs_predicted(pyplot, task, n_legend_entries, request):
         ("multioutput_regression", ["auto", "output", "None"]),
     ],
 )
-def test_invalid_subplot_by(pyplot, task, valid_values, request):
+def test_invalid_subplot_by(task, valid_values, request):
     """Check that we raise a proper error message when passing an inappropriate
     value for the `subplot_by` argument.
     """
@@ -74,7 +74,7 @@ def test_invalid_subplot_by(pyplot, task, valid_values, request):
         ),
     ],
 )
-def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
+def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
     """Check that we can pass valid values to `subplot_by`."""
     report = request.getfixturevalue(fixture_name)[0]
     display = report.metrics.prediction_error()
@@ -89,7 +89,7 @@ def test_valid_subplot_by(pyplot, fixture_name, subplot_by_tuples, request):
 
 
 @pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
-def test_subplot_by_data_source(pyplot, task, request):
+def test_subplot_by_data_source(task, request):
     """Check the behaviour when `subplot_by` is `data_source`."""
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     display = report.metrics.prediction_error(data_source="both")
@@ -107,7 +107,7 @@ def test_subplot_by_data_source(pyplot, task, request):
 
 
 @pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
-def test_source_both(pyplot, task, request):
+def test_source_both(task, request):
     """Check the behaviour of the plot when data_source='both'."""
     report = request.getfixturevalue(f"estimator_reports_{task}")[0]
     display = report.metrics.prediction_error(data_source="both")
@@ -134,14 +134,14 @@ def test_source_both(pyplot, task, request):
         ({"subsample": -20.0}, "When a floating-point, subsample=-20.0 should be"),
     ],
 )
-def test_wrong_subsample(pyplot, params, err_msg, estimator_reports_regression):
+def test_wrong_subsample(params, err_msg, estimator_reports_regression):
     """Check that we raise the proper error when making the parameters validation."""
     report = estimator_reports_regression[0]
     with pytest.raises(ValueError, match=err_msg):
         report.metrics.prediction_error(**params)
 
 
-def test_pass_kind_to_plot(pyplot, estimator_reports_regression):
+def test_pass_kind_to_plot(estimator_reports_regression):
     """Check that we raise an error when passing an invalid `kind` to plot."""
     report = estimator_reports_regression[0]
     display = report.metrics.prediction_error()

--- a/skore/tests/unit/displays/roc_curve/conftest.py
+++ b/skore/tests/unit/displays/roc_curve/conftest.py
@@ -1,12 +1,9 @@
-import matplotlib as mpl
 import pytest
-
-mpl.rc("figure", max_open_warning=False)
 
 
 @pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
-    pyplot, estimator_reports_binary_classification
+    estimator_reports_binary_classification,
 ):
     report = estimator_reports_binary_classification[0]
     display = report.metrics.roc()
@@ -17,7 +14,7 @@ def estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def estimator_reports_multiclass_classification_figure_axes(
-    pyplot, estimator_reports_multiclass_classification
+    estimator_reports_multiclass_classification,
 ):
     report = estimator_reports_multiclass_classification[0]
     display = report.metrics.roc()
@@ -28,7 +25,7 @@ def estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_binary_classification_figure_axes(
-    pyplot, cross_validation_reports_binary_classification
+    cross_validation_reports_binary_classification,
 ):
     report = cross_validation_reports_binary_classification[0]
     display = report.metrics.roc()
@@ -39,7 +36,7 @@ def cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, cross_validation_reports_multiclass_classification
+    cross_validation_reports_multiclass_classification,
 ):
     report = cross_validation_reports_multiclass_classification[0]
     display = report.metrics.roc()
@@ -50,7 +47,7 @@ def cross_validation_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_binary_classification_figure_axes(
-    pyplot, comparison_estimator_reports_binary_classification
+    comparison_estimator_reports_binary_classification,
 ):
     report = comparison_estimator_reports_binary_classification
     display = report.metrics.roc()
@@ -61,7 +58,7 @@ def comparison_estimator_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_estimator_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_estimator_reports_multiclass_classification
+    comparison_estimator_reports_multiclass_classification,
 ):
     report = comparison_estimator_reports_multiclass_classification
     display = report.metrics.roc()
@@ -72,7 +69,7 @@ def comparison_estimator_reports_multiclass_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_binary_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_binary_classification
+    comparison_cross_validation_reports_binary_classification,
 ):
     report = comparison_cross_validation_reports_binary_classification
     display = report.metrics.roc()
@@ -83,7 +80,7 @@ def comparison_cross_validation_reports_binary_classification_figure_axes(
 
 @pytest.fixture(scope="module")
 def comparison_cross_validation_reports_multiclass_classification_figure_axes(
-    pyplot, comparison_cross_validation_reports_multiclass_classification
+    comparison_cross_validation_reports_multiclass_classification,
 ):
     report = comparison_cross_validation_reports_multiclass_classification
     display = report.metrics.roc()

--- a/skore/tests/unit/displays/roc_curve/test_common.py
+++ b/skore/tests/unit/displays/roc_curve/test_common.py
@@ -21,7 +21,7 @@ from skore._utils._testing import check_frame_structure
 )
 class TestRocCurveDisplay:
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_class_attributes(self, pyplot, fixture_prefix, task, request):
+    def test_class_attributes(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
             report = report[0]
@@ -88,7 +88,7 @@ class TestRocCurveDisplay:
         ]
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_relplot_kwargs(self, pyplot, fixture_prefix, task, request):
+    def test_relplot_kwargs(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
             report = report[0]
@@ -109,7 +109,7 @@ class TestRocCurveDisplay:
         assert actual_colors == set(palette)
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_plot_structure(self, pyplot, fixture_prefix, task, request):
+    def test_plot_structure(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
             report = report[0]
@@ -128,7 +128,7 @@ class TestRocCurveDisplay:
         assert ax.get_xlim() == ax.get_ylim() == (-0.01, 1.01)
 
     @pytest.mark.parametrize("task", ["binary", "multiclass"])
-    def test_title(self, pyplot, fixture_prefix, task, request):
+    def test_title(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}_classification")
         if isinstance(report, tuple):
             report = report[0]

--- a/skore/tests/unit/displays/roc_curve/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/roc_curve/test_comparison_cross_validation.py
@@ -11,7 +11,7 @@ from sklearn.tree import DecisionTreeClassifier
 from skore import ComparisonReport, CrossValidationReport, compare, evaluate
 
 
-def test_data_source_both_legend_matches_curves(pyplot):
+def test_data_source_both_legend_matches_curves():
     """Legend colors must match the drawn curves with ``data_source="both"``.
 
     Non-regression test for https://github.com/probabl-ai/skore/issues/2925: with
@@ -62,7 +62,6 @@ def test_data_source_both_legend_matches_curves(pyplot):
 
 
 def test_legend_binary_classification(
-    pyplot,
     comparison_cross_validation_reports_binary_classification,
     comparison_cross_validation_reports_binary_classification_figure_axes,
 ):
@@ -93,7 +92,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     comparison_cross_validation_reports_multiclass_classification,
     comparison_cross_validation_reports_multiclass_classification_figure_axes,
 ):
@@ -125,7 +123,7 @@ def test_legend_multiclass_classification(
         assert legend_texts[-1] == "Chance level (AUC = 0.5)"
 
 
-def test_multiclass_str_labels_roc_plot(pyplot):
+def test_multiclass_str_labels_roc_plot():
     """Regression test for issue #2183 with multiclass comparison reports.
 
     Using string labels backed by numpy.str_ should not break

--- a/skore/tests/unit/displays/roc_curve/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/roc_curve/test_comparison_estimator.py
@@ -3,7 +3,6 @@ import pytest
 
 
 def test_legend_binary_classification(
-    pyplot,
     comparison_estimator_reports_binary_classification,
     comparison_estimator_reports_binary_classification_figure_axes,
 ):
@@ -31,7 +30,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     comparison_estimator_reports_multiclass_classification,
     comparison_estimator_reports_multiclass_classification_figure_axes,
 ):
@@ -138,7 +136,7 @@ def test_subplot_by_data_source(fixture_name, request):
         "comparison_estimator_reports_multiclass_classification",
     ],
 )
-def test_source_both(pyplot, fixture_name, request):
+def test_source_both(fixture_name, request):
     """Check the behaviour of the plot when data_source='both'."""
     report = request.getfixturevalue(fixture_name)
     display = report.metrics.roc(data_source="both")

--- a/skore/tests/unit/displays/roc_curve/test_cross_validation.py
+++ b/skore/tests/unit/displays/roc_curve/test_cross_validation.py
@@ -3,7 +3,6 @@ import pytest
 
 
 def test_legend_binary_classification(
-    pyplot,
     cross_validation_reports_binary_classification,
     cross_validation_reports_binary_classification_figure_axes,
 ):
@@ -27,7 +26,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     cross_validation_reports_multiclass_classification,
     cross_validation_reports_multiclass_classification_figure_axes,
 ):
@@ -105,7 +103,7 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
         "cross_validation_reports_multiclass_classification",
     ],
 )
-def test_data_source_both(pyplot, report_name, request):
+def test_data_source_both(report_name, request):
     """Check that `roc(data_source='both')` includes train and test data."""
     report = request.getfixturevalue(report_name)[0]
     display = report.metrics.roc(data_source="both")

--- a/skore/tests/unit/displays/roc_curve/test_estimator.py
+++ b/skore/tests/unit/displays/roc_curve/test_estimator.py
@@ -3,7 +3,6 @@ import pytest
 
 
 def test_legend_binary_classification(
-    pyplot,
     estimator_reports_binary_classification,
     estimator_reports_binary_classification_figure_axes,
 ):
@@ -24,7 +23,6 @@ def test_legend_binary_classification(
 
 
 def test_legend_multiclass_classification(
-    pyplot,
     estimator_reports_multiclass_classification,
     estimator_reports_multiclass_classification_figure_axes,
 ):
@@ -96,7 +94,7 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
         "estimator_reports_multiclass_classification",
     ],
 )
-def test_source_both(pyplot, fixture_name, request):
+def test_source_both(fixture_name, request):
     """Check the behaviour of the plot when data_source='both'."""
     report = request.getfixturevalue(fixture_name)[0]
     display = report.metrics.roc(data_source="both")

--- a/skore/tests/unit/displays/table_report/test_common.py
+++ b/skore/tests/unit/displays/table_report/test_common.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -80,9 +81,9 @@ def test_truncate_top_k_categories(dtype, other_label):
 
 
 @pytest.mark.parametrize("is_x_axis", [True, False])
-def test_resize_categorical_axis(pyplot, is_x_axis):
+def test_resize_categorical_axis(is_x_axis):
     """Check the behaviour of the `_resize_categorical_axis` function."""
-    figure, ax = pyplot.subplots(figsize=(10, 10))
+    figure, ax = plt.subplots(figsize=(10, 10))
     _resize_categorical_axis(
         figure=figure,
         ax=ax,
@@ -107,7 +108,7 @@ def test_truncate_top_k_categories_return_as_is(col):
     assert _truncate_top_k_categories(col, k=3) is col
 
 
-def test_corr_plot(pyplot, estimator_report):
+def test_corr_plot(estimator_report):
     display = estimator_report.data.summarize(data_source="train")
     fig = display.plot(kind="corr")
     ax = fig.axes[0]

--- a/skore/tests/unit/displays/table_report/test_estimator.py
+++ b/skore/tests/unit/displays/table_report/test_estimator.py
@@ -168,7 +168,7 @@ def test_frame(estimator_report, data_source):
     )
 
 
-def test_categorical_plots_1d(pyplot, display):
+def test_categorical_plots_1d(display):
     """Check the plot output with categorical data in 1-d."""
     fig = display.plot(x="gender")
     ax = fig.axes[0]
@@ -196,7 +196,7 @@ def test_categorical_plots_1d(pyplot, display):
     assert ax.containers[0].patches[0].get_facecolor() == (0.0, 0.0, 1.0, 0.75)
 
 
-def test_numeric_plots_1d(pyplot, estimator_report):
+def test_numeric_plots_1d(estimator_report):
     """Check the plot output with numeric data in 1-d."""
     display = estimator_report.data.summarize(data_source="train")
     ## for integers numeric values
@@ -221,7 +221,7 @@ def test_numeric_plots_1d(pyplot, estimator_report):
     assert ax.get_ylabel() == "year_first_hired"
 
 
-def test_top_k_categorical_plots_1d(pyplot, display):
+def test_top_k_categorical_plots_1d(display):
     """Check the plot output with categorical data in 1-d and top k categories."""
     fig = display.plot(x="division")
     ax = fig.axes[0]
@@ -231,7 +231,7 @@ def test_top_k_categorical_plots_1d(pyplot, display):
     assert len(ax.get_xticklabels()) == 30
 
 
-def test_hue_plots_1d(pyplot, display):
+def test_hue_plots_1d(display):
     """Check the plot output with hue in 1-d."""
     fig = display.plot(x="gender", hue="current_annual_salary")
     ax = fig.axes[0]
@@ -256,7 +256,7 @@ def test_hue_plots_1d(pyplot, display):
     assert ax.legend_.get_title().get_text() == "current_annual_salary"
 
 
-def test_plot_duration_data_1d(pyplot, display):
+def test_plot_duration_data_1d(display):
     """Check the plot output with duration data in 1-d."""
     ## 1D - timedelta as x
     fig = display.plot(x="timedelta_hired")
@@ -269,7 +269,7 @@ def test_plot_duration_data_1d(pyplot, display):
     assert ax.get_ylabel() == "Years"
 
 
-def test_plots_2d(pyplot, display):
+def test_plots_2d(display):
     """Check the general behaviour of the 2-d plots."""
     # scatter plot
     fig = display.plot(y="current_annual_salary", x="year_first_hired")
@@ -315,7 +315,7 @@ def test_plots_2d(pyplot, display):
     assert any("e+" in annotation for annotation in annotations)
 
 
-def test_hue_plots_2d(pyplot, display):
+def test_hue_plots_2d(display):
     """Check the plot output with hue parameter in 2-d."""
     fig = display.plot(x="year_first_hired", y="current_annual_salary", hue="division")
     ax = fig.axes[0]

--- a/skore/tests/unit/displays/test_common.py
+++ b/skore/tests/unit/displays/test_common.py
@@ -31,7 +31,7 @@ def test_display_inherits_display_mixin(display_cls):
         ("prediction_error", LinearRegression(), make_regression(random_state=42)),
     ],
 )
-def test_display_protocol(pyplot, capsys, plot_func, estimator, dataset):
+def test_display_protocol(capsys, plot_func, estimator, dataset):
     """Check that the display object adheres to the Display protocol."""
 
     X_train, X_test, y_train, y_test = train_test_split(*dataset, random_state=42)

--- a/skore/tests/unit/displays/test_repr.py
+++ b/skore/tests/unit/displays/test_repr.py
@@ -10,7 +10,7 @@ def test_default_repr_includes_frame_and_hint(repr_coefficients_display):
     )
 
 
-def test_default_repr_html_includes_plot_and_hint(pyplot, repr_coefficients_display):
+def test_default_repr_html_includes_plot_and_hint(repr_coefficients_display):
     display = repr_coefficients_display
     html = display._repr_html_()
     assert "data:image/png;base64," in html
@@ -18,7 +18,7 @@ def test_default_repr_html_includes_plot_and_hint(pyplot, repr_coefficients_disp
     assert "<code>.frame()</code> to access the plotted data." in html
 
 
-def test_default_repr_mimebundle(pyplot, repr_coefficients_display):
+def test_default_repr_mimebundle(repr_coefficients_display):
     bundle = repr_coefficients_display._repr_mimebundle_()
     assert bundle == {
         "text/plain": repr(repr_coefficients_display),

--- a/skore/tests/unit/displays/test_utils.py
+++ b/skore/tests/unit/displays/test_utils.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -107,18 +108,18 @@ def test_validate_style_kwargs_error(default_kwargs, user_kwargs):
 @pytest.mark.parametrize(
     "rotation, horizontalalignment", [(45, "right"), (90, "center"), (180, "left")]
 )
-def test_rotate_ticklabels(pyplot, rotation, horizontalalignment):
+def test_rotate_ticklabels(rotation, horizontalalignment):
     """Check that we can rotate the ticks labels on an axis."""
-    _, ax = pyplot.subplots()
+    _, ax = plt.subplots()
     ax.plot(range(10))
     _rotate_ticklabels(ax, rotation=rotation, horizontalalignment=horizontalalignment)
     assert ax.get_xticklabels()[0].get_rotation() == rotation
     assert ax.get_xticklabels()[0].get_horizontalalignment() == horizontalalignment
 
 
-def test_get_adjusted_fig_size(pyplot):
+def test_get_adjusted_fig_size():
     """Check the computation of the adjusted figure size."""
-    fig, ax = pyplot.subplots(figsize=(2, 4))
+    fig, ax = plt.subplots(figsize=(2, 4))
     assert _get_adjusted_fig_size(fig, ax, "width", 2) == pytest.approx(
         2.0 * _get_adjusted_fig_size(fig, ax, "width", 1)
     )
@@ -127,9 +128,9 @@ def test_get_adjusted_fig_size(pyplot):
     )
 
 
-def test_adjust_fig_size(pyplot):
+def test_adjust_fig_size():
     """Check the adjustment of the figure size."""
-    fig, ax = pyplot.subplots(figsize=(2, 4))
+    fig, ax = plt.subplots(figsize=(2, 4))
     _adjust_fig_size(fig, ax, 1, 2)
     expected_width = _get_adjusted_fig_size(fig, ax, "width", 1)
     expected_height = _get_adjusted_fig_size(fig, ax, "height", 2)

--- a/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/cross_validation/metrics/test_numeric.py
@@ -244,7 +244,7 @@ def test_metrics_aggregate(case):
 
 
 @pytest.mark.parametrize("metric", ["roc", "precision_recall"])
-def test_binary_classification_pos_label(pyplot, metric):
+def test_binary_classification_pos_label(metric):
     """Check the behaviour of the display methods when `pos_label` is not set."""
     X, y = make_classification(
         n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0

--- a/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
+++ b/skore/tests/unit/reports/comparison/estimator/metrics/test_numeric.py
@@ -214,7 +214,7 @@ def test_timings(comparison_estimator_reports_binary_classification):
 
 @pytest.mark.parametrize("metric", ["roc", "precision_recall"])
 def test_display_binary_classification_pos_label(
-    pyplot, metric, logistic_binary_classification_with_train_test
+    metric, logistic_binary_classification_with_train_test
 ):
     """Check the behaviour of the display methods when `pos_label` is not set."""
     classifier, X_train, X_test, y_train, y_test = (

--- a/skore/tests/unit/reports/cross_validation/metrics/test_plot.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_plot.py
@@ -15,9 +15,7 @@ def test_plot_roc(forest_binary_classification_data):
 
 
 @pytest.mark.parametrize("display", ["roc", "precision_recall"])
-def test_display_binary_classification(
-    pyplot, forest_binary_classification_data, display
-):
+def test_display_binary_classification(forest_binary_classification_data, display):
     """General behaviour of the function creating display on binary classification."""
     estimator, X, y = forest_binary_classification_data
     report = CrossValidationReport(estimator, X, y, splitter=2)
@@ -30,7 +28,7 @@ def test_display_binary_classification(
 
 
 @pytest.mark.parametrize("display", ["prediction_error"])
-def test_display_regression(pyplot, linear_regression_data, display):
+def test_display_regression(linear_regression_data, display):
     """General behaviour of the function creating display on regression."""
     estimator, X, y = linear_regression_data
     report = CrossValidationReport(estimator, X, y, splitter=2)
@@ -44,7 +42,7 @@ def test_display_regression(pyplot, linear_regression_data, display):
 
 @pytest.mark.parametrize("metric", ["roc", "precision_recall"])
 def test_display_binary_classification_pos_label(
-    pyplot, metric, forest_binary_classification_data
+    metric, forest_binary_classification_data
 ):
     """Check the behaviour of the display methods when `pos_label` needs to be set."""
     classifier, X, y = forest_binary_classification_data

--- a/skore/tests/unit/reports/estimator/metrics/test_plot.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_plot.py
@@ -16,9 +16,7 @@ def test_plot_roc(forest_binary_classification_with_test):
 
 
 @pytest.mark.parametrize("display", ["roc", "precision_recall"])
-def test_display_binary_classification(
-    pyplot, forest_binary_classification_with_test, display
-):
+def test_display_binary_classification(forest_binary_classification_with_test, display):
     """The call to display functions should be cached."""
     estimator, X_test, y_test = forest_binary_classification_with_test
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
@@ -30,7 +28,7 @@ def test_display_binary_classification(
 
 
 @pytest.mark.parametrize("metric", ["roc", "precision_recall"])
-def test_display_binary_classification_pos_label(pyplot, metric):
+def test_display_binary_classification_pos_label(metric):
     """Check the behaviour of the display methods when `pos_label` is not set."""
     X, y = make_classification(
         n_classes=2, class_sep=0.8, weights=[0.4, 0.6], random_state=0
@@ -51,7 +49,7 @@ def test_display_binary_classification_pos_label(pyplot, metric):
 
 @pytest.mark.parametrize("metric", ["roc", "precision_recall"])
 def test_display_binary_classification_decision_function_report_pos_label(
-    pyplot, metric, binary_classification_data
+    metric, binary_classification_data
 ):
     """Check that the default binary behaviour works with 1D decision scores."""
     X, y = binary_classification_data
@@ -133,7 +131,7 @@ def test_display_multiclass_label_selects_curve_and_validates(
 
 
 @pytest.mark.parametrize("display", ["prediction_error"])
-def test_display_regression(pyplot, linear_regression_with_test, display):
+def test_display_regression(linear_regression_with_test, display):
     """The call to display functions should be cached, as long as the arguments make it
     reproducible."""
     estimator, X_test, y_test = linear_regression_with_test
@@ -147,7 +145,7 @@ def test_display_regression(pyplot, linear_regression_with_test, display):
 
 @pytest.mark.parametrize("display", ["roc", "precision_recall"])
 def test_display_binary_classification_switching_data_source(
-    pyplot, forest_binary_classification_with_test, display
+    forest_binary_classification_with_test, display
 ):
     """Check that we don't hit the cache when switching the data source."""
     estimator, X_test, y_test = forest_binary_classification_with_test
@@ -162,9 +160,7 @@ def test_display_binary_classification_switching_data_source(
 
 
 @pytest.mark.parametrize("display", ["prediction_error"])
-def test_display_regression_switching_data_source(
-    pyplot, linear_regression_with_test, display
-):
+def test_display_regression_switching_data_source(linear_regression_with_test, display):
     """Check that we don't hit the cache when switching the data source."""
     estimator, X_test, y_test = linear_regression_with_test
     report = EstimatorReport(

--- a/skore/tests/unit/reports/test_container_inspection.py
+++ b/skore/tests/unit/reports/test_container_inspection.py
@@ -55,9 +55,7 @@ def test_permutation_importance_with_containers(report_cls, x_container, y_conta
 @pytest.mark.filterwarnings(
     "ignore:Only pandas and polars DataFrames are supported:UserWarning:skrub"
 )
-def test_data_summarize_plot_with_containers(
-    report_cls, x_container, y_container, pyplot
-):
+def test_data_summarize_plot_with_containers(report_cls, x_container, y_container):
     """Table report plots work with array, pandas, and polars-backed summaries."""
     X, y = make_regression(n_samples=100, n_features=3, random_state=42)
     feature_columns = [f"Feature {i}" for i in range(X.shape[1])]

--- a/skore/tests/unit/utils/repr/test_utils.py
+++ b/skore/tests/unit/utils/repr/test_utils.py
@@ -72,7 +72,7 @@ class TestRepairEstimatorHtmlForSlottedHost:
         assert o == c
 
 
-def test_figure_to_html_returns_base64_img(pyplot):
+def test_figure_to_html_returns_base64_img():
 
     fig = Figure()
     ax = fig.subplots()


### PR DESCRIPTION
Add top-level `conftest.py` which also applies to doctests in `src`.

Remove redundant `pyplot` fixture.
