### PR TITLE
chore(ci): Upgrade pytest

### DIFF
--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
@@ -332,7 +332,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
@@ -287,7 +287,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
@@ -333,7 +333,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
@@ -332,7 +332,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
@@ -333,7 +333,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -332,7 +332,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
@@ -333,7 +333,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
@@ -332,7 +332,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
@@ -332,7 +332,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
@@ -333,7 +333,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
@@ -335,7 +335,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
@@ -334,7 +334,7 @@ pyparsing==3.3.2
     #   pydot
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   skore (skore/pyproject.toml)
     #   pytest-cov

--- a/skore/tests/unit/project/test_sync.py
+++ b/skore/tests/unit/project/test_sync.py
@@ -76,7 +76,8 @@ def report_ids(project):
 
 
 @pytest.mark.parametrize(
-    ("source_mode", "destination_mode"), permutations(("local", "hub", "mlflow"), 2)
+    ("source_mode", "destination_mode"),
+    tuple(permutations(("local", "hub", "mlflow"), 2)),
 )
 def test_synchronize_supports_all_mode_pairs(source_mode, destination_mode):
     """Synchronize each distinct pair of project modes."""


### PR DESCRIPTION
Manually upgrade `pytest` using `--exclude-newer=7d`.

Fixing 

> ERROR tests/unit/project/test_sync.py - pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
Test: tests/unit/project/test_sync.py::test_synchronize_supports_all_mode_pairs, argvalues type: permutations
Please convert to a list or tuple.
See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
