### PR TITLE
fix(skore): Allow to send averaged metric for binary classification

### DIFF
--- a/skore/src/skore/_plugins/hub/metric.py
+++ b/skore/src/skore/_plugins/hub/metric.py
@@ -56,16 +56,9 @@ def select_exportable_metrics(
 ) -> pd.DataFrame:
     """Select metric summary rows suitable for hub export.
 
-    Drops rows with missing scores. For binary classification, drops
-    averaged rows (keeps per-label rows only).
+    Drops rows with missing scores.
     """
     metrics_summary = report.metrics.summarize(data_source="both").summary
-
-    if report._ml_task == "binary-classification":
-        return metrics_summary[
-            metrics_summary["score"].notna() & metrics_summary["average"].isna()
-        ]
-
     return metrics_summary[metrics_summary["score"].notna()]
 
 

--- a/skore/src/skore/_plugins/hub/report/cross_validation_report.py
+++ b/skore/src/skore/_plugins/hub/report/cross_validation_report.py
@@ -385,9 +385,7 @@ class CrossValidationReportPayload(ReportPayload[CrossValidationReport]):
         dimension so the UI can expose a toggle. Metrics aggregated across labels
         or outputs are aggregated independently for each ``average`` mode and sent
         with their ``average`` dimension so the UI can show them as the aggregate
-        variant, except for binary classification where only per-label rows are
-        sent (``average`` is always ``None``). Only non-scalar values (``NaN``)
-        are ignored.
+        variant. Only non-scalar values (``NaN``) are ignored.
         """
         metrics = select_exportable_metrics(self.report)
 

--- a/skore/src/skore/_plugins/hub/report/estimator_report.py
+++ b/skore/src/skore/_plugins/hub/report/estimator_report.py
@@ -84,8 +84,7 @@ class EstimatorReportPayload(ReportPayload[EstimatorReport]):
 
         Per-label (per-class) and per-output (multioutput regression) metrics are
         sent with their ``label``/``output``/``average`` dimension so the UI can
-        expose a toggle. For binary classification, only per-label rows are sent
-        (``average`` is always ``None``). Non-scalar values (``NaN``) are ignored.
+        expose a toggle. Non-scalar values (``NaN``) are ignored.
         """
         metrics = select_exportable_metrics(self.report)
         multimetric_names = find_multimetric_scalar_names(metrics)

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -10,6 +10,7 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.dummy import DummyRegressor
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.metrics import make_scorer, precision_score
 from sklearn.model_selection import (
     GroupKFold,
     KFold,
@@ -1047,28 +1048,18 @@ class TestCrossValidationReportPayload:
         ]
 
     @mark.filterwarnings(
-        "ignore:Precision is ill-defined.*:sklearn.exceptions.UndefinedMetricWarning",
-        (
-            "ignore:The behavior of DataFrame concatenation with empty or all-NA "
-            "entries:FutureWarning"
-        ),
+        "ignore:Precision is ill-defined.*:sklearn.exceptions.UndefinedMetricWarning"
     )
     @mark.respx(assert_all_called=False)
-    def test_binary_metrics_includes_averaged_rows(
-        self, project, small_cv_binary_classification
-    ):
-        from sklearn.metrics import make_scorer, precision_score
+    def test_binary_metrics_includes_averaged_rows(self, project):
+        X, y = make_classification(random_state=42, n_samples=10)
+        report = evaluate(RandomForestClassifier(random_state=42), X, y, splitter=2)
 
-        from skore._plugins.hub.report import CrossValidationReportPayload
-
-        small_cv_binary_classification.metrics.add(
-            make_scorer(precision_score, average="macro"),
-            name="xxx",
-        )
+        report.metrics.add(make_scorer(precision_score, average="macro"), name="xxx")
 
         payload = CrossValidationReportPayload(
             project=project,
-            report=small_cv_binary_classification,
+            report=report,
             key="<key>",
         )
 

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -1054,33 +1054,16 @@ class TestCrossValidationReportPayload:
         ),
     )
     @mark.respx(assert_all_called=False)
-    def test_binary_metrics_excludes_averaged_rows(
-        self, project, small_cv_binary_classification, monkeypatch
+    def test_binary_metrics_includes_averaged_rows(
+        self, project, small_cv_binary_classification
     ):
-        from unittest.mock import MagicMock
-
-        import pandas as pd
+        from sklearn.metrics import make_scorer, precision_score
 
         from skore._plugins.hub.report import CrossValidationReportPayload
 
-        display = small_cv_binary_classification.metrics.summarize(data_source="both")
-        data = display.summary.copy()
-        macro_row = (
-            data.loc[(data["name"] == "precision") & (data["data_source"] == "test")]
-            .iloc[0]
-            .copy()
-        )
-        macro_row["label"] = pd.NA
-        macro_row["average"] = "macro"
-        macro_row["score"] = 0.55
-        data = pd.concat([data, pd.DataFrame([macro_row])], ignore_index=True)
-
-        mock_display = MagicMock()
-        mock_display.summary = data
-        monkeypatch.setattr(
-            small_cv_binary_classification.metrics,
-            "summarize",
-            lambda **kwargs: mock_display,
+        small_cv_binary_classification.metrics.add(
+            make_scorer(precision_score, average="macro"),
+            name="xxx",
         )
 
         payload = CrossValidationReportPayload(
@@ -1089,7 +1072,6 @@ class TestCrossValidationReportPayload:
             key="<key>",
         )
 
-        assert not any(m.average == "macro" for m in payload.metrics)
         precision = [
             m
             for m in payload.metrics
@@ -1098,6 +1080,16 @@ class TestCrossValidationReportPayload:
         assert len(precision) >= 1
         assert all(m.average is None for m in precision)
         assert all(m.label is not None for m in precision)
+
+        custom = [
+            m
+            for m in payload.metrics
+            if m.name == "xxx_mean" and m.data_source == "test"
+        ]
+        assert len(custom) == 1
+        assert custom[0].average == "macro"
+        assert custom[0].label is None
+        assert custom[0].value is not None
 
     @mark.filterwarnings(
         "ignore:Precision is ill-defined.*:sklearn.exceptions.UndefinedMetricWarning"

--- a/skore/tests/unit/plugins/hub/report/test_estimator_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_estimator_report.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 from pytest import approx, fixture, mark, raises
 from sklearn.datasets import make_classification
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import make_scorer, precision_score
 
 from skore import CrossValidationReport, EstimatorReport, evaluate
 from skore._plugins.hub.artifact.media import (
@@ -314,23 +315,15 @@ class TestEstimatorReportPayload:
         ]
 
     @mark.respx(assert_all_called=False)
-    @mark.filterwarnings(
-        "ignore:The behavior of DataFrame concatenation with empty or all-NA "
-        "entries is deprecated:FutureWarning"
-    )
-    def test_binary_metrics_includes_averaged_rows(
-        self, project, binary_classification
-    ):
-        from sklearn.metrics import make_scorer, precision_score
+    def test_binary_metrics_includes_averaged_rows(self, project):
+        X, y = make_classification(random_state=42)
+        report = evaluate(RandomForestClassifier(random_state=42), X, y)
 
-        binary_classification.metrics.add(
-            make_scorer(precision_score, average="macro"),
-            name="xxx",
-        )
+        report.metrics.add(make_scorer(precision_score, average="macro"), name="xxx")
 
         payload = EstimatorReportPayload(
             project=project,
-            report=binary_classification,
+            report=report,
             key="<key>",
         )
 

--- a/skore/tests/unit/plugins/hub/report/test_estimator_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_estimator_report.py
@@ -318,31 +318,14 @@ class TestEstimatorReportPayload:
         "ignore:The behavior of DataFrame concatenation with empty or all-NA "
         "entries is deprecated:FutureWarning"
     )
-    def test_binary_metrics_excludes_averaged_rows(
-        self, project, binary_classification, monkeypatch
+    def test_binary_metrics_includes_averaged_rows(
+        self, project, binary_classification
     ):
-        from unittest.mock import MagicMock
+        from sklearn.metrics import make_scorer, precision_score
 
-        import pandas as pd
-
-        display = binary_classification.metrics.summarize(data_source="both")
-        data = display.summary.copy()
-        macro_row = (
-            data.loc[(data["name"] == "precision") & (data["data_source"] == "test")]
-            .iloc[0]
-            .copy()
-        )
-        macro_row["label"] = None
-        macro_row["average"] = "macro"
-        macro_row["score"] = 0.55
-        data = pd.concat([data, pd.DataFrame([macro_row])], ignore_index=True)
-
-        mock_display = MagicMock()
-        mock_display.summary = data
-        monkeypatch.setattr(
-            binary_classification.metrics,
-            "summarize",
-            lambda **kwargs: mock_display,
+        binary_classification.metrics.add(
+            make_scorer(precision_score, average="macro"),
+            name="xxx",
         )
 
         payload = EstimatorReportPayload(
@@ -351,7 +334,6 @@ class TestEstimatorReportPayload:
             key="<key>",
         )
 
-        assert not any(m.average == "macro" for m in payload.metrics)
         precision = [
             m
             for m in payload.metrics
@@ -360,6 +342,14 @@ class TestEstimatorReportPayload:
         assert len(precision) == 2
         assert {m.label for m in precision} == {0, 1}
         assert all(m.average is None for m in precision)
+
+        custom = [
+            m for m in payload.metrics if m.name == "xxx" and m.data_source == "test"
+        ]
+        assert len(custom) == 1
+        assert custom[0].average == "macro"
+        assert custom[0].label is None
+        assert custom[0].value is not None
 
     @mark.respx(assert_all_called=False)
     def test_multiclass_metrics_includes_aggregate_averages(

--- a/skore/tests/unit/plugins/hub/test_metric.py
+++ b/skore/tests/unit/plugins/hub/test_metric.py
@@ -40,7 +40,7 @@ def test_drops_rows_with_missing_scores() -> None:
     assert selected["name"].tolist() == ["accuracy"]
 
 
-def test_binary_classification_drops_averaged_rows() -> None:
+def test_binary_keeps_averaged_rows() -> None:
     report = _report(
         "binary-classification",
         [
@@ -52,8 +52,8 @@ def test_binary_classification_drops_averaged_rows() -> None:
 
     selected = select_exportable_metrics(report)
 
-    assert len(selected) == 2
-    assert selected["average"].isna().all()
+    assert len(selected) == 3
+    assert selected["average"].tolist() == [None, None, "macro"]
 
 
 def test_multiclass_keeps_averaged_rows() -> None:


### PR DESCRIPTION
This is a small fix when sending metrics on the hub. Currently we did not update the averaged metrics for the binary case because the built-in metrics blocking in this case.

But there is not reason that custom metric allowing it cannot be send to the hub.

So this PR is removing this lock.