### PR TITLE
fix(skore): Handle properly average multioutput metric in regression

### DIFF
--- a/skore/src/skore/_sklearn/metrics.py
+++ b/skore/src/skore/_sklearn/metrics.py
@@ -486,7 +486,19 @@ class Metric:
                     self._row(score=s, output=idx)
                     for idx, s in enumerate(score.tolist())
                 ]
-            return [self._row(score=score, average=kwargs.get("multioutput"))]
+
+            # A scalar score means the outputs were aggregated: "raw_values" is the
+            # only `multioutput` mode that is not an average. Weights are reported
+            # as "weighted" rather than their values, which would make the average
+            # differ from one report to the next.
+            multioutput = kwargs.get("multioutput")
+            if multioutput is None:
+                average = None
+            elif isinstance(multioutput, str):
+                average = None if multioutput == "raw_values" else multioutput
+            else:
+                average = "weighted"
+            return [self._row(score=score, average=average)]
         return [self._row(score=score)]
 
     def rows(

--- a/skore/tests/unit/plugins/hub/report/test_estimator_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_estimator_report.py
@@ -1,9 +1,10 @@
 from joblib import hash
 from pydantic import ValidationError
 from pytest import approx, fixture, mark, raises
-from sklearn.datasets import make_classification
+from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.metrics import make_scorer, precision_score
+from sklearn.linear_model import Ridge
+from sklearn.metrics import make_scorer, precision_score, r2_score
 
 from skore import CrossValidationReport, EstimatorReport, evaluate
 from skore._plugins.hub.artifact.media import (
@@ -397,6 +398,36 @@ class TestEstimatorReportPayload:
                 value=1.0,
             ),
         ]
+
+    @mark.respx(assert_all_called=False)
+    def test_metrics_multioutput_regression(self, project):
+        X, y = make_regression(n_targets=2, random_state=42)
+        report = evaluate(Ridge(random_state=42), X, y)
+        report.metrics.add(
+            make_scorer(r2_score, multioutput="uniform_average"),
+            name="r2_uniform",
+        )
+
+        payload = EstimatorReportPayload(
+            project=project,
+            report=report,
+            key="<key>",
+        )
+
+        r2_rows = [
+            m for m in payload.metrics if m.name == "r2" and m.data_source == "test"
+        ]
+        r2_uniform_rows = [
+            m
+            for m in payload.metrics
+            if m.name == "r2_uniform" and m.data_source == "test"
+        ]
+
+        assert {m.output for m in r2_rows} == {0, 1}
+        assert all(m.average is None for m in r2_rows)
+        assert len(r2_uniform_rows) == 1
+        assert r2_uniform_rows[0].average == "uniform_average"
+        assert r2_uniform_rows[0].output is None
 
     @mark.respx(assert_all_called=False)
     def test_metrics_multimetric_scorer(self, project):

--- a/skore/tests/unit/reports/estimator/metrics/test_summarize.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_summarize.py
@@ -18,7 +18,7 @@ from sklearn.datasets import make_classification
 from sklearn.decomposition import PCA
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import make_scorer, precision_score, recall_score
+from sklearn.metrics import make_scorer, precision_score, r2_score, recall_score
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 
@@ -231,6 +231,36 @@ def test_default_multioutput_regression(linear_regression_multioutput_with_test)
     assert len(data.loc["R²", "output"]) == 2
     assert len(data.loc["RMSE", "output"]) == 2
     assert set(data.loc["R²", "output"]) == {0, 1}
+
+
+@pytest.mark.parametrize(
+    "multioutput, expected_average",
+    [
+        ("raw_values", None),
+        ("uniform_average", "uniform_average"),
+        ("variance_weighted", "variance_weighted"),
+        ([0.3, 0.7], "weighted"),
+        (np.array([0.3, 0.7]), "weighted"),
+    ],
+)
+def test_multioutput_regression_average(
+    linear_regression_multioutput_with_test, multioutput, expected_average
+):
+    """`multioutput` aggregation modes are reported in the `average` column."""
+    estimator, X_test, y_test = linear_regression_multioutput_with_test
+    report = EstimatorReport(estimator, X_test=X_test, y_test=y_test)
+    report.metrics.add(make_scorer(r2_score, multioutput=multioutput), name="r2_custom")
+
+    data = report.metrics.summarize().summary
+    rows = data[data["name"] == "r2_custom"]
+
+    if expected_average is None:
+        assert set(rows["output"]) == {0, 1}
+        assert rows["average"].isna().all()
+    else:
+        assert len(rows) == 1
+        assert rows["output"].isna().all()
+        assert rows["average"].iloc[0] == expected_average
 
 
 def test_default_without_predict_proba(custom_classifier_no_predict_proba_with_test):


### PR DESCRIPTION
Currently, our metric used the classification API contract from scikit-learn to know if a metric is an average.

However, regression metrics use the `multioutput` keyword instead. This PR is using this API contract to be sure to show an average regression metric in the right place on Skore Hub.