### PR TITLE
refactor(skore): Use the registry key as the summarize row name

### DIFF
--- a/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_cross_validation/metrics_accessor.py
@@ -377,7 +377,7 @@ class _MetricsAccessor(BaseMetricsAccessor[CrossValidationReport], DirNamesMixin
                 cast(
                     MetricsSummaryRow,
                     {
-                        "name": metric.summary_name,
+                        "name": metric.name,
                         "verbose_name": row["metric_verbose_name"],
                         "estimator": report.estimator_name_,
                         "data_source": data_source,

--- a/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
+++ b/skore/src/skore/_sklearn/_estimator/metrics_accessor.py
@@ -186,7 +186,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
 
             rows.extend(
                 {
-                    "name": parsed_metric.summary_name,
+                    "name": parsed_metric.name,
                     "verbose_name": row["metric_verbose_name"],
                     "estimator": self._parent.estimator_name_,
                     "data_source": data_source,
@@ -216,7 +216,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
             cast(
                 MetricsSummaryRow,
                 {
-                    "name": metric.summary_name,
+                    "name": metric.name,
                     "verbose_name": row["metric_verbose_name"],
                     "estimator": self._parent.estimator_name_,
                     "data_source": data_source,

--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -180,14 +180,6 @@ class Metric:
         self.function = function
         self.function_kind = function_kind
 
-    @property
-    def summary_name(self) -> str:
-        """Name used in summarize output rows (may differ from registry ``name``)."""
-        cls_value = type(self).__dict__.get("summary_name")
-        if isinstance(cls_value, str):
-            return cls_value
-        return self.name
-
     @staticmethod
     def new(
         metric: MetricLike | Metric,
@@ -642,7 +634,6 @@ class Precision(Metric):
 
 class PrecisionMacro(Precision):
     name = "precision_macro"
-    summary_name = "precision"
     kwargs = {"average": "macro"}
 
     @staticmethod
@@ -675,7 +666,6 @@ class Recall(Metric):
 
 class RecallMacro(Recall):
     name = "recall_macro"
-    summary_name = "recall"
     kwargs = {"average": "macro"}
 
     @staticmethod
@@ -738,7 +728,6 @@ class RocAuc(Metric):
 
 class RocAucMacro(RocAuc):
     name = "roc_auc_macro"
-    summary_name = "roc_auc"
     kwargs = {"average": "macro", "multi_class": "ovr"}
 
     @staticmethod

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -58,15 +58,15 @@ def test_format_wide_multiclass(forest_multiclass_classification_with_test):
         "precision_0",
         "precision_1",
         "precision_2",
-        "precision_macro",
+        "precision_macro_macro",
         "recall_0",
         "recall_1",
         "recall_2",
-        "recall_macro",
+        "recall_macro_macro",
         "roc_auc_0",
         "roc_auc_1",
         "roc_auc_2",
-        "roc_auc_macro",
+        "roc_auc_macro_macro",
         "log_loss",
         "fit_time",
         "predict_time",
@@ -256,7 +256,7 @@ def test_frame_multiclass_includes_macro_metrics(
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     data = report.metrics.summarize().summary
 
-    for metric_name in ("precision", "recall", "roc_auc"):
+    for metric_name in ("precision_macro", "recall_macro", "roc_auc_macro"):
         macro_rows = data[(data["name"] == metric_name) & (data["average"] == "macro")]
         assert len(macro_rows) == 1
 

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -1098,9 +1098,9 @@ class TestCrossValidationReportPayload:
         )
 
         for metric_name in (
-            "precision_mean",
-            "recall_mean",
-            "roc_auc_mean",
+            "precision_macro_mean",
+            "recall_macro_mean",
+            "roc_auc_macro_mean",
         ):
             macro_metrics = [
                 m

--- a/skore/tests/unit/plugins/hub/report/test_estimator_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_estimator_report.py
@@ -364,7 +364,7 @@ class TestEstimatorReportPayload:
             key="<key>",
         )
 
-        for metric_name in ("precision", "recall", "roc_auc"):
+        for metric_name in ("precision_macro", "recall_macro", "roc_auc_macro"):
             macro_metrics = [
                 m
                 for m in payload.metrics

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -18,7 +18,7 @@ from sklearn.datasets import make_classification
 from sklearn.decomposition import PCA
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import precision_score, recall_score
+from sklearn.metrics import make_scorer, precision_score, recall_score
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 
@@ -140,6 +140,22 @@ def test_default_multiclass_classification_forest(
     assert len(per_label) == 3
     assert len(data.loc["Recall"].dropna(subset=["label"])) == 3
     assert set(per_label["label"]) == {0, 1, 2}
+
+
+def test_name_is_registry_key(forest_multiclass_classification_with_test):
+    """Rows are named after the registry key, for built-in and custom metrics alike."""
+    estimator, X_test, y_test = forest_multiclass_classification_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    report.metrics.add(
+        make_scorer(precision_score, average="weighted"), name="precision_weighted"
+    )
+
+    names = set(report.metrics.summarize().summary["name"])
+
+    # `score` is the only registered metric that `summarize` skips here, because
+    # RandomForestClassifier uses the default `ClassifierMixin.score`.
+    assert names == set(report.metrics.available()) - {"score"}
+    assert {"precision", "precision_macro", "precision_weighted"} <= names
 
 
 def test_default_multiclass_classification_svc(svc_multiclass_classification_with_test):


### PR DESCRIPTION
`Metric.summary_name` existed only so `PrecisionMacro`, `RecallMacro` and `RocAucMacro` reported themselves as `precision`, `recall` and `roc_auc` in `summarize().summary`. Metrics registered through `metrics.add` already report their registry key, so built-ins and custom metrics followed different rules.

The idea is to treat those metrics as any other metrics.