### PR TITLE
feat(project): Synchronize reports across storage modes

### DIFF
--- a/skore/src/skore/__init__.py
+++ b/skore/src/skore/__init__.py
@@ -16,7 +16,6 @@ from rich.theme import Theme
 from skore._config import configuration
 from skore._externals._sklearn_compat import parse_version
 from skore._project._summary import Summary
-from skore._project._sync import SyncOperation, SyncResult
 from skore._project.login import login
 from skore._project.project import Project
 from skore._sklearn import (
@@ -83,8 +82,6 @@ __all__ = [
     "RocCurveDisplay",
     "CalibrationDisplay",
     "Summary",
-    "SyncOperation",
-    "SyncResult",
     "TableReportDisplay",
     "TrainTestSplit",
     "compare",

--- a/skore/src/skore/__init__.py
+++ b/skore/src/skore/__init__.py
@@ -16,6 +16,7 @@ from rich.theme import Theme
 from skore._config import configuration
 from skore._externals._sklearn_compat import parse_version
 from skore._project._summary import Summary
+from skore._project._sync import SyncOperation, SyncResult
 from skore._project.login import login
 from skore._project.project import Project
 from skore._sklearn import (
@@ -82,6 +83,8 @@ __all__ = [
     "RocCurveDisplay",
     "CalibrationDisplay",
     "Summary",
+    "SyncOperation",
+    "SyncResult",
     "TableReportDisplay",
     "TrainTestSplit",
     "compare",

--- a/skore/src/skore/_plugins/local/project.py
+++ b/skore/src/skore/_plugins/local/project.py
@@ -481,12 +481,10 @@ class Project:
 
     def get(self, report_id: str) -> EstimatorReport | CrossValidationReport:
         """Get a persisted report by its ID."""
-        report_path = next(
-            iter((self.path / "reports").glob(f"*__id_{report_id}__*")), None
-        )
-        if report_path is None:
+        report_paths = sorted((self.path / "reports").glob(f"*__id_{report_id}__*"))
+        if not report_paths:
             raise KeyError(report_id)
-        return read_report(report_path)
+        return read_report(report_paths[-1])
 
     def summarize(self) -> list[dict[str, Any]]:
         """Obtain metadata/metrics for all persisted reports."""

--- a/skore/src/skore/_project/_sync.py
+++ b/skore/src/skore/_project/_sync.py
@@ -7,25 +7,14 @@ from typing import TYPE_CHECKING, Literal, cast
 from pandas import NA, DataFrame, Index, concat
 
 if TYPE_CHECKING:
-    from typing import Any, Protocol
-
-    class _Summary(Protocol):
-        def frame(self) -> DataFrame: ...
-
-    class _Project(Protocol):
-        def summarize(self) -> _Summary: ...
-
-        def get(self, id: str) -> Any: ...
-
-        def put(self, key: str, report: Any) -> Any: ...
+    from skore._project.project import Project
 
 
-_Direction = Literal["outbound", "inbound"]
-_Status = Literal["planned", "transferred", "skipped"]
-_RESULT_COLUMNS = ("key", "direction", "status")
+Direction = Literal["outbound", "inbound"]
+Status = Literal["planned", "transferred", "skipped"]
 
 
-def _snapshot(project: _Project) -> DataFrame:
+def _snapshot(project: Project) -> DataFrame:
     frame = project.summarize().frame()
     if frame.empty or "report_id" not in frame:
         # Treat legacy summaries from before `report_id` was stored as empty snapshots.
@@ -45,34 +34,36 @@ def _snapshot(project: _Project) -> DataFrame:
 
 def _transfer(
     reports: DataFrame,
-    source: _Project,
-    destination: _Project,
-    direction: _Direction,
+    source: Project,
+    destination: Project,
 ) -> None:
     for report_id, row in reports.iterrows():
         try:
             report = source.get(cast(str, row["backend_id"]))
             destination.put(cast(str, row["key"]), report)
         except Exception as exc:
-            exc.add_note(f"Failed to synchronize report {report_id!r} {direction}.")
+            exc.add_note(
+                f"Failed to synchronize report {report_id!r} "
+                f"from {source} to {destination}."
+            )
             raise
 
 
-def _result(
+def _build_result_frame(
     reports: DataFrame,
     *,
-    direction: _Direction | None,
-    status: _Status,
+    direction: Direction | None,
+    status: Status,
 ) -> DataFrame:
-    result = reports.loc[:, ["key"]].copy()
+    result = reports.loc[:, ["key"]]
     result["direction"] = NA if direction is None else direction
     result["status"] = status
     return result
 
 
 def synchronize(
-    source: _Project,
-    destination: _Project,
+    source: Project,
+    destination: Project,
     *,
     bidirectional: bool,
     dry_run: bool,
@@ -81,28 +72,41 @@ def synchronize(
     source_reports = _snapshot(source)
     destination_reports = _snapshot(destination)
 
-    outbound = source_reports.loc[
+    outbound_reports = source_reports.loc[
         source_reports.index.difference(destination_reports.index, sort=False)
     ]
-    inbound = destination_reports.loc[
+    inbound_reports = destination_reports.loc[
         destination_reports.index.difference(source_reports.index, sort=False)
     ]
-    skipped = source_reports.loc[
+    skipped_reports = source_reports.loc[
         source_reports.index.intersection(destination_reports.index, sort=False)
     ]
 
     if not dry_run:
-        _transfer(outbound, source, destination, "outbound")
+        _transfer(outbound_reports, source, destination)
         if bidirectional:
-            _transfer(inbound, destination, source, "inbound")
+            _transfer(inbound_reports, destination, source)
 
-    transfer_status: _Status = "planned" if dry_run else "transferred"
+    transfer_status: Status = "planned" if dry_run else "transferred"
     frames = [
-        _result(outbound, direction="outbound", status=transfer_status),
+        _build_result_frame(
+            outbound_reports,
+            direction="outbound",
+            status=transfer_status,
+        ),
     ]
     if bidirectional:
-        frames.append(_result(inbound, direction="inbound", status=transfer_status))
-    frames.append(_result(skipped, direction=None, status="skipped"))
+        frames.append(
+            _build_result_frame(
+                inbound_reports,
+                direction="inbound",
+                status=transfer_status,
+            )
+        )
+    frames.append(
+        _build_result_frame(skipped_reports, direction=None, status="skipped")
+    )
 
-    result = concat(frames).reindex(columns=_RESULT_COLUMNS).rename_axis("report_id")
+    result = concat(frames).reindex(columns=["key", "direction", "status"])
+    result = result.rename_axis("report_id")
     return cast(DataFrame, result.astype("string"))

--- a/skore/src/skore/_project/_sync.py
+++ b/skore/src/skore/_project/_sync.py
@@ -1,131 +1,52 @@
-"""Cross-mode project synchronization."""
+"""Project synchronization."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from pandas import isna
-
-from skore._project.types import ProjectMode
+from pandas import NA, DataFrame, concat
 
 if TYPE_CHECKING:
     from skore._project.project import Project
 
 
-@dataclass(frozen=True)
-class SyncOperation:
-    """A report transfer in a synchronization result.
-
-    Parameters
-    ----------
-    report_id : str
-        Canonical Skore report ID.
-    key : str
-        Source key used when storing the report at the destination.
-    source_mode : {"hub", "local", "mlflow"}
-        Storage mode from which the report is loaded.
-    destination_mode : {"hub", "local", "mlflow"}
-        Storage mode in which the report is stored.
-    """
-
-    report_id: str
-    key: str
-    source_mode: ProjectMode
-    destination_mode: ProjectMode
+_RESULT_COLUMNS = ["key", "direction", "status"]
 
 
-@dataclass(frozen=True)
-class SyncResult:
-    """The planned or completed operations of a project synchronization.
-
-    Parameters
-    ----------
-    operations : tuple of SyncOperation
-        Planned operations for a dry-run, otherwise completed operations.
-    skipped : tuple of str
-        Canonical report IDs already present in both projects.
-    dry_run : bool
-        Whether the operations were only planned.
-    """
-
-    operations: tuple[SyncOperation, ...]
-    skipped: tuple[str, ...]
-    dry_run: bool
-
-
-@dataclass(frozen=True)
-class _ReportRef:
-    report_id: str
-    backend_id: str
-    key: str
-
-
-@dataclass(frozen=True)
-class _Transfer:
-    operation: SyncOperation
-    source: Project
-    destination: Project
-    backend_id: str
-
-
-def _snapshot(project: Project) -> dict[str, _ReportRef]:
+def _snapshot(project: Project) -> DataFrame:
     frame = project.summarize().frame()
     if frame.empty:
-        return {}
+        return DataFrame(columns=["backend_id", "key"]).rename_axis("report_id")
 
-    reports: dict[str, _ReportRef] = {}
-    missing_backend_ids: list[str] = []
-
-    for backend_id, row in zip(
-        frame.index.get_level_values("id"), frame.to_dict("records"), strict=True
-    ):
-        report_id = row.get("report_id")
-        if report_id is None or isna(report_id):
-            missing_backend_ids.append(str(backend_id))
-            continue
-
-        report_id = str(report_id)
-        # Summaries are ordered by date. Reinsert duplicate IDs so the latest stored
-        # copy also determines transfer order and the key used at the destination.
-        reports.pop(report_id, None)
-        reports[report_id] = _ReportRef(
-            report_id=report_id,
-            backend_id=str(backend_id),
-            key=str(row["key"]),
-        )
-
-    if missing_backend_ids:
-        raise ValueError(
-            f"Cannot synchronize project {project.name!r} in {project.mode!r} mode "
-            "because these reports have no canonical `report_id`: "
-            f"{missing_backend_ids}."
-        )
-
-    return reports
+    return (
+        frame.reset_index("id")
+        .rename(columns={"id": "backend_id"})
+        .dropna(subset=["report_id"])
+        .drop_duplicates(subset=["report_id"], keep="last")
+        .set_index("report_id")
+    )
 
 
-def _transfers(
+def _transfer(
+    reports: DataFrame,
     source: Project,
     destination: Project,
-    source_reports: dict[str, _ReportRef],
-    destination_reports: dict[str, _ReportRef],
-) -> list[_Transfer]:
-    return [
-        _Transfer(
-            operation=SyncOperation(
-                report_id=report.report_id,
-                key=report.key,
-                source_mode=source.mode,
-                destination_mode=destination.mode,
-            ),
-            source=source,
-            destination=destination,
-            backend_id=report.backend_id,
-        )
-        for report_id, report in source_reports.items()
-        if report_id not in destination_reports
-    ]
+    direction: str,
+) -> None:
+    for report_id, row in reports.iterrows():
+        try:
+            report = source.get(row["backend_id"])
+            destination.put(row["key"], report)
+        except Exception as exc:
+            exc.add_note(f"Failed to synchronize report {report_id!r} {direction}.")
+            raise
+
+
+def _result(reports: DataFrame, *, direction: str | None, status: str) -> DataFrame:
+    result = reports.loc[:, ["key"]].copy()
+    result["direction"] = NA if direction is None else direction
+    result["status"] = status
+    return result
 
 
 def synchronize(
@@ -134,59 +55,32 @@ def synchronize(
     *,
     bidirectional: bool,
     dry_run: bool,
-) -> SyncResult:
-    """Synchronize two projects using canonical report IDs."""
+) -> DataFrame:
+    """Synchronize two projects using report IDs."""
     source_reports = _snapshot(source)
     destination_reports = _snapshot(destination)
 
-    if (
-        source.ml_task is not None
-        and destination.ml_task is not None
-        and source.ml_task != destination.ml_task
-    ):
-        raise ValueError(
-            "Cannot synchronize projects with different ML tasks: "
-            f"{source.ml_task!r} and {destination.ml_task!r}."
-        )
-
-    transfers = _transfers(
-        source,
-        destination,
-        source_reports,
-        destination_reports,
-    )
-    if bidirectional:
-        transfers.extend(
-            _transfers(
-                destination,
-                source,
-                destination_reports,
-                source_reports,
-            )
-        )
-
-    operations = tuple(transfer.operation for transfer in transfers)
-    skipped = tuple(
-        report_id for report_id in source_reports if report_id in destination_reports
-    )
+    outbound = source_reports.loc[
+        source_reports.index.difference(destination_reports.index, sort=False)
+    ]
+    inbound = destination_reports.loc[
+        destination_reports.index.difference(source_reports.index, sort=False)
+    ]
+    skipped = source_reports.loc[
+        source_reports.index.intersection(destination_reports.index, sort=False)
+    ]
 
     if not dry_run:
-        for transfer in transfers:
-            try:
-                report = transfer.source.get(transfer.backend_id)
-                if str(report.id) != transfer.operation.report_id:
-                    raise RuntimeError(
-                        "The loaded report ID does not match its project summary: "
-                        f"expected {transfer.operation.report_id!r}, got "
-                        f"{str(report.id)!r}."
-                    )
-                transfer.destination.put(transfer.operation.key, report)
-            except Exception as exc:
-                exc.add_note(
-                    f"Failed to synchronize report {transfer.operation.report_id!r} "
-                    f"from {transfer.operation.source_mode!r} to "
-                    f"{transfer.operation.destination_mode!r}."
-                )
-                raise
+        _transfer(outbound, source, destination, "outbound")
+        if bidirectional:
+            _transfer(inbound, destination, source, "inbound")
 
-    return SyncResult(operations=operations, skipped=skipped, dry_run=dry_run)
+    transfer_status = "planned" if dry_run else "transferred"
+    frames = [
+        _result(outbound, direction="outbound", status=transfer_status),
+    ]
+    if bidirectional:
+        frames.append(_result(inbound, direction="inbound", status=transfer_status))
+    frames.append(_result(skipped, direction=None, status="skipped"))
+
+    return concat(frames)[_RESULT_COLUMNS].rename_axis("report_id")

--- a/skore/src/skore/_project/_sync.py
+++ b/skore/src/skore/_project/_sync.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, cast
 
-from pandas import NA, DataFrame, Index, concat
+import pandas as pd
 
 if TYPE_CHECKING:
     from skore._project.project import Project
@@ -14,13 +14,13 @@ Direction = Literal["outbound", "inbound"]
 Status = Literal["planned", "transferred", "skipped"]
 
 
-def _snapshot(project: Project) -> DataFrame:
+def _snapshot(project: Project) -> pd.DataFrame:
     frame = project.summarize().frame()
     if frame.empty or "report_id" not in frame:
         # Treat legacy summaries from before `report_id` was stored as empty snapshots.
-        return DataFrame(
-            index=Index([], name="report_id", dtype=object),
-            columns=Index(["backend_id", "key"]),
+        return pd.DataFrame(
+            index=pd.Index([], name="report_id", dtype=object),
+            columns=pd.Index(["backend_id", "key"]),
         )
 
     return (
@@ -33,7 +33,7 @@ def _snapshot(project: Project) -> DataFrame:
 
 
 def _transfer(
-    reports: DataFrame,
+    reports: pd.DataFrame,
     source: Project,
     destination: Project,
 ) -> None:
@@ -50,13 +50,13 @@ def _transfer(
 
 
 def _build_result_frame(
-    reports: DataFrame,
+    reports: pd.DataFrame,
     *,
     direction: Direction | None,
     status: Status,
-) -> DataFrame:
+) -> pd.DataFrame:
     result = reports.loc[:, ["key"]]
-    result["direction"] = NA if direction is None else direction
+    result["direction"] = pd.NA if direction is None else direction
     result["status"] = status
     return result
 
@@ -67,7 +67,7 @@ def synchronize(
     *,
     bidirectional: bool,
     dry_run: bool,
-) -> DataFrame:
+) -> pd.DataFrame:
     """Synchronize two projects using report IDs."""
     source_reports = _snapshot(source)
     destination_reports = _snapshot(destination)
@@ -107,6 +107,6 @@ def synchronize(
         _build_result_frame(skipped_reports, direction=None, status="skipped")
     )
 
-    result = concat(frames).reindex(columns=["key", "direction", "status"])
+    result = pd.concat(frames).reindex(columns=["key", "direction", "status"])
     result = result.rename_axis("report_id")
-    return cast(DataFrame, result.astype("string"))
+    return cast(pd.DataFrame, result.astype("string"))

--- a/skore/src/skore/_project/_sync.py
+++ b/skore/src/skore/_project/_sync.py
@@ -1,0 +1,192 @@
+"""Cross-mode project synchronization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pandas import isna
+
+from skore._project.types import ProjectMode
+
+if TYPE_CHECKING:
+    from skore._project.project import Project
+
+
+@dataclass(frozen=True)
+class SyncOperation:
+    """A report transfer in a synchronization result.
+
+    Parameters
+    ----------
+    report_id : str
+        Canonical Skore report ID.
+    key : str
+        Source key used when storing the report at the destination.
+    source_mode : {"hub", "local", "mlflow"}
+        Storage mode from which the report is loaded.
+    destination_mode : {"hub", "local", "mlflow"}
+        Storage mode in which the report is stored.
+    """
+
+    report_id: str
+    key: str
+    source_mode: ProjectMode
+    destination_mode: ProjectMode
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """The planned or completed operations of a project synchronization.
+
+    Parameters
+    ----------
+    operations : tuple of SyncOperation
+        Planned operations for a dry-run, otherwise completed operations.
+    skipped : tuple of str
+        Canonical report IDs already present in both projects.
+    dry_run : bool
+        Whether the operations were only planned.
+    """
+
+    operations: tuple[SyncOperation, ...]
+    skipped: tuple[str, ...]
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class _ReportRef:
+    report_id: str
+    backend_id: str
+    key: str
+
+
+@dataclass(frozen=True)
+class _Transfer:
+    operation: SyncOperation
+    source: Project
+    destination: Project
+    backend_id: str
+
+
+def _snapshot(project: Project) -> dict[str, _ReportRef]:
+    frame = project.summarize().frame()
+    if frame.empty:
+        return {}
+
+    reports: dict[str, _ReportRef] = {}
+    missing_backend_ids: list[str] = []
+
+    for backend_id, row in zip(
+        frame.index.get_level_values("id"), frame.to_dict("records"), strict=True
+    ):
+        report_id = row.get("report_id")
+        if report_id is None or isna(report_id):
+            missing_backend_ids.append(str(backend_id))
+            continue
+
+        report_id = str(report_id)
+        # Summaries are ordered by date. Reinsert duplicate IDs so the latest stored
+        # copy also determines transfer order and the key used at the destination.
+        reports.pop(report_id, None)
+        reports[report_id] = _ReportRef(
+            report_id=report_id,
+            backend_id=str(backend_id),
+            key=str(row["key"]),
+        )
+
+    if missing_backend_ids:
+        raise ValueError(
+            f"Cannot synchronize project {project.name!r} in {project.mode!r} mode "
+            "because these reports have no canonical `report_id`: "
+            f"{missing_backend_ids}."
+        )
+
+    return reports
+
+
+def _transfers(
+    source: Project,
+    destination: Project,
+    source_reports: dict[str, _ReportRef],
+    destination_reports: dict[str, _ReportRef],
+) -> list[_Transfer]:
+    return [
+        _Transfer(
+            operation=SyncOperation(
+                report_id=report.report_id,
+                key=report.key,
+                source_mode=source.mode,
+                destination_mode=destination.mode,
+            ),
+            source=source,
+            destination=destination,
+            backend_id=report.backend_id,
+        )
+        for report_id, report in source_reports.items()
+        if report_id not in destination_reports
+    ]
+
+
+def synchronize(
+    source: Project,
+    destination: Project,
+    *,
+    bidirectional: bool,
+    dry_run: bool,
+) -> SyncResult:
+    """Synchronize two projects using canonical report IDs."""
+    source_reports = _snapshot(source)
+    destination_reports = _snapshot(destination)
+
+    if (
+        source.ml_task is not None
+        and destination.ml_task is not None
+        and source.ml_task != destination.ml_task
+    ):
+        raise ValueError(
+            "Cannot synchronize projects with different ML tasks: "
+            f"{source.ml_task!r} and {destination.ml_task!r}."
+        )
+
+    transfers = _transfers(
+        source,
+        destination,
+        source_reports,
+        destination_reports,
+    )
+    if bidirectional:
+        transfers.extend(
+            _transfers(
+                destination,
+                source,
+                destination_reports,
+                source_reports,
+            )
+        )
+
+    operations = tuple(transfer.operation for transfer in transfers)
+    skipped = tuple(
+        report_id for report_id in source_reports if report_id in destination_reports
+    )
+
+    if not dry_run:
+        for transfer in transfers:
+            try:
+                report = transfer.source.get(transfer.backend_id)
+                if str(report.id) != transfer.operation.report_id:
+                    raise RuntimeError(
+                        "The loaded report ID does not match its project summary: "
+                        f"expected {transfer.operation.report_id!r}, got "
+                        f"{str(report.id)!r}."
+                    )
+                transfer.destination.put(transfer.operation.key, report)
+            except Exception as exc:
+                exc.add_note(
+                    f"Failed to synchronize report {transfer.operation.report_id!r} "
+                    f"from {transfer.operation.source_mode!r} to "
+                    f"{transfer.operation.destination_mode!r}."
+                )
+                raise
+
+    return SyncResult(operations=operations, skipped=skipped, dry_run=dry_run)

--- a/skore/src/skore/_project/_sync.py
+++ b/skore/src/skore/_project/_sync.py
@@ -68,7 +68,7 @@ def synchronize(
     bidirectional: bool,
     dry_run: bool,
 ) -> pd.DataFrame:
-    """Synchronize two projects using report IDs."""
+    """Synchronize two projects."""
     source_reports = _snapshot(source)
     destination_reports = _snapshot(destination)
 

--- a/skore/src/skore/_project/_sync.py
+++ b/skore/src/skore/_project/_sync.py
@@ -2,21 +2,37 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
-from pandas import NA, DataFrame, concat
+from pandas import NA, DataFrame, Index, concat
 
 if TYPE_CHECKING:
-    from skore._project.project import Project
+    from typing import Any, Protocol
+
+    class _Summary(Protocol):
+        def frame(self) -> DataFrame: ...
+
+    class _Project(Protocol):
+        def summarize(self) -> _Summary: ...
+
+        def get(self, id: str) -> Any: ...
+
+        def put(self, key: str, report: Any) -> Any: ...
 
 
-_RESULT_COLUMNS = ["key", "direction", "status"]
+_Direction = Literal["outbound", "inbound"]
+_Status = Literal["planned", "transferred", "skipped"]
+_RESULT_COLUMNS = ("key", "direction", "status")
 
 
-def _snapshot(project: Project) -> DataFrame:
+def _snapshot(project: _Project) -> DataFrame:
     frame = project.summarize().frame()
-    if frame.empty:
-        return DataFrame(columns=["backend_id", "key"]).rename_axis("report_id")
+    if frame.empty or "report_id" not in frame:
+        # Treat legacy summaries from before `report_id` was stored as empty snapshots.
+        return DataFrame(
+            index=Index([], name="report_id", dtype=object),
+            columns=Index(["backend_id", "key"]),
+        )
 
     return (
         frame.reset_index("id")
@@ -29,20 +45,25 @@ def _snapshot(project: Project) -> DataFrame:
 
 def _transfer(
     reports: DataFrame,
-    source: Project,
-    destination: Project,
-    direction: str,
+    source: _Project,
+    destination: _Project,
+    direction: _Direction,
 ) -> None:
     for report_id, row in reports.iterrows():
         try:
-            report = source.get(row["backend_id"])
-            destination.put(row["key"], report)
+            report = source.get(cast(str, row["backend_id"]))
+            destination.put(cast(str, row["key"]), report)
         except Exception as exc:
             exc.add_note(f"Failed to synchronize report {report_id!r} {direction}.")
             raise
 
 
-def _result(reports: DataFrame, *, direction: str | None, status: str) -> DataFrame:
+def _result(
+    reports: DataFrame,
+    *,
+    direction: _Direction | None,
+    status: _Status,
+) -> DataFrame:
     result = reports.loc[:, ["key"]].copy()
     result["direction"] = NA if direction is None else direction
     result["status"] = status
@@ -50,8 +71,8 @@ def _result(reports: DataFrame, *, direction: str | None, status: str) -> DataFr
 
 
 def synchronize(
-    source: Project,
-    destination: Project,
+    source: _Project,
+    destination: _Project,
     *,
     bidirectional: bool,
     dry_run: bool,
@@ -75,7 +96,7 @@ def synchronize(
         if bidirectional:
             _transfer(inbound, destination, source, "inbound")
 
-    transfer_status = "planned" if dry_run else "transferred"
+    transfer_status: _Status = "planned" if dry_run else "transferred"
     frames = [
         _result(outbound, direction="outbound", status=transfer_status),
     ]
@@ -83,4 +104,5 @@ def synchronize(
         frames.append(_result(inbound, direction="inbound", status=transfer_status))
     frames.append(_result(skipped, direction=None, status="skipped"))
 
-    return concat(frames)[_RESULT_COLUMNS].rename_axis("report_id")
+    result = concat(frames).reindex(columns=_RESULT_COLUMNS).rename_axis("report_id")
+    return cast(DataFrame, result.astype("string"))

--- a/skore/src/skore/_project/project.py
+++ b/skore/src/skore/_project/project.py
@@ -9,7 +9,7 @@ from pandas import DataFrame, Index, MultiIndex, RangeIndex
 
 from skore._project import plugin
 from skore._project._summary import Summary
-from skore._project._sync import SyncResult, synchronize
+from skore._project._sync import synchronize
 from skore._project.dependencies import assert_optional_dependencies_installed
 from skore._project.types import ProjectMode
 
@@ -31,7 +31,7 @@ class Project:
     :func:`~skore.Project.summarize`, :func:`~skore.Project.get`, and
     :func:`~skore.Project.sync`, respectively to insert a key-report pair into the
     project, obtain the metadata/metrics of the inserted reports, get a specific report
-    by its id, and synchronize reports across storage modes.
+    by its id, and synchronize reports between projects.
 
     Three mutually exclusive modes are available and can be configured using the
     ``mode`` parameter of the constructor:
@@ -381,42 +381,33 @@ class Project:
         *,
         bidirectional: bool = False,
         dry_run: bool = False,
-    ) -> SyncResult:
+    ) -> DataFrame:
         """Copy missing reports to another project.
 
-        Reports are matched by canonical ID. Set ``bidirectional=True`` to copy missing
+        Reports are matched using the ``report_id`` column returned by
+        ``Project.summarize().frame()``. Set ``bidirectional=True`` to copy missing
         reports in both directions.
 
         Parameters
         ----------
         other : Project
-            Destination project. It must have the same name as this project and use a
-            different storage mode.
+            Destination project.
         bidirectional : bool, default=False
             If ``False``, transfer reports from this project to ``other``. If ``True``,
-            also transfer reports missing from this project. Both differences are
-            computed before any transfer.
+            also transfer reports missing from this project.
         dry_run : bool, default=False
             Return the planned operations without loading or storing reports.
 
         Returns
         -------
-        result : SyncResult
-            Planned operations when ``dry_run=True``, otherwise completed operations,
-            together with canonical IDs already present in both projects.
+        result : pandas.DataFrame
+            Synchronization status indexed by ``report_id``. The ``direction`` column
+            is ``"outbound"`` from this project to ``other``, ``"inbound"`` from
+            ``other`` to this project, or missing for skipped reports. The ``status``
+            column is ``"planned"``, ``"transferred"``, or ``"skipped"``.
         """
         if not isinstance(other, Project):
             raise TypeError(f"`other` must be a Project (found {type(other)!r}).")
-        if other.name != self.name:
-            raise ValueError(
-                "Synchronization requires projects with the same name "
-                f"(found {self.name!r} and {other.name!r})."
-            )
-        if other.mode == self.mode:
-            raise ValueError(
-                "Synchronization requires two different project modes "
-                f"(both were {self.mode!r})."
-            )
 
         return synchronize(
             self,

--- a/skore/src/skore/_project/project.py
+++ b/skore/src/skore/_project/project.py
@@ -213,7 +213,7 @@ class Project:
         """
         plugin, parameters = Project.__setup_plugin(mode, name, **kwargs)
 
-        self.__mode = mode
+        self.__mode: ProjectMode = mode
         self.__project = plugin(**parameters)
 
         ml_tasks = {report["ml_task"] for report in self.__project.summarize()}
@@ -408,6 +408,16 @@ class Project:
         """
         if not isinstance(other, Project):
             raise TypeError(f"`other` must be a Project (found {type(other)!r}).")
+        if (
+            self.mode == other.mode == "mlflow"
+            and self.tracking_uri != other.tracking_uri
+        ):
+            # MLflow uses process-global tracking state. Crossing stores could
+            # therefore read from or write to the wrong backend.
+            raise ValueError(
+                "Synchronization between MLflow projects requires the same "
+                "tracking URI."
+            )
 
         return synchronize(
             self,

--- a/skore/src/skore/_project/project.py
+++ b/skore/src/skore/_project/project.py
@@ -9,6 +9,7 @@ from pandas import DataFrame, Index, MultiIndex, RangeIndex
 
 from skore._project import plugin
 from skore._project._summary import Summary
+from skore._project._sync import SyncResult, synchronize
 from skore._project.dependencies import assert_optional_dependencies_installed
 from skore._project.types import ProjectMode
 
@@ -27,9 +28,10 @@ class Project:
     existing one.
 
     The class main methods are :func:`~skore.Project.put`,
-    :func:`~skore.Project.summarize` and :func:`~skore.Project.get`, respectively to
-    insert a key-report pair into the project, to obtain the metadata/metrics of the
-    inserted reports and to get a specific report by its id.
+    :func:`~skore.Project.summarize`, :func:`~skore.Project.get`, and
+    :func:`~skore.Project.sync`, respectively to insert a key-report pair into the
+    project, obtain the metadata/metrics of the inserted reports, get a specific report
+    by its id, and synchronize reports across storage modes.
 
     Three mutually exclusive modes are available and can be configured using the
     ``mode`` parameter of the constructor:
@@ -372,6 +374,56 @@ class Project:
                 ]
             )
         return Summary(frame, self.__project)
+
+    def sync(
+        self,
+        other: Project,
+        *,
+        bidirectional: bool = False,
+        dry_run: bool = False,
+    ) -> SyncResult:
+        """Copy missing reports to another project.
+
+        Reports are matched by canonical ID. Set ``bidirectional=True`` to copy missing
+        reports in both directions.
+
+        Parameters
+        ----------
+        other : Project
+            Destination project. It must have the same name as this project and use a
+            different storage mode.
+        bidirectional : bool, default=False
+            If ``False``, transfer reports from this project to ``other``. If ``True``,
+            also transfer reports missing from this project. Both differences are
+            computed before any transfer.
+        dry_run : bool, default=False
+            Return the planned operations without loading or storing reports.
+
+        Returns
+        -------
+        result : SyncResult
+            Planned operations when ``dry_run=True``, otherwise completed operations,
+            together with canonical IDs already present in both projects.
+        """
+        if not isinstance(other, Project):
+            raise TypeError(f"`other` must be a Project (found {type(other)!r}).")
+        if other.name != self.name:
+            raise ValueError(
+                "Synchronization requires projects with the same name "
+                f"(found {self.name!r} and {other.name!r})."
+            )
+        if other.mode == self.mode:
+            raise ValueError(
+                "Synchronization requires two different project modes "
+                f"(both were {self.mode!r})."
+            )
+
+        return synchronize(
+            self,
+            other,
+            bidirectional=bidirectional,
+            dry_run=dry_run,
+        )
 
     def __repr__(self) -> str:  # noqa: D105
         return self.__project.__repr__()

--- a/skore/tests/unit/plugins/local/test_project.py
+++ b/skore/tests/unit/plugins/local/test_project.py
@@ -123,6 +123,22 @@ def test_put_get_summarize(tmp_path, regression, regression_dummy, cv_regression
     assert Path(next(iter(summary))["local_path"]).is_relative_to(tmp_path)
 
 
+def test_get_uses_last_summary_entry_for_duplicate_id(tmp_path, monkeypatch):
+    project = Project(name="regression", workspace=tmp_path)
+    reports_path = project.path / "reports"
+    first = reports_path / "2026-01-01__id_shared__estimator__first"
+    last = reports_path / "2026-01-01__id_shared__estimator__last"
+    first.mkdir()
+    last.mkdir()
+    monkeypatch.setattr(
+        skore._plugins.local.project,
+        "read_report",
+        lambda path: Path(path).name,
+    )
+
+    assert project.get("shared") == last.name
+
+
 def test_permutation_importances(tmp_path, regression_dummy):
     project = Project(name="regression", workspace=tmp_path)
     importances = regression_dummy.inspection.permutation_importance().frame()

--- a/skore/tests/unit/plugins/mlflow/test_project.py
+++ b/skore/tests/unit/plugins/mlflow/test_project.py
@@ -144,6 +144,18 @@ class TestProject:
             == second._Project__storage_experiment_id
         )
 
+    def test_init_existing_project_with_sql_tracking_uri(self, tmp_path):
+        tracking_uri = f"sqlite:///{tmp_path}/existing-mlflow.db"
+
+        first = Project("<project>", tracking_uri=tracking_uri)
+        second = Project("<project>", tracking_uri=tracking_uri)
+
+        assert first.experiment_id == second.experiment_id
+        assert (
+            first._Project__storage_experiment_id
+            == second._Project__storage_experiment_id
+        )
+
     @pytest.mark.parametrize(
         ("report_fixture", "expected_ml_task", "expected_metric", "expected_artifacts"),
         [

--- a/skore/tests/unit/plugins/mlflow/test_project.py
+++ b/skore/tests/unit/plugins/mlflow/test_project.py
@@ -144,8 +144,11 @@ class TestProject:
             == second._Project__storage_experiment_id
         )
 
-    def test_init_existing_project_with_sql_tracking_uri(self, tmp_path):
-        tracking_uri = f"sqlite:///{tmp_path}/existing-mlflow.db"
+    @pytest.mark.filterwarnings(
+        "ignore:The filesystem tracking backend .* is deprecated:FutureWarning"
+    )
+    def test_init_existing_project_with_file_tracking_uri(self, tmp_path):
+        tracking_uri = (tmp_path / "existing-mlflow").as_uri()
 
         first = Project("<project>", tracking_uri=tracking_uri)
         second = Project("<project>", tracking_uri=tracking_uri)

--- a/skore/tests/unit/plugins/mlflow/test_project.py
+++ b/skore/tests/unit/plugins/mlflow/test_project.py
@@ -144,11 +144,8 @@ class TestProject:
             == second._Project__storage_experiment_id
         )
 
-    @pytest.mark.filterwarnings(
-        "ignore:The filesystem tracking backend .* is deprecated:FutureWarning"
-    )
-    def test_init_existing_project_with_file_tracking_uri(self, tmp_path):
-        tracking_uri = (tmp_path / "existing-mlflow").as_uri()
+    def test_init_reuses_existing_project(self, mlflow_tracking_uri):
+        tracking_uri = mlflow_tracking_uri()
 
         first = Project("<project>", tracking_uri=tracking_uri)
         second = Project("<project>", tracking_uri=tracking_uri)

--- a/skore/tests/unit/project/test_project.py
+++ b/skore/tests/unit/project/test_project.py
@@ -451,6 +451,21 @@ class TestProject:
 
         assert result.empty
 
+    def test_sync_rejects_mlflow_projects_with_different_tracking_uris(self):
+        project = Project(name="<name>", mode="mlflow", tracking_uri="<left>")
+        other = Project(name="<name>", mode="mlflow", tracking_uri="<right>")
+
+        with raises(ValueError, match="requires the same tracking URI"):
+            project.sync(other, dry_run=True)
+
+    def test_sync_allows_mlflow_projects_with_same_tracking_uri(self):
+        project = Project(name="<name>", mode="mlflow", tracking_uri="<uri>")
+        other = Project(name="<other>", mode="mlflow", tracking_uri="<uri>")
+
+        result = project.sync(other, dry_run=True)
+
+        assert result.empty
+
     def test_repr(self):
         project = Project(name="<name>", mode="local")
         assert repr(project) == repr(project._Project__project)

--- a/skore/tests/unit/project/test_project.py
+++ b/skore/tests/unit/project/test_project.py
@@ -9,7 +9,7 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
 
-from skore import CrossValidationReport, EstimatorReport, Project
+from skore import CrossValidationReport, EstimatorReport, Project, SyncResult
 from skore._project._summary import Summary
 
 
@@ -415,6 +415,38 @@ class TestProject:
         shell = InteractiveShell.instance()
         execution_result = shell.run_cell(snippet, silent=True)
         execution_result.raise_error()
+
+    def test_sync_uses_existing_counterpart(self, FakeHubProject, monkeypatch):
+        monkeypatch.setattr("skore._project.dependencies.requires", lambda _: [])
+        project = Project(name="<name>", mode="local", workspace="<local>")
+        other = Project(name="<name>", mode="hub", workspace="<hub>")
+        calls_before_sync = FakeHubProject.call_count
+
+        result = project.sync(other, dry_run=True)
+
+        assert isinstance(result, SyncResult)
+        assert result.dry_run is True
+        assert FakeHubProject.call_count == calls_before_sync
+
+    def test_sync_rejects_non_project(self):
+        project = Project(name="<name>", mode="local")
+
+        with raises(TypeError, match="`other` must be a Project"):
+            project.sync("hub", dry_run=True)
+
+    def test_sync_rejects_different_name(self):
+        project = Project(name="<name>", mode="local", workspace="<local>")
+        other = Project(name="<other>", mode="hub", workspace="<hub>")
+
+        with raises(ValueError, match="projects with the same name"):
+            project.sync(other, dry_run=True)
+
+    def test_sync_rejects_same_mode(self):
+        project = Project(name="<name>", mode="local", workspace="<left>")
+        other = Project(name="<name>", mode="local", workspace="<right>")
+
+        with raises(ValueError, match="two different project modes"):
+            project.sync(other, dry_run=True)
 
     def test_repr(self):
         project = Project(name="<name>", mode="local")

--- a/skore/tests/unit/project/test_project.py
+++ b/skore/tests/unit/project/test_project.py
@@ -3,13 +3,13 @@ from re import escape
 from unittest.mock import Mock
 from uuid import uuid4
 
-from pandas import Timestamp
+from pandas import DataFrame, Timestamp
 from pytest import fixture, mark, param, raises
 from sklearn.datasets import make_classification, make_regression
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
 
-from skore import CrossValidationReport, EstimatorReport, Project, SyncResult
+from skore import CrossValidationReport, EstimatorReport, Project
 from skore._project._summary import Summary
 
 
@@ -424,8 +424,9 @@ class TestProject:
 
         result = project.sync(other, dry_run=True)
 
-        assert isinstance(result, SyncResult)
-        assert result.dry_run is True
+        assert isinstance(result, DataFrame)
+        assert result.columns.tolist() == ["key", "direction", "status"]
+        assert result.empty
         assert FakeHubProject.call_count == calls_before_sync
 
     def test_sync_rejects_non_project(self):
@@ -434,19 +435,21 @@ class TestProject:
         with raises(TypeError, match="`other` must be a Project"):
             project.sync("hub", dry_run=True)
 
-    def test_sync_rejects_different_name(self):
+    def test_sync_allows_different_names(self):
         project = Project(name="<name>", mode="local", workspace="<local>")
         other = Project(name="<other>", mode="hub", workspace="<hub>")
 
-        with raises(ValueError, match="projects with the same name"):
-            project.sync(other, dry_run=True)
+        result = project.sync(other, dry_run=True)
 
-    def test_sync_rejects_same_mode(self):
+        assert result.empty
+
+    def test_sync_allows_same_mode(self):
         project = Project(name="<name>", mode="local", workspace="<left>")
         other = Project(name="<name>", mode="local", workspace="<right>")
 
-        with raises(ValueError, match="two different project modes"):
-            project.sync(other, dry_run=True)
+        result = project.sync(other, dry_run=True)
+
+        assert result.empty
 
     def test_repr(self):
         project = Project(name="<name>", mode="local")

--- a/skore/tests/unit/project/test_sync.py
+++ b/skore/tests/unit/project/test_sync.py
@@ -4,8 +4,8 @@ from typing import cast
 from unittest.mock import Mock
 
 import mlflow
+import pandas as pd
 import pytest
-from pandas import NA, DataFrame, Index, MultiIndex, RangeIndex, isna
 from pandas.testing import assert_frame_equal
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression, Ridge
@@ -15,10 +15,10 @@ from skore._project._sync import synchronize
 
 
 class FakeSummary:
-    def __init__(self, frame: DataFrame):
+    def __init__(self, frame: pd.DataFrame):
         self._frame = frame
 
-    def frame(self) -> DataFrame:
+    def frame(self) -> pd.DataFrame:
         return self._frame
 
 
@@ -47,12 +47,12 @@ class FakeProject:
         self.reports[backend_id] = report
 
     def summarize(self) -> FakeSummary:
-        frame = DataFrame(sorted(self.records, key=lambda row: row["date"]))
+        frame = pd.DataFrame(sorted(self.records, key=lambda row: row["date"]))
         if not frame.empty:
-            frame.index = MultiIndex.from_arrays(
+            frame.index = pd.MultiIndex.from_arrays(
                 [
-                    RangeIndex(len(frame)),
-                    Index(frame.pop("id"), name="id", dtype=str),
+                    pd.RangeIndex(len(frame)),
+                    pd.Index(frame.pop("id"), name="id", dtype=str),
                 ]
             )
         return FakeSummary(frame)
@@ -79,6 +79,7 @@ def report_ids(project):
     ("source_mode", "destination_mode"), permutations(("local", "hub", "mlflow"), 2)
 )
 def test_synchronize_supports_all_mode_pairs(source_mode, destination_mode):
+    """Synchronize each distinct pair of project modes."""
     source_report = report("report-1")
     source = FakeProject(
         source_mode,
@@ -89,13 +90,13 @@ def test_synchronize_supports_all_mode_pairs(source_mode, destination_mode):
 
     result = synchronize(source, destination, bidirectional=False, dry_run=False)
 
-    expected = DataFrame(
+    expected = pd.DataFrame(
         {
             "key": ["model"],
             "direction": ["outbound"],
             "status": ["transferred"],
         },
-        index=Index(["report-1"], name="report_id"),
+        index=pd.Index(["report-1"], name="report_id"),
         dtype="string",
     )
     assert_frame_equal(result, expected)
@@ -104,6 +105,7 @@ def test_synchronize_supports_all_mode_pairs(source_mode, destination_mode):
 
 
 def test_synchronize_bidirectionally_uses_initial_snapshots():
+    """Use initial snapshots for bidirectional synchronization."""
     left = FakeProject(
         "local",
         [
@@ -129,13 +131,13 @@ def test_synchronize_bidirectionally_uses_initial_snapshots():
 
     result = synchronize(left, right, bidirectional=True, dry_run=False)
 
-    expected = DataFrame(
+    expected = pd.DataFrame(
         {
             "key": ["left-only", "right-only", "shared"],
-            "direction": ["outbound", "inbound", NA],
+            "direction": ["outbound", "inbound", pd.NA],
             "status": ["transferred", "transferred", "skipped"],
         },
-        index=Index(["report-1", "report-3", "report-2"], name="report_id"),
+        index=pd.Index(["report-1", "report-3", "report-2"], name="report_id"),
         dtype="string",
     )
     assert_frame_equal(result, expected)
@@ -144,6 +146,7 @@ def test_synchronize_bidirectionally_uses_initial_snapshots():
 
 
 def test_synchronize_skips_same_id_without_loading_reports():
+    """Skip reports with IDs present in both projects without loading them."""
     left = FakeProject(
         "local",
         [record("left", "report-1", "left-key")],
@@ -159,13 +162,14 @@ def test_synchronize_skips_same_id_without_loading_reports():
 
     assert result.index.tolist() == ["report-1"]
     assert result.loc["report-1", "key"] == "left-key"
-    assert isna(result.loc["report-1", "direction"])
+    assert pd.isna(result.loc["report-1", "direction"])
     assert result.loc["report-1", "status"] == "skipped"
     left.get.assert_not_called()
     right.get.assert_not_called()
 
 
 def test_synchronize_allows_different_ids_with_same_key():
+    """Allow distinct reports to share a key."""
     left_report = report("report-1")
     left = FakeProject(
         "local",
@@ -184,6 +188,7 @@ def test_synchronize_allows_different_ids_with_same_key():
 
 
 def test_synchronize_uses_latest_source_duplicate():
+    """Transfer the most recent source record for duplicate report IDs."""
     latest = report("report-1")
     source = FakeProject(
         "local",
@@ -203,6 +208,7 @@ def test_synchronize_uses_latest_source_duplicate():
 
 
 def test_synchronize_ignores_missing_report_ids():
+    """Ignore records without a report ID."""
     identified_report = report("report-1")
     source = FakeProject(
         "local",
@@ -225,6 +231,7 @@ def test_synchronize_ignores_missing_report_ids():
 
 
 def test_synchronize_ignores_missing_report_id_column():
+    """Treat summaries without report IDs as empty."""
     source = FakeProject(
         "local",
         [{"id": "legacy", "key": "legacy", "date": "2026-01-01"}],
@@ -234,9 +241,9 @@ def test_synchronize_ignores_missing_report_id_column():
 
     result = synchronize(source, destination, bidirectional=False, dry_run=False)
 
-    expected = DataFrame(
-        index=Index([], name="report_id", dtype=object),
-        columns=Index(["key", "direction", "status"]),
+    expected = pd.DataFrame(
+        index=pd.Index([], name="report_id", dtype=object),
+        columns=pd.Index(["key", "direction", "status"]),
     ).astype("string")
     assert_frame_equal(result, expected)
     source.get.assert_not_called()
@@ -244,6 +251,7 @@ def test_synchronize_ignores_missing_report_id_column():
 
 
 def test_synchronize_dry_run_does_not_load_or_store_reports():
+    """Plan transfers without loading or storing reports."""
     source = FakeProject(
         "local",
         [record("source", "report-1", "model")],
@@ -261,6 +269,7 @@ def test_synchronize_dry_run_does_not_load_or_store_reports():
 
 
 def test_synchronize_stops_on_first_transfer_error():
+    """Stop on a failed transfer and resume the remaining reports later."""
     source = FakeProject(
         "local",
         [
@@ -284,9 +293,12 @@ def test_synchronize_stops_on_first_transfer_error():
 
     destination.put.side_effect = fail_second_put
 
-    with pytest.raises(RuntimeError, match="upload failed"):
+    with pytest.raises(RuntimeError, match="upload failed") as exc_info:
         synchronize(source, destination, bidirectional=False, dry_run=False)
 
+    assert exc_info.value.__notes__ == [
+        f"Failed to synchronize report 'report-2' from {source} to {destination}."
+    ]
     assert source.get.call_count == 2
     assert destination.put.call_count == 2
     assert report_ids(destination) == {"report-1"}
@@ -321,6 +333,7 @@ def isolated_mlflow_tracking(tmp_path, monkeypatch, mlflow_tracking_uri):
     r"ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow"
 )
 def test_sync_local_and_mlflow_bidirectionally(tmp_path, isolated_mlflow_tracking):
+    """Synchronize local and MLflow projects in both directions."""
     regression_data = make_regression(random_state=42, coef=False)
     X, y = regression_data[0], regression_data[1]
     local_report = cast(EstimatorReport, evaluate(LinearRegression(), X, y))

--- a/skore/tests/unit/project/test_sync.py
+++ b/skore/tests/unit/project/test_sync.py
@@ -1,0 +1,367 @@
+from itertools import permutations
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import mlflow
+import pytest
+from pandas import DataFrame, Index, MultiIndex, RangeIndex
+from sklearn.datasets import make_regression
+from sklearn.linear_model import LinearRegression, Ridge
+
+from skore import Project, SyncOperation, evaluate
+from skore._project._sync import synchronize
+
+
+class FakeProject:
+    def __init__(self, mode, records=(), reports=None, ml_task="regression"):
+        self.mode = mode
+        self.name = "project"
+        self.ml_task = ml_task
+        self.records = list(records)
+        self.reports = {} if reports is None else dict(reports)
+        self.get = Mock(side_effect=self._get)
+        self.put = Mock(side_effect=self._put)
+
+    def _get(self, backend_id):
+        return self.reports[backend_id]
+
+    def _put(self, key, report):
+        backend_id = f"{self.mode}-{len(self.records)}"
+        self.records.append(
+            {
+                "id": backend_id,
+                "report_id": str(report.id),
+                "key": key,
+                "date": f"2026-01-{len(self.records) + 1:02d}",
+            }
+        )
+        self.reports[backend_id] = report
+
+    def summarize(self):
+        frame = DataFrame(sorted(self.records, key=lambda row: row["date"]))
+        if not frame.empty:
+            frame.index = MultiIndex.from_arrays(
+                [
+                    RangeIndex(len(frame)),
+                    Index(frame.pop("id"), name="id", dtype=str),
+                ]
+            )
+        return SimpleNamespace(frame=lambda: frame)
+
+
+def record(backend_id, report_id, key, date="2026-01-01"):
+    return {
+        "id": backend_id,
+        "report_id": report_id,
+        "key": key,
+        "date": date,
+    }
+
+
+def report(report_id):
+    return SimpleNamespace(id=report_id)
+
+
+def report_ids(project):
+    return {row["report_id"] for row in project.records}
+
+
+@pytest.mark.parametrize(
+    ("source_mode", "destination_mode"), permutations(("local", "hub", "mlflow"), 2)
+)
+def test_synchronize_supports_all_mode_pairs(source_mode, destination_mode):
+    source_report = report("report-1")
+    source = FakeProject(
+        source_mode,
+        [record("source-1", "report-1", "model")],
+        {"source-1": source_report},
+    )
+    destination = FakeProject(destination_mode)
+
+    result = synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    assert result.operations == (
+        SyncOperation(
+            report_id="report-1",
+            key="model",
+            source_mode=source_mode,
+            destination_mode=destination_mode,
+        ),
+    )
+    assert result.skipped == ()
+    assert result.dry_run is False
+    source.get.assert_called_once_with("source-1")
+    destination.put.assert_called_once_with("model", source_report)
+
+
+def test_synchronize_bidirectionally_uses_initial_snapshots():
+    left = FakeProject(
+        "local",
+        [
+            record("left-1", "report-1", "left-only", "2026-01-01"),
+            record("left-2", "report-2", "shared", "2026-01-02"),
+        ],
+        {
+            "left-1": report("report-1"),
+            "left-2": report("report-2"),
+        },
+    )
+    right = FakeProject(
+        "hub",
+        [
+            record("right-2", "report-2", "another-key", "2026-01-01"),
+            record("right-3", "report-3", "right-only", "2026-01-02"),
+        ],
+        {
+            "right-2": report("report-2"),
+            "right-3": report("report-3"),
+        },
+    )
+
+    result = synchronize(left, right, bidirectional=True, dry_run=False)
+
+    assert [
+        (operation.report_id, operation.source_mode, operation.destination_mode)
+        for operation in result.operations
+    ] == [
+        ("report-1", "local", "hub"),
+        ("report-3", "hub", "local"),
+    ]
+    assert result.skipped == ("report-2",)
+    assert report_ids(left) == {"report-1", "report-2", "report-3"}
+    assert report_ids(right) == {"report-1", "report-2", "report-3"}
+
+
+def test_synchronize_skips_same_id_without_loading_reports():
+    left = FakeProject(
+        "local",
+        [record("left", "report-1", "left-key")],
+        {"left": report("report-1")},
+    )
+    right = FakeProject(
+        "hub",
+        [record("right", "report-1", "right-key")],
+        {"right": report("different-state")},
+    )
+
+    result = synchronize(left, right, bidirectional=True, dry_run=False)
+
+    assert result.operations == ()
+    assert result.skipped == ("report-1",)
+    left.get.assert_not_called()
+    right.get.assert_not_called()
+
+
+def test_synchronize_allows_different_ids_with_same_key():
+    left_report = report("report-1")
+    left = FakeProject(
+        "local",
+        [record("left", "report-1", "model")],
+        {"left": left_report},
+    )
+    right = FakeProject(
+        "hub",
+        [record("right", "report-2", "model")],
+        {"right": report("report-2")},
+    )
+
+    synchronize(left, right, bidirectional=False, dry_run=False)
+
+    right.put.assert_called_once_with("model", left_report)
+
+
+def test_synchronize_uses_latest_source_duplicate():
+    latest = report("report-1")
+    source = FakeProject(
+        "local",
+        [
+            record("old", "report-1", "old-key", "2026-01-01"),
+            record("latest", "report-1", "latest-key", "2026-01-02"),
+        ],
+        {"old": report("report-1"), "latest": latest},
+    )
+    destination = FakeProject("hub")
+
+    result = synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    assert result.operations[0].key == "latest-key"
+    source.get.assert_called_once_with("latest")
+    destination.put.assert_called_once_with("latest-key", latest)
+
+
+@pytest.mark.parametrize("missing_side", ["source", "destination"])
+def test_synchronize_rejects_missing_canonical_id_before_transfer(missing_side):
+    identified = FakeProject(
+        "local",
+        [record("identified", "report-1", "model")],
+        {"identified": report("report-1")},
+    )
+    unidentified = FakeProject(
+        "hub",
+        [record("unidentified", None, "legacy")],
+        {"unidentified": report("legacy-report")},
+    )
+    source, destination = (
+        (unidentified, identified)
+        if missing_side == "source"
+        else (identified, unidentified)
+    )
+
+    with pytest.raises(ValueError, match="no canonical `report_id`"):
+        synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    source.get.assert_not_called()
+    destination.put.assert_not_called()
+
+
+def test_synchronize_dry_run_does_not_load_or_store_reports():
+    source = FakeProject(
+        "local",
+        [record("source", "report-1", "model")],
+        {"source": report("report-1")},
+    )
+    destination = FakeProject("mlflow")
+
+    result = synchronize(source, destination, bidirectional=False, dry_run=True)
+
+    assert result.dry_run is True
+    assert [operation.report_id for operation in result.operations] == ["report-1"]
+    source.get.assert_not_called()
+    destination.put.assert_not_called()
+
+
+def test_synchronize_rejects_loaded_report_id_mismatch():
+    source = FakeProject(
+        "local",
+        [record("source", "expected", "model")],
+        {"source": report("actual")},
+    )
+    destination = FakeProject("hub")
+
+    with pytest.raises(RuntimeError, match="does not match its project summary"):
+        synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    destination.put.assert_not_called()
+
+
+def test_synchronize_rejects_different_ml_tasks_before_transfer():
+    source = FakeProject(
+        "local",
+        [record("source", "report-1", "model")],
+        {"source": report("report-1")},
+        ml_task="regression",
+    )
+    destination = FakeProject("hub", ml_task="binary-classification")
+
+    with pytest.raises(ValueError, match="different ML tasks"):
+        synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    source.get.assert_not_called()
+    destination.put.assert_not_called()
+
+
+def test_synchronize_stops_on_first_transfer_error():
+    source = FakeProject(
+        "local",
+        [
+            record("source-1", "report-1", "first", "2026-01-01"),
+            record("source-2", "report-2", "second", "2026-01-02"),
+        ],
+        {
+            "source-1": report("report-1"),
+            "source-2": report("report-2"),
+        },
+    )
+    destination = FakeProject("hub")
+    put_calls = 0
+
+    def fail_second_put(key, transferred_report):
+        nonlocal put_calls
+        put_calls += 1
+        if put_calls == 2:
+            raise RuntimeError("upload failed")
+        destination._put(key, transferred_report)
+
+    destination.put.side_effect = fail_second_put
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    assert source.get.call_count == 2
+    assert destination.put.call_count == 2
+    assert report_ids(destination) == {"report-1"}
+
+    source.get.reset_mock()
+    destination.put.reset_mock(side_effect=True)
+    destination.put.side_effect = destination._put
+
+    result = synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    assert [operation.report_id for operation in result.operations] == ["report-2"]
+    source.get.assert_called_once_with("source-2")
+
+
+@pytest.fixture
+def mlflow_tracking_uri(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    previous_tracking_uri = mlflow.get_tracking_uri()
+    tracking_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+    mlflow.set_tracking_uri(tracking_uri)
+    try:
+        yield tracking_uri
+    finally:
+        while mlflow.active_run() is not None:
+            mlflow.end_run()
+        mlflow.set_tracking_uri(previous_tracking_uri)
+
+
+@pytest.mark.filterwarnings(
+    r"ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow"
+)
+def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
+    X, y = make_regression(random_state=42)
+    local_report = evaluate(LinearRegression(), X, y)
+    mlflow_report = evaluate(Ridge(), X, y)
+    local = Project(
+        name="sync-project",
+        mode="local",
+        workspace=tmp_path / "local",
+    )
+    mlflow_project = Project(
+        name="sync-project",
+        mode="mlflow",
+        tracking_uri=mlflow_tracking_uri,
+    )
+    local.put("local-model", local_report)
+    mlflow_project.put("mlflow-model", mlflow_report)
+
+    dry_run = local.sync(
+        mlflow_project,
+        bidirectional=True,
+        dry_run=True,
+    )
+
+    assert {
+        (operation.source_mode, operation.destination_mode)
+        for operation in dry_run.operations
+    } == {("local", "mlflow"), ("mlflow", "local")}
+    assert len(local.summarize().frame()) == 1
+    assert len(mlflow_project.summarize().frame()) == 1
+
+    result = local.sync(
+        mlflow_project,
+        bidirectional=True,
+    )
+
+    assert result.dry_run is False
+    expected_ids = {str(local_report.id), str(mlflow_report.id)}
+    assert set(local.summarize().frame()["report_id"]) == expected_ids
+    assert set(mlflow_project.summarize().frame()["report_id"]) == expected_ids
+
+    repeated = local.sync(
+        mlflow_project,
+        bidirectional=True,
+    )
+
+    assert repeated.operations == ()
+    assert set(repeated.skipped) == expected_ids

--- a/skore/tests/unit/project/test_sync.py
+++ b/skore/tests/unit/project/test_sync.py
@@ -304,12 +304,10 @@ def test_synchronize_stops_on_first_transfer_error():
 
 
 @pytest.fixture
-def mlflow_tracking_uri(tmp_path, monkeypatch):
+def isolated_mlflow_tracking(tmp_path, monkeypatch, mlflow_tracking_uri):
     monkeypatch.chdir(tmp_path)
     previous_tracking_uri = mlflow.get_tracking_uri()
-    tracking_path = tmp_path / "mlruns"
-    tracking_path.mkdir()
-    tracking_uri = tracking_path.as_uri()
+    tracking_uri = mlflow_tracking_uri()
     mlflow.set_tracking_uri(tracking_uri)
     try:
         yield tracking_uri
@@ -322,10 +320,7 @@ def mlflow_tracking_uri(tmp_path, monkeypatch):
 @pytest.mark.filterwarnings(
     r"ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow"
 )
-@pytest.mark.filterwarnings(
-    "ignore:The filesystem tracking backend .* is deprecated:FutureWarning"
-)
-def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
+def test_sync_local_and_mlflow_bidirectionally(tmp_path, isolated_mlflow_tracking):
     regression_data = make_regression(random_state=42, coef=False)
     X, y = regression_data[0], regression_data[1]
     local_report = cast(EstimatorReport, evaluate(LinearRegression(), X, y))
@@ -338,7 +333,7 @@ def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
     mlflow_project = Project(
         name="sync-project",
         mode="mlflow",
-        tracking_uri=mlflow_tracking_uri,
+        tracking_uri=isolated_mlflow_tracking,
     )
     local.put("local-model", local_report)
     mlflow_project.put("mlflow-model", mlflow_report)

--- a/skore/tests/unit/project/test_sync.py
+++ b/skore/tests/unit/project/test_sync.py
@@ -1,15 +1,25 @@
 from itertools import permutations
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import Mock
 
 import mlflow
 import pytest
-from pandas import DataFrame, Index, MultiIndex, RangeIndex, isna
+from pandas import NA, DataFrame, Index, MultiIndex, RangeIndex, isna
+from pandas.testing import assert_frame_equal
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression, Ridge
 
-from skore import Project, evaluate
+from skore import EstimatorReport, Project, evaluate
 from skore._project._sync import synchronize
+
+
+class FakeSummary:
+    def __init__(self, frame: DataFrame):
+        self._frame = frame
+
+    def frame(self) -> DataFrame:
+        return self._frame
 
 
 class FakeProject:
@@ -36,7 +46,7 @@ class FakeProject:
         )
         self.reports[backend_id] = report
 
-    def summarize(self):
+    def summarize(self) -> FakeSummary:
         frame = DataFrame(sorted(self.records, key=lambda row: row["date"]))
         if not frame.empty:
             frame.index = MultiIndex.from_arrays(
@@ -45,7 +55,7 @@ class FakeProject:
                     Index(frame.pop("id"), name="id", dtype=str),
                 ]
             )
-        return SimpleNamespace(frame=lambda: frame)
+        return FakeSummary(frame)
 
 
 def record(backend_id, report_id, key, date="2026-01-01"):
@@ -79,14 +89,16 @@ def test_synchronize_supports_all_mode_pairs(source_mode, destination_mode):
 
     result = synchronize(source, destination, bidirectional=False, dry_run=False)
 
-    assert result.index.tolist() == ["report-1"]
-    assert result.to_dict("records") == [
+    expected = DataFrame(
         {
-            "key": "model",
-            "direction": "outbound",
-            "status": "transferred",
-        }
-    ]
+            "key": ["model"],
+            "direction": ["outbound"],
+            "status": ["transferred"],
+        },
+        index=Index(["report-1"], name="report_id"),
+        dtype="string",
+    )
+    assert_frame_equal(result, expected)
     source.get.assert_called_once_with("source-1")
     destination.put.assert_called_once_with("model", source_report)
 
@@ -117,25 +129,16 @@ def test_synchronize_bidirectionally_uses_initial_snapshots():
 
     result = synchronize(left, right, bidirectional=True, dry_run=False)
 
-    records = result.reset_index().to_dict("records")
-    assert records[:2] == [
+    expected = DataFrame(
         {
-            "report_id": "report-1",
-            "key": "left-only",
-            "direction": "outbound",
-            "status": "transferred",
+            "key": ["left-only", "right-only", "shared"],
+            "direction": ["outbound", "inbound", NA],
+            "status": ["transferred", "transferred", "skipped"],
         },
-        {
-            "report_id": "report-3",
-            "key": "right-only",
-            "direction": "inbound",
-            "status": "transferred",
-        },
-    ]
-    assert records[2]["report_id"] == "report-2"
-    assert records[2]["key"] == "shared"
-    assert isna(records[2]["direction"])
-    assert records[2]["status"] == "skipped"
+        index=Index(["report-1", "report-3", "report-2"], name="report_id"),
+        dtype="string",
+    )
+    assert_frame_equal(result, expected)
     assert report_ids(left) == {"report-1", "report-2", "report-3"}
     assert report_ids(right) == {"report-1", "report-2", "report-3"}
 
@@ -221,6 +224,25 @@ def test_synchronize_ignores_missing_report_ids():
     destination.put.assert_called_once_with("model", identified_report)
 
 
+def test_synchronize_ignores_missing_report_id_column():
+    source = FakeProject(
+        "local",
+        [{"id": "legacy", "key": "legacy", "date": "2026-01-01"}],
+        {"legacy": report("legacy-report")},
+    )
+    destination = FakeProject("hub")
+
+    result = synchronize(source, destination, bidirectional=False, dry_run=False)
+
+    expected = DataFrame(
+        index=Index([], name="report_id", dtype=object),
+        columns=Index(["key", "direction", "status"]),
+    ).astype("string")
+    assert_frame_equal(result, expected)
+    source.get.assert_not_called()
+    destination.put.assert_not_called()
+
+
 def test_synchronize_dry_run_does_not_load_or_store_reports():
     source = FakeProject(
         "local",
@@ -304,9 +326,10 @@ def mlflow_tracking_uri(tmp_path, monkeypatch):
     "ignore:The filesystem tracking backend .* is deprecated:FutureWarning"
 )
 def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
-    X, y = make_regression(random_state=42)
-    local_report = evaluate(LinearRegression(), X, y)
-    mlflow_report = evaluate(Ridge(), X, y)
+    regression_data = make_regression(random_state=42, coef=False)
+    X, y = regression_data[0], regression_data[1]
+    local_report = cast(EstimatorReport, evaluate(LinearRegression(), X, y))
+    mlflow_report = cast(EstimatorReport, evaluate(Ridge(), X, y))
     local = Project(
         name="sync-project",
         mode="local",
@@ -347,5 +370,5 @@ def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
     )
 
     assert set(repeated.index) == expected_ids
-    assert repeated["direction"].isna().all()
+    assert bool(repeated["direction"].isna().all())
     assert set(repeated["status"]) == {"skipped"}

--- a/skore/tests/unit/project/test_sync.py
+++ b/skore/tests/unit/project/test_sync.py
@@ -4,19 +4,18 @@ from unittest.mock import Mock
 
 import mlflow
 import pytest
-from pandas import DataFrame, Index, MultiIndex, RangeIndex
+from pandas import DataFrame, Index, MultiIndex, RangeIndex, isna
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression, Ridge
 
-from skore import Project, SyncOperation, evaluate
+from skore import Project, evaluate
 from skore._project._sync import synchronize
 
 
 class FakeProject:
-    def __init__(self, mode, records=(), reports=None, ml_task="regression"):
+    def __init__(self, mode, records=(), reports=None):
         self.mode = mode
         self.name = "project"
-        self.ml_task = ml_task
         self.records = list(records)
         self.reports = {} if reports is None else dict(reports)
         self.get = Mock(side_effect=self._get)
@@ -80,16 +79,14 @@ def test_synchronize_supports_all_mode_pairs(source_mode, destination_mode):
 
     result = synchronize(source, destination, bidirectional=False, dry_run=False)
 
-    assert result.operations == (
-        SyncOperation(
-            report_id="report-1",
-            key="model",
-            source_mode=source_mode,
-            destination_mode=destination_mode,
-        ),
-    )
-    assert result.skipped == ()
-    assert result.dry_run is False
+    assert result.index.tolist() == ["report-1"]
+    assert result.to_dict("records") == [
+        {
+            "key": "model",
+            "direction": "outbound",
+            "status": "transferred",
+        }
+    ]
     source.get.assert_called_once_with("source-1")
     destination.put.assert_called_once_with("model", source_report)
 
@@ -120,14 +117,25 @@ def test_synchronize_bidirectionally_uses_initial_snapshots():
 
     result = synchronize(left, right, bidirectional=True, dry_run=False)
 
-    assert [
-        (operation.report_id, operation.source_mode, operation.destination_mode)
-        for operation in result.operations
-    ] == [
-        ("report-1", "local", "hub"),
-        ("report-3", "hub", "local"),
+    records = result.reset_index().to_dict("records")
+    assert records[:2] == [
+        {
+            "report_id": "report-1",
+            "key": "left-only",
+            "direction": "outbound",
+            "status": "transferred",
+        },
+        {
+            "report_id": "report-3",
+            "key": "right-only",
+            "direction": "inbound",
+            "status": "transferred",
+        },
     ]
-    assert result.skipped == ("report-2",)
+    assert records[2]["report_id"] == "report-2"
+    assert records[2]["key"] == "shared"
+    assert isna(records[2]["direction"])
+    assert records[2]["status"] == "skipped"
     assert report_ids(left) == {"report-1", "report-2", "report-3"}
     assert report_ids(right) == {"report-1", "report-2", "report-3"}
 
@@ -146,8 +154,10 @@ def test_synchronize_skips_same_id_without_loading_reports():
 
     result = synchronize(left, right, bidirectional=True, dry_run=False)
 
-    assert result.operations == ()
-    assert result.skipped == ("report-1",)
+    assert result.index.tolist() == ["report-1"]
+    assert result.loc["report-1", "key"] == "left-key"
+    assert isna(result.loc["report-1", "direction"])
+    assert result.loc["report-1", "status"] == "skipped"
     left.get.assert_not_called()
     right.get.assert_not_called()
 
@@ -184,34 +194,31 @@ def test_synchronize_uses_latest_source_duplicate():
 
     result = synchronize(source, destination, bidirectional=False, dry_run=False)
 
-    assert result.operations[0].key == "latest-key"
+    assert result.loc["report-1", "key"] == "latest-key"
     source.get.assert_called_once_with("latest")
     destination.put.assert_called_once_with("latest-key", latest)
 
 
-@pytest.mark.parametrize("missing_side", ["source", "destination"])
-def test_synchronize_rejects_missing_canonical_id_before_transfer(missing_side):
-    identified = FakeProject(
+def test_synchronize_ignores_missing_report_ids():
+    identified_report = report("report-1")
+    source = FakeProject(
         "local",
-        [record("identified", "report-1", "model")],
-        {"identified": report("report-1")},
+        [
+            record("unidentified", None, "legacy", "2026-01-01"),
+            record("identified", "report-1", "model", "2026-01-02"),
+        ],
+        {
+            "unidentified": report("legacy-report"),
+            "identified": identified_report,
+        },
     )
-    unidentified = FakeProject(
-        "hub",
-        [record("unidentified", None, "legacy")],
-        {"unidentified": report("legacy-report")},
-    )
-    source, destination = (
-        (unidentified, identified)
-        if missing_side == "source"
-        else (identified, unidentified)
-    )
+    destination = FakeProject("hub")
 
-    with pytest.raises(ValueError, match="no canonical `report_id`"):
-        synchronize(source, destination, bidirectional=False, dry_run=False)
+    result = synchronize(source, destination, bidirectional=False, dry_run=False)
 
-    source.get.assert_not_called()
-    destination.put.assert_not_called()
+    assert result.index.tolist() == ["report-1"]
+    source.get.assert_called_once_with("identified")
+    destination.put.assert_called_once_with("model", identified_report)
 
 
 def test_synchronize_dry_run_does_not_load_or_store_reports():
@@ -224,38 +231,9 @@ def test_synchronize_dry_run_does_not_load_or_store_reports():
 
     result = synchronize(source, destination, bidirectional=False, dry_run=True)
 
-    assert result.dry_run is True
-    assert [operation.report_id for operation in result.operations] == ["report-1"]
-    source.get.assert_not_called()
-    destination.put.assert_not_called()
-
-
-def test_synchronize_rejects_loaded_report_id_mismatch():
-    source = FakeProject(
-        "local",
-        [record("source", "expected", "model")],
-        {"source": report("actual")},
-    )
-    destination = FakeProject("hub")
-
-    with pytest.raises(RuntimeError, match="does not match its project summary"):
-        synchronize(source, destination, bidirectional=False, dry_run=False)
-
-    destination.put.assert_not_called()
-
-
-def test_synchronize_rejects_different_ml_tasks_before_transfer():
-    source = FakeProject(
-        "local",
-        [record("source", "report-1", "model")],
-        {"source": report("report-1")},
-        ml_task="regression",
-    )
-    destination = FakeProject("hub", ml_task="binary-classification")
-
-    with pytest.raises(ValueError, match="different ML tasks"):
-        synchronize(source, destination, bidirectional=False, dry_run=False)
-
+    assert result.index.tolist() == ["report-1"]
+    assert result.loc["report-1", "direction"] == "outbound"
+    assert result.loc["report-1", "status"] == "planned"
     source.get.assert_not_called()
     destination.put.assert_not_called()
 
@@ -297,7 +275,9 @@ def test_synchronize_stops_on_first_transfer_error():
 
     result = synchronize(source, destination, bidirectional=False, dry_run=False)
 
-    assert [operation.report_id for operation in result.operations] == ["report-2"]
+    assert result.index.tolist() == ["report-2", "report-1"]
+    assert result.loc["report-2", "status"] == "transferred"
+    assert result.loc["report-1", "status"] == "skipped"
     source.get.assert_called_once_with("source-2")
 
 
@@ -305,7 +285,9 @@ def test_synchronize_stops_on_first_transfer_error():
 def mlflow_tracking_uri(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     previous_tracking_uri = mlflow.get_tracking_uri()
-    tracking_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+    tracking_path = tmp_path / "mlruns"
+    tracking_path.mkdir()
+    tracking_uri = tracking_path.as_uri()
     mlflow.set_tracking_uri(tracking_uri)
     try:
         yield tracking_uri
@@ -317,6 +299,9 @@ def mlflow_tracking_uri(tmp_path, monkeypatch):
 
 @pytest.mark.filterwarnings(
     r"ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow"
+)
+@pytest.mark.filterwarnings(
+    "ignore:The filesystem tracking backend .* is deprecated:FutureWarning"
 )
 def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
     X, y = make_regression(random_state=42)
@@ -341,10 +326,8 @@ def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
         dry_run=True,
     )
 
-    assert {
-        (operation.source_mode, operation.destination_mode)
-        for operation in dry_run.operations
-    } == {("local", "mlflow"), ("mlflow", "local")}
+    assert set(dry_run["direction"]) == {"outbound", "inbound"}
+    assert set(dry_run["status"]) == {"planned"}
     assert len(local.summarize().frame()) == 1
     assert len(mlflow_project.summarize().frame()) == 1
 
@@ -353,7 +336,7 @@ def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
         bidirectional=True,
     )
 
-    assert result.dry_run is False
+    assert set(result["status"]) == {"transferred"}
     expected_ids = {str(local_report.id), str(mlflow_report.id)}
     assert set(local.summarize().frame()["report_id"]) == expected_ids
     assert set(mlflow_project.summarize().frame()["report_id"]) == expected_ids
@@ -363,5 +346,6 @@ def test_sync_local_and_mlflow_bidirectionally(tmp_path, mlflow_tracking_uri):
         bidirectional=True,
     )
 
-    assert repeated.operations == ()
-    assert set(repeated.skipped) == expected_ids
+    assert set(repeated.index) == expected_ids
+    assert repeated["direction"].isna().all()
+    assert set(repeated["status"]) == {"skipped"}

--- a/sphinx/reference/project.rst
+++ b/sphinx/reference/project.rst
@@ -32,13 +32,6 @@ These functions and classes are meant for managing a `Project` and its reports.
    Project.sync
    Project.delete
 
-.. autosummary::
-   :toctree: api/
-   :template: base.rst
-
-   SyncOperation
-   SyncResult
-
 Skore project's summary
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sphinx/reference/project.rst
+++ b/sphinx/reference/project.rst
@@ -29,7 +29,15 @@ These functions and classes are meant for managing a `Project` and its reports.
    Project.put
    Project.get
    Project.summarize
+   Project.sync
    Project.delete
+
+.. autosummary::
+   :toctree: api/
+   :template: base.rst
+
+   SyncOperation
+   SyncResult
 
 Skore project's summary
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/sphinx/user_guide/project.rst
+++ b/sphinx/user_guide/project.rst
@@ -79,6 +79,8 @@ Reports are matched using the ``report_id`` column returned by
 ``Project.summarize().frame()`` and copied with their keys. Existing IDs are skipped;
 contents and metadata are not compared. Reports without a ``report_id`` are ignored.
 Set ``dry_run=True`` to return the transfer plan without loading or storing reports.
+Two MLflow projects must use the same tracking URI because MLflow uses process-global
+tracking state. Synchronization does not provide concurrency control.
 
 The returned :class:`pandas.DataFrame` is indexed by ``report_id``. Its ``direction``
 column is ``"outbound"`` from the caller to the other project, ``"inbound"`` from the

--- a/sphinx/user_guide/project.rst
+++ b/sphinx/user_guide/project.rst
@@ -79,10 +79,13 @@ Reports are matched using the ``report_id`` column returned by
 ``Project.summarize().frame()`` and copied with their keys. Existing IDs are skipped;
 contents and metadata are not compared. Reports without a ``report_id`` are ignored.
 Set ``dry_run=True`` to return the transfer plan without loading or storing reports.
-Two MLflow projects must use the same tracking URI because MLflow uses process-global
-tracking state. Synchronization does not provide concurrency control.
 
 The returned :class:`pandas.DataFrame` is indexed by ``report_id``. Its ``direction``
 column is ``"outbound"`` from the caller to the other project, ``"inbound"`` from the
 other project to the caller, or missing when a report is skipped. Its ``status`` column
 is ``"planned"``, ``"transferred"``, or ``"skipped"``.
+
+.. note::
+
+   Two MLflow projects must use the same tracking URI because MLflow uses process-global
+   tracking state. Synchronization does not provide concurrency control.

--- a/sphinx/user_guide/project.rst
+++ b/sphinx/user_guide/project.rst
@@ -56,3 +56,29 @@ returned by :meth:`Project.summarize`. This method returns a list of
 
 To retrieve a specific report for which you have its ``id`` (as returned by
 :meth:`Project.summarize`), use the :meth:`Project.get` method.
+
+Synchronizing projects
+----------------------
+
+Use :meth:`Project.sync` to transfer reports between projects with the same name and
+different storage modes. The project on which the method is called is the source.
+
+.. code-block:: python
+
+   project_hub = Project(
+       name=project_local.name,
+       mode="hub",
+       workspace="my-workspace",
+   )
+   result = project_local.sync(project_hub)
+
+The caller is the source; reverse the call for the opposite direction. With
+``bidirectional=True``, both differences are computed before transfers start.
+
+Reports are matched by canonical ID and copied with their keys. Existing IDs are skipped;
+contents and metadata are not compared. ``dry_run=True`` returns the transfer plan
+without calling ``get`` or ``put``.
+
+:class:`SyncResult` contains transfer operations and IDs already present in both
+projects. Synchronization requires canonical IDs, does not compare revisions, and
+provides no concurrency control.

--- a/sphinx/user_guide/project.rst
+++ b/sphinx/user_guide/project.rst
@@ -60,8 +60,8 @@ To retrieve a specific report for which you have its ``id`` (as returned by
 Synchronizing projects
 ----------------------
 
-Use :meth:`Project.sync` to transfer reports between projects with the same name and
-different storage modes. The project on which the method is called is the source.
+Use :meth:`Project.sync` to transfer reports between projects. The project on which the
+method is called is the source.
 
 .. code-block:: python
 
@@ -72,13 +72,15 @@ different storage modes. The project on which the method is called is the source
    )
    result = project_local.sync(project_hub)
 
-The caller is the source; reverse the call for the opposite direction. With
-``bidirectional=True``, both differences are computed before transfers start.
+The caller is the source; reverse the call for the opposite direction. Set
+``bidirectional=True`` to transfer missing reports in both directions.
 
-Reports are matched by canonical ID and copied with their keys. Existing IDs are skipped;
-contents and metadata are not compared. ``dry_run=True`` returns the transfer plan
-without calling ``get`` or ``put``.
+Reports are matched using the ``report_id`` column returned by
+``Project.summarize().frame()`` and copied with their keys. Existing IDs are skipped;
+contents and metadata are not compared. Reports without a ``report_id`` are ignored.
+Set ``dry_run=True`` to return the transfer plan without loading or storing reports.
 
-:class:`SyncResult` contains transfer operations and IDs already present in both
-projects. Synchronization requires canonical IDs, does not compare revisions, and
-provides no concurrency control.
+The returned :class:`pandas.DataFrame` is indexed by ``report_id``. Its ``direction``
+column is ``"outbound"`` from the caller to the other project, ``"inbound"`` from the
+other project to the caller, or missing when a report is skipped. Its ``status`` column
+is ``"planned"``, ``"transferred"``, or ``"skipped"``.


### PR DESCRIPTION
## Summary
- add one-way and bidirectional project synchronization using canonical report IDs
- preserve report keys and support dry-run transfer plans
- validate project compatibility and make retries skip completed transfers


```python
local = Project("demo", mode="local", workspace="./data")
hub = Project("demo", mode="hub", workspace="team")

local.sync(hub)  # local → Hub
local.sync(hub, bidirectional=True)  # both directions
```

