### PR TITLE
fix(skore): Allow re-adding default metrics

### DIFF
--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -931,10 +931,8 @@ class MetricRegistry(UserDict[str, Metric]):
         if position not in ("first", "last"):
             raise ValueError(f"position must be 'first' or 'last', got {position!r}.")
 
-        if metric.name in {m.name for m in BUILTIN_METRICS}:
-            raise ValueError(
-                f"Cannot add {metric.name!r}: it is a built-in metric name."
-            )
+        if metric.name == "score":
+            raise ValueError(f"Cannot add {metric.name!r}: it is a reserved name.")
 
         if metric.name in self.data:
             raise ValueError(

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -154,16 +154,28 @@ class TestBasicAdd:
         assert "business_loss" in report._metric_registry
         assert "accuracy_score" in report._metric_registry
 
-    def test_cannot_override_builtin_metric(self, binary_classification_report):
-        """Test that adding with a built-in technical name raises an error."""
+    def test_cannot_use_reserved_name(self, binary_classification_report):
+        """Test that adding a metric named 'score' raises an error."""
+        report = binary_classification_report
+
+        def score(y_true, y_pred):
+            return 1.0
+
+        err_msg = "Cannot add 'score': it is a reserved name."
+        with pytest.raises(ValueError, match=err_msg):
+            report.metrics.add(make_scorer(score))
+
+    def test_readd_default_metric(self, binary_classification_report):
+        """Test that a default metric can be removed and added back."""
         report = binary_classification_report
 
         def accuracy(y_true, y_pred):
             return 1.0
 
-        err_msg = "Cannot add 'accuracy': it is a built-in metric name."
-        with pytest.raises(ValueError, match=err_msg):
-            report.metrics.add(make_scorer(accuracy))
+        report.metrics.remove("accuracy")
+        report.metrics.add(make_scorer(accuracy))
+
+        assert report.metrics.get("accuracy") == 1.0
 
 
 class TestRemove:


### PR DESCRIPTION
#### Change description

Treat default and user-added metrics uniformly when managing registry names. Default metrics can now be removed and re-added under the same name, while `score` remains reserved because `.score()` has dedicated behavior.

This extracts the error-policy change discussed in #3195 without introducing the task-driven metrics factory.

#### Contribution checklist

- [x] Unit tests were added or updated (if necessary)
- [x] Documentation was added or updated (if necessary)
- [x] The code passes our style conventions (you can check this by running pre-commit on your code with `pre-commit run --all-files`)
- [x] All the tests pass (please test locally before pushing)
- [x] The documentation builds and renders properly (if it does, our bot will add a comment linking to a preview of the documentation to review it visually)
- [ ] All the commits in the PR are signed (more information [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
- [x] The pull request title respects the Conventional Commits convention (more information [here](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests))

#### AI usage disclosure

AI tools were involved for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
