### PR TITLE
chore: Remove `joblib<0.14` support

### DIFF
--- a/skore/pyproject.toml
+++ b/skore/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
   "jinja2",
-  "joblib",
+  "joblib>=1.4",
   "matplotlib",
   "narwhals>=2.0.1",
   "numpy",

--- a/skore/src/skore/__init__.py
+++ b/skore/src/skore/__init__.py
@@ -6,9 +6,7 @@ experiment results, and inspect model behavior through interactive reports.
 
 from importlib.metadata import version
 from logging import INFO, NullHandler, getLogger
-from warnings import warn
 
-from joblib import __version__ as joblib_version
 from matplotlib import pyplot as plt
 from rich.console import Console
 from rich.theme import Theme
@@ -35,7 +33,6 @@ from skore._displays.inspection.impurity_decrease import (
 from skore._displays.inspection.permutation_importance import (
     PermutationImportanceDisplay,
 )
-from skore._externals.sklearn_compat import parse_version
 from skore._project.login import login
 from skore._project.project import Project
 from skore._project.summary import Summary
@@ -47,16 +44,6 @@ from skore._utils.show_versions import show_versions
 
 plt.ion()
 setup_jupyter_display()
-
-
-if parse_version(joblib_version) < parse_version("1.4"):
-    configuration.show_progress = False
-    warn(
-        "Because your version of joblib is older than 1.4, some of the features of "
-        "skore will not be enabled (e.g. progress bars). You can update joblib to "
-        "benefit from these features.",
-        stacklevel=2,
-    )
 
 
 __version__ = version("skore")

--- a/skore/tests/unit/test_init.py
+++ b/skore/tests/unit/test_init.py
@@ -1,26 +1,7 @@
-from importlib import import_module
 from importlib.metadata import version
-from sys import modules
-from unittest.mock import Mock
 
-from pytest import warns
-
-import skore
-
-
-def test_warning_old_joblib(monkeypatch):
-    configuration = Mock()
-
-    monkeypatch.setattr("joblib.__version__", "1.3.0")
-    monkeypatch.setattr("skore._config.configuration", configuration)
-    monkeypatch.delitem(modules, "skore")
-
-    with warns(UserWarning, match="Because your version of joblib is older than 1.4"):
-        import_module("skore")
-
-    assert hasattr(configuration, "show_progress") is True
-    assert configuration.show_progress is False
+from skore import __version__
 
 
 def test__version__returns_version():
-    assert skore.__version__ == version("skore")
+    assert __version__ == version("skore")


### PR DESCRIPTION
The [1.3.2](https://pypi.org/project/joblib/1.3.2/) was released the 2023-08-09.