### PR TITLE
fix(skore): Support `data_source="both"` for `CrossValidationReport` in `PredictionErrorDisplay`

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -1152,7 +1152,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
     def prediction_error(
         self,
         *,
-        data_source: DataSource = "test",
+        data_source: DataSource | Literal["both"] = "test",
         subsample: float | int | None = 1_000,
         seed: int | None = None,
     ) -> PredictionErrorDisplay:
@@ -1160,11 +1160,12 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
 
         Parameters
         ----------
-        data_source : {"test", "train"}, default="test"
+        data_source : {"test", "train", "both"}, default="test"
             The data source to use.
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
+            - "both" : use both train and test and display them side by side.
 
         subsample : float, int or None, default=1_000
             Sampling the samples to be shown on the scatter plot. If `float`,

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -53,7 +53,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
-            - "both" : use both the train and test sets, showing them side-by-side.
+            - "both" : use both the train and test sets, showing them together.
 
         metric : str or list of str or None, default=None
             The metrics to report, from the list of registered metrics. None means show
@@ -1049,7 +1049,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
-            - "both" : use both the train and test and show them side-by-side.
+            - "both" : use both the train and test and show them together.
 
         Returns
         -------
@@ -1106,7 +1106,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
-            - "both" : use both the train and test and show them side-by-side.
+            - "both" : use both the train and test and show them together.
 
         Returns
         -------
@@ -1165,7 +1165,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
 
             - "test" : use the test set provided when creating the report.
             - "train" : use the train set provided when creating the report.
-            - "both" : use both train and test and display them side by side.
+            - "both" : use both train and test and display them together.
 
         subsample : float, int or None, default=1_000
             Sampling the samples to be shown on the scatter plot. If `float`,

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -15,6 +15,7 @@ from skore._sklearn._plot.base import DisplayMixin
 from skore._sklearn._plot.utils import (
     _concat_frames_with_column_data,
     _despine_matplotlib_axis,
+    _reorder_categoricals_by_appearance,
     _validate_style_kwargs,
 )
 from skore._sklearn.types import DataSource, MLTask, ReportType
@@ -260,6 +261,7 @@ class PredictionErrorDisplay(DisplayMixin):
 
         plot_data = self.frame()
         col, hue, style = self._get_plot_columns(subplot_by)
+        plot_data = _reorder_categoricals_by_appearance(plot_data, [col, hue, style])
         relplot_kwargs = {
             "col": col,
             "hue": hue,

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -326,13 +326,14 @@ class PredictionErrorDisplay(DisplayMixin):
         handles = []
         labels = []
         if facet._legend is not None:
-            handles = list(facet._legend.legend_handles)
-            labels = [t.get_text() for t in facet._legend.get_texts()]
+            handles, labels = self._format_relplot_legend(
+                facet._legend.legend_handles,
+                [t.get_text() for t in facet._legend.get_texts()],
+                hue,
+                style,
+                plot_data,
+            )
             facet._legend.remove()
-            if hue == "split":
-                labels = [f"Split #{label}" for label in labels]
-            if hue == "output" and style is None:
-                labels = [f"Output #{label}" for label in labels]
         handles.append(
             Line2D([0], [0], **self._default_perfect_model_kwargs)  # type: ignore[arg-type]
         )
@@ -412,6 +413,34 @@ class PredictionErrorDisplay(DisplayMixin):
         style = "data_source" if has_both_sources and col != "data_source" else None
 
         return col, hue, style
+
+    @staticmethod
+    def _format_relplot_legend(
+        handles,
+        labels: list[str],
+        *,
+        hue: str | None,
+        style: str | None,
+        plot_data: DataFrame,
+    ) -> tuple[list, list[str]]:
+        """Filter seaborn legend entries and format hue labels."""
+        hue_values = (
+            {str(value) for value in plot_data[hue].unique()}
+            if hue is not None
+            else set()
+        )
+        formatted_handles = []
+        formatted_labels = []
+        for handle, label in zip(handles, labels, strict=True):
+            if label == hue or label == style:
+                continue
+            if hue == "split" and label in hue_values:
+                label = f"Split #{label}"
+            elif hue == "output" and label in hue_values:
+                label = f"Output #{label}"
+            formatted_handles.append(handle)
+            formatted_labels.append(label)
+        return formatted_handles, formatted_labels
 
     @classmethod
     def _compute_data_for_display(

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -329,9 +329,9 @@ class PredictionErrorDisplay(DisplayMixin):
             handles, labels = self._format_relplot_legend(
                 facet._legend.legend_handles,
                 [t.get_text() for t in facet._legend.get_texts()],
-                hue,
-                style,
-                plot_data,
+                huehue,
+                style=style,
+                plot_data=plot_data,
             )
             facet._legend.remove()
         handles.append(

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -329,7 +329,7 @@ class PredictionErrorDisplay(DisplayMixin):
             handles, labels = self._format_relplot_legend(
                 facet._legend.legend_handles,
                 [t.get_text() for t in facet._legend.get_texts()],
-                huehue,
+                hue=hue,
                 style=style,
                 plot_data=plot_data,
             )

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -259,7 +259,7 @@ class PredictionErrorDisplay(DisplayMixin):
             ]
             y_line = [0, 0]
 
-        plot_data = self.frame()
+        plot_data = self.frame().copy() # Ensure a fresh DataFrame since `frame()` returns a slice
         col, hue, style = self._get_plot_columns(subplot_by)
         plot_data = _reorder_categoricals_by_appearance(plot_data, [col, hue, style])
         relplot_kwargs = {

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 import numpy as np
 import seaborn as sns
+from matplotlib.artist import Artist
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from numpy.typing import ArrayLike
@@ -259,7 +260,9 @@ class PredictionErrorDisplay(DisplayMixin):
             ]
             y_line = [0, 0]
 
-        plot_data = self.frame().copy() # Ensure a fresh DataFrame since `frame()` returns a slice
+        plot_data = (
+            self.frame().copy()
+        )  # Ensure a fresh DataFrame since `frame()` returns a slice
         col, hue, style = self._get_plot_columns(subplot_by)
         plot_data = _reorder_categoricals_by_appearance(plot_data, [col, hue, style])
         relplot_kwargs = {
@@ -323,8 +326,8 @@ class PredictionErrorDisplay(DisplayMixin):
         # Add the perfect model line to the legend
         # We retrieve the legend elements created by seaborn, add the perfect model line
         # and create a new legend manually.
-        handles = []
-        labels = []
+        handles: list[Artist] = []
+        labels: list[str] = []
         if facet._legend is not None:
             handles, labels = self._format_relplot_legend(
                 facet._legend.legend_handles,
@@ -416,13 +419,13 @@ class PredictionErrorDisplay(DisplayMixin):
 
     @staticmethod
     def _format_relplot_legend(
-        handles,
+        handles: list[Artist],
         labels: list[str],
         *,
         hue: str | None,
         style: str | None,
         plot_data: DataFrame,
-    ) -> tuple[list, list[str]]:
+    ) -> tuple[list[Artist], list[str]]:
         """Filter seaborn legend entries and format hue labels."""
         hue_values = (
             {str(value) for value in plot_data[hue].unique()}
@@ -432,7 +435,9 @@ class PredictionErrorDisplay(DisplayMixin):
         formatted_handles = []
         formatted_labels = []
         for handle, label in zip(handles, labels, strict=True):
-            if (hue is not None and label == hue) or (style is not None and label == style):
+            if (hue is not None and label == hue) or (
+                style is not None and label == style
+            ):
                 continue
             if hue == "split" and label in hue_values:
                 label = f"Split #{label}"

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -432,7 +432,7 @@ class PredictionErrorDisplay(DisplayMixin):
         formatted_handles = []
         formatted_labels = []
         for handle, label in zip(handles, labels, strict=True):
-            if label in hue or label in style:
+            if (hue is not None and label == hue) or (style is not None and label == style):
                 continue
             if hue == "split" and label in hue_values:
                 label = f"Split #{label}"

--- a/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
+++ b/skore/src/skore/_sklearn/_plot/metrics/prediction_error.py
@@ -432,7 +432,7 @@ class PredictionErrorDisplay(DisplayMixin):
         formatted_handles = []
         formatted_labels = []
         for handle, label in zip(handles, labels, strict=True):
-            if label == hue or label == style:
+            if label in hue or label in style:
                 continue
             if hue == "split" and label in hue_values:
                 label = f"Split #{label}"

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -267,7 +267,6 @@ def _reorder_categoricals_by_appearance(
     Reordering the categories to the order of appearance makes seaborn draw in that
     same order, keeping curves and legend in sync.
     """
-    plot_data = plot_data.copy()
     for column in columns:
         if column is None:
             continue

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -267,6 +267,7 @@ def _reorder_categoricals_by_appearance(
     Reordering the categories to the order of appearance makes seaborn draw in that
     same order, keeping curves and legend in sync.
     """
+    plot_data = plot_data.copy() #avoid mutating the dispaly frame
     for column in columns:
         if column is None:
             continue

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -267,7 +267,7 @@ def _reorder_categoricals_by_appearance(
     Reordering the categories to the order of appearance makes seaborn draw in that
     same order, keeping curves and legend in sync.
     """
-    plot_data = plot_data.copy() #avoid mutating the dispaly frame
+    plot_data = plot_data.copy()  # avoid mutating the display frame
     for column in columns:
         if column is None:
             continue

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -267,6 +267,7 @@ def _reorder_categoricals_by_appearance(
     Reordering the categories to the order of appearance makes seaborn draw in that
     same order, keeping curves and legend in sync.
     """
+    plot_data = plot_data.copy()
     for column in columns:
         if column is None:
             continue

--- a/skore/src/skore/_sklearn/_plot/utils.py
+++ b/skore/src/skore/_sklearn/_plot/utils.py
@@ -267,7 +267,6 @@ def _reorder_categoricals_by_appearance(
     Reordering the categories to the order of appearance makes seaborn draw in that
     same order, keeping curves and legend in sync.
     """
-    plot_data = plot_data.copy()  # avoid mutating the display frame
     for column in columns:
         if column is None:
             continue

--- a/skore/tests/unit/displays/prediction_error/test_comparison_cross_validation.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_cross_validation.py
@@ -86,3 +86,58 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
         fig = display.plot(subplot_by=subplot_by)
         axes = fig.axes
         assert len(axes) == expected_len
+
+
+@pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
+def test_subplot_by_data_source(task, request):
+    """Check the behaviour when `subplot_by` is `data_source`."""
+    report = request.getfixturevalue(f"comparison_cross_validation_reports_{task}")
+    display = report.metrics.prediction_error(data_source="both")
+    if task == "multioutput_regression":
+        with pytest.raises(
+            ValueError,
+            match="Invalid `subplot_by` parameter."
+            + " Valid options are: auto, output, estimator. Got 'data_source' instead.",
+        ):
+            display.plot(subplot_by="data_source")
+    else:
+        fig = display.plot(subplot_by="data_source")
+        axes = fig.axes
+        assert len(axes) == 2
+        legend = fig.axes[len(fig.axes) // 2].get_legend()
+        legend_texts = [t.get_text() for t in legend.get_texts()]
+        assert legend_texts == ["Split #0", "Split #1", "Perfect predictions"]
+
+
+@pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
+def test_source_both(task, request):
+    """Check the behaviour of the plot when `data_source='both'`."""
+    report = request.getfixturevalue(f"comparison_cross_validation_reports_{task}")
+    display = report.metrics.prediction_error(data_source="both")
+    assert display.data_source == "both"
+    plot_data = display.frame()
+    assert "data_source" in plot_data.columns
+    assert set(plot_data["data_source"]) == {"train", "test"}
+    fig = display.plot()
+    legend = fig.axes[len(fig.axes) // 2].get_legend()
+    assert legend is not None
+    legend_texts = [t.get_text() for t in legend.get_texts()]
+    assert legend_texts[-1] == "Perfect predictions"
+    assert "train" in legend_texts
+    assert "test" in legend_texts
+    if task == "regression":
+        assert legend_texts == [
+            "Split #0",
+            "Split #1",
+            "train",
+            "test",
+            "Perfect predictions",
+        ]
+    else:
+        assert legend_texts == [
+            "Output #0",
+            "Output #1",
+            "train",
+            "test",
+            "Perfect predictions",
+        ]

--- a/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
@@ -122,5 +122,5 @@ def test_source_both(task, request):
     assert "data_source" in plot_data.columns
     assert set(plot_data["data_source"]) == {"train", "test"}
     if task == "multioutput_regression":
-        assert "output #0" in legend_texts
-        assert "output #1" in legend_texts
+        assert "Output #0" in legend_texts
+        assert "Output #1" in legend_texts

--- a/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
@@ -114,7 +114,7 @@ def test_source_both(task, request):
     legend = fig.axes[len(fig.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
-    assert len(legend_texts) == 3 if task == "regression" else 5
+    assert len(legend_texts) == (3 if task == "regression" else 5)
     assert legend_texts[-1] == "Perfect predictions"
     assert "train" in legend_texts
     assert "test" in legend_texts

--- a/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_comparison_estimator.py
@@ -114,7 +114,7 @@ def test_source_both(task, request):
     legend = fig.axes[len(fig.axes) // 2].get_legend()
     assert legend is not None
     legend_texts = [t.get_text() for t in legend.get_texts()]
-    assert len(legend_texts) == 3 if task == "regression" else 7
+    assert len(legend_texts) == 3 if task == "regression" else 5
     assert legend_texts[-1] == "Perfect predictions"
     assert "train" in legend_texts
     assert "test" in legend_texts
@@ -122,5 +122,5 @@ def test_source_both(task, request):
     assert "data_source" in plot_data.columns
     assert set(plot_data["data_source"]) == {"train", "test"}
     if task == "multioutput_regression":
-        assert "0" in legend_texts
-        assert "1" in legend_texts
+        assert "output #0" in legend_texts
+        assert "output #1" in legend_texts

--- a/skore/tests/unit/displays/prediction_error/test_cross_validation.py
+++ b/skore/tests/unit/displays/prediction_error/test_cross_validation.py
@@ -81,3 +81,54 @@ def test_valid_subplot_by(fixture_name, subplot_by_tuples, request):
             assert isinstance(axes[0], mpl.axes.Axes)
         else:
             assert len(axes) == expected_len
+
+
+@pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
+def test_subplot_by_data_source(task, request):
+    """Check the behaviour when `subplot_by` is `data_source`."""
+    report = request.getfixturevalue(f"cross_validation_reports_{task}")[0]
+    display = report.metrics.prediction_error(data_source="both")
+    fig = display.plot(subplot_by="data_source")
+    axes = fig.axes
+    assert len(axes) == 2
+    legend = fig.axes[len(fig.axes) // 2].get_legend()
+    legend_texts = [t.get_text() for t in legend.get_texts()]
+    assert legend_texts[-1] == "Perfect predictions"
+    if task == "regression":
+        assert legend_texts == ["Split #0", "Split #1", "Perfect predictions"]
+    else:
+        assert legend_texts == ["Output #0", "Output #1", "Perfect predictions"]
+
+
+@pytest.mark.parametrize("task", ["regression", "multioutput_regression"])
+def test_source_both(task, request):
+    """Check the behaviour of the plot when data_source='both'."""
+    report = request.getfixturevalue(f"cross_validation_reports_{task}")[0]
+    display = report.metrics.prediction_error(data_source="both")
+    assert display.data_source == "both"
+    plot_data = display.frame()
+    assert "data_source" in plot_data.columns
+    assert set(plot_data["data_source"]) == {"train", "test"}
+    fig = display.plot()
+    legend = fig.axes[len(fig.axes) // 2].get_legend()
+    assert legend is not None
+    legend_texts = [t.get_text() for t in legend.get_texts()]
+    assert legend_texts[-1] == "Perfect predictions"
+    assert "train" in legend_texts
+    assert "test" in legend_texts
+    if task == "regression":
+        assert legend_texts == [
+            "Split #0",
+            "Split #1",
+            "train",
+            "test",
+            "Perfect predictions",
+        ]
+    else:
+        assert legend_texts == [
+            "Output #0",
+            "Output #1",
+            "train",
+            "test",
+            "Perfect predictions",
+        ]

--- a/skore/tests/unit/displays/prediction_error/test_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_estimator.py
@@ -122,8 +122,8 @@ def test_source_both(task, request):
     assert "data_source" in plot_data.columns
     assert set(plot_data["data_source"]) == {"train", "test"}
     if task == "multioutput_regression":
-        assert "0" in legend_texts
-        assert "1" in legend_texts
+        assert "output #0" in legend_texts
+        assert "output #1" in legend_texts
 
 
 @pytest.mark.parametrize(

--- a/skore/tests/unit/displays/prediction_error/test_estimator.py
+++ b/skore/tests/unit/displays/prediction_error/test_estimator.py
@@ -122,8 +122,8 @@ def test_source_both(task, request):
     assert "data_source" in plot_data.columns
     assert set(plot_data["data_source"]) == {"train", "test"}
     if task == "multioutput_regression":
-        assert "output #0" in legend_texts
-        assert "output #1" in legend_texts
+        assert "Output #0" in legend_texts
+        assert "Output #1" in legend_texts
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Change description
Fixes #2925 (PART 2)

We used the `_reoder_categorical_by_appeareance` that we made in https://github.com/probabl-ai/skore/pull/3006 while working towards ROC and PR displayss.

##### what was fixed in this pr 
1. API gap: the `PredictionErrorDisplay` was able to plot `data_source="both"` but was not done officially 
2. Broken Legend: (caused due to https://github.com/probabl-ai/skore/pull/3154/changes#diff-9743801367e9202a4e11d880a61d0dab744a6c2c1262259c8b233dc7d525bd08L330) 
The old code prefixed every label with "Split #", producing junk like:
`Split #split, Split #0, Split #1, Split #data_source, Split #train, Split #test`
insted of 
`Split #0, Split #1, train, test, Perfect predictions`
now only real hue values will be converted as split wise column header , derops the other section headers that not not required by https://github.com/probabl-ai/skore/pull/3154/changes#diff-9743801367e9202a4e11d880a61d0dab744a6c2c1262259c8b233dc7d525bd08R418

##### code block for bug report and fixing it 
```python
import matplotlib
matplotlib.use('Agg')
from sklearn.datasets import load_diabetes
from sklearn.ensemble import HistGradientBoostingRegressor
from sklearn.tree import DecisionTreeRegressor
from skore import compare, evaluate

X, y = load_diabetes(return_X_y=True)
report = compare([
    evaluate(HistGradientBoostingRegressor(), X, y, splitter=2),
    evaluate(DecisionTreeRegressor(max_depth=3), X, y, splitter=2),
])

display = report.metrics.prediction_error(data_source="both")
fig = display.plot(kind="actual_vs_predicted")
fig.savefig(r'F:\skore_05\prediction_error_with_bug.png', dpi=80, bbox_inches='tight')

```
##### currently 
<img width="1208" height="613" alt="image" src="https://github.com/user-attachments/assets/affd2b7e-f934-4100-b192-089dd90853bf" />

##### after fix
 (change in the order of the graph and legend is also updated)
<img width="1013" height="484" alt="image" src="https://github.com/user-attachments/assets/a177cc17-7c99-42dc-9c56-e8c41113d4e3" />


#### Contribution checklist
- [x] Unit tests were added or updated
- [ ] Documentation was added or updated
- [ ] The code passes our style conventions 
- [x] All the tests pass
- [ ] The documentation builds and renders properly
- [x] All the commits in the PR are signed
- [ ] The pull request title respects the Conventional Commits convention

#### AI usage disclosure
AI tools were involved for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding