### PR TITLE
fix(skore): Solve recurssion error with parallelization in metric summary

### DIFF
--- a/skore/src/skore/_sklearn/_base.py
+++ b/skore/src/skore/_sklearn/_base.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from skore._sklearn._checks.accessor import _ChecksAccessor
+    from skore._sklearn._cross_validation.report import CrossValidationReport
+    from skore._sklearn._estimator.report import EstimatorReport
+    from skore._sklearn._plot import MetricsSummaryDisplay
     from skore._utils.repr.data import AccessorHelpData
 
 
@@ -177,6 +180,20 @@ class _BaseAccessor(AccessorHelpMixin, Generic[ParentT]):
 
     def _repr_mimebundle_(self, **kwargs):
         return {"text/plain": repr(self), "text/html": self._repr_html_()}
+
+
+def _summarize_report_metrics(
+    report: EstimatorReport | CrossValidationReport,
+    *,
+    data_source: DataSource | Literal["both"],
+    metric: str | list[str] | None = None,
+) -> MetricsSummaryDisplay:
+    """Compute a metrics summary for ``report``.
+
+    Pure Python function to avoid pickling a metrics accessor as a bound method's
+    ``__self__``.
+    """
+    return report.metrics._summarize_display(data_source=data_source, metric=metric)
 
 
 class BaseMetricsAccessor(_BaseAccessor, Generic[ParentT]):

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -4,13 +4,13 @@ import numbers
 import warnings
 from typing import Any, Literal
 
-import joblib
 import pandas as pd
+from joblib import Parallel
 from numpy.typing import ArrayLike
 from sklearn.utils.metaestimators import available_if
 
 from skore._externals._pandas_accessors import DirNamesMixin
-from skore._sklearn._base import BaseMetricsAccessor
+from skore._sklearn._base import BaseMetricsAccessor, _summarize_report_metrics
 from skore._sklearn._comparison.report import ComparisonReport
 from skore._sklearn._plot.metrics import (
     ConfusionMatrixDisplay,
@@ -26,6 +26,7 @@ from skore._utils._accessor import (
     _check_supported_ml_task,
 )
 from skore._utils._fixes import _validate_joblib_parallel_params
+from skore._utils._parallel import delayed
 from skore._utils._progress_bar import track
 
 DataSource = Literal["test", "train", "both"]
@@ -84,7 +85,7 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         precision              0.98...              0.98...
         recall                 0.92...              0.92...
         """
-        parallel = joblib.Parallel(
+        parallel = Parallel(
             **_validate_joblib_parallel_params(
                 n_jobs=self._parent.n_jobs, return_as="generator"
             )
@@ -93,7 +94,8 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         summaries = list(
             track(
                 parallel(
-                    joblib.delayed(report.metrics._summarize_display)(
+                    delayed(_summarize_report_metrics)(
+                        report,
                         data_source=data_source,
                         metric=metric,
                     )

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike
 from sklearn.utils.metaestimators import available_if
 
 from skore._externals._pandas_accessors import DirNamesMixin
-from skore._sklearn._base import BaseMetricsAccessor
+from skore._sklearn._base import BaseMetricsAccessor, _summarize_report_metrics
 from skore._sklearn._cross_validation.report import CrossValidationReport
 from skore._sklearn._plot import (
     ConfusionMatrixDisplay,
@@ -126,7 +126,8 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
         summaries = list(
             track(
                 parallel(
-                    delayed(report.metrics._summarize_display)(
+                    delayed(_summarize_report_metrics)(
+                        report,
                         data_source=data_source,
                         metric=metric,
                     )

--- a/skore/tests/unit/reports/comparison/test_metrics.py
+++ b/skore/tests/unit/reports/comparison/test_metrics.py
@@ -126,3 +126,30 @@ def test_available_with_unknown_report_name_raises(report):
     comparison_report = ComparisonReport(reports)
     with pytest.raises(ValueError, match="Unknown report name"):
         comparison_report.metrics.available(report_name="unknown")
+
+
+def test_non_default_n_jobs():
+    """summarize() must work when ComparisonReport uses process-based parallelism.
+
+    Joblib must not pickle a bound metrics-accessor method; that used to recurse
+    while unpickling ``__getattr__`` / ``available()`` in worker processes.
+    """
+    X, y = make_classification(random_state=0)
+    reports = {
+        "LinearSVC": EstimatorReport(
+            LinearSVC(), X_train=X, X_test=X, y_train=y, y_test=y, pos_label=1
+        ),
+        "LogisticRegression": EstimatorReport(
+            LogisticRegression(),
+            X_train=X,
+            X_test=X,
+            y_train=y,
+            y_test=y,
+            pos_label=1,
+        ),
+    }
+    comparison_report = ComparisonReport(reports, n_jobs=2)
+    display = comparison_report.metrics.summarize()
+
+    assert isinstance(display, MetricsSummaryDisplay)
+    assert set(display.summary["estimator"]) == {"LinearSVC", "LogisticRegression"}

--- a/skore/tests/unit/reports/cross_validation/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/cross_validation/metrics/test_summarize.py
@@ -339,3 +339,17 @@ def test_pos_label_overwrite(metric, logistic_binary_classification_data):
 
     assert len(display.summary) == 2  # One line per split
     assert display.summary["label"].isna().all()
+
+
+def test_non_default_n_jobs(forest_binary_classification_data):
+    """summarize() must work when the report uses process-based parallelism.
+
+    Joblib must not pickle a bound metrics-accessor method; that used to recurse
+    while unpickling ``__getattr__`` / ``available()`` in worker processes.
+    """
+    estimator, X, y = forest_binary_classification_data
+    report = CrossValidationReport(estimator, X=X, y=y, splitter=5, n_jobs=2)
+    display = report.metrics.summarize()
+
+    assert isinstance(display, MetricsSummaryDisplay)
+    assert set(display.summary["split"]) == {0, 1, 2, 3, 4}


### PR DESCRIPTION
closes #3177
closes #3175 

This PR move from a methods bound to self to a pure Python function when used in parallel with joblib to avoid recursion when pickling/unpickling the object.