### PR TITLE
fix(docs): Don't fail sphinx CI when an intersphinx inventory is unreachable

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -13,9 +13,12 @@ extensions, themes, and gallery settings.
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import logging
 import os
 import pathlib
 import sys
+
+from sphinx.util import logging as sphinx_logging
 
 # Make it possible to load custom extensions from sphinxext directory
 sys.path.append(str(pathlib.Path("sphinxext").resolve()))
@@ -164,6 +167,23 @@ intersphinx_mapping = {
     "seaborn": ("http://seaborn.pydata.org", None),
     "xgboost": ("https://xgboost.readthedocs.io/en/stable/", None),
 }
+
+
+class _SuppressIntersphinxFetchWarnings(logging.Filter):
+    """Don't fail the build when an intersphinx inventory can't be fetched.
+
+    We run the build with warnings-as-errors to catch real doc issues, but a
+    third-party docs site being briefly unreachable from the CI runner (e.g.
+    a connection timeout) shouldn't break the whole build.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "failed to reach any of the inventories" not in record.getMessage()
+
+
+sphinx_logging.getLogger("sphinx.ext.intersphinx").logger.addFilter(
+    _SuppressIntersphinxFetchWarnings()
+)
 
 numpydoc_show_class_members = False
 


### PR DESCRIPTION
## Summary
- The `sphinx` CI job on `main` is failing because Sphinx runs with `--fail-on-warning`, and `docs.scipy.org` was unreachable from the CI runner (`ConnectTimeout`) when fetching its intersphinx inventory — this happened twice in a row on two separate commits.
- That warning has no `type`/`subtype` set by Sphinx, so it can't be excluded via `suppress_warnings` in `conf.py`.
- Added a targeted logging filter that only drops that specific "failed to reach any of the inventories" message before it reaches sphinx's warning-as-error handling, so a flaky third-party docs site can't break the whole doc build. All other warnings (broken refs, etc.) still fail the build as before.

## Test plan
- [x] Reproduced the exact failure locally against sphinx==8.1.3 (the version pinned in CI) with an unreachable intersphinx target and `--fail-on-warning`: build failed with the same "1 warning (with warnings treated as errors)" message.
- [x] Confirmed the filter fixes it: same setup with the filter added, build succeeds (exit 0).
- [x] Confirmed the filter doesn't mask real issues: a genuinely broken `:doc:` reference still fails the build with the filter active.
- [x] `ruff check sphinx/conf.py` passes.
- [ ] CI: sphinx workflow on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)