### PR TITLE
fix: Use relative path for symlink target

### DIFF
--- a/skore/src/skore/_plugins/local/project.py
+++ b/skore/src/skore/_plugins/local/project.py
@@ -111,7 +111,7 @@ def _write_report(
     with contextlib.suppress(FileNotFoundError):
         symlink.unlink()
     with contextlib.suppress(OSError):
-        symlink.symlink_to(output_dir)
+        symlink.symlink_to(filename)
 
     if isinstance(report, EstimatorReport):
         _write_estimator_report(report, workspace, output_dir, name=name)


### PR DESCRIPTION

I just changed the absolute value of the path provided in the OS function to a more relativistic value (filename).


closes #3260 


- [ ] Unit tests were added or updated (if necessary)
- [ ] Documentation was added or updated (if necessary)
- [x] The code passes our style conventions (you can check this by running pre-commit on your code
with `pre-commit run --all-files`)
- [x] All the tests pass (please test locally before pushing)
- [ ] The documentation builds and renders properly (if it does, our bot will add a comment linking
to a preview of the documentation to review it visually)
- [x] All the commits in the PR are signed (more information
[here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
- [x] The pull request title respects the Conventional Commits convention (more information
[here](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests))

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure you understand our [automated contributions policy](https://docs.skore.probabl.ai/stable/contributing.html#automated-contributions-policy)
-->
AI tools were involved for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
 

I think that i have made some mistake if it does not pass the CI tests i will probably close and reopen PR after the changes.