### PR TITLE
chore(skore): Align default metrics with is_computable and discouraged

### DIFF
--- a/examples/model_evaluation/plot_custom_metrics.py
+++ b/examples/model_evaluation/plot_custom_metrics.py
@@ -12,7 +12,7 @@ particular beta, etc.
 
 This example walks through how to register such metrics with
 :meth:`~skore.EstimatorReport.metrics.add` so they are computed and displayed
-alongside the built-in ones.
+alongside the default ones.
 """
 
 # %%
@@ -69,7 +69,7 @@ report.metrics.add(make_scorer(specificity))
 report.metrics.summarize().frame()
 
 # %%
-# ``specificity`` now appears alongside the built-in metrics. It can also be computed
+# ``specificity`` now appears alongside the default metrics. It can also be computed
 # individually using the :meth:`~skore.EstimatorReport.metrics.get` method:
 report.metrics.get("specificity")
 

--- a/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_comparison/metrics_accessor.py
@@ -18,7 +18,7 @@ from skore._sklearn._plot.metrics import (
     PredictionErrorDisplay,
     RocCurveDisplay,
 )
-from skore._sklearn.metrics import Metric, MetricLike
+from skore._sklearn.metrics import Metric, MetricLike, Score
 from skore._sklearn.types import Aggregate
 from skore._utils._accessor import (
     _check_any_sub_report_has_metric,
@@ -154,11 +154,11 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         )
 
     def _metric(
-        self, metric_name: str, *, data_source: DataSource, **kwargs: Any
+        self, metric: str | Metric, *, data_source: DataSource, **kwargs: Any
     ) -> MetricsSummaryDisplay:
         """Compute a single metric across compared reports, forwarding *kwargs*."""
         summaries = [
-            report.metrics._metric(metric_name, data_source=data_source, **kwargs)
+            report.metrics._metric(metric, data_source=data_source, **kwargs)
             for report in self._parent.reports_.values()
         ]
 
@@ -212,19 +212,20 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
 
     def add(
         self,
-        metric: MetricLike,
+        metric: MetricLike | Metric,
         *,
         name: str | None = None,
         verbose_name: str | None = None,
         greater_is_better: bool = True,
         position: Literal["first", "last"] = "first",
+        force: bool = False,
         **kwargs: Any,
     ) -> None:
         """Add a custom metric to :meth:`summarize`.
 
         Parameters
         ----------
-        metric : str, sklearn scorer, or callable
+        metric : str, sklearn scorer, callable, or Metric
             The metric to add.
 
             - If a string, it will be run through :func:`sklearn.metrics.get_scorer`.
@@ -237,6 +238,8 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
               :meth:`summarize` will show one row per class label under the metric name.
               If your metric has the form ``(y_true, y_pred, **kw) -> float``, see
               :func:`sklearn.metrics.make_scorer` to convert it to a scorer.
+            - If a :class:`~skore._sklearn.metrics.Metric`, it is registered as-is
+              (or as a copy when ``name`` / ``verbose_name`` are set).
 
         name : str or None, default=None
             Custom name for the metric. If ``None``, the name is inferred
@@ -253,6 +256,12 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         position : {"first", "last"}, default="first"
             Where to place the metric in default :meth:`summarize` ordering
             for each compared report. See :meth:`EstimatorReport.metrics.add`.
+
+        force : bool, default=False
+            If ``False`` and the metric's
+            :meth:`~skore._sklearn.metrics.Metric.discouraged` returns a
+            reason, raise instead of registering. Pass ``True`` to register it
+            anyway. See :meth:`EstimatorReport.metrics.add`.
 
         **kwargs : Any
             Default keyword arguments passed to the score function at call
@@ -289,6 +298,7 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
                 verbose_name=verbose_name,
                 greater_is_better=greater_is_better,
                 position=position,
+                force=force,
                 **kwargs,
             )
 
@@ -352,7 +362,7 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         Precision 0                  0.901961              0.901961
                   1                  0.984127              0.984127
         """
-        return self._metric(metric_name=name, data_source=data_source, **kwargs).frame(
+        return self._metric(name, data_source=data_source, **kwargs).frame(
             aggregate=aggregate,
             verbose_name=True,
             flat_index=False,
@@ -481,7 +491,7 @@ class _MetricsAccessor(BaseMetricsAccessor[ComparisonReport], DirNamesMixin):
         Metric
         Score                       0.94...               0.94...
         """
-        return self._metric("score", data_source=data_source).frame(
+        return self._metric(Score(), data_source=data_source).frame(
             aggregate=aggregate,
             verbose_name=True,
             flat_index=False,

--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -18,7 +18,7 @@ from skore._sklearn._plot import (
     RocCurveDisplay,
 )
 from skore._sklearn._plot.metrics.metrics_summary_display import MetricsSummaryRow
-from skore._sklearn.metrics import Metric, MetricLike
+from skore._sklearn.metrics import Metric, MetricLike, Score
 from skore._sklearn.types import Aggregate
 from skore._utils._accessor import _check_estimator_report_has_method
 from skore._utils._fixes import _validate_joblib_parallel_params
@@ -166,19 +166,20 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
 
     def add(
         self,
-        metric: MetricLike,
+        metric: MetricLike | Metric,
         *,
         name: str | None = None,
         verbose_name: str | None = None,
         greater_is_better: bool = True,
         position: Literal["first", "last"] = "first",
+        force: bool = False,
         **kwargs: Any,
     ) -> None:
         """Add a custom metric to :meth:`summarize`.
 
         Parameters
         ----------
-        metric : str, sklearn scorer, or callable
+        metric : str, sklearn scorer, callable, or Metric
             The metric to add.
 
             - If a string, it will be run through :func:`sklearn.metrics.get_scorer`.
@@ -191,6 +192,8 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
               :meth:`summarize` will show one row per class label under the metric name.
               If your metric has the form ``(y_true, y_pred, **kw) -> float``, see
               :func:`sklearn.metrics.make_scorer` to convert it to a scorer.
+            - If a :class:`~skore._sklearn.metrics.Metric`, it is registered as-is
+              (or as a copy when ``name`` / ``verbose_name`` are set).
 
         name : str or None, default=None
             Custom name for the metric. If ``None``, the name is inferred
@@ -207,6 +210,12 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
         position : {"first", "last"}, default="first"
             Where to place the metric in default :meth:`summarize` ordering
             for each split report. See :meth:`EstimatorReport.metrics.add`.
+
+        force : bool, default=False
+            If ``False`` and the metric's
+            :meth:`~skore._sklearn.metrics.Metric.discouraged` returns a
+            reason, raise instead of registering. Pass ``True`` to register it
+            anyway. See :meth:`EstimatorReport.metrics.add`.
 
         **kwargs : Any
             Default keyword arguments passed to the score function at call
@@ -244,6 +253,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
                 verbose_name=verbose_name,
                 greater_is_better=greater_is_better,
                 position=position,
+                force=force,
                 **kwargs,
             )
 
@@ -303,7 +313,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
         Precision 0               0.93...  0.04...
                   1               0.94...  0.02...
         """
-        return self._metric(metric_name=name, data_source=data_source, **kwargs).frame(
+        return self._metric(name, data_source=data_source, **kwargs).frame(
             aggregate=aggregate,
             verbose_name=True,
             flat_index=False,
@@ -360,7 +370,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
 
     def _metric(
         self,
-        metric_name: str,
+        metric: str | Metric,
         *,
         data_source: DataSource,
         **kwargs: Any,
@@ -368,16 +378,22 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
         """Compute a single metric across cross-validation splits.
 
         This helper allows passing kwargs to the sub-reports, unlike :meth:`summarize`.
+        A :class:`Metric` instance may be passed directly to compute a metric that is
+        not registered, as :meth:`score` does for a discouraged default score.
         """
         rows: list[MetricsSummaryRow] = []
         for split_idx, report in enumerate(self._parent.reports_):
-            metric = report._metric_registry[metric_name]
-            metric_rows = metric.rows(report=report, data_source=data_source, **kwargs)
+            resolved = (
+                report._metric_registry[metric] if isinstance(metric, str) else metric
+            )
+            metric_rows = resolved.rows(
+                report=report, data_source=data_source, **kwargs
+            )
             rows.extend(
                 cast(
                     MetricsSummaryRow,
                     {
-                        "name": metric.summary_name,
+                        "name": resolved.summary_name,
                         "verbose_name": row["metric_verbose_name"],
                         "estimator": report.estimator_name_,
                         "data_source": data_source,
@@ -440,7 +456,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
         Metric
         Score               0.94...  0.00...
         """
-        return self._metric("score", data_source=data_source).frame(
+        return self._metric(Score(), data_source=data_source).frame(
             aggregate=aggregate,
             verbose_name=True,
             flat_index=False,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -4,8 +4,6 @@ from collections.abc import Iterable
 from typing import Any, Literal, cast
 
 import pandas as pd
-from sklearn.base import ClassifierMixin, RegressorMixin
-from sklearn.pipeline import Pipeline
 from sklearn.utils.metaestimators import available_if
 
 from skore._externals._pandas_accessors import DirNamesMixin
@@ -150,17 +148,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
         elif isinstance(metric, Iterable) and metric:
             parsed_metrics = [registry[m] for m in metric]
         else:
-            predictor = self._parent.estimator_
-            if isinstance(predictor, Pipeline):
-                predictor = predictor.steps[-1][1]
-            has_default_score = getattr(type(predictor), "score", None) in (
-                ClassifierMixin.score,
-                RegressorMixin.score,
-            )
-            if has_default_score:
-                parsed_metrics = [s for s in registry.values() if s.name != "score"]
-            else:
-                parsed_metrics = list(registry.values())
+            parsed_metrics = list(registry.values())
 
         rows: list[MetricsSummaryRow] = []
         errors = []
@@ -205,18 +193,24 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
 
     def _metric(
         self,
-        metric_name: str,
+        metric: str | Metric,
         *,
         data_source: DataSource,
         **kwargs: Any,
     ) -> MetricsSummaryDisplay:
-        """Compute a single metric, forwarding ``kwargs`` to the score function."""
-        metric = self._parent._metric_registry[metric_name]
+        """Compute a single metric, forwarding ``kwargs`` to the score function.
+
+        A :class:`Metric` instance may be passed directly to compute a metric that
+        is not registered, as :meth:`score` does for a discouraged default score.
+        """
+        resolved = (
+            self._parent._metric_registry[metric] if isinstance(metric, str) else metric
+        )
         rows = [
             cast(
                 MetricsSummaryRow,
                 {
-                    "name": metric.summary_name,
+                    "name": resolved.summary_name,
                     "verbose_name": row["metric_verbose_name"],
                     "estimator": self._parent.estimator_name_,
                     "data_source": data_source,
@@ -227,7 +221,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
                     "output": row["output"],
                 },
             )
-            for row in metric.rows(
+            for row in resolved.rows(
                 report=self._parent, data_source=data_source, **kwargs
             )
         ]
@@ -251,19 +245,20 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
 
     def add(
         self,
-        metric: MetricLike,
+        metric: MetricLike | Metric,
         *,
         name: str | None = None,
         verbose_name: str | None = None,
         greater_is_better: bool = True,
         position: Literal["first", "last"] = "first",
+        force: bool = False,
         **kwargs: Any,
     ) -> None:
         """Add a custom metric to :meth:`summarize`.
 
         Parameters
         ----------
-        metric : str, sklearn scorer, or callable
+        metric : str, sklearn scorer, callable, or Metric
             The metric to add.
 
             - If a string, it will be run through :func:`sklearn.metrics.get_scorer`.
@@ -276,6 +271,8 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
               :meth:`summarize` will show one row per class label under the metric name.
               If your metric has the form ``(y_true, y_pred, **kw) -> float``, see
               :func:`sklearn.metrics.make_scorer` to convert it to a scorer.
+            - If a :class:`~skore._sklearn.metrics.Metric`, it is registered as-is
+              (or as a copy when ``name`` / ``verbose_name`` are set).
 
         name : str or None, default=None
             Custom name for the metric. If ``None``, the name is inferred
@@ -293,6 +290,12 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
             Where to place the metric in default :meth:`summarize` ordering.
             ``"first"`` inserts at the front; repeated ``"first"`` adds stack
             newest-first. ``"last"`` appends at the end.
+
+        force : bool, default=False
+            If ``False`` and the metric's
+            :meth:`~skore._sklearn.metrics.Metric.discouraged` returns a reason, raise
+            instead of registering. Pass ``True`` to register it anyway (e.g. to put a
+            discouraged default ``Score`` back into :meth:`summarize`).
 
         **kwargs : Any
             Default keyword arguments passed to the score function at call
@@ -328,7 +331,9 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
                     greater_is_better=greater_is_better,
                     kwargs=kwargs,
                 ),
+                report=self._parent,
                 position=position,
+                force=force,
             )
         except MissingKwargsError as error:
             args_msg = ", ".join(f"{kwarg}=..." for kwarg in error.missing_kwargs)
@@ -473,7 +478,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
         }
         return {k: v for k, v in times.items() if v is not None}
 
-    @available_if(lambda self: Score.available(self._parent))
+    @available_if(lambda self: Score.is_computable(self._parent))
     def score(
         self,
         *,

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -875,7 +875,7 @@ def default_metrics(report: EstimatorReport) -> list[Metric]:
         The metric instances to register, in default display order.
     """
     ml_task = report._ml_task
-    metrics: list[Metric] = []
+    metrics: list[Metric] = [Score()]
 
     if ml_task == "binary-classification":
         metrics += [Accuracy(), Precision(), Recall(), RocAuc(), LogLoss(), Brier()]
@@ -894,7 +894,6 @@ def default_metrics(report: EstimatorReport) -> list[Metric]:
         metrics += [R2(), Rmse(), Mae(), Mape()]
 
     metrics += [FitTime(), PredictTime()]
-    metrics.insert(0, Score())
 
     return metrics
 

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -857,24 +857,46 @@ class Score(Metric):
         )
 
 
-# Order matters for default display
-BUILTIN_METRICS: list[Metric] = [
-    Accuracy(),
-    Precision(),
-    PrecisionMacro(),
-    Recall(),
-    RecallMacro(),
-    RocAuc(),
-    RocAucMacro(),
-    LogLoss(),
-    Brier(),
-    R2(),
-    Rmse(),
-    Mae(),
-    Mape(),
-    FitTime(),
-    PredictTime(),
-]
+def default_metrics(report: EstimatorReport) -> list[Metric]:
+    """Build the metrics registered by default for ``report``, in display order.
+
+    Selection is driven by the ML task. This is the single place to evolve the
+    default set. Metrics that the estimator cannot support are filtered out by
+    :meth:`Metric.available`.
+
+    Parameters
+    ----------
+    report : EstimatorReport
+        The report to build the default metrics for.
+
+    Returns
+    -------
+    list of :class:`Metric`
+        The metric instances to register, in default display order.
+    """
+    ml_task = report._ml_task
+    metrics: list[Metric] = []
+
+    if ml_task == "binary-classification":
+        metrics += [Accuracy(), Precision(), Recall(), RocAuc(), LogLoss(), Brier()]
+    elif ml_task == "multiclass-classification":
+        metrics += [
+            Accuracy(),
+            Precision(),
+            PrecisionMacro(),
+            Recall(),
+            RecallMacro(),
+            RocAuc(),
+            RocAucMacro(),
+            LogLoss(),
+        ]
+    elif ml_task in ("regression", "multioutput-regression"):
+        metrics += [R2(), Rmse(), Mae(), Mape()]
+
+    metrics += [FitTime(), PredictTime()]
+    metrics.insert(0, Score())
+
+    return metrics
 
 
 class MetricRegistry(UserDict[str, Metric]):
@@ -899,13 +921,9 @@ class MetricRegistry(UserDict[str, Metric]):
         # Needs to be called ``data`` since we inherit from :class:`UserDict`
         self.data = OrderedDict(
             (metric.name, metric)
-            for metric in BUILTIN_METRICS
+            for metric in default_metrics(report)
             if metric.available(report)
         )
-
-        if Score.available(report):
-            self.data["score"] = Score()
-            self.data.move_to_end("score", last=False)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self.data.keys())})"
@@ -931,10 +949,8 @@ class MetricRegistry(UserDict[str, Metric]):
         if position not in ("first", "last"):
             raise ValueError(f"position must be 'first' or 'last', got {position!r}.")
 
-        if metric.name in {m.name for m in BUILTIN_METRICS}:
-            raise ValueError(
-                f"Cannot add {metric.name!r}: it is a built-in metric name."
-            )
+        if metric.name == "score":
+            raise ValueError(f"Cannot add {metric.name!r}: it is a reserved name.")
 
         if metric.name in self.data:
             raise ValueError(

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -14,8 +14,9 @@ import numpy as np
 import sklearn
 import sklearn.metrics
 from numpy.typing import ArrayLike
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.metrics._scorer import _BaseScorer
+from sklearn.pipeline import Pipeline
 
 from skore._sklearn.types import DataSource, PositiveLabel
 from skore._utils._cache_key import make_cache_key
@@ -346,13 +347,23 @@ class Metric:
         return state
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
-        """Whether this metric is applicable to the given report.
+    def is_computable(report: EstimatorReport) -> bool:
+        """Whether this metric can technically be computed on ``report``.
 
         Override this when the metric is not defined for every ML task or estimator
         (e.g. accuracy is not a regression metric).
         """
         return True
+
+    @staticmethod
+    def discouraged(report: EstimatorReport) -> str | None:
+        """Why registering this metric is not advisable for ``report``, or ``None``.
+
+        Where :meth:`is_computable` answers whether the metric *can* be computed,
+        this answers whether it is worth registering. Override to return a short
+        reason; :meth:`MetricRegistry.add` raises unless ``force=True``.
+        """
+        return None
 
     def _raw(
         self,
@@ -573,10 +584,6 @@ class FitTime(Metric):
     function_kind = None
     kwargs = {"cast": True}
 
-    @staticmethod
-    def available(report: EstimatorReport) -> bool:
-        return True
-
     def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
         if kwargs["cast"] and report._fit_time is None:
             return float("nan")
@@ -592,10 +599,6 @@ class PredictTime(Metric):
     function = None
     function_kind = None
     kwargs = {"cast": True}
-
-    @staticmethod
-    def available(report: EstimatorReport) -> bool:
-        return True
 
     def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
         predict_time = report._predict_time.get(data_source)
@@ -613,7 +616,7 @@ class Accuracy(Metric):
     function_kind = FunctionKind.METRIC
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
 
@@ -627,7 +630,7 @@ class Precision(Metric):
     kwargs = {"average": None}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
     def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
@@ -646,7 +649,7 @@ class PrecisionMacro(Precision):
     kwargs = {"average": "macro"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task == "multiclass-classification"
 
 
@@ -660,7 +663,7 @@ class Recall(Metric):
     kwargs = {"average": None}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in ("binary-classification", "multiclass-classification")
 
     def _raw(self, *, report: EstimatorReport, data_source="test", **kwargs):
@@ -679,7 +682,7 @@ class RecallMacro(Recall):
     kwargs = {"average": "macro"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task == "multiclass-classification"
 
 
@@ -692,7 +695,7 @@ class Brier(Metric):
     function_kind = FunctionKind.METRIC
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task == "binary-classification" and hasattr(
             report.learner_, "predict_proba"
         )
@@ -720,7 +723,7 @@ class RocAuc(Metric):
     kwargs = {"average": None, "multi_class": "ovr"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         has_predict_proba = hasattr(report.learner_, "predict_proba")
         has_decision_function = hasattr(report.learner_, "decision_function")
         if report._ml_task == "binary-classification":
@@ -742,8 +745,8 @@ class RocAucMacro(RocAuc):
     kwargs = {"average": "macro", "multi_class": "ovr"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
-        return report._ml_task == "multiclass-classification" and RocAuc.available(
+    def is_computable(report: EstimatorReport) -> bool:
+        return report._ml_task == "multiclass-classification" and RocAuc.is_computable(
             report
         )
 
@@ -757,7 +760,7 @@ class LogLoss(Metric):
     function_kind = FunctionKind.METRIC
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in (
             "binary-classification",
             "multiclass-classification",
@@ -774,7 +777,7 @@ class R2(Metric):
     kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
 
@@ -788,7 +791,7 @@ class Rmse(Metric):
     kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
 
@@ -802,7 +805,7 @@ class Mae(Metric):
     kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
 
@@ -816,7 +819,7 @@ class Mape(Metric):
     kwargs = {"multioutput": "raw_values"}
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return report._ml_task in ("regression", "multioutput-regression")
 
 
@@ -828,8 +831,23 @@ class Score(Metric):
     function_kind = None
 
     @staticmethod
-    def available(report: EstimatorReport) -> bool:
+    def is_computable(report: EstimatorReport) -> bool:
         return hasattr(report.estimator_, "score")
+
+    @staticmethod
+    def discouraged(report: EstimatorReport) -> str | None:
+        predictor = report.estimator_
+        if isinstance(predictor, Pipeline):
+            predictor = predictor.steps[-1][1]
+        if getattr(type(predictor), "score", None) in (
+            ClassifierMixin.score,
+            RegressorMixin.score,
+        ):
+            return (
+                "the estimator uses scikit-learn's default score, which duplicates "
+                "an already reported metric"
+            )
+        return None
 
     def _raw(
         self,
@@ -857,45 +875,27 @@ class Score(Metric):
         )
 
 
-def default_metrics(report: EstimatorReport) -> list[Metric]:
-    """Build the metrics registered by default for ``report``, in display order.
-
-    Selection is driven by the ML task. This is the single place to evolve the
-    default set. Metrics that the estimator cannot support are filtered out by
-    :meth:`Metric.available`.
-
-    Parameters
-    ----------
-    report : EstimatorReport
-        The report to build the default metrics for.
-
-    Returns
-    -------
-    list of :class:`Metric`
-        The metric instances to register, in default display order.
-    """
-    ml_task = report._ml_task
-    metrics: list[Metric] = [Score()]
-
-    if ml_task == "binary-classification":
-        metrics += [Accuracy(), Precision(), Recall(), RocAuc(), LogLoss(), Brier()]
-    elif ml_task == "multiclass-classification":
-        metrics += [
-            Accuracy(),
-            Precision(),
-            PrecisionMacro(),
-            Recall(),
-            RecallMacro(),
-            RocAuc(),
-            RocAucMacro(),
-            LogLoss(),
-        ]
-    elif ml_task in ("regression", "multioutput-regression"):
-        metrics += [R2(), Rmse(), Mae(), Mape()]
-
-    metrics += [FitTime(), PredictTime()]
-
-    return metrics
+# The metrics a report may register by default. Order matters for default display.
+# Which ones land in a given registry is decided by :meth:`Metric.is_computable`
+# and :meth:`Metric.discouraged`.
+DEFAULT_METRICS: list[Metric] = [
+    Score(),
+    Accuracy(),
+    Precision(),
+    PrecisionMacro(),
+    Recall(),
+    RecallMacro(),
+    RocAuc(),
+    RocAucMacro(),
+    LogLoss(),
+    Brier(),
+    R2(),
+    Rmse(),
+    Mae(),
+    Mape(),
+    FitTime(),
+    PredictTime(),
+]
 
 
 class MetricRegistry(UserDict[str, Metric]):
@@ -918,11 +918,13 @@ class MetricRegistry(UserDict[str, Metric]):
         super().__init__()
 
         # Needs to be called ``data`` since we inherit from :class:`UserDict`
-        self.data = OrderedDict(
-            (metric.name, metric)
-            for metric in default_metrics(report)
-            if metric.available(report)
-        )
+        self.data = OrderedDict()
+        for metric in DEFAULT_METRICS:
+            if not metric.is_computable(report):
+                continue
+            if metric.discouraged(report) is not None:
+                continue
+            self.data[metric.name] = metric
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self.data.keys())})"
@@ -931,7 +933,9 @@ class MetricRegistry(UserDict[str, Metric]):
         self,
         metric: Metric,
         *,
+        report: EstimatorReport,
         position: Literal["first", "last"] = "first",
+        force: bool = False,
     ) -> None:
         """Add a custom metric to the registry.
 
@@ -940,15 +944,30 @@ class MetricRegistry(UserDict[str, Metric]):
         metric : Metric
             The metric instance to add.
 
+        report : EstimatorReport
+            The parent report, used to evaluate :meth:`Metric.discouraged`.
+
         position : {"first", "last"}, default="first"
             Where to place the metric in iteration order (e.g. default
             :meth:`~skore.EstimatorReport.metrics.summarize` row order).
             ``"first"`` inserts at the front; ``"last"`` at the end.
+
+        force : bool, default=False
+            If ``False`` and :meth:`Metric.discouraged` returns a reason, raise
+            instead of registering. Pass ``True`` to register anyway.
         """
         if position not in ("first", "last"):
             raise ValueError(f"position must be 'first' or 'last', got {position!r}.")
 
-        if metric.name == "score":
+        if (reason := metric.discouraged(report)) is not None and not force:
+            raise ValueError(
+                f"Cannot add {metric.name!r}: {reason}. "
+                "Pass force=True to register it anyway."
+            )
+
+        # Reserve the name for :class:`Score` itself; allow force-adding Score
+        # when it was skipped as discouraged.
+        if metric.name == Score.name and not isinstance(metric, Score):
             raise ValueError(f"Cannot add {metric.name!r}: it is a reserved name.")
 
         if metric.name in self.data:
@@ -965,7 +984,7 @@ class MetricRegistry(UserDict[str, Metric]):
     def remove(self, *, report: EstimatorReport, name: str) -> None:
         """Remove a metric from the registry.
 
-        Built-in metrics may be removed; they stay absent for the lifetime of this
+        Default metrics may be removed; they stay absent for the lifetime of this
         registry (the same instance is kept for the parent report).
 
         Parameters

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -17,7 +17,7 @@ from sklearn.metrics import (
 )
 
 from skore import EstimatorReport
-from skore._sklearn.metrics import FunctionKind, Metric, MissingKwargsError
+from skore._sklearn.metrics import FunctionKind, Metric, MissingKwargsError, Score
 from skore._utils._testing import check_cache_changed, check_cache_unchanged
 
 
@@ -178,6 +178,60 @@ class TestBasicAdd:
         assert report.metrics.get("accuracy") == 1.0
 
 
+class TestDiscouraged:
+    """Test the methodological gate applied on top of technical computability."""
+
+    def test_default_score_is_not_registered(self, binary_classification_report):
+        """A default scikit-learn `score` is computable but not registered."""
+        report = binary_classification_report
+
+        assert Score.is_computable(report)
+        assert Score.discouraged(report) is not None
+        assert "score" not in report.metrics.available()
+
+        with pytest.raises(KeyError, match="score"):
+            report.metrics.get("score")
+
+        # It stays reachable through its dedicated method.
+        assert report.metrics.score() == pytest.approx(report.metrics.accuracy())
+
+    def test_add_score_raises_unless_forced(self, binary_classification_report):
+        """Adding a discouraged Score raises unless force=True."""
+        report = binary_classification_report
+
+        err_msg = re.escape(
+            "Cannot add 'score': the estimator uses scikit-learn's default score"
+        )
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add(Score())
+
+        report.metrics.add(Score(), force=True)
+        assert report.metrics.get("score") == pytest.approx(report.metrics.accuracy())
+
+    def test_custom_score_is_registered(
+        self, logistic_binary_classification_with_train_test
+    ):
+        """An estimator defining its own `score` keeps the metric registered."""
+
+        class MyEstimator(LogisticRegression):
+            def score(self, X, y, sample_weight=None):
+                return 1.0
+
+        _, X_train, X_test, y_train, y_test = (
+            logistic_binary_classification_with_train_test
+        )
+        report = EstimatorReport(
+            MyEstimator(),
+            X_train=X_train,
+            y_train=y_train,
+            X_test=X_test,
+            y_test=y_test,
+        )
+
+        assert Score.discouraged(report) is None
+        assert report.metrics.get("score") == 1.0
+
+
 class TestRemove:
     """Test metric remove functionality."""
 
@@ -296,7 +350,7 @@ class TestAddPosition:
         keys = list(report._metric_registry.keys())
         assert keys[0] == "metric_b"
         assert keys[1] == "metric_a"
-        assert keys[2] == "score"
+        assert keys[2] == "accuracy"
 
         display = report.metrics.summarize()
         assert display.summary.iloc[0]["verbose_name"] == "Metric B"
@@ -347,7 +401,7 @@ class TestAddPosition:
 
         keys = list(report._metric_registry.keys())
         assert keys[0] == "m_first"
-        assert keys[1] == "score"
+        assert keys[1] == "accuracy"
         assert keys[-1] == "m_last"
 
     def test_readd_raises_without_remove(self, binary_classification_report):
@@ -388,7 +442,7 @@ class TestAddPosition:
             function_kind=FunctionKind.METRIC,
         )
         with pytest.raises(ValueError, match="position must be 'first' or 'last'"):
-            report._metric_registry.add(m, position="middle")  # type: ignore[arg-type]
+            report._metric_registry.add(m, report=report, position="middle")  # type: ignore[arg-type]
 
 
 class TestCacheBehavior:
@@ -977,10 +1031,16 @@ class TestMetricNew:
         assert metric.name == "MyScorer"
 
 
-def test_available_default(binary_classification_report):
-    """Test that the default available() returns True."""
+def test_is_computable_default(binary_classification_report):
+    """Test that the default is_computable() returns True."""
     m = Metric(name="test")
-    assert m.available(binary_classification_report) is True
+    assert m.is_computable(binary_classification_report) is True
+
+
+def test_discouraged_default(binary_classification_report):
+    """Test that the default discouraged() returns None."""
+    m = Metric(name="test")
+    assert m.discouraged(binary_classification_report) is None
 
 
 def test_no_function(binary_classification_report):

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -154,16 +154,28 @@ class TestBasicAdd:
         assert "business_loss" in report._metric_registry
         assert "accuracy_score" in report._metric_registry
 
-    def test_cannot_override_builtin_metric(self, binary_classification_report):
-        """Test that adding with a built-in technical name raises an error."""
+    def test_cannot_use_reserved_name(self, binary_classification_report):
+        """Test that adding a metric named 'score' raises an error."""
+        report = binary_classification_report
+
+        def score(y_true, y_pred):
+            return 1.0
+
+        err_msg = "Cannot add 'score': it is a reserved name."
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add(make_scorer(score))
+
+    def test_readd_default_metric(self, binary_classification_report):
+        """Test that a default metric can be removed and added back."""
         report = binary_classification_report
 
         def accuracy(y_true, y_pred):
             return 1.0
 
-        err_msg = "Cannot add 'accuracy': it is a built-in metric name."
-        with pytest.raises(ValueError, match=err_msg):
-            report.metrics.add(make_scorer(accuracy))
+        report.metrics.remove("accuracy")
+        report.metrics.add(make_scorer(accuracy))
+
+        assert report.metrics.get("accuracy") == 1.0
 
 
 class TestRemove:

--- a/sphinx/user_guide/reporters.rst
+++ b/sphinx/user_guide/reporters.rst
@@ -82,7 +82,7 @@ addition, set `data_source` to `X_y` to pass a new dataset using the parameters 
 
 There are individual methods to compute each metric specific to the problem at hand.
 They return usual python objects such as floats, integers, or dictionaries.
-Any metric registered in the report (built-in or custom) whose name is a valid
+Any metric registered in the report (default or custom) whose name is a valid
 Python identifier is also available as ``report.metrics.<name>(...)``. Use
 :meth:`~skore.EstimatorReport.metrics.available` to list names,
 :meth:`~skore.EstimatorReport.metrics.get` when you prefer an explicit lookup,
@@ -108,14 +108,15 @@ is returned by :meth:`~skore.MetricsSummaryDisplay.frame` as a
 :class:`pandas.DataFrame`, or as a :class:`pandas.Series` when the wide layout
 has only one value column (for example a single-estimator report). In the
 Series case, metrics are indexed by name, e.g. ``result.loc["accuracy"]``. By
-default, skore computes some built-in metrics based on the ML task
-(classification or regression).
+default, skore registers the metrics that can be computed for the ML task
+(classification or regression) and that are worth reporting for the estimator
+at hand.
 
 Users can register their own metrics with :meth:`~skore.EstimatorReport.metrics.add`
 followed by :meth:`~skore.EstimatorReport.metrics.summarize`. We accept different
 types of metric:
 
-1. A string that corresponds to a scikit-learn scorer name or a built-in `skore`
+1. A string that corresponds to a scikit-learn scorer name or a default `skore`
    metric name. Scikit-learn metrics that require a ``neg_`` prefix (e.g.
    ``neg_mean_squared_error``) can also be passed without it (e.g.
    ``mean_squared_error``); the alias is resolved automatically.


### PR DESCRIPTION
## Summary

- Replace the task-branching `default_metrics` factory with a flat `DEFAULT_METRICS` catalog.
- Rename `Metric.available` → `Metric.is_computable` (technical: can we compute it?).
- Add `Metric.discouraged(report) -> str | None` (methodological: should we register it?). Defaults skip discouraged metrics silently; `metrics.add(..., force=False)` raises with the reason unless `force=True`.
- Move the `has_default_score` display filter onto `Score.discouraged`, so sklearn's default `score` is no longer registered for LogisticRegression / RandomForest / etc.
- Allow `metrics.add(Score(), force=True)` to put a discouraged score back into `summarize` / `get`; `metrics.score()` remains the dedicated escape hatch.

## Behavior change

Defaults only register metrics that are both computable and not discouraged. User `.add` never checks `is_computable`; only `discouraged` can block it (unless `force=True`).

For estimators that use scikit-learn's default `ClassifierMixin.score` / `RegressorMixin.score`, `"score"` is skipped from the registry for the same reason (use `report.metrics.score()`, or `add(Score(), force=True)` to put it back).

## Example

The point of `discouraged` is to refuse registering a metric that *can* be computed but should not be reported for the problem at hand. Override it on your metric class; `.add` raises with that reason unless the caller passes `force=True`:

```python
from sklearn.datasets import load_breast_cancer
from sklearn.linear_model import LogisticRegression
from sklearn.metrics import accuracy_score
from skore import evaluate
from skore._sklearn.metrics import FunctionKind, Metric

class AccuracyOnImbalanced(Metric):
    """Accuracy that refuses to be registered on binary classification reports."""

    name = "accuracy_on_imbalanced"
    verbose_name = "Accuracy (imbalanced)"
    function = staticmethod(accuracy_score)
    response_method = "predict"
    greater_is_better = True
    function_kind = FunctionKind.METRIC

    @staticmethod
    def discouraged(report):
        if report._ml_task == "binary-classification":
            return (
                "accuracy is often misleading for binary classification; "
                "prefer precision, recall, or ROC AUC"
            )
        return None

X, y = load_breast_cancer(return_X_y=True)
report = evaluate(LogisticRegression(max_iter=10_000), X, y, splitter=0.2)

# Refused with the reason from discouraged().
report.metrics.add(AccuracyOnImbalanced())
# ValueError: Cannot add 'accuracy_on_imbalanced': accuracy is often misleading
# for binary classification; prefer precision, recall, or ROC AUC. Pass
# force=True to register it anyway.

# Opt in explicitly when you still want it.
report.metrics.add(AccuracyOnImbalanced(), force=True)
report.metrics.accuracy_on_imbalanced()
# 0.94...
```

Custom metrics without a `discouraged` override keep today's behavior: `.add` registers them unconditionally (still not filtered by `is_computable`).

## Out of scope (flagged, not fixed here)

- The `neg_` alias claim in `summarize` / `get` docstrings that lookup does not implement
- `Metric.new` silently dropping some arguments
- `MetricRow` / `MetricsSummaryRow` duplication
- Stale `'score'` listing in accepted design record `docs/design/0007-show-neg-when-used.md` (left as history)

## Test plan

- [x] Registry / discouraged / force-add unit tests
- [x] CV and comparison `metrics.score()` still work when score is not registered
- [x] Doctests on metrics accessors
- [x] No circular `registry ↔ report` reference (state size test)
- [x] Merged with `main` (`#3196` registry-key row names kept via `resolved.name`)