### PR TITLE
feat(skore)!: Add n_bins="auto" option to CalibrationDisplay

### DIFF
--- a/skore/src/skore/_displays/inspection/calibration_curve.py
+++ b/skore/src/skore/_displays/inspection/calibration_curve.py
@@ -151,6 +151,7 @@ class CalibrationDisplay(DisplayMixin):
         """Compute the data for the calibration curve display."""
         y_arr = np.asarray(y)
         y_pred_arr = np.asarray(y_pred)
+        new_n_bins = int(np.ceil(len(y_arr) ** (1 / 3))) if n_bins == "auto" else n_bins
 
         classes = np.unique(y_arr)
         y_true_onehot = _one_hot_encode(y_arr, classes)
@@ -160,7 +161,7 @@ class CalibrationDisplay(DisplayMixin):
             frac_pos, pred_prob = calibration_curve(
                 y_true_onehot[:, class_idx],
                 y_pred_arr[:, class_idx],
-                n_bins=n_bins,
+                n_bins=new_n_bins,
                 strategy=strategy,
             )
             df = pd.DataFrame(

--- a/skore/src/skore/_displays/inspection/calibration_curve.py
+++ b/skore/src/skore/_displays/inspection/calibration_curve.py
@@ -51,7 +51,7 @@ class CalibrationDisplay(DisplayMixin):
     >>> report = evaluate(LogisticRegression(), X, y, splitter=0.2)
     >>> display = report.inspection.calibration_curve(n_bins="auto", strategy="uniform")
     >>> display.frame()
-       predicted_probability  fraction_of_positives data_source  label
+        predicted_probability  fraction_of_positives data_source  label
     0               0.013323               0.018338        test      0
     1               0.052453               0.049888        test      0
     2               0.088494               0.093787        test      0

--- a/skore/src/skore/_displays/inspection/calibration_curve.py
+++ b/skore/src/skore/_displays/inspection/calibration_curve.py
@@ -49,7 +49,7 @@ class CalibrationDisplay(DisplayMixin):
     ...     n_samples=100_000, n_features=20, n_informative=2, n_redundant=10,
     ...     random_state=42)
     >>> report = evaluate(LogisticRegression(), X, y, splitter=0.2)
-    >>> display = report.inspection.calibration_curve(n_bins=5, strategy="uniform")
+    >>> display = report.inspection.calibration_curve(n_bins="auto", strategy="uniform")
     >>> display.frame()
         predicted_probability  fraction_of_positives data_source  label
     0               0.058169               0.058186        test      0
@@ -144,7 +144,7 @@ class CalibrationDisplay(DisplayMixin):
         y_pred: ArrayLike,
         y: ArrayLike,
         report_type: ReportType,
-        n_bins: int = 5,
+        n_bins: int | Literal["auto"] = 5,
         strategy: Literal["uniform", "quantile"] = "quantile",
         report_pos_label: PositiveLabel = None,
     ) -> CalibrationDisplay:

--- a/skore/src/skore/_displays/inspection/calibration_curve.py
+++ b/skore/src/skore/_displays/inspection/calibration_curve.py
@@ -50,7 +50,7 @@ class CalibrationDisplay(DisplayMixin):
     ...     random_state=42)
     >>> report = evaluate(LogisticRegression(), X, y, splitter=0.2)
     >>> display = report.inspection.calibration_curve(n_bins="auto", strategy="uniform")
-    >>> display.frame()
+    >>> display.frame().head(10)
         predicted_probability  fraction_of_positives data_source  label
     0               0.013323               0.018338        test      0
     1               0.052453               0.049888        test      0

--- a/skore/src/skore/_displays/inspection/calibration_curve.py
+++ b/skore/src/skore/_displays/inspection/calibration_curve.py
@@ -51,17 +51,17 @@ class CalibrationDisplay(DisplayMixin):
     >>> report = evaluate(LogisticRegression(), X, y, splitter=0.2)
     >>> display = report.inspection.calibration_curve(n_bins="auto", strategy="uniform")
     >>> display.frame()
-        predicted_probability  fraction_of_positives data_source  label
-    0               0.058169               0.058186        test      0
-    1               0.291218               0.279537        test      0
-    2               0.501687               0.507645        test      0
-    3               0.709106               0.705734        test      0
-    4               0.942051               0.940309        test      0
-    5               0.057949               0.059691        test      1
-    6               0.290894               0.294266        test      1
-    7               0.498313               0.492355        test      1
-    8               0.708782               0.720463        test      1
-    9               0.941831               0.941814        test      1
+       predicted_probability  fraction_of_positives data_source  label
+    0               0.013323               0.018338        test      0
+    1               0.052453               0.049888        test      0
+    2               0.088494               0.093787        test      0
+    3               0.124554               0.113264        test      0
+    4               0.160065               0.145329        test      0
+    5               0.195742               0.187050        test      0
+    6               0.232088               0.215909        test      0
+    7               0.266940               0.232376        test      0
+    8               0.303651               0.271739        test      0
+    9               0.338850               0.387692        test      0
     """
 
     _default_line_kwargs = {
@@ -144,14 +144,13 @@ class CalibrationDisplay(DisplayMixin):
         y_pred: ArrayLike,
         y: ArrayLike,
         report_type: ReportType,
-        n_bins: int | Literal["auto"] = 5,
+        n_bins: int | Literal["auto"] = "auto",
         strategy: Literal["uniform", "quantile"] = "quantile",
         report_pos_label: PositiveLabel = None,
     ) -> CalibrationDisplay:
         """Compute the data for the calibration curve display."""
         y_arr = np.asarray(y)
         y_pred_arr = np.asarray(y_pred)
-        new_n_bins = int(np.ceil(len(y_arr) ** (1 / 3))) if n_bins == "auto" else n_bins
 
         classes = np.unique(y_arr)
         y_true_onehot = _one_hot_encode(y_arr, classes)
@@ -161,7 +160,9 @@ class CalibrationDisplay(DisplayMixin):
             frac_pos, pred_prob = calibration_curve(
                 y_true_onehot[:, class_idx],
                 y_pred_arr[:, class_idx],
-                n_bins=new_n_bins,
+                n_bins=int(np.ceil(len(y_arr) ** (1 / 3)))
+                if n_bins == "auto"
+                else n_bins,
                 strategy=strategy,
             )
             df = pd.DataFrame(

--- a/skore/src/skore/_displays/inspection/calibration_curve.py
+++ b/skore/src/skore/_displays/inspection/calibration_curve.py
@@ -50,18 +50,13 @@ class CalibrationDisplay(DisplayMixin):
     ...     random_state=42)
     >>> report = evaluate(LogisticRegression(), X, y, splitter=0.2)
     >>> display = report.inspection.calibration_curve(n_bins="auto", strategy="uniform")
-    >>> display.frame().head(10)
+    >>> display.frame().head(5)
         predicted_probability  fraction_of_positives data_source  label
     0               0.013323               0.018338        test      0
     1               0.052453               0.049888        test      0
     2               0.088494               0.093787        test      0
     3               0.124554               0.113264        test      0
     4               0.160065               0.145329        test      0
-    5               0.195742               0.187050        test      0
-    6               0.232088               0.215909        test      0
-    7               0.266940               0.232376        test      0
-    8               0.303651               0.271739        test      0
-    9               0.338850               0.387692        test      0
     """
 
     _default_line_kwargs = {

--- a/skore/src/skore/_reports/estimator/inspection.py
+++ b/skore/src/skore/_reports/estimator/inspection.py
@@ -383,7 +383,7 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             The data source for the calibration curve. If None, the default data
             source is used.
 
-        n_bins : int or {"auto"}, default=5
+        n_bins : int or "auto", default=5
             The number of bins to use for the calibration curve. Default is 5.
 
         strategy : {"uniform", "quantile"}, default="quantile"

--- a/skore/src/skore/_reports/estimator/inspection.py
+++ b/skore/src/skore/_reports/estimator/inspection.py
@@ -368,7 +368,7 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
-        n_bins: int = 5,
+        n_bins: int | Literal["auto"] = 5,
         strategy: Literal["uniform", "quantile"] = "quantile",
     ) -> CalibrationDisplay:
         """Display the calibration curve.
@@ -383,7 +383,7 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             The data source for the calibration curve. If None, the default data
             source is used.
 
-        n_bins : int, default=5
+        n_bins : int or {"auto"}, default=5
             The number of bins to use for the calibration curve. Default is 5.
 
         strategy : {"uniform", "quantile"}, default="quantile"

--- a/skore/src/skore/_reports/estimator/inspection.py
+++ b/skore/src/skore/_reports/estimator/inspection.py
@@ -368,7 +368,7 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
         self,
         *,
         data_source: DataSource = "test",
-        n_bins: int | Literal["auto"] = 5,
+        n_bins: int | Literal["auto"] = "auto",
         strategy: Literal["uniform", "quantile"] = "quantile",
     ) -> CalibrationDisplay:
         """Display the calibration curve.
@@ -383,7 +383,7 @@ class _InspectionAccessor(_BaseAccessor[EstimatorReport], DirNamesMixin):
             The data source for the calibration curve. If None, the default data
             source is used.
 
-        n_bins : int or "auto", default=5
+        n_bins : int or "auto", default="auto"
             The number of bins to use for the calibration curve. Default is 5.
 
         strategy : {"uniform", "quantile"}, default="quantile"

--- a/skore/tests/unit/displays/calibration_curve/conftest.py
+++ b/skore/tests/unit/displays/calibration_curve/conftest.py
@@ -2,6 +2,11 @@ import pytest
 
 
 @pytest.fixture(scope="module")
+def estimator_type():
+    return "linear"
+
+
+@pytest.fixture(scope="module")
 def estimator_reports_binary_classification_figure_axes(
     estimator_reports_binary_classification,
 ):

--- a/skore/tests/unit/displays/calibration_curve/test_common.py
+++ b/skore/tests/unit/displays/calibration_curve/test_common.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pytest
 
+import skore._displays.inspection.calibration_curve as mod
 from skore import CalibrationDisplay
 
 
@@ -24,6 +26,32 @@ class TestCalibrationDisplay:
         fig = display.plot()
         assert fig is not None
         assert len(fig.axes) >= 1
+
+    @pytest.mark.parametrize(
+        "use_explicit_auto", [False, True], ids=["default", "explicit-auto"]
+    )
+    def test_auto_n_bins_uses_cube_root_rule(
+        self, fixture_prefix, task, request, monkeypatch, use_explicit_auto
+    ):
+        report = request.getfixturevalue(f"{fixture_prefix}_{task}")
+        if isinstance(report, tuple):
+            report = report[0]
+
+        observed_n_bins = []
+
+        def fake_calibration_curve(y_true, y_pred, *, n_bins, strategy):
+            expected_n_bins = int(np.ceil(len(y_true) ** (1 / 3)))
+            observed_n_bins.append(n_bins)
+            assert n_bins == expected_n_bins
+            return np.array([0.0]), np.array([0.5])
+
+        monkeypatch.setattr(mod, "calibration_curve", fake_calibration_curve)
+        display = report.inspection.calibration_curve(
+            **({"n_bins": "auto"} if use_explicit_auto else {})
+        )
+        assert isinstance(display, CalibrationDisplay)
+        assert observed_n_bins
+        assert all(n_bins == observed_n_bins[0] for n_bins in observed_n_bins)
 
     def test_frame_structure(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")

--- a/skore/tests/unit/displays/calibration_curve/test_common.py
+++ b/skore/tests/unit/displays/calibration_curve/test_common.py
@@ -35,7 +35,7 @@ class TestCalibrationDisplay:
         frame = display.frame(label=label)
         n_samples = len(report.y_test)
         expected_n_bins = int(np.ceil(n_samples ** (1 / 3)))
-        assert len(frame) <= expected_n_bins
+        assert len(frame) == expected_n_bins
 
     def test_frame_structure(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")

--- a/skore/tests/unit/displays/calibration_curve/test_common.py
+++ b/skore/tests/unit/displays/calibration_curve/test_common.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import skore._displays.inspection.calibration_curve as mod
 from skore import CalibrationDisplay
 
 
@@ -27,31 +26,16 @@ class TestCalibrationDisplay:
         assert fig is not None
         assert len(fig.axes) >= 1
 
-    @pytest.mark.parametrize(
-        "use_explicit_auto", [False, True], ids=["default", "explicit-auto"]
-    )
-    def test_auto_n_bins_uses_cube_root_rule(
-        self, fixture_prefix, task, request, monkeypatch, use_explicit_auto
-    ):
+    def test_auto_n_bins_uses_cube_root_rule(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")
         if isinstance(report, tuple):
             report = report[0]
-
-        observed_n_bins = []
-
-        def fake_calibration_curve(y_true, y_pred, *, n_bins, strategy):
-            expected_n_bins = int(np.ceil(len(y_true) ** (1 / 3)))
-            observed_n_bins.append(n_bins)
-            assert n_bins == expected_n_bins
-            return np.array([0.0]), np.array([0.5])
-
-        monkeypatch.setattr(mod, "calibration_curve", fake_calibration_curve)
-        display = report.inspection.calibration_curve(
-            **({"n_bins": "auto"} if use_explicit_auto else {})
-        )
-        assert isinstance(display, CalibrationDisplay)
-        assert observed_n_bins
-        assert all(n_bins == observed_n_bins[0] for n_bins in observed_n_bins)
+        display = report.inspection.calibration_curve()
+        label = display.labels[0]
+        frame = display.frame(label=label)
+        n_samples = len(report.y_test)
+        expected_n_bins = int(np.ceil(n_samples ** (1 / 3)))
+        assert len(frame) <= expected_n_bins
 
     def test_frame_structure(self, fixture_prefix, task, request):
         report = request.getfixturevalue(f"{fixture_prefix}_{task}")

--- a/skore/tests/unit/displays/calibration_curve/test_common.py
+++ b/skore/tests/unit/displays/calibration_curve/test_common.py
@@ -31,8 +31,7 @@ class TestCalibrationDisplay:
         if isinstance(report, tuple):
             report = report[0]
         display = report.inspection.calibration_curve()
-        label = display.labels[0]
-        frame = display.frame(label=label)
+        frame = display.frame(label=display.labels[0])
         n_samples = len(report.y_test)
         expected_n_bins = int(np.ceil(n_samples ** (1 / 3)))
         assert len(frame) <= expected_n_bins


### PR DESCRIPTION
#### Description
Fixes #2937 
Reference Issues : https://github.com/scikit-learn/scikit-learn/issues/33658 (for information)
Reference PR : https://github.com/scikit-learn/scikit-learn/pull/33856 (for code)

the pr adds `n_bins="auto"` option in the CalibrationDisplay report
here the default `n_bins` is also changed to `n_bins="auto"`

#### Testing code
From file path --> `F:\skore_05\skore\src\skore\_displays\inspection\calibration_curve.py`
```python
from sklearn.datasets import make_classification
from sklearn.linear_model import LogisticRegression
from skore import evaluate

X, y = make_classification(
n_samples=100_000, n_features=20, n_informative=2, n_redundant=10,random_state=42)
report = evaluate(LogisticRegression(), X, y, splitter=0.2)
display = report.inspection.calibration_curve(n_bins="auto", strategy="uniform")
print(display.frame().head())
```

##### Output in `main`
(Here the `n_bins=5`)
```
(venv) direk@dkakkar:/mnt/f/skore_05$ python test_code.py
   predicted_probability  fraction_of_positives data_source  label
0               0.058169               0.058186        test      0
1               0.291218               0.279537        test      0
2               0.501687               0.507645        test      0
3               0.709106               0.705734        test      0
4               0.942051               0.940309        test      0
(venv) direk@dkakkar:/mnt/f/skore_05$ 
```

##### Output in `direkkakkar319-ops:CalibrationDisplay`
(Here the `n_bins="auto"` )
```
(venv) direk@dkakkar:/mnt/f/skore_05$ python test_code.py
   predicted_probability  fraction_of_positives data_source  label
0               0.013323               0.018338        test      0
1               0.052453               0.049888        test      0
2               0.088494               0.093787        test      0
3               0.124554               0.113264        test      0
4               0.160065               0.145329        test      0
(venv) direk@dkakkar:/mnt/f/skore_05$ 
```