### PR TITLE
fix(hub): Keep browser output out of the login Live region

### DIFF
--- a/skore/src/skore/_plugins/hub/authentication/login.py
+++ b/skore/src/skore/_plugins/hub/authentication/login.py
@@ -54,20 +54,19 @@ def login(*, timeout: int = 600) -> None:
     try:
         credentials = APIKey()
     except KeyError:
-        with Live(console=console, auto_refresh=False) as live:
+        with Live(console=console, auto_refresh=False, transient=True) as live:
             credentials = Token(timeout=timeout, live=live)
 
-            live.update(
-                Panel(
-                    Align.center(
-                        "Successfully logged in, using [b]interactive authentication."
-                    ),
-                    title="[cyan]Login to [bold]Skore Hub",
-                    border_style="cyan",
-                    padding=1,
-                )
+        console.print(
+            Panel(
+                Align.center(
+                    "Successfully logged in, using [b]interactive authentication."
+                ),
+                title="[cyan]Login to [bold]Skore Hub",
+                border_style="cyan",
+                padding=1,
             )
-            live.refresh()
+        )
     else:
         console.print(
             Panel(

--- a/skore/src/skore/_plugins/hub/authentication/login.py
+++ b/skore/src/skore/_plugins/hub/authentication/login.py
@@ -5,7 +5,6 @@ from logging import getLogger
 from os import environ
 
 from rich.align import Align
-from rich.live import Live
 from rich.panel import Panel
 
 from skore import console
@@ -54,9 +53,7 @@ def login(*, timeout: int = 600) -> None:
     try:
         credentials = APIKey()
     except KeyError:
-        with Live(console=console, auto_refresh=False, transient=True) as live:
-            credentials = Token(timeout=timeout, live=live)
-
+        credentials = Token(timeout=timeout)
         console.print(
             Panel(
                 Align.center(

--- a/skore/src/skore/_plugins/hub/authentication/login.py
+++ b/skore/src/skore/_plugins/hub/authentication/login.py
@@ -1,10 +1,13 @@
 """Login to ``skore hub``."""
 
 from collections.abc import Callable
+from io import StringIO
 from logging import getLogger
 from os import environ
 
 from rich.align import Align
+from rich.console import Console
+from rich.live import Live
 from rich.panel import Panel
 
 from skore import console
@@ -24,6 +27,27 @@ logger = getLogger(__name__)
 credentials: Callable[[], dict[str, str]] | None = None
 
 
+def _login_panel(message: str) -> Panel:
+    return Panel(
+        Align.center(message),
+        title="[cyan]Login to [bold]Skore Hub",
+        border_style="cyan",
+        padding=1,
+    )
+
+
+def _panel_line_count(panel: Panel) -> int:
+    buffer = StringIO()
+    Console(
+        file=buffer,
+        width=console.width,
+        color_system=None,
+        force_terminal=True,
+        highlight=False,
+    ).print(panel)
+    return buffer.getvalue().count("\n")
+
+
 def login(*, timeout: int = 600) -> None:
     """Login to ``skore hub``.
 
@@ -39,37 +63,27 @@ def login(*, timeout: int = 600) -> None:
 
     if credentials is not None:
         logger.debug(f"Already logged in {URI()} with {credentials.__module__}.")
-        console.print(
-            Panel(
-                Align.center("Already logged in."),
-                title="[cyan]Login to [b]Skore Hub",
-                border_style="cyan",
-                padding=1,
-            )
-        )
+        console.print(_login_panel("Already logged in."))
 
         return
 
     try:
         credentials = APIKey()
     except KeyError:
-        credentials = Token(timeout=timeout)
-        console.print(
-            Panel(
-                Align.center(
-                    "Successfully logged in, using [b]interactive authentication."
-                ),
-                title="[cyan]Login to [bold]Skore Hub",
-                border_style="cyan",
-                padding=1,
+        success = "Successfully logged in, using [b]interactive authentication."
+        with Live(
+            console=console,
+            auto_refresh=False,
+            redirect_stdout=False,
+            redirect_stderr=False,
+        ) as live:
+            credentials = Token(timeout=timeout, live=live)
+            extra = max(
+                0,
+                live._live_render.last_render_height
+                - _panel_line_count(_login_panel(success)),
             )
-        )
+            live.update(_login_panel(success + extra * "\n"))
+            live.refresh()
     else:
-        console.print(
-            Panel(
-                Align.center("Successfully logged in, using [b]API key."),
-                title="[cyan]Login to [bold]Skore Hub",
-                border_style="cyan",
-                padding=1,
-            )
-        )
+        console.print(_login_panel("Successfully logged in, using [b]API key."))

--- a/skore/src/skore/_plugins/hub/authentication/login.py
+++ b/skore/src/skore/_plugins/hub/authentication/login.py
@@ -1,12 +1,10 @@
 """Login to ``skore hub``."""
 
 from collections.abc import Callable
-from io import StringIO
 from logging import getLogger
 from os import environ
 
 from rich.align import Align
-from rich.console import Console
 from rich.live import Live
 from rich.panel import Panel
 
@@ -36,18 +34,6 @@ def _login_panel(message: str) -> Panel:
     )
 
 
-def _panel_line_count(panel: Panel) -> int:
-    buffer = StringIO()
-    Console(
-        file=buffer,
-        width=console.width,
-        color_system=None,
-        force_terminal=True,
-        highlight=False,
-    ).print(panel)
-    return buffer.getvalue().count("\n")
-
-
 def login(*, timeout: int = 600) -> None:
     """Login to ``skore hub``.
 
@@ -70,20 +56,14 @@ def login(*, timeout: int = 600) -> None:
     try:
         credentials = APIKey()
     except KeyError:
-        success = "Successfully logged in, using [b]interactive authentication."
-        with Live(
-            console=console,
-            auto_refresh=False,
-            redirect_stdout=False,
-            redirect_stderr=False,
-        ) as live:
+        with Live(console=console, auto_refresh=False) as live:
             credentials = Token(timeout=timeout, live=live)
-            extra = max(
-                0,
-                live._live_render.last_render_height
-                - _panel_line_count(_login_panel(success)),
+
+            live.update(
+                _login_panel(
+                    "Successfully logged in, using [b]interactive authentication."
+                )
             )
-            live.update(_login_panel(success + extra * "\n"))
             live.refresh()
     else:
         console.print(_login_panel("Successfully logged in, using [b]API key."))

--- a/skore/src/skore/_plugins/hub/authentication/token.py
+++ b/skore/src/skore/_plugins/hub/authentication/token.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from shutil import which
-from subprocess import DEVNULL, Popen
+from os import close, devnull, dup, dup2
 from threading import RLock
 from time import sleep
 from urllib.parse import urljoin
@@ -20,18 +19,31 @@ from skore._plugins.hub.authentication.uri import URI
 
 
 def open_webbrowser(url: str) -> None:
-    """Open ``url`` without leaking browser or GTK messages onto the terminal."""
-    opener = which("xdg-open") or which("open")
-    if opener:
-        Popen(
-            [opener, url],
-            stdin=DEVNULL,
-            stdout=DEVNULL,
-            stderr=DEVNULL,
-            start_new_session=True,
-        )
-        return
-    _open_webbrowser(url)
+    """
+    Open ``url`` in a browser, keeping the browser's own output off the terminal.
+
+    ``webbrowser`` launches some browsers, such as ``xdg-open``, without redirecting the
+    child's stdio. Messages like ``Gtk-Message`` then land in the middle of a ``rich``
+    ``Live`` region and desynchronize its cursor bookkeeping, which leaves a stale panel
+    border behind on the next refresh.
+
+    Point the file descriptors the child inherits at ``os.devnull`` for the duration of
+    the call, rather than spawning the browser here, so that ``BROWSER`` and the
+    standard ``webbrowser`` resolution order keep working.
+    """
+    with open(devnull, "wb") as null:
+        stdout, stderr = dup(1), dup(2)
+
+        try:
+            dup2(null.fileno(), 1)
+            dup2(null.fileno(), 2)
+
+            _open_webbrowser(url)
+        finally:
+            dup2(stdout, 1)
+            dup2(stderr, 2)
+            close(stdout)
+            close(stderr)
 
 
 def get_oauth_device_login(success_uri: str | None = None) -> tuple[str, str, str]:
@@ -226,7 +238,7 @@ class Token:
                 "at [link=https://skore.probabl.ai/account]"
                 "https://skore.probabl.ai/account[/link].[/i]\n\n"
                 "Opening browser for interactive authentication; if this fails, "
-                f"please visit:\n{url}"
+                f"please visit:\n[link={url}]{url}[/link]"
             ),
             title="[cyan]Login to [bold]Skore Hub",
             border_style="cyan",

--- a/skore/src/skore/_plugins/hub/authentication/token.py
+++ b/skore/src/skore/_plugins/hub/authentication/token.py
@@ -9,9 +9,6 @@ from urllib.parse import urljoin
 from webbrowser import open as open_webbrowser
 
 from httpx import HTTPStatusError, TimeoutException
-from rich.align import Align
-from rich.live import Live
-from rich.panel import Panel
 
 from skore import console
 from skore._plugins.hub.authentication.uri import URI
@@ -199,28 +196,18 @@ class Token:
     Refresh the token on-the-fly if necessary.
     """
 
-    def __init__(self, *, timeout: int = 600, live: Live | None = None) -> None:
+    def __init__(self, *, timeout: int = 600) -> None:
         url, device_code, user_code = get_oauth_device_login()
-        panel = Panel(
-            Align.center(
-                "[b]API key not detected.[/b]\n\n"
-                "Starting interactive authentication for the session.\n"
-                "[i]We recommend that you create an API key and use it to log in, "
-                "at [link=https://skore.probabl.ai/account]"
-                "https://skore.probabl.ai/account[/link].[/i]\n\n"
-                "Opening browser for interactive authentication; if this fails, "
-                f"please visit:\n[link={url}]{url}[/link]"
-            ),
-            title="[cyan]Login to [bold]Skore Hub",
-            border_style="cyan",
-            padding=1,
+        console.print(
+            "[b]API key not detected.[/b]\n\n"
+            "Starting interactive authentication for the session.\n"
+            "[i]We recommend that you create an API key and use it to log in, "
+            "at [link=https://skore.probabl.ai/account]"
+            "https://skore.probabl.ai/account[/link].[/i]\n\n"
+            "Opening browser for interactive authentication; if this fails, "
+            f"please visit:\n[link={url}]{url}[/link]",
+            soft_wrap=True,
         )
-
-        if live:
-            live.update(panel)
-            live.refresh()
-        else:
-            console.print(panel, soft_wrap=True)
 
         open_webbrowser(url)
 

--- a/skore/src/skore/_plugins/hub/authentication/token.py
+++ b/skore/src/skore/_plugins/hub/authentication/token.py
@@ -3,15 +3,35 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from shutil import which
+from subprocess import DEVNULL, Popen
 from threading import RLock
 from time import sleep
 from urllib.parse import urljoin
-from webbrowser import open as open_webbrowser
+from webbrowser import open as _open_webbrowser
 
 from httpx import HTTPStatusError, TimeoutException
+from rich.align import Align
+from rich.live import Live
+from rich.panel import Panel
 
 from skore import console
 from skore._plugins.hub.authentication.uri import URI
+
+
+def open_webbrowser(url: str) -> None:
+    """Open ``url`` without leaking browser or GTK messages onto the terminal."""
+    opener = which("xdg-open") or which("open")
+    if opener:
+        Popen(
+            [opener, url],
+            stdin=DEVNULL,
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+            start_new_session=True,
+        )
+        return
+    _open_webbrowser(url)
 
 
 def get_oauth_device_login(success_uri: str | None = None) -> tuple[str, str, str]:
@@ -196,18 +216,28 @@ class Token:
     Refresh the token on-the-fly if necessary.
     """
 
-    def __init__(self, *, timeout: int = 600) -> None:
+    def __init__(self, *, timeout: int = 600, live: Live | None = None) -> None:
         url, device_code, user_code = get_oauth_device_login()
-        console.print(
-            "[b]API key not detected.[/b]\n\n"
-            "Starting interactive authentication for the session.\n"
-            "[i]We recommend that you create an API key and use it to log in, "
-            "at [link=https://skore.probabl.ai/account]"
-            "https://skore.probabl.ai/account[/link].[/i]\n\n"
-            "Opening browser for interactive authentication; if this fails, "
-            f"please visit:\n[link={url}]{url}[/link]",
-            soft_wrap=True,
+        panel = Panel(
+            Align.center(
+                "[b]API key not detected.[/b]\n\n"
+                "Starting interactive authentication for the session.\n"
+                "[i]We recommend that you create an API key and use it to log in, "
+                "at [link=https://skore.probabl.ai/account]"
+                "https://skore.probabl.ai/account[/link].[/i]\n\n"
+                "Opening browser for interactive authentication; if this fails, "
+                f"please visit:\n{url}"
+            ),
+            title="[cyan]Login to [bold]Skore Hub",
+            border_style="cyan",
+            padding=1,
         )
+
+        if live:
+            live.update(panel)
+            live.refresh()
+        else:
+            console.print(panel, soft_wrap=True)
 
         open_webbrowser(url)
 

--- a/skore/tests/unit/plugins/hub/authentication/test_login.py
+++ b/skore/tests/unit/plugins/hub/authentication/test_login.py
@@ -5,7 +5,6 @@ from httpx import (
     TimeoutException,
 )
 from pytest import mark, raises
-from rich.panel import Panel
 
 from skore._plugins.hub.authentication import login as login_module
 
@@ -68,63 +67,6 @@ def test_login_with_token(monkeypatch, respx_mock):
 
     assert login_module.credentials is not None
     assert login_module.credentials() == {"Authorization": "Bearer D"}
-
-
-@mark.respx()
-def test_login_interactive_success_replaces_waiting_panel(monkeypatch, respx_mock):
-    """Interactive login updates the waiting Live panel to success, same frame."""
-    monkeypatch.setattr(
-        "skore._plugins.hub.authentication.token.open_webbrowser",
-        lambda _: True,
-    )
-    respx_mock.get(LOGIN_URL).mock(
-        Response(
-            200,
-            json={
-                "authorization_url": "<url>",
-                "device_code": "<device>",
-                "user_code": "<user>",
-            },
-        )
-    )
-    respx_mock.get(PROBE_URL).mock(Response(200))
-    respx_mock.post(CALLBACK_URL).mock(Response(200))
-    respx_mock.get(TOKEN_URL).mock(
-        Response(
-            200,
-            json={
-                "token": {
-                    "access_token": "D",
-                    "refresh_token": "E",
-                    "expires_at": DATETIME_MAX,
-                }
-            },
-        )
-    )
-
-    live_updates = []
-    printed = []
-
-    class TrackingLive(login_module.Live):
-        def update(self, renderable, *, refresh=False):
-            live_updates.append(renderable)
-            return super().update(renderable, refresh=refresh)
-
-    original_print = login_module.console.print
-
-    def capture_print(*args, **kwargs):
-        printed.extend(args)
-        original_print(*args, **kwargs)
-
-    monkeypatch.setattr(login_module, "Live", TrackingLive)
-    monkeypatch.setattr(login_module.console, "print", capture_print)
-
-    login_module.login()
-
-    assert len(live_updates) == 2
-    assert "API key not detected" in str(live_updates[0].renderable)
-    assert "interactive authentication" in str(live_updates[1].renderable)
-    assert not any(isinstance(item, Panel) for item in printed)
 
 
 @mark.respx()

--- a/skore/tests/unit/plugins/hub/authentication/test_login.py
+++ b/skore/tests/unit/plugins/hub/authentication/test_login.py
@@ -71,8 +71,8 @@ def test_login_with_token(monkeypatch, respx_mock):
 
 
 @mark.respx()
-def test_login_interactive_success_prints_one_panel(monkeypatch, respx_mock):
-    """Interactive login prints one titled panel, after unboxed waiting copy."""
+def test_login_interactive_success_replaces_waiting_panel(monkeypatch, respx_mock):
+    """Interactive login updates the waiting Live panel to success, same frame."""
     monkeypatch.setattr(
         "skore._plugins.hub.authentication.token.open_webbrowser",
         lambda _: True,
@@ -102,24 +102,29 @@ def test_login_interactive_success_prints_one_panel(monkeypatch, respx_mock):
         )
     )
 
+    live_updates = []
     printed = []
+
+    class TrackingLive(login_module.Live):
+        def update(self, renderable, *, refresh=False):
+            live_updates.append(renderable)
+            return super().update(renderable, refresh=refresh)
+
     original_print = login_module.console.print
 
     def capture_print(*args, **kwargs):
         printed.extend(args)
         original_print(*args, **kwargs)
 
+    monkeypatch.setattr(login_module, "Live", TrackingLive)
     monkeypatch.setattr(login_module.console, "print", capture_print)
 
     login_module.login()
 
-    panels = [panel for panel in printed if isinstance(panel, Panel)]
-    assert len(panels) == 1
-    assert "interactive authentication" in str(panels[0].renderable)
-    assert any(
-        isinstance(message, str) and "API key not detected" in message
-        for message in printed
-    )
+    assert len(live_updates) == 2
+    assert "API key not detected" in str(live_updates[0].renderable)
+    assert "interactive authentication" in str(live_updates[1].renderable)
+    assert not any(isinstance(item, Panel) for item in printed)
 
 
 @mark.respx()

--- a/skore/tests/unit/plugins/hub/authentication/test_login.py
+++ b/skore/tests/unit/plugins/hub/authentication/test_login.py
@@ -5,6 +5,7 @@ from httpx import (
     TimeoutException,
 )
 from pytest import mark, raises
+from rich.panel import Panel
 
 from skore._plugins.hub.authentication import login as login_module
 
@@ -67,6 +68,69 @@ def test_login_with_token(monkeypatch, respx_mock):
 
     assert login_module.credentials is not None
     assert login_module.credentials() == {"Authorization": "Bearer D"}
+
+
+@mark.respx()
+def test_login_interactive_success_panel_is_printed_after_live(monkeypatch, respx_mock):
+    """Success is printed after Live exits so it does not nest in the waiting panel."""
+    monkeypatch.setattr(
+        "skore._plugins.hub.authentication.token.open_webbrowser",
+        lambda _: True,
+    )
+    respx_mock.get(LOGIN_URL).mock(
+        Response(
+            200,
+            json={
+                "authorization_url": "<url>",
+                "device_code": "<device>",
+                "user_code": "<user>",
+            },
+        )
+    )
+    respx_mock.get(PROBE_URL).mock(Response(200))
+    respx_mock.post(CALLBACK_URL).mock(Response(200))
+    respx_mock.get(TOKEN_URL).mock(
+        Response(
+            200,
+            json={
+                "token": {
+                    "access_token": "D",
+                    "refresh_token": "E",
+                    "expires_at": DATETIME_MAX,
+                }
+            },
+        )
+    )
+
+    live_kwargs = {}
+    live_updates = []
+    printed = []
+
+    class TrackingLive(login_module.Live):
+        def __init__(self, *args, **kwargs):
+            live_kwargs.update(kwargs)
+            super().__init__(*args, **kwargs)
+
+        def update(self, renderable, *, refresh=False):
+            live_updates.append(renderable)
+            return super().update(renderable, refresh=refresh)
+
+    original_print = login_module.console.print
+
+    def capture_print(*args, **kwargs):
+        printed.extend(args)
+        original_print(*args, **kwargs)
+
+    monkeypatch.setattr(login_module, "Live", TrackingLive)
+    monkeypatch.setattr(login_module.console, "print", capture_print)
+
+    login_module.login()
+
+    assert live_kwargs.get("transient") is True
+    assert len(live_updates) == 1
+    success_panels = [panel for panel in printed if isinstance(panel, Panel)]
+    assert len(success_panels) == 1
+    assert "interactive authentication" in str(success_panels[0].renderable)
 
 
 @mark.respx()

--- a/skore/tests/unit/plugins/hub/authentication/test_login.py
+++ b/skore/tests/unit/plugins/hub/authentication/test_login.py
@@ -71,8 +71,8 @@ def test_login_with_token(monkeypatch, respx_mock):
 
 
 @mark.respx()
-def test_login_interactive_success_panel_is_printed_after_live(monkeypatch, respx_mock):
-    """Success is printed after Live exits so it does not nest in the waiting panel."""
+def test_login_interactive_success_prints_one_panel(monkeypatch, respx_mock):
+    """Interactive login prints one titled panel, after unboxed waiting copy."""
     monkeypatch.setattr(
         "skore._plugins.hub.authentication.token.open_webbrowser",
         lambda _: True,
@@ -102,35 +102,24 @@ def test_login_interactive_success_panel_is_printed_after_live(monkeypatch, resp
         )
     )
 
-    live_kwargs = {}
-    live_updates = []
     printed = []
-
-    class TrackingLive(login_module.Live):
-        def __init__(self, *args, **kwargs):
-            live_kwargs.update(kwargs)
-            super().__init__(*args, **kwargs)
-
-        def update(self, renderable, *, refresh=False):
-            live_updates.append(renderable)
-            return super().update(renderable, refresh=refresh)
-
     original_print = login_module.console.print
 
     def capture_print(*args, **kwargs):
         printed.extend(args)
         original_print(*args, **kwargs)
 
-    monkeypatch.setattr(login_module, "Live", TrackingLive)
     monkeypatch.setattr(login_module.console, "print", capture_print)
 
     login_module.login()
 
-    assert live_kwargs.get("transient") is True
-    assert len(live_updates) == 1
-    success_panels = [panel for panel in printed if isinstance(panel, Panel)]
-    assert len(success_panels) == 1
-    assert "interactive authentication" in str(success_panels[0].renderable)
+    panels = [panel for panel in printed if isinstance(panel, Panel)]
+    assert len(panels) == 1
+    assert "interactive authentication" in str(panels[0].renderable)
+    assert any(
+        isinstance(message, str) and "API key not detected" in message
+        for message in printed
+    )
 
 
 @mark.respx()

--- a/skore/tests/unit/plugins/hub/authentication/test_token.py
+++ b/skore/tests/unit/plugins/hub/authentication/test_token.py
@@ -159,6 +159,31 @@ def test_post_oauth_refresh_token(respx_mock):
     assert expires_at == "C"
 
 
+def test_open_webbrowser_discards_child_stdio(monkeypatch):
+    launched = {}
+
+    monkeypatch.setattr(
+        "skore._plugins.hub.authentication.token.which",
+        lambda command: "/usr/bin/xdg-open" if command == "xdg-open" else None,
+    )
+
+    def fake_popen(args, **kwargs):
+        launched["args"] = args
+        launched["kwargs"] = kwargs
+
+    monkeypatch.setattr("skore._plugins.hub.authentication.token.Popen", fake_popen)
+
+    from subprocess import DEVNULL
+
+    from skore._plugins.hub.authentication.token import open_webbrowser
+
+    open_webbrowser("https://example.test")
+
+    assert launched["args"] == ["/usr/bin/xdg-open", "https://example.test"]
+    assert launched["kwargs"]["stdout"] is DEVNULL
+    assert launched["kwargs"]["stderr"] is DEVNULL
+
+
 class TestToken:
     @mark.respx()
     def test_init(self, monkeypatch, respx_mock):

--- a/skore/tests/unit/plugins/hub/authentication/test_token.py
+++ b/skore/tests/unit/plugins/hub/authentication/test_token.py
@@ -1,4 +1,6 @@
 from datetime import UTC, datetime
+from subprocess import run
+from sys import executable
 from urllib.parse import urljoin
 
 from httpx import HTTPError, Response, TimeoutException
@@ -9,6 +11,7 @@ from skore._plugins.hub.authentication.token import (
     get_oauth_device_code_probe,
     get_oauth_device_login,
     get_oauth_device_token,
+    open_webbrowser,
     post_oauth_device_callback,
     post_oauth_refresh_token,
 )
@@ -159,29 +162,47 @@ def test_post_oauth_refresh_token(respx_mock):
     assert expires_at == "C"
 
 
-def test_open_webbrowser_discards_child_stdio(monkeypatch):
-    launched = {}
+def test_open_webbrowser_silences_browser_output(monkeypatch, capfd):
+    # The browser is a child process writing straight to the inherited file
+    # descriptors, so it must be silenced at the descriptor level, not by swapping
+    # `sys.stdout`/`sys.stderr`. Noise landing mid-`Live` desynchronizes rich's cursor
+    # bookkeeping and leaves a stale panel border behind.
+    def noisy_browser(url):
+        run([executable, "-c", "from sys import stderr; stderr.write('Gtk-Message')"])
+        return True
 
     monkeypatch.setattr(
-        "skore._plugins.hub.authentication.token.which",
-        lambda command: "/usr/bin/xdg-open" if command == "xdg-open" else None,
+        "skore._plugins.hub.authentication.token._open_webbrowser", noisy_browser
     )
-
-    def fake_popen(args, **kwargs):
-        launched["args"] = args
-        launched["kwargs"] = kwargs
-
-    monkeypatch.setattr("skore._plugins.hub.authentication.token.Popen", fake_popen)
-
-    from subprocess import DEVNULL
-
-    from skore._plugins.hub.authentication.token import open_webbrowser
 
     open_webbrowser("https://example.test")
 
-    assert launched["args"] == ["/usr/bin/xdg-open", "https://example.test"]
-    assert launched["kwargs"]["stdout"] is DEVNULL
-    assert launched["kwargs"]["stderr"] is DEVNULL
+    assert capfd.readouterr() == ("", "")
+
+
+def test_open_webbrowser_restores_stdio(monkeypatch, capfd):
+    monkeypatch.setattr(
+        "skore._plugins.hub.authentication.token._open_webbrowser", lambda url: True
+    )
+
+    open_webbrowser("https://example.test")
+    run([executable, "-c", "from sys import stderr; stderr.write('after')"])
+
+    assert capfd.readouterr().err == "after"
+
+
+def test_open_webbrowser_uses_webbrowser(monkeypatch):
+    # Resolution must be delegated to `webbrowser`, so that `BROWSER` and the standard
+    # browser ordering keep working.
+    opened = []
+
+    monkeypatch.setattr(
+        "skore._plugins.hub.authentication.token._open_webbrowser", opened.append
+    )
+
+    open_webbrowser("https://example.test")
+
+    assert opened == ["https://example.test"]
 
 
 class TestToken:


### PR DESCRIPTION
Interactive `skore.login()` left a stale panel border behind, showing two frames titled `Login to Skore Hub`, with browser GTK warnings printed into the display.

<img width="1500" height="375" alt="image" src="https://github.com/user-attachments/assets/85cb1d70-6bdb-4438-8d7d-c5064aa0f856" />

On Linux `webbrowser` picks `BackgroundBrowser("xdg-open")`, which unlike `UnixBrowser._invoke` passes no stdio redirection, so the browser inherits fds 1 and 2 and writes straight to the terminal inside the `Live` region. The cursor then sits one line lower than `Live` believes, its next refresh erases the wrong lines, and the top border of the waiting panel survives.

The fix silences the child by pointing the descriptors it inherits at `os.devnull` for the duration of the call. It redirects rather than spawns the browser, so `BROWSER` and the standard `webbrowser` resolution order keep working — launching `xdg-open` ourselves would break URL forwarding in VS Code Remote and Codespaces, and `which("open")` resolves to `openvt` on some distributions.

No panel padding is needed once the noise is gone: `LiveRender.position_cursor()` erases exactly `last_render_height` lines, so `Live` already shrinks correctly. The `[link=...]` hyperlink is kept too, since an OSC-8 sequence is zero-width for both rich's measurement and the terminal and never affected the line count.

`login.py` is left as just a refactor extracting `_login_panel`, which also unifies the title markup that was `[b]` in one branch and `[bold]` in the others.

On main:
[Screencast From 2026-09-10 14-54-56.webm](https://github.com/user-attachments/assets/0c44c27e-696c-4492-846d-7b96e696e03c)



With this PR:
[Screencast From 2026-09-10 14-56-24.webm](https://github.com/user-attachments/assets/8628b01b-e8fb-4fd3-b582-7224f1d9ca89)


