### PR TITLE
fix: skip medias/metrics that raise during put() instead of failing the whole upload

### DIFF
--- a/skore/src/skore/_plugins/hub/artifact/media/performance.py
+++ b/skore/src/skore/_plugins/hub/artifact/media/performance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC
 from collections.abc import Callable
 from functools import reduce
@@ -25,8 +26,20 @@ class PerformanceDataFrame(Media[Report], ABC):  # noqa: D101
         except AttributeError:
             return None
 
-        display = function(data_source=self.data_source)
-        frame = display.frame(**(self.parameters or {}))  # type: ignore[arg-type]
+        try:
+            display = function(data_source=self.data_source)
+            frame = display.frame(**(self.parameters or {}))  # type: ignore[arg-type]
+        except Exception as exception:
+            warnings.warn(
+                (
+                    f"Skipping performance media '{self.name}' "
+                    f"for data source '{self.data_source}' because it could not be "
+                    f"computed: {exception}"
+                ),
+                UserWarning,
+                stacklevel=2,
+            )
+            return None
 
         return dumps(
             frame.astype(object).where(frame.notna(), "NaN").to_dict(orient="tight")

--- a/skore/src/skore/_plugins/local/metadata.py
+++ b/skore/src/skore/_plugins/local/metadata.py
@@ -95,7 +95,10 @@ class EstimatorReportMetadata(ReportMetadata):  # noqa: D101
         if not hasattr(report.metrics, name):
             return None
 
-        return cast_to_float(getattr(report.metrics, name)(data_source="test"))
+        try:
+            return cast_to_float(getattr(report.metrics, name)(data_source="test"))
+        except Exception:
+            return None
 
     def __post_init__(self, report: EstimatorReport) -> None:  # type: ignore[override]
         """Initialize dynamic fields."""
@@ -131,15 +134,18 @@ class CrossValidationReportMetadata(ReportMetadata):  # noqa: D101
         if not hasattr(report.metrics, name):
             return None, None
 
-        dataframe = getattr(report.metrics, name)(
-            data_source="test",
-            aggregate=("mean", "std"),
-        )
+        try:
+            dataframe = getattr(report.metrics, name)(
+                data_source="test",
+                aggregate=("mean", "std"),
+            )
 
-        return (
-            cast_to_float(dataframe.iloc[0, 0]),
-            cast_to_float(dataframe.iloc[0, 1]),
-        )
+            return (
+                cast_to_float(dataframe.iloc[0, 0]),
+                cast_to_float(dataframe.iloc[0, 1]),
+            )
+        except Exception:
+            return None, None
 
     @staticmethod
     def timing(

--- a/skore/tests/unit/plugins/hub/artifact/media/test_performance.py
+++ b/skore/tests/unit/plugins/hub/artifact/media/test_performance.py
@@ -1,5 +1,5 @@
 from pydantic import ValidationError
-from pytest import mark, param, raises
+from pytest import mark, param, raises, warns
 
 from skore._plugins.hub.artifact.media import (
     ConfusionMatrixDataFrameTestAll,
@@ -15,6 +15,7 @@ from skore._plugins.hub.artifact.media import (
 )
 from skore._plugins.hub.artifact.serializer import Serializer
 from skore._plugins.hub.json import dumps
+from skore._plugins.hub.report import EstimatorReportPayload
 
 
 @mark.filterwarnings(
@@ -269,3 +270,70 @@ def test_performance(
         match=f"Input should be an instance of {report.__class__.__name__}",
     ):
         Media(project=project, report=None)
+
+
+@mark.respx()
+def test_performance_content_failure_warns_and_skips_upload(
+    monkeypatch, regression, project, upload_mock
+):
+    def prediction_error(_, data_source):
+        raise ValueError(f"unsupported predictions for {data_source}")
+
+    monkeypatch.setattr(
+        regression.metrics.__class__, "prediction_error", prediction_error
+    )
+
+    media = PredictionErrorDataFrameTest(project=project, report=regression)
+
+    with warns(
+        UserWarning,
+        match=(
+            "Skipping performance media 'prediction_error'.*"
+            "test.*unsupported predictions for test"
+        ),
+    ):
+        assert media.content_to_upload() is None
+
+    upload_mock.reset_mock()
+
+    with warns(
+        UserWarning,
+        match=(
+            "Skipping performance media 'prediction_error'.*"
+            "test.*unsupported predictions for test"
+        ),
+    ):
+        assert media.checksum is None
+
+    assert not upload_mock.called
+
+
+@mark.respx()
+def test_performance_payload_filters_failing_media(monkeypatch, regression, project):
+    original_prediction_error = regression.metrics.prediction_error
+
+    def prediction_error(_, data_source):
+        if data_source == "test":
+            raise ValueError("unsupported predictions for test")
+
+        return original_prediction_error(data_source=data_source)
+
+    monkeypatch.setattr(
+        regression.metrics.__class__, "prediction_error", prediction_error
+    )
+    monkeypatch.setattr(
+        EstimatorReportPayload,
+        "MEDIAS",
+        (PredictionErrorDataFrameTest, PredictionErrorDataFrameTrain),
+    )
+
+    payload = EstimatorReportPayload(project=project, report=regression, key="<key>")
+
+    with warns(
+        UserWarning,
+        match=(
+            "Skipping performance media 'prediction_error'.*"
+            "test.*unsupported predictions for test"
+        ),
+    ):
+        assert list(map(type, payload.medias)) == [PredictionErrorDataFrameTrain]

--- a/skore/tests/unit/plugins/local/test_project.py
+++ b/skore/tests/unit/plugins/local/test_project.py
@@ -12,6 +12,10 @@ from sklearn.model_selection import train_test_split
 
 from skore import CrossValidationReport, EstimatorReport
 from skore._plugins.local import Project
+from skore._plugins.local.metadata import (
+    CrossValidationReportMetadata,
+    EstimatorReportMetadata,
+)
 from skore._plugins.local.storage import DiskCacheStorage
 
 
@@ -283,6 +287,57 @@ class TestProject:
 
         assert len(project._Project__artifacts_storage) == 1
         assert len(project._Project__metadata_storage) == 2
+
+    def test_metadata_metric_returns_none_when_accessor_is_missing(
+        self, regression, cv_regression
+    ):
+        assert EstimatorReportMetadata.metric(regression, "<missing>") is None
+        assert CrossValidationReportMetadata.metric(cv_regression, "<missing>") == (
+            None,
+            None,
+        )
+
+    @pytest.mark.parametrize("metric_name", ["rmse", "log_loss", "roc_auc"])
+    def test_put_estimator_report_skips_failing_metadata_metric(
+        self, monkeypatch, tmp_path, regression, metric_name
+    ):
+        def failing_metric(*_, **__):
+            raise ValueError("unsupported predictions")
+
+        monkeypatch.setattr(
+            regression.metrics.__class__, metric_name, failing_metric, raising=False
+        )
+
+        assert EstimatorReportMetadata.metric(regression, metric_name) is None
+
+        project = Project("<project>", workspace=tmp_path)
+        project.put("<key>", regression)
+
+        metadata = next(iter(project._Project__metadata_storage.values()))
+        assert metadata[metric_name] is None
+
+    @pytest.mark.parametrize("metric_name", ["rmse", "log_loss", "roc_auc"])
+    def test_put_cross_validation_report_skips_failing_metadata_metric(
+        self, monkeypatch, tmp_path, cv_regression, metric_name
+    ):
+        def failing_metric(*_, **__):
+            raise ValueError("unsupported predictions")
+
+        monkeypatch.setattr(
+            cv_regression.metrics.__class__, metric_name, failing_metric, raising=False
+        )
+
+        assert CrossValidationReportMetadata.metric(cv_regression, metric_name) == (
+            None,
+            None,
+        )
+
+        project = Project("<project>", workspace=tmp_path)
+        project.put("<key>", cv_regression)
+
+        metadata = next(iter(project._Project__metadata_storage.values()))
+        assert metadata[f"{metric_name}_mean"] is None
+        assert metadata[f"{metric_name}_std"] is None
 
     def test_get(self, tmp_path, regression):
         project = Project("<project>", workspace=tmp_path)


### PR DESCRIPTION
#### Change description

`project.put()` no longer aborts when a single performance display or summary metric raises. Regressors whose `predict()` returns something other than a 1-D point estimate (e.g. TabICL's quantile DataFrame) made `report.metrics.prediction_error(...)` raise a broadcast `ValueError` inside `PerformanceDataFrame.content_to_upload`, which escaped through `Artifact.checksum` and `ReportPayload.medias` and failed the whole upload. The local plugin had the sibling failure: `ReportMetadata` unconditionally computed rmse/r2-style summary metrics that raise on the same shape.

Two changes, mirroring the skip-instead-of-raise policy from #3124:

- `PerformanceDataFrame.content_to_upload` wraps the display computation in a `try/except` that warns with the skipped media's name and returns `None`. `checksum` already maps `None` content to `None` and `ReportPayload.medias` already filters those out, so no changes were needed in `artifact.py`/`report.py`, and upload or network errors still propagate because the guard sits before the upload.
- The `metric()` helpers in `EstimatorReportMetadata` and `CrossValidationReportMetadata` already return `None` for missing accessors; they now also catch exceptions raised while computing the metric, letting put persist the report with null metadata fields.

Not a breaking change: reports that uploaded fine before produce identical payloads; reports that previously crashed now upload with the failing display skipped and a warning naming it.

Fixes #3118

#### Contribution checklist

- [x] All the tests pass (please test locally before pushing)
- [x] The documentation builds and renders properly (if it does, our bot will add a comment linking
to a preview of the documentation to review it visually)
- [x] All the commits in the PR are signed (more information
[here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
- [x] The pull request title respects the Conventional Commits convention (more information
[here](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests))

#### AI usage disclosure

AI tools were involved for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
