### PR TITLE
docs(skore): Use `pd.merge` to align properly index when concatenating in getting started

### DIFF
--- a/examples/getting_started/plot_getting_started.py
+++ b/examples/getting_started/plot_getting_started.py
@@ -292,16 +292,9 @@ _ = final_report.metrics.confusion_matrix().plot()
 # experiment phase.
 
 # %%
-import pandas as pd
-
-final_frame = final_metrics.frame().to_frame().reset_index().assign(source="held-out")
-cv_frame = (
-    logreg_cv_report.metrics.summarize()
-    .frame()
-    .reset_index()
-    .assign(source="cross-validation")
-)
-pd.concat([final_frame, cv_frame], ignore_index=True)
+final_frame = final_metrics.frame().to_frame()
+cv_frame = logreg_cv_report.metrics.summarize().frame()
+final_frame.merge(cv_frame, on="metric", how="outer")
 
 # %%
 # As expected, our final model gets better performance, likely thanks to the


### PR DESCRIPTION
We got a small regression when concatenating the output of `.frame` in the getting started:

<img width="821" height="588" alt="image" src="https://github.com/user-attachments/assets/1da6e4b5-4a9c-4bbc-96df-8beefa80d636" />

This PR is using now `.merge` to avoid this issue and make sure that we align on the metric column.