### PR TITLE
Making SKD011's and SKD002's dependency robust

### DIFF
--- a/skore/src/skore/_checks/skd011_golden_feature.py
+++ b/skore/src/skore/_checks/skd011_golden_feature.py
@@ -109,9 +109,6 @@ class CheckGoldenFeature(Check):
     slow = True
 
     def check_function(self, report: _BaseReport) -> str | None:
-        skd002_result = getattr(report, "_check_results_cache", {}).get("SKD002")
-        if skd002_result is not None and skd002_result["section"] == "issue":
-            raise CheckNotApplicable("Skipped because SKD002 detected underfitting.")
 
         if report._report_type == "cross-validation":
             report = cast("CrossValidationReport", report)
@@ -138,6 +135,9 @@ class CheckGoldenFeature(Check):
         preprocessor_, predictor_ = split_preprocessor_estimator(
             get_fitted_estimator(report)
         )
+        skd002_result = getattr(report, "_check_results_cache", {}).get("SKD002")
+        if skd002_result is not None and skd002_result["section"] == "issue":
+            raise CheckNotApplicable("Skipped because SKD002 detected underfitting.")
         feature_names = _get_feature_names(
             predictor_,
             transformer=preprocessor_,

--- a/skore/src/skore/_reports/base.py
+++ b/skore/src/skore/_reports/base.py
@@ -92,6 +92,7 @@ class _BaseReport(ReportHelpMixin):
         """
         if not hasattr(self, "_check_results_cache"):
             self._check_results_cache: dict[CheckCode, CheckResult] = {}
+        self._ignored_codes = ignored_codes
 
         checks_to_run = [
             check
@@ -107,20 +108,7 @@ class _BaseReport(ReportHelpMixin):
             total=len(checks_to_run),
             disable=fast_mode,
         ):
-            try:
-                explanation = check.check_function(self)
-                section: CheckSection = (
-                    getattr(check, "severity", "issue") if explanation else "passed"
-                )
-            except CheckNotApplicable as exc:
-                explanation = exc.args[0] if exc.args else None
-                section = "not_applicable"
-            self._check_results_cache[check.code] = {
-                "title": check.title,
-                "docs_url": check.docs_url,
-                "explanation": explanation,
-                "section": section,
-            }
+            self._run_check(check)
 
         if "comparison" in self._report_type:
             return self._aggregate_checks(ignored_codes, fast_mode=fast_mode)
@@ -157,6 +145,40 @@ class _BaseReport(ReportHelpMixin):
                 summary[check.code] = self._check_results_cache[check.code]
 
         return summary
+
+    def _run_check(self, check):
+        if not hasattr(self, "_check_results_cache"):
+            self._check_results_cache: dict[CheckCode, CheckResult] = {}
+        if check.code in self._check_results_cache:
+            return self._check_results_cache[check.code]
+        try:
+            explanation = check.check_function(self)
+            section: CheckSection = (
+                getattr(check, "severity", "issue") if explanation else "passed"
+            )
+        except CheckNotApplicable as exc:
+            explanation = exc.args[0] if exc.args else None
+            section = "not_applicable"
+        self._check_results_cache[check.code] = {
+            "title": check.title,
+            "docs_url": check.docs_url,
+            "explanation": explanation,
+            "section": section,
+        }
+        return self._check_results_cache[check.code]
+
+    def _get_check_result(self, code: CheckCode) -> CheckResult | None:
+        if hasattr(self, "_check_results_cache") and code in self._check_results_cache:
+            return self._check_results_cache[code]
+
+        if code in getattr(self, "_ignored_codes", set()):
+            return None
+
+        for check in self._checks_registry:
+            if check.code == code and self._report_type in check.report_types:
+                return self._run_check(check)
+
+        return None
 
     def _checks_summary_html_fragment(self) -> str:
         """HTML snippet for the checks summary tab in report reprs."""


### PR DESCRIPTION
Previously, CheckGoldenFeature (SKD011) checked whether SKD002 (underfitting) had already flagged an issue by reading directly from report._check_results_cache.

This only worked because checks happen to run in increasing numeric order by default, so SKD002's result was already cached by the time SKD011 ran. If the registry were ever reordered (via .remove()/.add()), or a future dependency pointed from a lower-numbered check to a higher-numbered one, this would silently do nothing — a missing cache entry looks identical to "SKD002 ran and found no issue."

closes #3258

- [ ] Unit tests were added or updated (if necessary)
- [ ] Documentation was added or updated (if necessary)
- [x] The code passes our style conventions (you can check this by running pre-commit on your code
with `pre-commit run --all-files`)
- [x] All the tests pass (please test locally before pushing)
- [ ] The documentation builds and renders properly (if it does, our bot will add a comment linking
to a preview of the documentation to review it visually)
- [x] All the commits in the PR are signed (more information
[here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
- [x] The pull request title respects the Conventional Commits convention (more information
[here](https://docs.skore.probabl.ai/stable/contributing.html#pull-requests))

AI tools were involved for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


