### PR TITLE
fix(ci/release.yml): Update `gh-action-pypi-publish` to `v1.14.2` allowing metadata v2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           verify-metadata: false
 


### PR DESCRIPTION
Take benefice of https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2 after https://github.com/pypa/hatch/releases/tag/hatchling-v1.32.0.

> So what most people will find useful is @takluyver's update of Twine to v7 that we use internally (https://github.com/pypa/gh-action-pypi-publish/pull/416). This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI.
