### PR TITLE
fix(skore): Stop summary table scroll from chaining to the notebook

### DIFF
--- a/skore/src/skore/_utils/repr/common/css/report.css
+++ b/skore/src/skore/_utils/repr/common/css/report.css
@@ -478,6 +478,7 @@
     min-width: 11em;
     max-height: 260px;
     overflow-y: auto;
+    overscroll-behavior: contain;
     padding: 0.25em;
     background-color: var(--color-background);
     border: 1px solid var(--color-orange);
@@ -562,6 +563,7 @@
     min-width: 11em;
     max-height: 220px;
     overflow-y: auto;
+    overscroll-behavior: contain;
     padding: 0.25em 0.5em;
     background-color: var(--color-background);
     border: 1px solid var(--color-orange);
@@ -745,6 +747,7 @@
     flex: 1 1 auto;
     min-width: 0;
     overflow-x: auto;
+    overscroll-behavior-x: contain;
     white-space: nowrap;
     padding: 0.3em 0.5em;
     color: var(--color-text);
@@ -819,6 +822,14 @@
     max-height: 450px;
     overflow: auto;
     max-width: 100%;
+}
+
+/* Keep the wheel inside the table once it reaches an edge, instead of chaining
+   to the host page: in a notebook (VS Code, JupyterLab) that would scroll the
+   whole cell list. The class is set from JS only while the table overflows,
+   because containment on a table that fits would freeze the page around it. */
+.summary-table-wrap.summary-table-wrap--scrollable {
+    overscroll-behavior-y: contain;
 }
 
 .summary-table {

--- a/skore/src/skore/_utils/repr/project/js/summary-table.js
+++ b/skore/src/skore/_utils/repr/project/js/summary-table.js
@@ -2,6 +2,7 @@ const SKORE_SUMMARY_ELLIPSIS_COLUMNS = new Set(["id", "dataset"]);
 
 function setupTable(ctx) {
     const { shadowRoot, tbody, dataRows } = ctx;
+    const tableWrap = shadowRoot.querySelector(".summary-table-wrap");
 
     shadowRoot.querySelectorAll(".summary-sortable").forEach((th) => {
         const columnKey = th.dataset.columnKey;
@@ -229,6 +230,16 @@ function setupTable(ctx) {
         });
     }
 
+    function syncScrollContainment() {
+        if (!tableWrap) {
+            return;
+        }
+        tableWrap.classList.toggle(
+            "summary-table-wrap--scrollable",
+            tableWrap.scrollHeight > tableWrap.clientHeight
+        );
+    }
+
     function refresh() {
         const term = currentSearchTerm();
         const activeByField = collectCheckboxFilters();
@@ -298,6 +309,7 @@ function setupTable(ctx) {
         }
 
         updateSortIndicators();
+        syncScrollContainment();
     }
 
     ctx.filterValues.forEach((checkbox) => {

--- a/skore/tests/unit/project/test_summary.py
+++ b/skore/tests/unit/project/test_summary.py
@@ -570,26 +570,6 @@ class TestSummary:
         assert "text/html" in mimebundle
         assert "text/plain" in mimebundle
 
-    def test_html_repr_scroll_containment(self, estimator_report_regression):
-        """The table traps the wheel only while it overflows (see #3131)."""
-        summary = _summary_from_project(FakeProject(estimator_report_regression))
-
-        html = summary._html_repr()
-
-        assert (
-            ".summary-table-wrap.summary-table-wrap--scrollable {\n"
-            "    overscroll-behavior-y: contain;\n"
-            "}"
-        ) in html
-        assert "function syncScrollContainment()" in html
-        assert '"summary-table-wrap--scrollable",' in html
-        # Popovers always trap it: scrolling should not move the page under an
-        # open menu.
-        assert (
-            ".skore-summary-columns-panel {" in html
-            and "overscroll-behavior: contain;" in html
-        )
-
     def test_html_repr_empty(self):
         summary = _summary_from_project(FakeProject())
 

--- a/skore/tests/unit/project/test_summary.py
+++ b/skore/tests/unit/project/test_summary.py
@@ -570,6 +570,26 @@ class TestSummary:
         assert "text/html" in mimebundle
         assert "text/plain" in mimebundle
 
+    def test_html_repr_scroll_containment(self, estimator_report_regression):
+        """The table traps the wheel only while it overflows (see #3131)."""
+        summary = _summary_from_project(FakeProject(estimator_report_regression))
+
+        html = summary._html_repr()
+
+        assert (
+            ".summary-table-wrap.summary-table-wrap--scrollable {\n"
+            "    overscroll-behavior-y: contain;\n"
+            "}"
+        ) in html
+        assert "function syncScrollContainment()" in html
+        assert '"summary-table-wrap--scrollable",' in html
+        # Popovers always trap it: scrolling should not move the page under an
+        # open menu.
+        assert (
+            ".skore-summary-columns-panel {" in html
+            and "overscroll-behavior: contain;" in html
+        )
+
     def test_html_repr_empty(self):
         summary = _summary_from_project(FakeProject())
 


### PR DESCRIPTION
Fixes #3131.

Scrolling the project summary table in VS Code also scrolled the notebook underneath it, because `.summary-table-wrap` had no `overscroll-behavior` and the wheel chained to the host page once the table hit an edge.

Set `overscroll-behavior: contain` on the summary scroll containers. For the table, containment is toggled from `refresh()` only while it overflows — applying it unconditionally would freeze scrolling around a short table.