### PR TITLE
fix(skore): Change suffix name for _macro default metric

### DIFF
--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -632,8 +632,8 @@ class Precision(Metric):
         return super()._raw(report=report, data_source=data_source, **kwargs)
 
 
-class PrecisionMacro(Precision):
-    name = "precision_macro"
+class PrecisionAvg(Precision):
+    name = "precision_avg"
     kwargs = {"average": "macro"}
 
     @staticmethod
@@ -664,8 +664,8 @@ class Recall(Metric):
         return super()._raw(report=report, data_source=data_source, **kwargs)
 
 
-class RecallMacro(Recall):
-    name = "recall_macro"
+class RecallAvg(Recall):
+    name = "recall_avg"
     kwargs = {"average": "macro"}
 
     @staticmethod
@@ -726,8 +726,8 @@ class RocAuc(Metric):
         return sklearn.metrics.roc_auc_score(y_true, y_score, **kwargs)
 
 
-class RocAucMacro(RocAuc):
-    name = "roc_auc_macro"
+class RocAucAvg(RocAuc):
+    name = "roc_auc_avg"
     kwargs = {"average": "macro", "multi_class": "ovr"}
 
     @staticmethod
@@ -850,11 +850,11 @@ class Score(Metric):
 BUILTIN_METRICS: list[Metric] = [
     Accuracy(),
     Precision(),
-    PrecisionMacro(),
+    PrecisionAvg(),
     Recall(),
-    RecallMacro(),
+    RecallAvg(),
     RocAuc(),
-    RocAucMacro(),
+    RocAucAvg(),
     LogLoss(),
     Brier(),
     R2(),

--- a/skore/tests/unit/displays/metrics_summary/test_estimator.py
+++ b/skore/tests/unit/displays/metrics_summary/test_estimator.py
@@ -58,15 +58,15 @@ def test_format_wide_multiclass(forest_multiclass_classification_with_test):
         "precision_0",
         "precision_1",
         "precision_2",
-        "precision_macro_macro",
+        "precision_avg_macro",
         "recall_0",
         "recall_1",
         "recall_2",
-        "recall_macro_macro",
+        "recall_avg_macro",
         "roc_auc_0",
         "roc_auc_1",
         "roc_auc_2",
-        "roc_auc_macro_macro",
+        "roc_auc_avg_macro",
         "log_loss",
         "fit_time",
         "predict_time",
@@ -256,7 +256,7 @@ def test_frame_multiclass_includes_macro_metrics(
     report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
     data = report.metrics.summarize().summary
 
-    for metric_name in ("precision_macro", "recall_macro", "roc_auc_macro"):
+    for metric_name in ("precision_avg", "recall_avg", "roc_auc_avg"):
         macro_rows = data[(data["name"] == metric_name) & (data["average"] == "macro")]
         assert len(macro_rows) == 1
 

--- a/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_cross_validation_report.py
@@ -1098,9 +1098,9 @@ class TestCrossValidationReportPayload:
         )
 
         for metric_name in (
-            "precision_macro_mean",
-            "recall_macro_mean",
-            "roc_auc_macro_mean",
+            "precision_avg_mean",
+            "recall_avg_mean",
+            "roc_auc_avg_mean",
         ):
             macro_metrics = [
                 m

--- a/skore/tests/unit/plugins/hub/report/test_estimator_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_estimator_report.py
@@ -364,7 +364,7 @@ class TestEstimatorReportPayload:
             key="<key>",
         )
 
-        for metric_name in ("precision_macro", "recall_macro", "roc_auc_macro"):
+        for metric_name in ("precision_avg", "recall_avg", "roc_auc_avg"):
             macro_metrics = [
                 m
                 for m in payload.metrics

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -132,7 +132,7 @@ def test_default_multiclass_classification_forest(
         expected_average={"macro"},
     )
 
-    assert "precision_macro" in report.metrics.available()
+    assert "precision_avg" in report.metrics.available()
 
     assert display.summary["output"].isna().all()
     data = display.summary.set_index("verbose_name")
@@ -155,7 +155,7 @@ def test_name_is_registry_key(forest_multiclass_classification_with_test):
     # `score` is the only registered metric that `summarize` skips here, because
     # RandomForestClassifier uses the default `ClassifierMixin.score`.
     assert names == set(report.metrics.available()) - {"score"}
-    assert {"precision", "precision_macro", "precision_weighted"} <= names
+    assert {"precision", "precision_avg", "precision_weighted"} <= names
 
 
 def test_default_multiclass_classification_svc(svc_multiclass_classification_with_test):


### PR DESCRIPTION
closes #3205 

Rename the `_macro` suffixes to `_avg` to have a better naming when suffix with the average parameter in the `.summarize` method