### PR TITLE
fix(summarize): Use dict keys as metric names

### DIFF
--- a/skore/src/skore/_displays/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_displays/metrics/metrics_summary_display.py
@@ -361,10 +361,7 @@ class MetricsSummaryDisplay(DisplayMixin):
             for level_index, name in enumerate(table.index.names):
                 if name == "label":
                     levels[level_index] = pd.Index(
-                        [
-                            "" if value == "" else str(value)
-                            for value in levels[level_index]
-                        ],
+                        [str(value) for value in levels[level_index]],
                         dtype="string",
                         name=name,
                     )

--- a/skore/src/skore/_displays/metrics/metrics_summary_display.py
+++ b/skore/src/skore/_displays/metrics/metrics_summary_display.py
@@ -8,6 +8,7 @@ import pandas as pd
 from sklearn.utils.validation import _is_arraylike
 
 from skore._displays.base import DisplayMixin
+from skore._metrics.metrics import _to_verbose
 from skore._sklearn.types import Aggregate
 from skore._utils.index import flatten_multi_index, squeeze_single_column
 
@@ -371,11 +372,11 @@ class MetricsSummaryDisplay(DisplayMixin):
 
         if verbose_name:
             table.index.names = [
-                None if name is None else name.replace("_", " ").title()
+                None if name is None else _to_verbose(name)
                 for name in table.index.names
             ]
             table.columns.names = [
-                None if name is None else name.replace("_", " ").title()
+                None if name is None else _to_verbose(name)
                 for name in table.columns.names
             ]
             table = table.rename(columns={"favorability": "Favorability"})

--- a/skore/src/skore/_metrics/metrics.py
+++ b/skore/src/skore/_metrics/metrics.py
@@ -61,6 +61,9 @@ class MetricRow(TypedDict):
 
     Parameters
     ----------
+    name : str
+        Metric name.
+
     metric_verbose_name : str
         Human-readable metric name.
 
@@ -80,6 +83,7 @@ class MetricRow(TypedDict):
         Output index for multioutput regression metrics.
     """
 
+    name: str
     metric_verbose_name: str
     greater_is_better: bool | None
     score: float
@@ -437,6 +441,7 @@ class Metric:
     ) -> MetricRow:
         """Build a single :class:`MetricRow`."""
         return MetricRow(
+            name=self.name,
             metric_verbose_name=self.verbose_name,
             greater_is_better=self.greater_is_better,
             score=score.item() if hasattr(score, "item") else score,
@@ -459,7 +464,8 @@ class Metric:
             for submetric_name, submetric_value in score.items():
                 rows = self._to_rows(submetric_value, report=report, **kwargs)
                 for r in rows:
-                    r["metric_verbose_name"] = submetric_name
+                    r["name"] = submetric_name
+                    r["metric_verbose_name"] = _to_verbose(submetric_name)
                 result.extend(rows)
             return result
 
@@ -545,9 +551,7 @@ class Metric:
             # We assume each submetric's values are grouped together
             return {
                 name: self._to_pretty(list(rows_))
-                for name, rows_ in groupby(
-                    rows, key=lambda row: row["metric_verbose_name"]
-                )
+                for name, rows_ in groupby(rows, key=lambda row: row["name"])
             }
 
         if rows[0]["label"] is not None:

--- a/skore/src/skore/_metrics/metrics.py
+++ b/skore/src/skore/_metrics/metrics.py
@@ -52,6 +52,10 @@ _METRIC_ALIASES: dict[str, str] = {
 }
 
 
+def _to_verbose(name: str) -> str:
+    return name.replace("_", " ").title()
+
+
 class MetricRow(TypedDict):
     """A single row of a metric output.
 
@@ -173,7 +177,7 @@ class Metric:
             return
 
         self.name = name
-        self.verbose_name = verbose_name or name.replace("_", " ").title()
+        self.verbose_name = verbose_name or _to_verbose(name)
         self.greater_is_better = greater_is_better
         self.response_method = response_method
         self.function = function
@@ -238,7 +242,7 @@ class Metric:
 
             if name is not None:
                 result.name = name
-                result.verbose_name = name.replace("_", " ").title()
+                result.verbose_name = _to_verbose(name)
 
             if verbose_name is not None:
                 result.verbose_name = verbose_name

--- a/skore/src/skore/_reports/estimator/metrics.py
+++ b/skore/src/skore/_reports/estimator/metrics.py
@@ -174,6 +174,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
             except Exception as exception:
                 metric_rows = [
                     MetricRow(
+                        name=parsed_metric.name,
                         metric_verbose_name=parsed_metric.verbose_name,
                         greater_is_better=parsed_metric.greater_is_better,
                         label=None,
@@ -186,7 +187,7 @@ class _MetricsAccessor(BaseMetricsAccessor[EstimatorReport], DirNamesMixin):
 
             rows.extend(
                 {
-                    "name": parsed_metric.name,
+                    "name": row["name"],
                     "verbose_name": row["metric_verbose_name"],
                     "estimator": self._parent.estimator_name_,
                     "data_source": data_source,

--- a/skore/tests/unit/plugins/hub/report/test_estimator_report.py
+++ b/skore/tests/unit/plugins/hub/report/test_estimator_report.py
@@ -497,9 +497,9 @@ class TestEstimatorReportPayload:
         custom = [m for m in payload.metrics if m.name.startswith("score_")]
         assert {m.name for m in custom} == {"score_a_1", "score_b_1", "score_c_1"}
         assert {m.verbose_name for m in custom} == {
-            "score_a_1",
-            "score_b_1",
-            "score_c_1",
+            "Score A 1",
+            "Score B 1",
+            "Score C 1",
         }
         # train + test for each submetric
         assert len(custom) == 6

--- a/skore/tests/unit/reports/estimator/metrics/test_registry.py
+++ b/skore/tests/unit/reports/estimator/metrics/test_registry.py
@@ -609,10 +609,15 @@ class TestMultiMetric:
 
         display = report.metrics.summarize(metric="multimetric_scorer")
 
-        assert list(display.summary["verbose_name"]) == [
+        assert list(display.summary["name"]) == [
             "accuracy",
             "precision",  # Label 0
             "precision",  # Label 1
+        ]
+        assert list(display.summary["verbose_name"]) == [
+            "Accuracy",
+            "Precision",  # Label 0
+            "Precision",  # Label 1
         ]
         assert list(display.summary["label"]) == [pd.NA, np.int64(0), np.int64(1)]
 
@@ -644,10 +649,15 @@ class TestMultiMetric:
 
         display = report.metrics.summarize(metric="score")
 
-        assert list(display.summary["verbose_name"]) == [
+        assert list(display.summary["name"]) == [
             "accuracy",
             "precision",  # Label 0
             "precision",  # Label 1
+        ]
+        assert list(display.summary["verbose_name"]) == [
+            "Accuracy",
+            "Precision",  # Label 0
+            "Precision",  # Label 1
         ]
         assert list(display.summary["label"]) == [pd.NA, np.int64(0), np.int64(1)]
 


### PR DESCRIPTION
Closes https://github.com/probabl-ai/skore/issues/3249

```py
from sklearn.datasets import make_classification
from sklearn.linear_model import LogisticRegression

from skore import evaluate

X, y = make_classification(return_X_y=True)

estimator_report = evaluate(
    LogisticRegression(),
    X,
    y,
    pos_label=1,
)

def custom(estimator, X, y):
    return {"A": 1, "B": 2}

estimator_report.metrics.add(custom)

# "A" and "B" are used intead of "custom"
estimator_report.metrics.summarize().frame()
# metric
# A               1.000000
# B               2.000000
# accuracy        0.800000
# precision       0.888889
# recall          0.727273
# roc_auc         0.969697
# log_loss        0.304507
# brier_score     0.100096
# fit_time        0.005184
# predict_time    0.000279
# Name: LogisticRegression, dtype: float64

# "A" and "B" appear alongside verbose-named metrics
estimator_report.metrics.summarize().frame(flat_index=False, verbose_name=True)
# Metric
# A                   1.000000
# B                   2.000000
# Accuracy            1.000000
# Precision           1.000000
# Recall              1.000000
# ROC AUC             1.000000
# Log loss            0.064413
# Brier score         0.013533
# Fit time (s)        0.002224
# Predict time (s)    0.000121
# Name: LogisticRegression, dtype: float64
```

