### PR TITLE
fix: compute coefficient feature std on a plain array so polars inputs work

### DIFF
--- a/skore/src/skore/_displays/inspection/coefficients.py
+++ b/skore/src/skore/_displays/inspection/coefficients.py
@@ -782,7 +782,9 @@ class CoefficientsDisplay(DisplayMixin):
                 _, variance = mean_variance_axis(X_transformed, axis=0)
                 std = np.sqrt(variance)
             else:
-                std = np.std(X_transformed, axis=0)
+                # ``np.std`` defers to the container's own ``std`` method, and a
+                # polars frame does not take ``axis``; reduce a plain array.
+                std = np.std(np.asarray(X_transformed), axis=0)
             # the intercept is given a unit standard deviation to leave it unscaled
             feature_std = np.concatenate([[1.0], std])
         else:

--- a/skore/tests/unit/displays/coefficients/test_estimator.py
+++ b/skore/tests/unit/displays/coefficients/test_estimator.py
@@ -212,3 +212,25 @@ def test_scale_features_plot_labels(regression_train_test_split):
     fig = report.inspection.coefficients().plot(scale_features=True)
     assert fig.axes[0].get_xlabel() == "Magnitude of scaled coefficient"
     assert fig.get_suptitle() == "Scaled coefficients of Ridge"
+
+
+def test_feature_std_with_polars_train_data():
+    """Feature standard deviations are computed on a polars frame too (#3263).
+
+    ``np.std`` defers to the container's ``std`` method, and a polars frame does
+    not accept ``axis``; the display has to reduce a plain array.
+    """
+    polars = pytest.importorskip("polars")
+    X, y = make_regression(n_samples=40, n_features=3, random_state=0)
+    X = polars.DataFrame(X, schema=["a", "b", "c"])
+    report = EstimatorReport(
+        LinearRegression(), X_train=X, y_train=y, X_test=X, y_test=y
+    )
+
+    display = report.inspection.coefficients()
+
+    feature_std = display.coefficients.set_index("feature")["feature_std"]
+    np.testing.assert_allclose(feature_std["Intercept"], 1.0)
+    np.testing.assert_allclose(
+        feature_std[["a", "b", "c"]].to_numpy(), np.std(X.to_numpy(), axis=0)
+    )


### PR DESCRIPTION
#### Change description

`CoefficientsDisplay._compute_data_for_display` computed the training feature standard deviation with `np.std(X_transformed, axis=0)`. `np.std` defers to the container's own `std` method, and `polars.DataFrame.std()` does not accept `axis`, so with a polars `X` (and no preprocessor that turns it into an array) the call raised `TypeError: DataFrame.std() got an unexpected keyword argument 'axis'`. In the hub plugin that surfaced as the `PydanticSerializationError` from the report, because the `medias` computed field builds the coefficients artifact; the same error is reachable locally through `report.inspection.coefficients()`.

The reduction now runs on `np.asarray(X_transformed)`. For pandas and numpy inputs this is the same population standard deviation as before (`ddof=0`); the sparse branch is untouched.

Closes #3263

The polars `y` from the report is not involved: with the fix, the payload in the issue dumps successfully (verified with the repro script and the hub test fixtures).

#### Contribution checklist

- [x] Unit tests were added or updated (if necessary): `test_feature_std_with_polars_train_data` in `tests/unit/displays/coefficients/test_estimator.py`, fails on `main` with the error above.
- [ ] Documentation was added or updated (if necessary): not needed.
- [x] The code passes our style conventions (`pre-commit run --files …`: all hooks pass, including ruff and mypy)
- [x] All the tests pass (`tests/unit/displays/coefficients/test_estimator.py`: 16 passed)
- [ ] The documentation builds and renders properly: no documentation change.
- [x] All the commits in the PR are signed
- [x] The pull request title respects the Conventional Commits convention
