### PR TITLE
feat(checks): Improve the golden feature check (SKD011)

### DIFF
--- a/skore/src/skore/_checks/skd011_golden_feature.py
+++ b/skore/src/skore/_checks/skd011_golden_feature.py
@@ -17,11 +17,71 @@ from skore._checks.utils import (
     split_preprocessor_estimator,
 )
 from skore._sklearn.feature_names import _get_feature_names
+from skore._utils.dataframe import _normalize_y_as_dataframe
 
 if TYPE_CHECKING:
+    from skore._checks.utils import MetricKey
+    from skore._displays.metrics.metrics_summary_display import MetricsSummaryRow
     from skore._reports.base import _BaseReport
     from skore._reports.cross_validation.report import CrossValidationReport
     from skore._reports.estimator.report import EstimatorReport
+    from skore._sklearn.types import EstimatorLike
+
+
+def _on_par(
+    candidate: dict[MetricKey, MetricsSummaryRow],
+    reference: dict[MetricKey, MetricsSummaryRow],
+) -> bool:
+    return majority_vote(
+        [
+            not check_score_better_than_baseline(
+                score=reference[key]["score"],
+                baseline=candidate[key]["score"],
+                greater_is_better=reference[key]["greater_is_better"],
+                floor=0.03,
+                fraction=0.10,
+            )
+            for key in reference.keys() & candidate.keys()
+        ]
+    )[0]
+
+
+def _predictor_test_scores(
+    report: EstimatorReport | CrossValidationReport,
+    predictor: EstimatorLike,
+    metric_registry,
+    X,
+    y,
+    X_test=None,
+    y_test=None,
+) -> dict[MetricKey, MetricsSummaryRow]:
+    if report._report_type == "cross-validation":
+        from skore._reports.cross_validation.report import CrossValidationReport
+
+        report = CrossValidationReport(
+            clone(predictor),
+            X=X,
+            y=y,
+            splitter=report.splitter,
+            pos_label=report.pos_label,
+            n_jobs=report.n_jobs,
+        )
+        for sub_report in report.reports_:
+            sub_report._metric_registry = metric_registry
+        return collect_scores(report, data_source="test")
+
+    from skore._reports.estimator.report import EstimatorReport
+
+    report = EstimatorReport(
+        clone(predictor),
+        X_train=X,
+        y_train=y,
+        X_test=X_test,
+        y_test=y_test,
+        pos_label=report.pos_label,
+    )
+    report._metric_registry = metric_registry
+    return collect_scores(report, data_source="test")
 
 
 class CheckGoldenFeature(Check):
@@ -29,7 +89,9 @@ class CheckGoldenFeature(Check):
 
     Detects a single feature that, used alone to refit the estimator, reaches
     scores close to the full model on the report's default predictive metrics.
-    This often signals data leakage or excessive reliance on one feature.
+    Features whose scores also match a model trained on the target itself are
+    reported as likely target leakage. Skipped when SKD002 has already flagged
+    underfitting.
     """
 
     code = "SKD011"
@@ -40,6 +102,10 @@ class CheckGoldenFeature(Check):
     slow = True
 
     def check_function(self, report: _BaseReport) -> str | None:
+        skd002_result = getattr(report, "_check_results_cache", {}).get("SKD002")
+        if skd002_result is not None and skd002_result["section"] == "issue":
+            raise CheckNotApplicable("Skipped because SKD002 detected underfitting.")
+
         if report._report_type == "cross-validation":
             report = cast("CrossValidationReport", report)
             X = nw.from_native(get_preprocessed_X(report))
@@ -48,7 +114,8 @@ class CheckGoldenFeature(Check):
                 raise CheckNotApplicable("Train data has only one feature.")
             n_features = X.shape[1]
             metric_registry = report.reports_[0]._metric_registry.copy()
-            from skore._reports.cross_validation.report import CrossValidationReport
+            X_train = X_test = X
+            y_train = y_test = y
         else:
             report = cast("EstimatorReport", report)
             X_train = nw.from_native(get_preprocessed_X(report, data_source="train"))
@@ -59,7 +126,7 @@ class CheckGoldenFeature(Check):
                 raise CheckNotApplicable("Train data has only one feature.")
             n_features = X_train.shape[1]
             metric_registry = report._metric_registry
-            from skore._reports.estimator.report import EstimatorReport
+            X, y = X_train, y_train
 
         preprocessor_, predictor_ = split_preprocessor_estimator(
             get_fitted_estimator(report)
@@ -67,61 +134,86 @@ class CheckGoldenFeature(Check):
         feature_names = _get_feature_names(
             predictor_,
             transformer=preprocessor_,
-            X=X if report._report_type == "cross-validation" else X_train,
+            X=X,
             n_features=n_features,
         )
         full_feature_scores = collect_scores(report, data_source="test")
 
-        golden_features: list[str] = []
-        single_feature_report: EstimatorReport | CrossValidationReport
+        golden_scores: dict[str, dict[MetricKey, MetricsSummaryRow]] = {}
         for i in range(n_features):
             try:
                 if report._report_type == "cross-validation":
-                    single_feature_report = CrossValidationReport(
-                        clone(predictor_),
-                        X=X.select(nw.col(feature_names[i])).to_native(),
-                        y=y,
-                        splitter=report.splitter,
-                        pos_label=report.pos_label,
-                        n_jobs=report.n_jobs,
+                    single_feature_scores = _predictor_test_scores(
+                        report,
+                        predictor_,
+                        metric_registry,
+                        X.select(nw.col(feature_names[i])).to_native(),
+                        y,
                     )
-                    for sub_report in single_feature_report.reports_:
-                        sub_report._metric_registry = metric_registry
                 else:
-                    single_feature_report = EstimatorReport(
-                        clone(predictor_),
-                        X_train=X_train.select(nw.col(feature_names[i])).to_native(),
-                        y_train=y_train,
+                    single_feature_scores = _predictor_test_scores(
+                        report,
+                        predictor_,
+                        metric_registry,
+                        X_train.select(nw.col(feature_names[i])).to_native(),
+                        y_train,
                         X_test=X_test.select(nw.col(feature_names[i])).to_native(),
                         y_test=y_test,
-                        pos_label=report.pos_label,
                     )
-                    single_feature_report._metric_registry = metric_registry
-                single_feature_scores = collect_scores(
-                    single_feature_report, data_source="test"
-                )
             except Exception as exc:
                 raise CheckNotApplicable(
                     "Failed to create report from single feature."
                 ) from exc
-            votes = [
-                not check_score_better_than_baseline(
-                    score=full_feature_scores[key]["score"],
-                    baseline=single_feature_scores[key]["score"],
-                    greater_is_better=full_feature_scores[key]["greater_is_better"],
-                    floor=0.03,
-                    fraction=0.10,
-                )
-                for key in full_feature_scores.keys() & single_feature_scores.keys()
-            ]
-            if majority_vote(votes)[0]:
-                golden_features.append(str(feature_names[i]))
+            if _on_par(single_feature_scores, full_feature_scores):
+                golden_scores[str(feature_names[i])] = single_feature_scores
 
-        if golden_features:
+        if not golden_scores:
+            return None
+
+        def _full_model_message(names: list[str]) -> str:
             return (
-                f"A model trained on feature(s) {golden_features} alone has similar "
+                f"A model trained on feature(s) {names} alone has similar "
                 "performance to a model trained on all the features, on the default "
                 "predictive metrics. This may signal data leakage or excessive "
                 "reliance on a single feature."
             )
-        return None
+
+        try:
+            if report._report_type == "cross-validation":
+                target_scores = _predictor_test_scores(
+                    report,
+                    predictor_,
+                    metric_registry,
+                    _normalize_y_as_dataframe(y),
+                    y,
+                )
+            else:
+                target_scores = _predictor_test_scores(
+                    report,
+                    predictor_,
+                    metric_registry,
+                    _normalize_y_as_dataframe(y_train),
+                    y_train,
+                    X_test=_normalize_y_as_dataframe(y_test),
+                    y_test=y_test,
+                )
+        except Exception:
+            return _full_model_message(list(golden_scores))
+
+        target_like = [
+            name
+            for name, scores in golden_scores.items()
+            if _on_par(scores, target_scores)
+        ]
+        proxy = [name for name in golden_scores if name not in target_like]
+        messages = []
+        if target_like:
+            messages.append(
+                f"A model trained on feature(s) {target_like} alone has similar "
+                "performance to a model trained on the target itself, on the default "
+                "predictive metrics. This likely means the target is present among "
+                "the features."
+            )
+        if proxy:
+            messages.append(_full_model_message(proxy))
+        return "\n".join(messages)

--- a/skore/src/skore/_checks/skd011_golden_feature.py
+++ b/skore/src/skore/_checks/skd011_golden_feature.py
@@ -92,9 +92,9 @@ class CheckGoldenFeature(Check):
     Features whose scores also match a model trained on the target itself are
     reported as likely target leakage.
 
-    If SKD002 has already flagged underfitting on the same report, This check is marked
-    as not applicable so a uniformly bad model is not treated as having many golden
-    features.
+    If SKD002 (underfitting) was already reported on the same report, this check is
+    marked as not applicable so a uniformly bad model is not treated as having many
+    golden features.
 
     Note: for skrub learners whose preprocessing vectorizes columns (e.g.
     :class:`~skrub.TableVectorizer`), a raw "golden column" may not appear as a

--- a/skore/src/skore/_checks/skd011_golden_feature.py
+++ b/skore/src/skore/_checks/skd011_golden_feature.py
@@ -90,8 +90,11 @@ class CheckGoldenFeature(Check):
     Detects a single feature that, used alone to refit the estimator, reaches
     scores close to the full model on the report's default predictive metrics.
     Features whose scores also match a model trained on the target itself are
-    reported as likely target leakage. Skipped when SKD002 has already flagged
-    underfitting.
+    reported as likely target leakage.
+
+    If SKD002 has already flagged underfitting on the same report, This check is marked
+    as not applicable so a uniformly bad model is not treated as having many golden
+    features.
 
     Note: for skrub learners whose preprocessing vectorizes columns (e.g.
     :class:`~skrub.TableVectorizer`), a raw "golden column" may not appear as a

--- a/skore/tests/unit/checks/test_skd011_golden_feature.py
+++ b/skore/tests/unit/checks/test_skd011_golden_feature.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.cross_decomposition import PLSRegression
+from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
@@ -43,6 +44,8 @@ def test_detects_golden_feature(report_type, estimator):
     assert "Feature 1" in explanation
     assert "Feature 2" not in explanation
     assert "Feature 3" not in explanation
+    assert "target itself" in explanation
+    assert "all the features" not in explanation
 
 
 @pytest.mark.parametrize("report_type", ["estimator", "cross-validation"])
@@ -112,3 +115,76 @@ def test_not_applicable_when_single_feature_refit_fails(report_type, regression_
         CheckNotApplicable, match="Failed to create report from single feature."
     ):
         CheckGoldenFeature().check_function(report)
+
+
+@pytest.mark.parametrize("report_type", ["estimator", "cross-validation"])
+def test_not_applicable_when_skd002_detected(report_type, regression_data):
+    """SKD011 is skipped when SKD002 has already flagged underfitting."""
+    X, y = regression_data
+    report = evaluate(
+        DummyRegressor(), X, y, splitter=0.2 if report_type == "estimator" else 3
+    )
+    ignore = [
+        check.code
+        for check in report._checks_registry
+        if check.code not in {"SKD002", "SKD011"}
+    ]
+    summary = report.checks.summarize(ignore=ignore)
+    assert "SKD011" in set(summary.frame(section="not_applicable")["code"])
+    assert "SKD011" not in set(summary.frame(section="tip")["code"])
+    explanation = (
+        summary.frame(section="not_applicable")
+        .set_index("code")
+        .loc["SKD011", "explanation"]
+    )
+    assert "SKD002" in explanation
+
+
+@pytest.mark.parametrize("report_type", ["estimator", "cross-validation"])
+def test_message_when_target_in_features(report_type):
+    """SKD011 mentions the target itself when a feature is a copy of y."""
+    rng = np.random.RandomState(0)
+    n = 200
+    y = rng.normal(size=n)
+    X = pd.DataFrame({"leaked": y, "noise": rng.normal(size=n)})
+    report = evaluate(
+        LinearRegression(),
+        X,
+        y,
+        splitter=0.2 if report_type == "estimator" else 3,
+    )
+    explanation = CheckGoldenFeature().check_function(report)
+    assert explanation is not None
+    assert "leaked" in explanation
+    assert "noise" not in explanation
+    assert "target itself" in explanation
+    assert "all the features" not in explanation
+
+
+@pytest.mark.parametrize("report_type", ["estimator", "cross-validation"])
+def test_message_when_proxy_feature(report_type):
+    """SKD011 keeps the full-model wording when a feature is a proxy, not y."""
+    rng = np.random.RandomState(0)
+    n = 400
+    signal = rng.normal(size=n)
+    y = signal + rng.normal(scale=1.0, size=n)
+    X = pd.DataFrame(
+        {
+            "signal": signal,
+            "noise1": rng.normal(size=n),
+            "noise2": rng.normal(size=n),
+        }
+    )
+    report = evaluate(
+        LinearRegression(),
+        X,
+        y,
+        splitter=0.2 if report_type == "estimator" else 3,
+    )
+    explanation = CheckGoldenFeature().check_function(report)
+    assert explanation is not None
+    assert "signal" in explanation
+    assert "noise1" not in explanation
+    assert "noise2" not in explanation
+    assert "all the features" in explanation
+    assert "target itself" not in explanation

--- a/sphinx/user_guide/automated_checks.rst
+++ b/sphinx/user_guide/automated_checks.rst
@@ -476,12 +476,21 @@ This check is *slow*: it requires fitting one model per feature. Skip it with
 How it is detected
 ^^^^^^^^^^^^^^^^^^
 
+The check does not run when :ref:`SKD002 <skd002-underfitting>` has already
+flagged underfitting on the same report: an underfit model performs similarly
+with any single feature, which would otherwise produce false golden-feature tips.
+
 For each input feature, `skore` clones the report's estimator, refits it on
 that single feature, and scores it on the test set. A feature is considered as
 *golden* when its single-feature scores are close to the full model's scores within
 an adaptive threshold (``max(0.03, 0.10 * |full_score|)``) on a **strict
 majority** of the report's default predictive metrics (timing metrics
 excluded).
+
+When golden features are found, `skore` also refits the estimator using the
+target as the only feature. Golden features whose scores are close to that
+oracle (same adaptive threshold) are described as likely copies of the target;
+the others are described as features the model relies on almost exclusively.
 
 The check only runs when the report has at least two features.
 


### PR DESCRIPTION
Towards #3063:
- SKD011 skips underfit models. If SKD002 has already flagged underfitting on the same report, golden-feature detection is marked not applicable so a uniformly bad model is not treated as having many golden features.

- SKD011 splits the tip using a target-as-feature oracle. After golden features are found, the predictor is refit on the target as the only column. Features that match that oracle are described as likely copies of the target; the others keep the existing “matches the full model” wording. When both apply, the two sentences are joined with a newline.
