### PR TITLE
perf(ci): Speed up pytest via xdist and faster MLflow tracking

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -192,16 +192,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-    env:
-      # Keep BLAS/OpenMP/joblib single-threaded so pytest-xdist workers do not
-      # oversubscribe CPUs (critical on Windows where nested parallelism thrashing
-      # previously made the suite slower than serial).
-      OMP_NUM_THREADS: "1"
-      OPENBLAS_NUM_THREADS: "1"
-      MKL_NUM_THREADS: "1"
-      BLIS_NUM_THREADS: "1"
-      NUMEXPR_NUM_THREADS: "1"
-      LOKY_MAX_CPU_COUNT: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -192,6 +192,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    env:
+      # Keep BLAS/OpenMP/joblib single-threaded so pytest-xdist workers do not
+      # oversubscribe CPUs (critical on Windows where nested parallelism thrashing
+      # previously made the suite slower than serial).
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      BLIS_NUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
+      LOKY_MAX_CPU_COUNT: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
@@ -295,7 +295,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -345,7 +347,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
@@ -251,7 +251,9 @@ protobuf==6.33.6
     #   databricks-sdk
     #   mlflow-skinny
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -300,7 +302,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
@@ -296,7 +296,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -346,7 +348,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
@@ -295,7 +295,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -345,7 +347,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
@@ -296,7 +296,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -346,7 +348,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -295,7 +295,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -345,7 +347,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
@@ -296,7 +296,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -346,7 +348,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
@@ -295,7 +295,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -345,7 +347,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
@@ -295,7 +295,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -345,7 +347,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
@@ -296,7 +296,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -346,7 +348,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
@@ -298,7 +298,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -348,7 +350,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
@@ -297,7 +297,9 @@ protobuf==6.33.6
     #   mlflow-tracing
     #   opentelemetry-proto
 psutil==7.2.2
-    # via ipython
+    # via
+    #   ipython
+    #   pytest-xdist
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -347,7 +349,7 @@ pytest-order==1.4.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
-pytest-xdist==3.8.0
+pytest-xdist[psutil]==3.8.0
     # via skore (skore/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via

--- a/skore/conftest.py
+++ b/skore/conftest.py
@@ -1,5 +1,21 @@
 """Top-level conftest applying to both `tests/` and doctests under `src/`."""
 
+# ruff: noqa: E402
+import os
+
+# Cap native thread pools before NumPy and sklearn are imported below, otherwise
+# pytest-xdist workers oversubscribe the CPUs (BLAS and joblib nesting inside each
+# worker) and the suite gets slower than it is serially, especially on Windows.
+for _thread_env_var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "BLIS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "LOKY_MAX_CPU_COUNT",
+):
+    os.environ.setdefault(_thread_env_var, "1")
+
 import matplotlib
 import matplotlib.pyplot
 

--- a/skore/conftest.py
+++ b/skore/conftest.py
@@ -14,7 +14,7 @@ for _thread_env_var in (
     "NUMEXPR_NUM_THREADS",
     "LOKY_MAX_CPU_COUNT",
 ):
-    os.environ.setdefault(_thread_env_var, "1")
+    os.environ[_thread_env_var] = "1"
 
 import matplotlib
 import matplotlib.pyplot

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -145,6 +145,9 @@ filterwarnings = [
   # mlflow-related
   # NOTE: Only affects python 3.11
   "ignore:SelectableGroups dict interface is deprecated. Use select.:DeprecationWarning",
+  # mlflow writes its YAML and requirement files through `codecs.open()`, which
+  # Python 3.14 deprecates. Reached by every test that logs a report.
+  'ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow',
   # sklearn needs to update its scipy.optimize calls
   'ignore:.*`disp` and `iprint` options of the L-BFGS-B solver are deprecated:DeprecationWarning',
   # seaborn's boxplot still passes the deprecated `vert=` kwarg to matplotlib.

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -133,6 +133,8 @@ addopts = [
   "--import-mode=importlib",
   "--no-header",
   "--verbosity=2",
+  "-n",
+  "logical",
   "--dist=loadscope",
   "--durations=25",
 ]

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -54,7 +54,7 @@ test-base = [
   "pytest-cov",
   "pytest-order",
   "pytest-randomly",
-  "pytest-xdist",
+  "pytest-xdist[psutil]",
   "respx",
   "scipy-stubs",
   "skore[hub, jupyter, mlflow]",
@@ -133,8 +133,7 @@ addopts = [
   "--import-mode=importlib",
   "--no-header",
   "--verbosity=2",
-  "-n",
-  "logical",
+  "--numprocesses=logical",
   "--dist=loadscope",
   "--durations=25",
 ]

--- a/skore/src/skore/_plugins/mlflow/project.py
+++ b/skore/src/skore/_plugins/mlflow/project.py
@@ -119,10 +119,13 @@ class Project:
         self.__tracking_uri = mlflow.get_tracking_uri()
         try:
             self.__storage_experiment_id = mlflow.create_experiment("__skore-storage__")
-        except RestException:
+        except (RestException, MlflowException) as exc:
+            # Local SQLite/FileStore raises MlflowException on duplicate names; remote
+            # tracking servers raise RestException. Reuse the existing experiment either
+            # way so multiple Project instances can share one tracking URI.
             storage_experiment = mlflow.get_experiment_by_name("__skore-storage__")
             if storage_experiment is None:
-                raise
+                raise exc
             self.__storage_experiment_id = storage_experiment.experiment_id
         self.__mlflow_client = MlflowClient()
         self.__name = name

--- a/skore/src/skore/_plugins/mlflow/project.py
+++ b/skore/src/skore/_plugins/mlflow/project.py
@@ -19,7 +19,7 @@ import mlflow
 import mlflow.sklearn
 import pandas as pd
 from mlflow.entities import Run as MLFlowRun
-from mlflow.exceptions import MlflowException, RestException
+from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 from mlflow.utils.autologging_utils import disable_discrete_autologging
 from mlflow.utils.logging_utils import MLFLOW_LOGGING_STREAM
@@ -119,13 +119,13 @@ class Project:
         self.__tracking_uri = mlflow.get_tracking_uri()
         try:
             self.__storage_experiment_id = mlflow.create_experiment("__skore-storage__")
-        except (RestException, MlflowException) as exc:
-            # Local SQLite/FileStore raises MlflowException on duplicate names; remote
-            # tracking servers raise RestException. Reuse the existing experiment either
-            # way so multiple Project instances can share one tracking URI.
+        except MlflowException:
+            # Local stores raise a plain `MlflowException` on duplicate names, while
+            # tracking servers raise its `RestException` subclass. Reuse the existing
+            # experiment either way, so several projects can share a tracking URI.
             storage_experiment = mlflow.get_experiment_by_name("__skore-storage__")
             if storage_experiment is None:
-                raise exc
+                raise
             self.__storage_experiment_id = storage_experiment.experiment_id
         self.__mlflow_client = MlflowClient()
         self.__name = name

--- a/skore/tests/conftest.py
+++ b/skore/tests/conftest.py
@@ -1,18 +1,3 @@
-import os
-
-# Cap native/thread pools before NumPy/sklearn import. Without this, pytest-xdist
-# workers oversubscribe CPUs (BLAS + joblib inside each worker) and the suite can
-# get much slower than serial, especially on Windows runners.
-for _thread_env_var in (
-    "OMP_NUM_THREADS",
-    "OPENBLAS_NUM_THREADS",
-    "MKL_NUM_THREADS",
-    "BLIS_NUM_THREADS",
-    "NUMEXPR_NUM_THREADS",
-    "LOKY_MAX_CPU_COUNT",
-):
-    os.environ.setdefault(_thread_env_var, "1")
-
 from datetime import UTC, datetime
 
 import numpy as np

--- a/skore/tests/conftest.py
+++ b/skore/tests/conftest.py
@@ -1,4 +1,6 @@
 from datetime import UTC, datetime
+from itertools import count
+from shutil import copyfile
 
 import numpy as np
 import pytest
@@ -47,6 +49,38 @@ def monkeypatch_configuration(monkeypatch):
     """Ensure that the test gets the default configuration,
     independently of the others."""
     monkeypatch.setattr("skore._config.configuration.local", LocalConfiguration())
+
+
+@pytest.fixture(scope="session")
+def _mlflow_schema(tmp_path_factory):
+    """Path to a SQLite database on which MLflow already ran its migrations."""
+    import mlflow
+
+    path = tmp_path_factory.mktemp("mlflow-schema") / "mlflow.db"
+
+    # Instantiating the store is what runs the Alembic migrations.
+    mlflow.MlflowClient(tracking_uri=f"sqlite:///{path}")
+
+    return path
+
+
+@pytest.fixture
+def mlflow_tracking_uri(_mlflow_schema, tmp_path):
+    """
+    Return a factory of isolated MLflow tracking URIs.
+
+    Each URI is backed by its own copy of an already migrated database: running the
+    migrations takes about a second, which otherwise dominates the runtime of the
+    MLflow tests.
+    """
+    counter = count()
+
+    def make_tracking_uri():
+        path = tmp_path / f"mlflow-{next(counter)}.db"
+        copyfile(_mlflow_schema, path)
+        return f"sqlite:///{path}"
+
+    return make_tracking_uri
 
 
 @pytest.fixture

--- a/skore/tests/conftest.py
+++ b/skore/tests/conftest.py
@@ -1,3 +1,18 @@
+import os
+
+# Cap native/thread pools before NumPy/sklearn import. Without this, pytest-xdist
+# workers oversubscribe CPUs (BLAS + joblib inside each worker) and the suite can
+# get much slower than serial, especially on Windows runners.
+for _thread_env_var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "BLIS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "LOKY_MAX_CPU_COUNT",
+):
+    os.environ.setdefault(_thread_env_var, "1")
+
 from datetime import UTC, datetime
 
 import numpy as np

--- a/skore/tests/unit/plugins/mlflow/conftest.py
+++ b/skore/tests/unit/plugins/mlflow/conftest.py
@@ -27,14 +27,10 @@ def monkeypatch_rich(monkeypatch):
 
 
 @fixture(autouse=True)
-def isolated_mlflow_tracking(tmp_path, monkeypatch):
-    # Prefer the filesystem store over sqlite:// so tests skip Alembic schema init on
-    # every new tmp DB. That migration dominates MLflow test time on Windows CI.
-    # MLflow 3 requires an explicit opt-in; setting the env var is a no-op on MLflow 2.
-    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+def isolated_mlflow_tracking(tmp_path, monkeypatch, mlflow_tracking_uri):
     monkeypatch.chdir(tmp_path)
     previous_tracking_uri = mlflow.get_tracking_uri()
-    tracking_uri = (tmp_path / "mlruns").as_uri()
+    tracking_uri = mlflow_tracking_uri()
     mlflow.set_tracking_uri(tracking_uri)
     try:
         yield tracking_uri

--- a/skore/tests/unit/plugins/mlflow/conftest.py
+++ b/skore/tests/unit/plugins/mlflow/conftest.py
@@ -28,9 +28,13 @@ def monkeypatch_rich(monkeypatch):
 
 @fixture(autouse=True)
 def isolated_mlflow_tracking(tmp_path, monkeypatch):
+    # Prefer the filesystem store over sqlite:// so tests skip Alembic schema init on
+    # every new tmp DB. That migration dominates MLflow test time on Windows CI.
+    # MLflow 3 requires an explicit opt-in; setting the env var is a no-op on MLflow 2.
+    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
     monkeypatch.chdir(tmp_path)
     previous_tracking_uri = mlflow.get_tracking_uri()
-    tracking_uri = f"sqlite:///{tmp_path}/mlflow.db"
+    tracking_uri = (tmp_path / "mlruns").as_uri()
     mlflow.set_tracking_uri(tracking_uri)
     try:
         yield tracking_uri

--- a/skore/tests/unit/plugins/mlflow/test_project.py
+++ b/skore/tests/unit/plugins/mlflow/test_project.py
@@ -125,8 +125,9 @@ class TestProject:
         "metrics.roc.png",
     ]
 
-    def test_init_with_explicit_tracking_uri(self, tmp_path):
-        tracking_uri = f"sqlite:///{tmp_path}/custom-mlflow.db"
+    def test_init_with_explicit_tracking_uri(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+        tracking_uri = (tmp_path / "custom-mlruns").as_uri()
 
         project = Project("<project>", tracking_uri=tracking_uri)
 
@@ -134,6 +135,18 @@ class TestProject:
         assert project.tracking_uri == tracking_uri
         assert repr(project) == (
             f"Project(name='<project>', mode='mlflow', tracking_uri='{tracking_uri}')"
+        )
+
+    def test_init_reuses_existing_storage_experiment(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+        tracking_uri = (tmp_path / "shared-mlruns").as_uri()
+
+        first = Project("first", tracking_uri=tracking_uri)
+        second = Project("second", tracking_uri=tracking_uri)
+
+        assert (
+            first._Project__storage_experiment_id
+            == second._Project__storage_experiment_id
         )
 
     @pytest.mark.parametrize(
@@ -259,15 +272,17 @@ class TestProject:
             assert (report_dir / artifact).exists()
         assert (report_dir / "metrics_details" / "per_split.csv").exists()
 
-    def test_get_unknown_id_with_explicit_tracking_uri(self, tmp_path):
-        tracking_uri = f"sqlite:///{tmp_path}/missing-id.db"
+    def test_get_unknown_id_with_explicit_tracking_uri(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+        tracking_uri = (tmp_path / "missing-id-mlruns").as_uri()
         project = Project("<project>", tracking_uri=tracking_uri)
 
         with pytest.raises(KeyError):
             project.get("missing-run-id")
 
-    def test_delete(self, tmp_path, reg_report):
-        tracking_uri = f"sqlite:///{tmp_path}/mlflow.db"
+    def test_delete(self, tmp_path, reg_report, monkeypatch):
+        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+        tracking_uri = (tmp_path / "mlruns-delete").as_uri()
         project = Project("project", tracking_uri=tracking_uri)
         project.put("<key>", reg_report)
 

--- a/skore/tests/unit/plugins/mlflow/test_project.py
+++ b/skore/tests/unit/plugins/mlflow/test_project.py
@@ -112,9 +112,6 @@ def test_log_artifact_logs_series_metrics_as_csv(monkeypatch) -> None:
     assert "0.9" in csv_text
 
 
-@pytest.mark.filterwarnings(
-    r"ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow"
-)
 class TestProject:
     CLF_ARTIFACTS = [
         "metrics.confusion_matrix.png",
@@ -125,9 +122,8 @@ class TestProject:
         "metrics.roc.png",
     ]
 
-    def test_init_with_explicit_tracking_uri(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
-        tracking_uri = (tmp_path / "custom-mlruns").as_uri()
+    def test_init_with_explicit_tracking_uri(self, mlflow_tracking_uri):
+        tracking_uri = mlflow_tracking_uri()
 
         project = Project("<project>", tracking_uri=tracking_uri)
 
@@ -137,9 +133,8 @@ class TestProject:
             f"Project(name='<project>', mode='mlflow', tracking_uri='{tracking_uri}')"
         )
 
-    def test_init_reuses_existing_storage_experiment(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
-        tracking_uri = (tmp_path / "shared-mlruns").as_uri()
+    def test_init_reuses_existing_storage_experiment(self, mlflow_tracking_uri):
+        tracking_uri = mlflow_tracking_uri()
 
         first = Project("first", tracking_uri=tracking_uri)
         second = Project("second", tracking_uri=tracking_uri)
@@ -272,17 +267,15 @@ class TestProject:
             assert (report_dir / artifact).exists()
         assert (report_dir / "metrics_details" / "per_split.csv").exists()
 
-    def test_get_unknown_id_with_explicit_tracking_uri(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
-        tracking_uri = (tmp_path / "missing-id-mlruns").as_uri()
+    def test_get_unknown_id_with_explicit_tracking_uri(self, mlflow_tracking_uri):
+        tracking_uri = mlflow_tracking_uri()
         project = Project("<project>", tracking_uri=tracking_uri)
 
         with pytest.raises(KeyError):
             project.get("missing-run-id")
 
-    def test_delete(self, tmp_path, reg_report, monkeypatch):
-        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
-        tracking_uri = (tmp_path / "mlruns-delete").as_uri()
+    def test_delete(self, reg_report, mlflow_tracking_uri):
+        tracking_uri = mlflow_tracking_uri()
         project = Project("project", tracking_uri=tracking_uri)
         project.put("<key>", reg_report)
 

--- a/skore/tests/unit/project/test_project_contract.py
+++ b/skore/tests/unit/project/test_project_contract.py
@@ -81,9 +81,11 @@ class TestLocalProjectContract:
 class TestMlflowProjectContract:
     @pytest.fixture(autouse=True)
     def isolated_mlflow_tracking(self, tmp_path, monkeypatch):
+        # Prefer file:// over sqlite:// to avoid per-test Alembic schema init.
+        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
         monkeypatch.chdir(tmp_path)
         previous_tracking_uri = mlflow.get_tracking_uri()
-        tracking_uri = f"sqlite:///{tmp_path}/mlflow.db"
+        tracking_uri = (tmp_path / "mlruns").as_uri()
         mlflow.set_tracking_uri(tracking_uri)
         try:
             yield tracking_uri

--- a/skore/tests/unit/project/test_project_contract.py
+++ b/skore/tests/unit/project/test_project_contract.py
@@ -80,12 +80,10 @@ class TestLocalProjectContract:
 
 class TestMlflowProjectContract:
     @pytest.fixture(autouse=True)
-    def isolated_mlflow_tracking(self, tmp_path, monkeypatch):
-        # Prefer file:// over sqlite:// to avoid per-test Alembic schema init.
-        monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+    def isolated_mlflow_tracking(self, tmp_path, monkeypatch, mlflow_tracking_uri):
         monkeypatch.chdir(tmp_path)
         previous_tracking_uri = mlflow.get_tracking_uri()
-        tracking_uri = (tmp_path / "mlruns").as_uri()
+        tracking_uri = mlflow_tracking_uri()
         mlflow.set_tracking_uri(tracking_uri)
         try:
             yield tracking_uri
@@ -94,9 +92,6 @@ class TestMlflowProjectContract:
                 mlflow.end_run()
             mlflow.set_tracking_uri(previous_tracking_uri)
 
-    @pytest.mark.filterwarnings(
-        r"ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow"
-    )
     def test_api_contract(
         self, regression_report, second_regression_report, isolated_mlflow_tracking
     ):


### PR DESCRIPTION
This PR should speed up the different tests using `xdist` and using the file system instead of sqlite for MLflow.

We go from 25 minutes on the window tests to 6-10 minutes.