### PR TITLE
fix(skore): Revert to compact metric HTML repr for cross-validation report

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/report.py
+++ b/skore/src/skore/_sklearn/_cross_validation/report.py
@@ -595,8 +595,11 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
 
     def __repr__(self) -> str:
         """Return a string representation."""
-        metrics_frame = self.metrics.summarize(data_source="test").frame(
-            verbose_name=True, flat_index=False
+        metrics_frame = (
+            self.metrics.summarize(data_source="test")
+            .frame(verbose_name=True, flat_index=False)
+            .droplevel(level=0, axis="columns")
+            .rename_axis(None, axis="columns")
         )
         return f"""{self.__class__.__name__}:
         {self.estimator_name_!r}
@@ -617,9 +620,10 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
             The markdown summary of the report.
         """
         metrics_text = repr(
-            self.metrics.summarize(data_source="test").frame(
-                verbose_name=True, flat_index=False
-            )
+            self.metrics.summarize(data_source="test")
+            .frame(verbose_name=True, flat_index=False)
+            .droplevel(level=0, axis="columns")
+            .rename_axis(None, axis="columns")
         )
         timings = self.metrics.timings()
         summary = summarize_dataframe(
@@ -663,6 +667,8 @@ class CrossValidationReport(_BaseReport, DirNamesMixin):
                 verbose_name=True,
                 flat_index=False,
             )
+            .droplevel(level=0, axis="columns")
+            .rename_axis(None, axis="columns")
             .reset_index()
             .to_html(index=False)
         )

--- a/skore/tests/unit/reports/cross_validation/test_report.py
+++ b/skore/tests/unit/reports/cross_validation/test_report.py
@@ -231,6 +231,29 @@ def _assert_cross_validation_report_repr_html(
     assert "CrossValidationReport.metrics" in html_out
 
 
+def test_metrics_summary_html_is_compact(forest_binary_classification_data):
+    """Metrics tab HTML must not keep the estimator / Aggregate MultiIndex levels.
+
+    After #3094, frame(verbose_name=True, flat_index=False) returns a named
+    MultiIndex on the columns. Without droplevel + rename_axis, to_html emits a
+    second header row and a leading index column of level names.
+    """
+    estimator, X, y = forest_binary_classification_data
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=2)
+    metrics_html = report._html_repr_fragments()["metrics_summary"]
+
+    thead = metrics_html[metrics_html.find("<thead>") : metrics_html.find("</thead>")]
+    tbody = metrics_html[metrics_html.find("<tbody>") : metrics_html.find("</tbody>")]
+    assert thead.count("<tr") == 1
+    assert "<th>" not in tbody
+    assert "Estimator" not in metrics_html
+    assert "Aggregate" not in metrics_html
+
+    repr_str = repr(report)
+    assert "Estimator" not in repr_str
+    assert "Aggregate" not in repr_str
+
+
 def test_text_repr(forest_binary_classification_data):
     estimator, X, y = forest_binary_classification_data
     report = evaluate(estimator, X, y, splitter=2)


### PR DESCRIPTION
Small regression introduced in #3094 when it comes to the cross-validation report. We are back to:

<img width="820" height="361" alt="image" src="https://github.com/user-attachments/assets/ed02f835-3216-4f7a-84dc-74eccfd3e112" />
