### PR TITLE
chore(ci): Upgrade lockfiles

### DIFF
--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,21 +179,21 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
@@ -217,27 +215,27 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -262,25 +260,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -300,7 +296,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -341,7 +337,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -352,11 +348,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -398,7 +394,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -406,7 +402,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
@@ -414,12 +410,12 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tomli==2.4.1
     # via coverage
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   aiohttp
     #   aiosignal
@@ -443,19 +439,20 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
 uuid6==2025.0.1
     # via skore (skore/pyproject.toml)
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -467,7 +464,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.6_and_mlflow-2/test-requirements.txt
@@ -1,16 +1,16 @@
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 blinker==1.9.0
     # via flask
@@ -18,18 +18,18 @@ build==1.5.0
     # via skore (skore/pyproject.toml)
 cachetools==5.5.2
     # via mlflow-skinny
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -40,27 +40,25 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==50.0.0
     # via google-auth
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via mlflow-skinny
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -70,19 +68,19 @@ fonttools==4.63.0
     # via matplotlib
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==23.0.0
     # via mlflow
@@ -107,7 +105,7 @@ importlib-metadata==8.9.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -135,11 +133,11 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
-markdown==3.10.2
+markdown==3.10.3
     # via mlflow
 markdown-it-py==4.2.0
     # via rich
@@ -149,7 +147,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -165,11 +163,11 @@ mlflow==2.22.5
     #   skore (skore/pyproject.toml)
 mlflow-skinny==2.22.5
     # via mlflow
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
@@ -190,14 +188,14 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via mlflow-skinny
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
@@ -226,23 +224,21 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 protobuf==6.33.6
     # via
@@ -296,7 +292,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -307,9 +303,9 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -347,7 +343,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -355,18 +351,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via fastapi
 threadpoolctl==3.6.0
     # via scikit-learn
 tomli==2.4.1
     # via coverage
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   anyio
@@ -388,19 +384,20 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
 uuid6==2025.0.1
     # via skore (skore/pyproject.toml)
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via prompt-toolkit
 werkzeug==3.1.8
     # via flask

--- a/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.11/scikit-learn-1.9/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,21 +179,21 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
@@ -218,27 +216,27 @@ numpy==2.4.6
     #   skrub
 numpy-typing-compat==20251206.2.4
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
 optype[numpy]==0.17.1
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -263,25 +261,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -301,7 +297,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +338,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -353,11 +349,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -399,7 +395,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -407,7 +403,7 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
@@ -415,12 +411,12 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tomli==2.4.1
     # via coverage
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   aiohttp
     #   aiosignal
@@ -444,19 +440,20 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
 uuid6==2025.0.1
     # via skore (skore/pyproject.toml)
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -468,7 +465,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.6/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,27 +179,27 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -215,29 +213,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -262,25 +260,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -300,7 +296,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -341,7 +337,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -352,11 +348,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -379,14 +375,14 @@ scikit-learn==1.6.1
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -398,7 +394,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -406,18 +402,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   aiohttp
     #   aiosignal
@@ -440,19 +436,20 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
 uuid6==2025.0.1
     # via skore (skore/pyproject.toml)
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -464,7 +461,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.12/scikit-learn-1.9/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,28 +179,28 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
     #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -216,29 +214,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -263,25 +261,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -301,7 +297,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +338,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -353,11 +349,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -380,14 +376,14 @@ scikit-learn==1.9.0
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -399,7 +395,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -407,18 +403,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   aiohttp
     #   aiosignal
@@ -441,19 +437,20 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
 uuid6==2025.0.1
     # via skore (skore/pyproject.toml)
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -465,7 +462,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.6/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,27 +179,27 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -215,29 +213,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -262,25 +260,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -300,7 +296,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -341,7 +337,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -352,11 +348,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -379,14 +375,14 @@ scikit-learn==1.6.1
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -398,7 +394,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -406,18 +402,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   fastapi
@@ -435,19 +431,20 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
 uuid6==2025.0.1
     # via skore (skore/pyproject.toml)
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -459,7 +456,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.13/scikit-learn-1.9/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,28 +179,28 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
     #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -216,29 +214,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -263,25 +261,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -301,7 +297,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +338,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -353,11 +349,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -380,14 +376,14 @@ scikit-learn==1.9.0
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -399,7 +395,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -407,18 +403,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   fastapi
@@ -436,19 +432,20 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
 uuid6==2025.0.1
     # via skore (skore/pyproject.toml)
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -460,7 +457,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.7/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,27 +179,27 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -215,29 +213,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -262,25 +260,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -300,7 +296,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -341,7 +337,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -352,11 +348,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -379,14 +375,14 @@ scikit-learn==1.7.2
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -398,7 +394,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -406,18 +402,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   fastapi
@@ -435,17 +431,18 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -457,7 +454,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.8/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,27 +179,27 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -215,29 +213,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -262,25 +260,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -300,7 +296,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -341,7 +337,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -352,11 +348,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -379,14 +375,14 @@ scikit-learn==1.8.0
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -398,7 +394,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -406,18 +402,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   fastapi
@@ -435,17 +431,18 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -457,7 +454,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/sphinx-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/sphinx-requirements.txt
@@ -1,26 +1,26 @@
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
 alabaster==1.0.0
     # via sphinx
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-altair==6.1.0
+altair==6.2.2
     # via skore (skore/pyproject.toml)
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via
@@ -31,26 +31,26 @@ babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
     # via pydata-sphinx-theme
 blinker==1.9.0
     # via flask
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
 choreographer==1.3.0
     # via kaleido
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -61,19 +61,17 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 docutils==0.21.2
     # via
@@ -82,13 +80,13 @@ docutils==0.21.2
     #   sphinx-tabs
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
 flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -98,19 +96,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -122,7 +120,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via skore (skore/pyproject.toml)
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 idna==3.18
     # via
@@ -134,7 +132,7 @@ imagesize==2.0.0
     # via sphinx
 importlib-metadata==9.0.0
     # via mlflow-skinny
-ipython==9.14.0
+ipython==9.16.1
     # via ipywidgets
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -169,7 +167,7 @@ logistro==2.0.1
     # via
     #   choreographer
     #   kaleido
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -179,7 +177,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -189,23 +187,23 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   altair
     #   plotly
     #   scikit-learn
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -220,27 +218,27 @@ numpy==2.4.6
     #   xgboost-cpu
 numpydoc==1.10.0
     # via skore (skore/pyproject.toml)
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
 orjson==3.11.9
     # via
     #   skore (skore/pyproject.toml)
     #   kaleido
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   altair
@@ -267,17 +265,17 @@ pillow==12.3.0
     # via
     #   matplotlib
     #   sphinx-gallery
-platformdirs==4.10.0
+platformdirs==4.11.0
     # via choreographer
-plotly==6.8.0
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -295,7 +293,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via mlflow
 pyasn1==0.6.4
     # via pyasn1-modules
@@ -311,7 +309,7 @@ pydantic==2.13.4
     #   mlflow-tracing
 pydantic-core==2.46.4
     # via pydantic
-pydata-sphinx-theme==0.18.0
+pydata-sphinx-theme==0.19.0
     # via skore (skore/pyproject.toml)
 pydot==4.0.1
     # via skrub
@@ -335,7 +333,7 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via mlflow-skinny
@@ -352,7 +350,7 @@ requests==2.34.2
     #   sphinx
 rich[jupyter]==15.0.0
     # via skore (skore/pyproject.toml)
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
@@ -363,7 +361,7 @@ scikit-learn==1.9.0
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -385,7 +383,7 @@ smmap==5.0.3
     # via gitdb
 snowballstemmer==3.1.1
     # via sphinx
-soupsieve==2.8.4
+soupsieve==2.9.1
     # via beautifulsoup4
 sphinx==8.1.3
     # via
@@ -422,7 +420,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -430,18 +428,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   altair
@@ -461,15 +459,16 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -479,9 +478,9 @@ werkzeug==3.1.8
     #   flask-cors
 widgetsnbextension==4.0.15
     # via ipywidgets
-xgboost-cpu==3.2.0
+xgboost-cpu==3.4.0
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,28 +179,28 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
     #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -216,29 +214,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -263,25 +261,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -301,7 +297,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -342,7 +338,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -353,11 +349,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -380,14 +376,14 @@ scikit-learn==1.9.0
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -399,7 +395,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -407,18 +403,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   fastapi
@@ -436,17 +432,18 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -458,7 +455,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_mlflow-3/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,30 +179,30 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via
     #   --override skore/overrides.txt
     #   skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
     #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -218,29 +216,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -265,25 +263,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -303,7 +299,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -344,7 +340,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -355,11 +351,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -382,14 +378,14 @@ scikit-learn==1.9.0
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -401,7 +397,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -409,18 +405,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   fastapi
@@ -438,17 +434,18 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -460,7 +457,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
+++ b/ci/requirements/skore/python-3.14/scikit-learn-1.9_and_pandas-2/test-requirements.txt
@@ -1,22 +1,22 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via mlflow
 aiosignal==1.4.0
     # via aiohttp
-alembic==1.18.4
+alembic==1.19.0
     # via mlflow
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
-annotated-types==0.7.0
+annotated-types==0.8.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
-asttokens==3.0.1
+asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
     # via aiohttp
@@ -24,22 +24,22 @@ blinker==1.9.0
     # via flask
 build==1.5.0
     # via skore (skore/pyproject.toml)
-cachetools==7.1.4
+cachetools==7.1.7
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-certifi==2026.5.20
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.1.1
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   flask
     #   mlflow-skinny
@@ -50,31 +50,29 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.14.1
+coverage[toml]==7.15.3
     # via pytest-cov
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   google-auth
     #   mlflow
 cycler==0.12.1
     # via matplotlib
-databricks-sdk==0.114.0
+databricks-sdk==0.125.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-decorator==5.3.1
-    # via ipython
-distlib==0.4.1
+distlib==0.4.3
     # via virtualenv
-docker==7.1.0
+docker==7.2.0
     # via mlflow
 execnet==2.1.2
     # via pytest-xdist
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
+fastapi==0.141.1
     # via mlflow-skinny
-filelock==3.29.1
+filelock==3.32.2
     # via
     #   python-discovery
     #   virtualenv
@@ -82,7 +80,7 @@ flask==3.1.3
     # via
     #   flask-cors
     #   mlflow
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via mlflow
 fonttools==4.63.0
     # via matplotlib
@@ -92,19 +90,19 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.54
+gitpython==3.1.58
     # via mlflow-skinny
-google-auth==2.53.0
+google-auth==2.56.3
     # via databricks-sdk
 graphene==3.4.3
     # via mlflow
-graphql-core==3.2.8
+graphql-core==3.2.11
     # via
     #   graphene
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
-greenlet==3.5.1
+greenlet==3.5.4
     # via sqlalchemy
 gunicorn==26.0.0
     # via mlflow
@@ -118,7 +116,7 @@ httpx==0.28.1
     # via
     #   skore (skore/pyproject.toml)
     #   respx
-huey==3.0.1
+huey==3.3.4
     # via mlflow
 identify==2.6.19
     # via pre-commit
@@ -132,7 +130,7 @@ importlib-metadata==9.0.0
     # via mlflow-skinny
 iniconfig==2.3.0
     # via pytest
-ipython==9.14.0
+ipython==9.16.1
     # via
     #   skore (skore/pyproject.toml)
     #   ipywidgets
@@ -159,9 +157,9 @@ jupyterlab-widgets==3.0.16
     # via ipywidgets
 kiwisolver==1.5.0
     # via matplotlib
-librt==0.11.0
+librt==0.13.0
     # via mypy
-mako==1.3.12
+mako==1.4.1
     # via alembic
 markdown-it-py==4.2.0
     # via rich
@@ -171,7 +169,7 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -181,28 +179,28 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-mlflow==3.13.0
+mlflow==3.15.1
     # via skore (skore/pyproject.toml)
-mlflow-skinny==3.13.0
+mlflow-skinny==3.15.1
     # via mlflow
-mlflow-tracing==3.13.0
+mlflow-tracing==3.15.1
     # via mlflow
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.1.0
+mypy==2.3.0
     # via skore (skore/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
-narwhals==2.22.0
+narwhals==2.24.0
     # via
     #   skore (skore/pyproject.toml)
     #   plotly
     #   scikit-learn
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   skore (skore/pyproject.toml)
     #   contourpy
@@ -216,29 +214,29 @@ numpy==2.4.6
     #   seaborn
     #   skops
     #   skrub
-numpy-typing-compat==20251206.2.4
+numpy-typing-compat==20260602.2.5
     # via optype
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   mlflow-skinny
     #   mlflow-tracing
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via opentelemetry-sdk
-optype[numpy]==0.17.1
+optype[numpy]==0.18.0
     # via scipy-stubs
 orjson==3.11.9
     # via skore (skore/pyproject.toml)
-packaging==26.2
+packaging==26.3
     # via
     #   skore (skore/pyproject.toml)
     #   build
@@ -264,25 +262,23 @@ pexpect==4.9.0
     # via ipython
 pillow==12.3.0
     # via matplotlib
-platformdirs==4.10.0
-    # via
-    #   python-discovery
-    #   virtualenv
-plotly==6.8.0
+platformdirs==4.11.0
+    # via virtualenv
+plotly==6.9.0
     # via skore (skore/pyproject.toml)
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-polars==1.41.2
+polars==1.43.2
     # via skore (skore/pyproject.toml)
-polars-runtime-32==1.41.2
+polars-runtime-32==1.43.2
     # via polars
-pre-commit==4.6.0
+pre-commit==4.6.1
     # via skore (skore/pyproject.toml)
-prettytable==3.17.0
+prettytable==3.18.0
     # via skops
-prompt-toolkit==3.0.52
+prompt-toolkit==3.0.53
     # via ipython
 propcache==0.5.2
     # via
@@ -302,7 +298,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==24.0.0
+pyarrow==25.0.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
@@ -343,7 +339,7 @@ pytest==9.1.1
     #   pytest-xdist
 pytest-cov==7.1.0
     # via skore (skore/pyproject.toml)
-pytest-order==1.4.0
+pytest-order==1.5.0
     # via skore (skore/pyproject.toml)
 pytest-randomly==4.1.0
     # via skore (skore/pyproject.toml)
@@ -354,11 +350,11 @@ python-dateutil==2.9.0.post0
     #   graphene
     #   matplotlib
     #   pandas
-python-discovery==1.4.0
+python-discovery==1.5.1
     # via virtualenv
 python-dotenv==1.2.2
     # via mlflow-skinny
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via
@@ -381,14 +377,14 @@ scikit-learn==1.9.0
     #   mlflow
     #   skops
     #   skrub
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   skore (skore/pyproject.toml)
     #   mlflow
     #   scikit-learn
     #   skops
     #   skrub
-scipy-stubs==1.17.1.5
+scipy-stubs==1.18.0.1
     # via skore (skore/pyproject.toml)
 seaborn==0.13.2
     # via skore (skore/pyproject.toml)
@@ -400,7 +396,7 @@ skrub==0.10.0
     # via skore (skore/pyproject.toml)
 smmap==5.0.3
     # via gitdb
-sqlalchemy==2.0.50
+sqlalchemy==2.0.51
     # via
     #   alembic
     #   mlflow
@@ -408,18 +404,18 @@ sqlparse==0.5.5
     # via mlflow-skinny
 stack-data==0.6.3
     # via ipython
-starlette==1.3.1
+starlette==1.4.1
     # via
     #   fastapi
     #   mlflow-skinny
 threadpoolctl==3.6.0
     # via scikit-learn
-traitlets==5.15.1
+traitlets==5.16.1
     # via
     #   ipython
     #   ipywidgets
     #   matplotlib-inline
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   alembic
     #   fastapi
@@ -437,17 +433,18 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-tzdata==2026.2
+tzdata==2026.3
     # via pandas
 urllib3==2.7.0
     # via
+    #   databricks-sdk
     #   docker
     #   requests
-uvicorn==0.49.0
+uvicorn==0.52.1
     # via mlflow-skinny
-virtualenv==21.4.2
+virtualenv==21.7.1
     # via pre-commit
-wcwidth==0.7.0
+wcwidth==0.8.2
     # via
     #   prettytable
     #   prompt-toolkit
@@ -459,7 +456,7 @@ widgetsnbextension==4.0.15
     # via ipywidgets
 xdoctest==1.3.2
     # via skore (skore/pyproject.toml)
-yarl==1.24.2
+yarl==1.24.5
     # via aiohttp
 zipp==4.1.0
     # via importlib-metadata

--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -150,8 +150,18 @@ filterwarnings = [
   # mlflow writes its YAML and requirement files through `codecs.open()`, which
   # Python 3.14 deprecates. Reached by every test that logs a report.
   'ignore:codecs\.open\(\) is deprecated:DeprecationWarning:mlflow',
-  # sklearn needs to update its scipy.optimize calls
+  # sklearn (<=1.9) still passes ``iprint``/``disp`` to scipy's L-BFGS-B.
+  # SciPy (<=1.17) emits a DeprecationWarning; SciPy (>=1.18) treats them as
+  # unknown options (OptimizeWarning). Do not pin module to ``scipy``: the
+  # warning uses ``stacklevel=3``, so it is attributed to sklearn.
   'ignore:.*`disp` and `iprint` options of the L-BFGS-B solver are deprecated:DeprecationWarning',
+  'ignore:Unknown solver options:scipy.optimize._optimize.OptimizeWarning',
+  # skrub (<=0.10) datetime encoder still uses NumPy's generic timedelta unit
+  # (deprecated in NumPy 2.5).
+  'ignore:The .generic. unit for NumPy timedelta is deprecated:DeprecationWarning:skrub',
+  # joblib (<=1.5) numpy_pickle still assigns ``array.shape`` (deprecated in
+  # NumPy 2.5).
+  'ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:joblib',
   # seaborn's boxplot still passes the deprecated `vert=` kwarg to matplotlib.
   # Hit whenever any plot Display renders a boxplot, so keep at the top level.
   'ignore:vert.*was deprecated in Matplotlib:matplotlib._api.deprecation.MatplotlibDeprecationWarning:seaborn',


### PR DESCRIPTION
Manually upgrade the whole lockfiles using `--exclude-newer=7d`, and filter out warnings that we can't manage.

---

https://github.com/probabl-ai/skore/security/dependabot/1398 can't be addressed for now (`cryptography>50`), till mlflow doesn't update its cryptography dependency range (`cryptography<50`).


