### PR TITLE
feat(project): Add synchronization mode shortcut

### DIFF
--- a/skore/src/skore/_project/project.py
+++ b/skore/src/skore/_project/project.py
@@ -377,10 +377,11 @@ class Project:
 
     def sync(
         self,
-        other: Project,
+        other: Project | ProjectMode,
         *,
         bidirectional: bool = False,
         dry_run: bool = False,
+        **kwargs: Any,
     ) -> DataFrame:
         """Copy missing reports to another project.
 
@@ -390,13 +391,18 @@ class Project:
 
         Parameters
         ----------
-        other : Project
-            Destination project.
+        other : Project or {"hub", "local", "mlflow"}
+            Destination project. When a mode is given, build the destination with this
+            project's name and the mode-specific keyword arguments.
         bidirectional : bool, default=False
             If ``False``, transfer reports from this project to ``other``. If ``True``,
             also transfer reports missing from this project.
         dry_run : bool, default=False
             Return the planned operations without loading or storing reports.
+        **kwargs : dict
+            Mode-specific arguments used to build the destination when ``other`` is a
+            mode string. For example, pass ``workspace`` for ``"hub"`` or
+            ``tracking_uri`` for ``"mlflow"``.
 
         Returns
         -------
@@ -406,7 +412,14 @@ class Project:
             ``other`` to this project, or missing for skipped reports. The ``status``
             column is ``"planned"``, ``"transferred"``, or ``"skipped"``.
         """
-        if not isinstance(other, Project):
+        if isinstance(other, str):
+            other = Project(self.name, mode=other, **kwargs)
+        elif kwargs:
+            raise TypeError(
+                "Extra keyword arguments are only supported when `other` is a mode "
+                "string."
+            )
+        elif not isinstance(other, Project):
             raise TypeError(f"`other` must be a Project (found {type(other)!r}).")
         if (
             self.mode == other.mode == "mlflow"

--- a/skore/tests/unit/project/test_project.py
+++ b/skore/tests/unit/project/test_project.py
@@ -429,11 +429,30 @@ class TestProject:
         assert result.empty
         assert FakeHubProject.call_count == calls_before_sync
 
-    def test_sync_rejects_non_project(self):
+    def test_sync_builds_counterpart_from_mode(self, FakeHubProject, monkeypatch):
+        monkeypatch.setattr("skore._project.dependencies.requires", lambda _: [])
+        project = Project(name="<name>", mode="local", workspace="<local>")
+
+        result = project.sync("hub", workspace="<hub>", dry_run=True)
+
+        assert result.empty
+        assert FakeHubProject.call_args.kwargs == {
+            "name": "<name>",
+            "workspace": "<hub>",
+        }
+
+    def test_sync_rejects_extra_kwargs_for_project(self):
+        project = Project(name="<name>", mode="local")
+        other = Project(name="<other>", mode="local")
+
+        with raises(TypeError, match="only supported when `other` is a mode string"):
+            project.sync(other, workspace="<workspace>", dry_run=True)
+
+    def test_sync_rejects_non_project_or_mode(self):
         project = Project(name="<name>", mode="local")
 
         with raises(TypeError, match="`other` must be a Project"):
-            project.sync("hub", dry_run=True)
+            project.sync(42, dry_run=True)
 
     def test_sync_allows_different_names(self):
         project = Project(name="<name>", mode="local", workspace="<local>")

--- a/sphinx/user_guide/project.rst
+++ b/sphinx/user_guide/project.rst
@@ -75,6 +75,13 @@ method is called is the source.
 The caller is the source; reverse the call for the opposite direction. Set
 ``bidirectional=True`` to transfer missing reports in both directions.
 
+When both projects have the same name, pass the destination mode as a shortcut. The
+destination is built with the caller's name and the supplied mode-specific arguments.
+
+.. code-block:: python
+
+   result = project_local.sync("hub", workspace="my-workspace")
+
 Reports are matched using the ``report_id`` column returned by
 ``Project.summarize().frame()`` and copied with their keys. Existing IDs are skipped;
 contents and metadata are not compared. Reports without a ``report_id`` are ignored.


### PR DESCRIPTION
## Summary
- Let `Project.sync()` build a same-name destination from a storage mode.
- Keep explicit `Project` destinations for custom names.
- Document the shortcut and cover validation.

## Validation
- `uv run --extra test --locked pytest tests/unit/project/test_project.py -q`
- `uv run --extra test --locked mypy src/skore/_project/project.py`
- `uv run --extra test --locked pre-commit run --files src/skore/_project/project.py tests/unit/project/test_project.py ../sphinx/user_guide/project.rst` (all relevant hooks passed; the full mypy hook has an existing unrelated error in `skore/_sklearn/_plot/base.py`)
