### PR TITLE
fix(docs): Stop old doc versions from competing with stable/ in search

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -276,6 +276,15 @@ jobs:
           name: sphinx-html-artifact
           path: html/
 
+      - name: Mark as non-indexable
+        # This job only ever deploys to `dev/` or `X.Y/`, never `stable/` (which is
+        # deployed separately from its own artifact download in `sphinx-deploy-stable`).
+        # These are not the canonical copy of the documentation, so search engines
+        # should not index them.
+        run: |
+          find html/ -name '*.html' -exec sed -i \
+            's#<head>#<head>\n    <meta name="robots" content="noindex,follow">#' {} +
+
       - name: Deploy HTML artifacts
         uses: ./.github/actions/sphinx/deploy-aws
         with:

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -88,6 +88,14 @@ autodoc_typehints = "none"
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 
+# Every build (dev/, X.Y/, stable/) is produced from the same artifact and deployed
+# as-is to several S3 destinations (see .github/workflows/sphinx.yml). Setting
+# `html_baseurl` makes Sphinx emit a `<link rel="canonical">` on every page pointing
+# at its `stable/` counterpart, regardless of which destination the artifact ends up
+# in. This consolidates SEO ranking signal on `stable/` and prevents old or dev
+# versions from competing with it in search results.
+html_baseurl = f"{os.environ['SPHINX_URL']}/stable/"
+
 html_css_files = ["css/custom.css"]
 html_js_files = [
     "js/sg_plotly_resize.js"


### PR DESCRIPTION
## What's wrong

Every doc version (`/0.9/`, `/0.14/`, `/stable/`, ...) is a separate, publicly indexable page with no `<link rel="canonical">` and no `<meta name="robots">`. Google has no signal that `/stable/` is the authoritative copy, so old versions can outrank it.

## What this PR does

- **Canonical tags**: `html_baseurl` is now set in `sphinx/conf.py`, so Sphinx emits `<link rel="canonical" href=".../stable/...">` on every page, whichever version it's built for.
- **`noindex` on old versions**: the CI job that deploys to `dev/` and `X.Y/` now injects `<meta name="robots" content="noindex,follow">` before upload. The `stable/` deploy uses its own separate artifact download and is untouched, so it stays indexable.

Both only affect **future** builds/deploys — same artifact, same conf, no other behavior change.

## Still needed (can't be fixed by this PR)

These act on content already published; nothing in this repo can retroactively change files sitting in S3:

- [ ] Rebuild/redeploy (or directly patch in S3) the already-live `/0.9/`, `/0.12/`, `/0.13/`, `/0.14/` folders so they actually get the new canonical + `noindex` tags.
- [ ] In Search Console, use URL Inspection on the old ranking URL to confirm the new canonical is picked up, and request indexing on the corresponding `/stable/` URL.
- [ ] Once Search Console confirms the old versions are dropped from the index, optionally add a `robots.txt` disallow for them (skip this until then — disallowing crawl now would prevent Google from ever seeing the new `noindex` tag on already-indexed pages).