### PR TITLE
feat(hub): Stop computing TableReport plot SVGs

### DIFF
--- a/skore/src/skore/_plugins/hub/artifact/media/data.py
+++ b/skore/src/skore/_plugins/hub/artifact/media/data.py
@@ -18,12 +18,14 @@ class TableReport(Media[Report]):  # noqa: D101
 
     def content_to_upload(self) -> bytes:  # noqa: D102
         display = (
-            self.report.data.summarize()
+            self.report.data.summarize(with_plots=False)
             if (
                 isinstance(self.report, CrossValidationReport)
                 or (self.data_source is None)
             )
-            else self.report.data.summarize(data_source=self.data_source)
+            else self.report.data.summarize(
+                data_source=self.data_source, with_plots=False
+            )
         )
 
         table_report = display.summary

--- a/skore/src/skore/_sklearn/_cross_validation/data_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/data_accessor.py
@@ -97,6 +97,7 @@ class _DataAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
         with_y: bool = True,
         subsample: int | None = None,
         subsample_strategy: Literal["head", "random"] = "head",
+        with_plots: bool = True,
         seed: int | None = None,
     ) -> TableReportDisplay:
         """Plot dataset statistics.
@@ -120,6 +121,10 @@ class _DataAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
               dataframe, similar to Pandas: ``df.head(n)``.
             - If ``"random"``: randomly subsample the dataframe by using a uniform
               distribution. The random seed is controlled by ``seed``.
+
+        with_plots : bool, default=True
+            Whether to compute the TableReport plots, which can be computationally
+            expensive.
 
         seed : int, default=None
             The random seed to use when randomly subsampling. It only has an effect when
@@ -146,7 +151,7 @@ class _DataAccessor(_BaseAccessor[CrossValidationReport], DirNamesMixin):
             subsample_strategy=subsample_strategy,
             seed=seed,
         )
-        return TableReportDisplay._compute_data_for_display(df)
+        return TableReportDisplay._compute_data_for_display(df, with_plots=with_plots)
 
     def analyze(self, **kwargs) -> TableReportDisplay:
         """Use :meth:`summarize` instead."""

--- a/skore/src/skore/_sklearn/_estimator/data_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/data_accessor.py
@@ -75,6 +75,7 @@ class _DataAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         with_y: bool = True,
         subsample: int | None = None,
         subsample_strategy: Literal["head", "random"] = "head",
+        with_plots: bool = True,
         seed: int | None = None,
     ) -> TableReportDisplay:
         """Plot dataset statistics.
@@ -104,6 +105,10 @@ class _DataAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             - If ``"random"``: randomly subsample the dataframe by using a uniform
               distribution. The random seed is controlled by ``seed``.
 
+        with_plots : bool, default=True
+            Whether to compute the TableReport plots, which can be computationally
+            expensive.
+
         seed : int, default=None
             The random seed to use when randomly subsampling. It only has an effect when
             ``subsample`` is not None and ``subsample_strategy='random'``.
@@ -130,7 +135,7 @@ class _DataAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             subsample_strategy=subsample_strategy,
             seed=seed,
         )
-        return TableReportDisplay._compute_data_for_display(df)
+        return TableReportDisplay._compute_data_for_display(df, with_plots=with_plots)
 
     def analyze(self, **kwargs) -> TableReportDisplay:
         """Use :meth:`summarize` instead."""

--- a/skore/src/skore/_sklearn/_plot/data/table_report.py
+++ b/skore/src/skore/_sklearn/_plot/data/table_report.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Literal
 
 import narwhals as nw
@@ -199,7 +201,11 @@ class TableReportDisplay(DisplayMixin):
         self.summary = summary
 
     @classmethod
-    def _compute_data_for_display(cls, dataset: UserDataFrame) -> "TableReportDisplay":
+    def _compute_data_for_display(
+        cls,
+        dataset: UserDataFrame,
+        with_plots: bool,
+    ) -> TableReportDisplay:
         """Private method to create a TableReportDisplay from a dataset.
 
         Parameters
@@ -207,20 +213,23 @@ class TableReportDisplay(DisplayMixin):
         dataset : UserDataFrame
             The dataset to summarize, as a pandas or polars DataFrame.
 
+        with_plots : bool
+            Whether to compute the TableReport plots, which can be computationally
+            expensive.
+
         Returns
         -------
         display : TableReportDisplay
             Object that stores computed values.
         """
         with plt.ioff():
-            return cls(
-                summarize_dataframe(
-                    dataset,
-                    with_plots=True,
-                    title=None,
-                    verbose=0,
-                )
+            summary = summarize_dataframe(
+                dataset,
+                with_plots=with_plots,
+                title=None,
+                verbose=0,
             )
+        return cls(summary)
 
     @DisplayMixin.style_plot
     def plot(


### PR DESCRIPTION

If skrub is >= 0.10, skrub will compute plot data which the Hub can use, so we can avoid computing the plot SVGs lib-side (which dominate the computation cost of `put`).

Closes https://github.com/probabl-ai/skore/issues/3019

<details>

<summary>Performance profile</summary>

### Benchmark

For a `put` of 3-fold CV, I got

before: 12.76 +/- 0.95 s (run with `uv run --with=skrub~=0.9.0 bench.py`)
after: 8.05 +/- 0.26 s (run with `uv run --with=skrub~=0.10.0 bench.py`)

```py
# bench.py

from skore import evaluate, Project, login
import statistics
from skore._utils._measure_time import MeasureTime
from sklearn.datasets import make_classification
from sklearn.ensemble import HistGradientBoostingClassifier

X, y = make_classification(random_state=0)

# 3-fold CV
report = evaluate(HistGradientBoostingClassifier(random_state=0), X, y, splitter=3)

login()
project = Project(name="bench-classif", mode="hub", workspace="auguste-workspace")


times = []
for _ in range(3):
    with MeasureTime() as t:
        project.put("test", report)

    times.append(t())

mean = statistics.mean(times)
stdev = statistics.stdev(times, xbar=mean)

print(f"{mean} +/- {stdev}")
```


### Flamegraphs

Before:

<img width="1200" height="2826" alt="profile-before" src="https://github.com/user-attachments/assets/95a33b52-ce47-42ff-93f3-32f004f4a217" />

After:

<img width="1200" height="3114" alt="profile-after" src="https://github.com/user-attachments/assets/03f75c37-643e-48e5-bbe1-672ddc876771" />

Note the time spent in `summarize_dataframe`.

</details>
